### PR TITLE
feat: introduce tailwind-styled-components for improved readability

### DIFF
--- a/apps/www/components/ui/menubar.tsx
+++ b/apps/www/components/ui/menubar.tsx
@@ -1,20 +1,20 @@
 "use client"
 
-import React from "react"
-import * as Primitive from "@radix-ui/react-menubar"
+import * as React from "react"
+import * as MenuBarPrimitive from "@radix-ui/react-menubar"
 import { Check, ChevronRight, Circle } from "lucide-react"
 import tw from "tailwind-styled-components"
 
 import { cn } from "@/lib/utils"
 
 const Styled = {
-  Root: tw(Primitive.Root)`
+  Root: tw(MenuBarPrimitive.Root)`
     flex h-10 items-center space-x-1 rounded-md border 
     border-slate-300 bg-white p-1 
     dark:border-slate-700 
     dark:bg-slate-800
   `,
-  Trigger: tw(Primitive.Trigger)`
+  Trigger: tw(MenuBarPrimitive.Trigger)`
     flex cursor-default select-none items-center rounded-[0.2rem] 
     py-1.5 px-3 text-sm font-medium outline-none 
     focus:bg-slate-100 
@@ -23,7 +23,7 @@ const Styled = {
     dark:focus:bg-slate-700 
     dark:data-[state=open]:bg-slate-700
   `,
-  SubTrigger: tw(Primitive.SubTrigger)`
+  SubTrigger: tw(MenuBarPrimitive.SubTrigger)`
     flex cursor-default select-none items-center rounded-sm 
     py-1.5 px-2 text-sm font-medium outline-none 
     focus:bg-slate-100 
@@ -31,7 +31,7 @@ const Styled = {
     dark:focus:bg-slate-700 
     dark:data-[state=open]:bg-slate-700
   `,
-  SubContent: tw(Primitive.SubContent)`
+  SubContent: tw(MenuBarPrimitive.SubContent)`
     z-50 min-w-[8rem] overflow-hidden 
     rounded-md border border-slate-100 
     bg-white p-1 shadow-md 
@@ -39,14 +39,14 @@ const Styled = {
     dark:border-slate-700 
     dark:bg-slate-800
   `,
-  Content: tw(Primitive.Content)`
+  Content: tw(MenuBarPrimitive.Content)`
     z-50 min-w-[12rem] overflow-hidden rounded-md 
     border border-slate-100 bg-white p-1 
     text-slate-700 shadow-md animate-in slide-in-from-top-1 
     dark:border-slate-800 
     dark:bg-slate-800 dark:text-slate-400
   `,
-  Item: tw(Primitive.Item)`
+  Item: tw(MenuBarPrimitive.Item)`
     relative flex cursor-default select-none items-center 
     rounded-sm py-1.5 px-2 text-sm font-medium outline-none 
     focus:bg-slate-100 
@@ -54,7 +54,7 @@ const Styled = {
     data-[disabled]:opacity-50 
     dark:focus:bg-slate-700
   `,
-  CheckboxItem: tw(Primitive.CheckboxItem)`
+  CheckboxItem: tw(MenuBarPrimitive.CheckboxItem)`
     relative flex cursor-default select-none items-center 
     rounded-sm py-1.5 pl-8 pr-2 text-sm font-medium outline-none 
     focus:bg-slate-100 
@@ -62,7 +62,7 @@ const Styled = {
     data-[disabled]:opacity-50 
     dark:focus:bg-slate-700
   `,
-  RadioItem: tw(Primitive.RadioItem)`
+  RadioItem: tw(MenuBarPrimitive.RadioItem)`
     relative flex cursor-default select-none items-center 
     rounded-sm py-1.5 pl-8 pr-2 text-sm font-medium outline-none 
     focus:bg-slate-100 
@@ -73,26 +73,26 @@ const Styled = {
   Shortcut: tw.span`
     ml-auto text-xs tracking-widest text-slate-500
   `,
-  Separator: tw(Primitive.Separator)`
+  Separator: tw(MenuBarPrimitive.Separator)`
     -mx-1 my-1 h-px bg-slate-100 dark:bg-slate-700
   `,
 }
 
-const MenubarMenu = Primitive.Menu
+const MenubarMenu = MenuBarPrimitive.Menu
 
-const MenubarGroup = Primitive.Group
+const MenubarGroup = MenuBarPrimitive.Group
 
-const MenubarPortal = Primitive.Portal
+const MenubarPortal = MenuBarPrimitive.Portal
 
-const MenubarSub = Primitive.Sub
+const MenubarSub = MenuBarPrimitive.Sub
 
-const MenubarRadioGroup = Primitive.RadioGroup
+const MenubarRadioGroup = MenuBarPrimitive.RadioGroup
 
 const MenubarTrigger = Styled.Trigger
 
 const MenubarSubTrigger = React.forwardRef<
-  React.ElementRef<typeof Primitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof Primitive.SubTrigger> & {
+  React.ElementRef<typeof MenuBarPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof MenuBarPrimitive.SubTrigger> & {
     inset?: boolean
   }
 >(({ className, inset, children, ...props }, ref) => (
@@ -106,19 +106,19 @@ const MenubarSubTrigger = React.forwardRef<
   </Styled.SubTrigger>
 ))
 
-MenubarSubTrigger.displayName = Primitive.SubTrigger.displayName
+MenubarSubTrigger.displayName = MenuBarPrimitive.SubTrigger.displayName
 
 const MenubarSubContent = Styled.SubContent
 
 const MenubarContent = React.forwardRef<
-  React.ElementRef<typeof Primitive.Content>,
-  React.ComponentPropsWithoutRef<typeof Primitive.Content>
+  React.ElementRef<typeof MenuBarPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof MenuBarPrimitive.Content>
 >(
   (
     { className, align = "start", alignOffset = -4, sideOffset = 8, ...props },
     ref
   ) => (
-    <Primitive.Portal>
+    <MenuBarPrimitive.Portal>
       <Styled.Content
         ref={ref}
         align={align}
@@ -127,15 +127,15 @@ const MenubarContent = React.forwardRef<
         className={cn(className)}
         {...props}
       />
-    </Primitive.Portal>
+    </MenuBarPrimitive.Portal>
   )
 )
 
-MenubarContent.displayName = Primitive.Content.displayName
+MenubarContent.displayName = MenuBarPrimitive.Content.displayName
 
 const MenubarItem = React.forwardRef<
-  React.ElementRef<typeof Primitive.Item>,
-  React.ComponentPropsWithoutRef<typeof Primitive.Item> & {
+  React.ElementRef<typeof MenuBarPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof MenuBarPrimitive.Item> & {
     inset?: boolean
   }
 >(({ className, inset, ...props }, ref) => (
@@ -146,11 +146,11 @@ const MenubarItem = React.forwardRef<
   />
 ))
 
-MenubarItem.displayName = Primitive.Item.displayName
+MenubarItem.displayName = MenuBarPrimitive.Item.displayName
 
 const MenubarCheckboxItem = React.forwardRef<
-  React.ElementRef<typeof Primitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof Primitive.CheckboxItem>
+  React.ElementRef<typeof MenuBarPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof MenuBarPrimitive.CheckboxItem>
 >(({ className, children, checked, ...props }, ref) => (
   <Styled.CheckboxItem
     ref={ref}
@@ -159,39 +159,39 @@ const MenubarCheckboxItem = React.forwardRef<
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <Primitive.ItemIndicator>
+      <MenuBarPrimitive.ItemIndicator>
         <Check className="h-4 w-4" />
-      </Primitive.ItemIndicator>
+      </MenuBarPrimitive.ItemIndicator>
     </span>
     {children}
   </Styled.CheckboxItem>
 ))
 
-MenubarCheckboxItem.displayName = Primitive.CheckboxItem.displayName
+MenubarCheckboxItem.displayName = MenuBarPrimitive.CheckboxItem.displayName
 
 const MenubarRadioItem = React.forwardRef<
-  React.ElementRef<typeof Primitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof Primitive.RadioItem>
+  React.ElementRef<typeof MenuBarPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof MenuBarPrimitive.RadioItem>
 >(({ className, children, ...props }, ref) => (
   <Styled.RadioItem ref={ref} className={cn(className)} {...props}>
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <Primitive.ItemIndicator>
+      <MenuBarPrimitive.ItemIndicator>
         <Circle className="h-2 w-2 fill-current" />
-      </Primitive.ItemIndicator>
+      </MenuBarPrimitive.ItemIndicator>
     </span>
     {children}
   </Styled.RadioItem>
 ))
 
-MenubarRadioItem.displayName = Primitive.RadioItem.displayName
+MenubarRadioItem.displayName = MenuBarPrimitive.RadioItem.displayName
 
 const MenubarLabel = React.forwardRef<
-  React.ElementRef<typeof Primitive.Label>,
-  React.ComponentPropsWithoutRef<typeof Primitive.Label> & {
+  React.ElementRef<typeof MenuBarPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof MenuBarPrimitive.Label> & {
     inset?: boolean
   }
 >(({ className, inset, ...props }, ref) => (
-  <Primitive.Label
+  <MenuBarPrimitive.Label
     ref={ref}
     className={cn(
       "px-2 py-1.5 text-sm font-semibold text-slate-900 dark:text-slate-300",
@@ -202,11 +202,11 @@ const MenubarLabel = React.forwardRef<
   />
 ))
 
-MenubarLabel.displayName = Primitive.Label.displayName
+MenubarLabel.displayName = MenuBarPrimitive.Label.displayName
 
 const MenubarSeparator = Styled.Separator
 
-MenubarSeparator.displayName = Primitive.Separator.displayName
+MenubarSeparator.displayName = MenuBarPrimitive.Separator.displayName
 
 const MenubarShortcut = Styled.Shortcut
 

--- a/apps/www/components/ui/menubar.tsx
+++ b/apps/www/components/ui/menubar.tsx
@@ -1,182 +1,197 @@
 "use client"
 
-import * as React from "react"
-import * as MenubarPrimitive from "@radix-ui/react-menubar"
+import React from "react"
+import * as Primitive from "@radix-ui/react-menubar"
 import { Check, ChevronRight, Circle } from "lucide-react"
+import tw from "tailwind-styled-components"
 
 import { cn } from "@/lib/utils"
 
-const MenubarMenu = MenubarPrimitive.Menu
+const Styled = {
+  Root: tw(Primitive.Root)`
+    flex h-10 items-center space-x-1 rounded-md border 
+    border-slate-300 bg-white p-1 
+    dark:border-slate-700 
+    dark:bg-slate-800
+  `,
+  Trigger: tw(Primitive.Trigger)`
+    flex cursor-default select-none items-center rounded-[0.2rem] 
+    py-1.5 px-3 text-sm font-medium outline-none 
+    focus:bg-slate-100 
+    data-[state=open]:bg-slate-100 
+    dark:text-slate-300 
+    dark:focus:bg-slate-700 
+    dark:data-[state=open]:bg-slate-700
+  `,
+  SubTrigger: tw(Primitive.SubTrigger)`
+    flex cursor-default select-none items-center rounded-sm 
+    py-1.5 px-2 text-sm font-medium outline-none 
+    focus:bg-slate-100 
+    data-[state=open]:bg-slate-100 
+    dark:focus:bg-slate-700 
+    dark:data-[state=open]:bg-slate-700
+  `,
+  SubContent: tw(Primitive.SubContent)`
+    z-50 min-w-[8rem] overflow-hidden 
+    rounded-md border border-slate-100 
+    bg-white p-1 shadow-md 
+    animate-in slide-in-from-left-1 
+    dark:border-slate-700 
+    dark:bg-slate-800
+  `,
+  Content: tw(Primitive.Content)`
+    z-50 min-w-[12rem] overflow-hidden rounded-md 
+    border border-slate-100 bg-white p-1 
+    text-slate-700 shadow-md animate-in slide-in-from-top-1 
+    dark:border-slate-800 
+    dark:bg-slate-800 dark:text-slate-400
+  `,
+  Item: tw(Primitive.Item)`
+    relative flex cursor-default select-none items-center 
+    rounded-sm py-1.5 px-2 text-sm font-medium outline-none 
+    focus:bg-slate-100 
+    data-[disabled]:pointer-events-none 
+    data-[disabled]:opacity-50 
+    dark:focus:bg-slate-700
+  `,
+  CheckboxItem: tw(Primitive.CheckboxItem)`
+    relative flex cursor-default select-none items-center 
+    rounded-sm py-1.5 pl-8 pr-2 text-sm font-medium outline-none 
+    focus:bg-slate-100 
+    data-[disabled]:pointer-events-none 
+    data-[disabled]:opacity-50 
+    dark:focus:bg-slate-700
+  `,
+  RadioItem: tw(Primitive.RadioItem)`
+    relative flex cursor-default select-none items-center 
+    rounded-sm py-1.5 pl-8 pr-2 text-sm font-medium outline-none 
+    focus:bg-slate-100 
+    data-[disabled]:pointer-events-none 
+    data-[disabled]:opacity-50 
+    dark:focus:bg-slate-700
+  `,
+  Shortcut: tw.span`
+    ml-auto text-xs tracking-widest text-slate-500
+  `,
+  Separator: tw(Primitive.Separator)`
+    -mx-1 my-1 h-px bg-slate-100 dark:bg-slate-700
+  `,
+}
 
-const MenubarGroup = MenubarPrimitive.Group
+const MenubarMenu = Primitive.Menu
 
-const MenubarPortal = MenubarPrimitive.Portal
+const MenubarGroup = Primitive.Group
 
-const MenubarSub = MenubarPrimitive.Sub
+const MenubarPortal = Primitive.Portal
 
-const MenubarRadioGroup = MenubarPrimitive.RadioGroup
+const MenubarSub = Primitive.Sub
 
-const Menubar = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <MenubarPrimitive.Root
-    ref={ref}
-    className={cn(
-      "flex h-10 items-center space-x-1 rounded-md border border-slate-300 bg-white p-1 dark:border-slate-700 dark:bg-slate-800",
-      className
-    )}
-    {...props}
-  />
-))
-Menubar.displayName = MenubarPrimitive.Root.displayName
+const MenubarRadioGroup = Primitive.RadioGroup
 
-const MenubarTrigger = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Trigger>
->(({ className, ...props }, ref) => (
-  <MenubarPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "flex cursor-default select-none items-center rounded-[0.2rem] py-1.5 px-3 text-sm font-medium outline-none focus:bg-slate-100 data-[state=open]:bg-slate-100 dark:focus:bg-slate-700 dark:data-[state=open]:bg-slate-700",
-      className
-    )}
-    {...props}
-  />
-))
-MenubarTrigger.displayName = MenubarPrimitive.Trigger.displayName
+const MenubarTrigger = Styled.Trigger
 
 const MenubarSubTrigger = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.SubTrigger> & {
+  React.ElementRef<typeof Primitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof Primitive.SubTrigger> & {
     inset?: boolean
   }
 >(({ className, inset, children, ...props }, ref) => (
-  <MenubarPrimitive.SubTrigger
+  <Styled.SubTrigger
     ref={ref}
-    className={cn(
-      "flex cursor-default select-none items-center rounded-sm py-1.5 px-2 text-sm font-medium outline-none focus:bg-slate-100 data-[state=open]:bg-slate-100 dark:focus:bg-slate-700 dark:data-[state=open]:bg-slate-700",
-      inset && "pl-8",
-      className
-    )}
+    className={cn(inset && "pl-8", className)}
     {...props}
   >
     {children}
     <ChevronRight className="ml-auto h-4 w-4" />
-  </MenubarPrimitive.SubTrigger>
+  </Styled.SubTrigger>
 ))
-MenubarSubTrigger.displayName = MenubarPrimitive.SubTrigger.displayName
 
-const MenubarSubContent = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.SubContent>
->(({ className, ...props }, ref) => (
-  <MenubarPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border border-slate-100 bg-white p-1 shadow-md animate-in slide-in-from-left-1 dark:border-slate-700 dark:bg-slate-800",
-      className
-    )}
-    {...props}
-  />
-))
-MenubarSubContent.displayName = MenubarPrimitive.SubContent.displayName
+MenubarSubTrigger.displayName = Primitive.SubTrigger.displayName
+
+const MenubarSubContent = Styled.SubContent
 
 const MenubarContent = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Content>
+  React.ElementRef<typeof Primitive.Content>,
+  React.ComponentPropsWithoutRef<typeof Primitive.Content>
 >(
   (
     { className, align = "start", alignOffset = -4, sideOffset = 8, ...props },
     ref
   ) => (
-    <MenubarPrimitive.Portal>
-      <MenubarPrimitive.Content
+    <Primitive.Portal>
+      <Styled.Content
         ref={ref}
         align={align}
         alignOffset={alignOffset}
         sideOffset={sideOffset}
-        className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border border-slate-100 bg-white p-1 text-slate-700 shadow-md animate-in slide-in-from-top-1 dark:border-slate-800 dark:bg-slate-800 dark:text-slate-400",
-          className
-        )}
+        className={cn(className)}
         {...props}
       />
-    </MenubarPrimitive.Portal>
+    </Primitive.Portal>
   )
 )
-MenubarContent.displayName = MenubarPrimitive.Content.displayName
+
+MenubarContent.displayName = Primitive.Content.displayName
 
 const MenubarItem = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Item> & {
+  React.ElementRef<typeof Primitive.Item>,
+  React.ComponentPropsWithoutRef<typeof Primitive.Item> & {
     inset?: boolean
   }
 >(({ className, inset, ...props }, ref) => (
-  <MenubarPrimitive.Item
+  <Styled.Item
     ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 px-2 text-sm font-medium outline-none focus:bg-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-700",
-      inset && "pl-8",
-      className
-    )}
+    className={cn(inset && "pl-8", className)}
     {...props}
   />
 ))
-MenubarItem.displayName = MenubarPrimitive.Item.displayName
+
+MenubarItem.displayName = Primitive.Item.displayName
 
 const MenubarCheckboxItem = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.CheckboxItem>
+  React.ElementRef<typeof Primitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof Primitive.CheckboxItem>
 >(({ className, children, checked, ...props }, ref) => (
-  <MenubarPrimitive.CheckboxItem
+  <Styled.CheckboxItem
     ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm font-medium outline-none focus:bg-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-700",
-      className
-    )}
+    className={cn(className)}
     checked={checked}
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <MenubarPrimitive.ItemIndicator>
+      <Primitive.ItemIndicator>
         <Check className="h-4 w-4" />
-      </MenubarPrimitive.ItemIndicator>
+      </Primitive.ItemIndicator>
     </span>
     {children}
-  </MenubarPrimitive.CheckboxItem>
+  </Styled.CheckboxItem>
 ))
-MenubarCheckboxItem.displayName = MenubarPrimitive.CheckboxItem.displayName
+
+MenubarCheckboxItem.displayName = Primitive.CheckboxItem.displayName
 
 const MenubarRadioItem = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.RadioItem>
+  React.ElementRef<typeof Primitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof Primitive.RadioItem>
 >(({ className, children, ...props }, ref) => (
-  <MenubarPrimitive.RadioItem
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm font-medium outline-none focus:bg-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-700",
-      className
-    )}
-    {...props}
-  >
+  <Styled.RadioItem ref={ref} className={cn(className)} {...props}>
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <MenubarPrimitive.ItemIndicator>
+      <Primitive.ItemIndicator>
         <Circle className="h-2 w-2 fill-current" />
-      </MenubarPrimitive.ItemIndicator>
+      </Primitive.ItemIndicator>
     </span>
     {children}
-  </MenubarPrimitive.RadioItem>
+  </Styled.RadioItem>
 ))
-MenubarRadioItem.displayName = MenubarPrimitive.RadioItem.displayName
+
+MenubarRadioItem.displayName = Primitive.RadioItem.displayName
 
 const MenubarLabel = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Label> & {
+  React.ElementRef<typeof Primitive.Label>,
+  React.ComponentPropsWithoutRef<typeof Primitive.Label> & {
     inset?: boolean
   }
 >(({ className, inset, ...props }, ref) => (
-  <MenubarPrimitive.Label
+  <Primitive.Label
     ref={ref}
     className={cn(
       "px-2 py-1.5 text-sm font-semibold text-slate-900 dark:text-slate-300",
@@ -186,35 +201,18 @@ const MenubarLabel = React.forwardRef<
     {...props}
   />
 ))
-MenubarLabel.displayName = MenubarPrimitive.Label.displayName
 
-const MenubarSeparator = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <MenubarPrimitive.Separator
-    ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-slate-100 dark:bg-slate-700", className)}
-    {...props}
-  />
-))
-MenubarSeparator.displayName = MenubarPrimitive.Separator.displayName
+MenubarLabel.displayName = Primitive.Label.displayName
 
-const MenubarShortcut = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLSpanElement>) => {
-  return (
-    <span
-      className={cn(
-        "ml-auto text-xs tracking-widest text-slate-500",
-        className
-      )}
-      {...props}
-    />
-  )
-}
-MenubarShortcut.displayname = "MenubarShortcut"
+const MenubarSeparator = Styled.Separator
+
+MenubarSeparator.displayName = Primitive.Separator.displayName
+
+const MenubarShortcut = Styled.Shortcut
+
+MenubarShortcut.displayName = "MenubarShortcut"
+
+const Menubar = Styled.Root
 
 export {
   Menubar,

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -51,6 +51,7 @@
     "react-dom": "^18.2.0",
     "sharp": "^0.31.3",
     "tailwind-merge": "^1.8.0",
+    "tailwind-styled-components": "2.1.6",
     "zod": "^3.20.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,7 @@ importers:
       sharp: ^0.31.3
       shiki: ^0.12.1
       tailwind-merge: ^1.8.0
+      tailwind-styled-components: 2.1.6
       tailwindcss: ^3.1.7
       typescript: ^4.5.3
       unist: ^8.0.11
@@ -159,6 +160,7 @@ importers:
       react-dom: 18.2.0_react@18.2.0
       sharp: 0.31.3
       tailwind-merge: 1.8.0
+      tailwind-styled-components: 2.1.6_biqbaboplfbrettd7655fr4n2y
       zod: 3.20.2
     devDependencies:
       '@types/node': 17.0.45
@@ -232,6 +234,7 @@ importers:
       react-dom: ^18.2.0
       sharp: ^0.31.3
       tailwind-merge: ^1.8.0
+      tailwind-styled-components: 2.1.6
       tailwindcss: ^3.1.7
       tailwindcss-animate: ^1.0.5
       typescript: ^4.5.3
@@ -272,6 +275,7 @@ importers:
       react-dom: 18.2.0_react@18.2.0
       sharp: 0.31.3
       tailwind-merge: 1.8.0
+      tailwind-styled-components: 2.1.6_biqbaboplfbrettd7655fr4n2y
       tailwindcss-animate: 1.0.5_tailwindcss@3.2.4
     devDependencies:
       '@ianvs/prettier-plugin-sort-imports': 3.7.1_prettier@2.8.1
@@ -5801,7 +5805,7 @@ packages:
       react: '*'
       react-dom: '*'
     dependencies:
-      next: 13.1.6_7xlrwlvvs7cv2obrs6a5y6oxxq
+      next: 13.1.6_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
@@ -7100,6 +7104,17 @@ packages:
 
   /tailwind-merge/1.8.0:
     resolution: {integrity: sha512-tER/2SbYRdfPYg6m4pDWZSlbymLTmDi+dx4iCsJmgmz4UDGzgnVelOvBe3GNtGCw9Bmc4MiObfJJbKeVL+KnMQ==}
+    dev: false
+
+  /tailwind-styled-components/2.1.6_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-qqZXvwMYrZoLS75eyxeU+XgrwBmrcJA7568Jj+RWsah0EswKzLc0vkaHtLQFYiHbWy8lDwKVMRFsUWQ4GBpHzA==}
+    peerDependencies:
+      react: '>= 16.8.0'
+      react-dom: '>= 16.8.0'
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      tailwind-merge: 1.8.0
     dev: false
 
   /tailwindcss-animate/1.0.5_tailwindcss@3.2.4:

--- a/templates/next-template/components/ui/menubar.tsx
+++ b/templates/next-template/components/ui/menubar.tsx
@@ -1,20 +1,20 @@
 "use client"
 
-import React from "react"
-import * as Primitive from "@radix-ui/react-menubar"
+import * as React from "react"
+import * as MenuBarPrimitive from "@radix-ui/react-menubar"
 import { Check, ChevronRight, Circle } from "lucide-react"
 import tw from "tailwind-styled-components"
 
 import { cn } from "@/lib/utils"
 
 const Styled = {
-  Root: tw(Primitive.Root)`
+  Root: tw(MenuBarPrimitive.Root)`
     flex h-10 items-center space-x-1 rounded-md border 
     border-slate-300 bg-white p-1 
     dark:border-slate-700 
     dark:bg-slate-800
   `,
-  Trigger: tw(Primitive.Trigger)`
+  Trigger: tw(MenuBarPrimitive.Trigger)`
     flex cursor-default select-none items-center rounded-[0.2rem] 
     py-1.5 px-3 text-sm font-medium outline-none 
     focus:bg-slate-100 
@@ -23,7 +23,7 @@ const Styled = {
     dark:focus:bg-slate-700 
     dark:data-[state=open]:bg-slate-700
   `,
-  SubTrigger: tw(Primitive.SubTrigger)`
+  SubTrigger: tw(MenuBarPrimitive.SubTrigger)`
     flex cursor-default select-none items-center rounded-sm 
     py-1.5 px-2 text-sm font-medium outline-none 
     focus:bg-slate-100 
@@ -31,7 +31,7 @@ const Styled = {
     dark:focus:bg-slate-700 
     dark:data-[state=open]:bg-slate-700
   `,
-  SubContent: tw(Primitive.SubContent)`
+  SubContent: tw(MenuBarPrimitive.SubContent)`
     z-50 min-w-[8rem] overflow-hidden 
     rounded-md border border-slate-100 
     bg-white p-1 shadow-md 
@@ -39,14 +39,14 @@ const Styled = {
     dark:border-slate-700 
     dark:bg-slate-800
   `,
-  Content: tw(Primitive.Content)`
+  Content: tw(MenuBarPrimitive.Content)`
     z-50 min-w-[12rem] overflow-hidden rounded-md 
     border border-slate-100 bg-white p-1 
     text-slate-700 shadow-md animate-in slide-in-from-top-1 
     dark:border-slate-800 
     dark:bg-slate-800 dark:text-slate-400
   `,
-  Item: tw(Primitive.Item)`
+  Item: tw(MenuBarPrimitive.Item)`
     relative flex cursor-default select-none items-center 
     rounded-sm py-1.5 px-2 text-sm font-medium outline-none 
     focus:bg-slate-100 
@@ -54,7 +54,7 @@ const Styled = {
     data-[disabled]:opacity-50 
     dark:focus:bg-slate-700
   `,
-  CheckboxItem: tw(Primitive.CheckboxItem)`
+  CheckboxItem: tw(MenuBarPrimitive.CheckboxItem)`
     relative flex cursor-default select-none items-center 
     rounded-sm py-1.5 pl-8 pr-2 text-sm font-medium outline-none 
     focus:bg-slate-100 
@@ -62,7 +62,7 @@ const Styled = {
     data-[disabled]:opacity-50 
     dark:focus:bg-slate-700
   `,
-  RadioItem: tw(Primitive.RadioItem)`
+  RadioItem: tw(MenuBarPrimitive.RadioItem)`
     relative flex cursor-default select-none items-center 
     rounded-sm py-1.5 pl-8 pr-2 text-sm font-medium outline-none 
     focus:bg-slate-100 
@@ -73,26 +73,26 @@ const Styled = {
   Shortcut: tw.span`
     ml-auto text-xs tracking-widest text-slate-500
   `,
-  Separator: tw(Primitive.Separator)`
+  Separator: tw(MenuBarPrimitive.Separator)`
     -mx-1 my-1 h-px bg-slate-100 dark:bg-slate-700
   `,
 }
 
-const MenubarMenu = Primitive.Menu
+const MenubarMenu = MenuBarPrimitive.Menu
 
-const MenubarGroup = Primitive.Group
+const MenubarGroup = MenuBarPrimitive.Group
 
-const MenubarPortal = Primitive.Portal
+const MenubarPortal = MenuBarPrimitive.Portal
 
-const MenubarSub = Primitive.Sub
+const MenubarSub = MenuBarPrimitive.Sub
 
-const MenubarRadioGroup = Primitive.RadioGroup
+const MenubarRadioGroup = MenuBarPrimitive.RadioGroup
 
 const MenubarTrigger = Styled.Trigger
 
 const MenubarSubTrigger = React.forwardRef<
-  React.ElementRef<typeof Primitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof Primitive.SubTrigger> & {
+  React.ElementRef<typeof MenuBarPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof MenuBarPrimitive.SubTrigger> & {
     inset?: boolean
   }
 >(({ className, inset, children, ...props }, ref) => (
@@ -106,19 +106,19 @@ const MenubarSubTrigger = React.forwardRef<
   </Styled.SubTrigger>
 ))
 
-MenubarSubTrigger.displayName = Primitive.SubTrigger.displayName
+MenubarSubTrigger.displayName = MenuBarPrimitive.SubTrigger.displayName
 
 const MenubarSubContent = Styled.SubContent
 
 const MenubarContent = React.forwardRef<
-  React.ElementRef<typeof Primitive.Content>,
-  React.ComponentPropsWithoutRef<typeof Primitive.Content>
+  React.ElementRef<typeof MenuBarPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof MenuBarPrimitive.Content>
 >(
   (
     { className, align = "start", alignOffset = -4, sideOffset = 8, ...props },
     ref
   ) => (
-    <Primitive.Portal>
+    <MenuBarPrimitive.Portal>
       <Styled.Content
         ref={ref}
         align={align}
@@ -127,15 +127,15 @@ const MenubarContent = React.forwardRef<
         className={cn(className)}
         {...props}
       />
-    </Primitive.Portal>
+    </MenuBarPrimitive.Portal>
   )
 )
 
-MenubarContent.displayName = Primitive.Content.displayName
+MenubarContent.displayName = MenuBarPrimitive.Content.displayName
 
 const MenubarItem = React.forwardRef<
-  React.ElementRef<typeof Primitive.Item>,
-  React.ComponentPropsWithoutRef<typeof Primitive.Item> & {
+  React.ElementRef<typeof MenuBarPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof MenuBarPrimitive.Item> & {
     inset?: boolean
   }
 >(({ className, inset, ...props }, ref) => (
@@ -146,11 +146,11 @@ const MenubarItem = React.forwardRef<
   />
 ))
 
-MenubarItem.displayName = Primitive.Item.displayName
+MenubarItem.displayName = MenuBarPrimitive.Item.displayName
 
 const MenubarCheckboxItem = React.forwardRef<
-  React.ElementRef<typeof Primitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof Primitive.CheckboxItem>
+  React.ElementRef<typeof MenuBarPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof MenuBarPrimitive.CheckboxItem>
 >(({ className, children, checked, ...props }, ref) => (
   <Styled.CheckboxItem
     ref={ref}
@@ -159,39 +159,39 @@ const MenubarCheckboxItem = React.forwardRef<
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <Primitive.ItemIndicator>
+      <MenuBarPrimitive.ItemIndicator>
         <Check className="h-4 w-4" />
-      </Primitive.ItemIndicator>
+      </MenuBarPrimitive.ItemIndicator>
     </span>
     {children}
   </Styled.CheckboxItem>
 ))
 
-MenubarCheckboxItem.displayName = Primitive.CheckboxItem.displayName
+MenubarCheckboxItem.displayName = MenuBarPrimitive.CheckboxItem.displayName
 
 const MenubarRadioItem = React.forwardRef<
-  React.ElementRef<typeof Primitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof Primitive.RadioItem>
+  React.ElementRef<typeof MenuBarPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof MenuBarPrimitive.RadioItem>
 >(({ className, children, ...props }, ref) => (
   <Styled.RadioItem ref={ref} className={cn(className)} {...props}>
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <Primitive.ItemIndicator>
+      <MenuBarPrimitive.ItemIndicator>
         <Circle className="h-2 w-2 fill-current" />
-      </Primitive.ItemIndicator>
+      </MenuBarPrimitive.ItemIndicator>
     </span>
     {children}
   </Styled.RadioItem>
 ))
 
-MenubarRadioItem.displayName = Primitive.RadioItem.displayName
+MenubarRadioItem.displayName = MenuBarPrimitive.RadioItem.displayName
 
 const MenubarLabel = React.forwardRef<
-  React.ElementRef<typeof Primitive.Label>,
-  React.ComponentPropsWithoutRef<typeof Primitive.Label> & {
+  React.ElementRef<typeof MenuBarPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof MenuBarPrimitive.Label> & {
     inset?: boolean
   }
 >(({ className, inset, ...props }, ref) => (
-  <Primitive.Label
+  <MenuBarPrimitive.Label
     ref={ref}
     className={cn(
       "px-2 py-1.5 text-sm font-semibold text-slate-900 dark:text-slate-300",
@@ -202,11 +202,11 @@ const MenubarLabel = React.forwardRef<
   />
 ))
 
-MenubarLabel.displayName = Primitive.Label.displayName
+MenubarLabel.displayName = MenuBarPrimitive.Label.displayName
 
 const MenubarSeparator = Styled.Separator
 
-MenubarSeparator.displayName = Primitive.Separator.displayName
+MenubarSeparator.displayName = MenuBarPrimitive.Separator.displayName
 
 const MenubarShortcut = Styled.Shortcut
 

--- a/templates/next-template/components/ui/menubar.tsx
+++ b/templates/next-template/components/ui/menubar.tsx
@@ -1,182 +1,197 @@
 "use client"
 
-import * as React from "react"
-import * as MenubarPrimitive from "@radix-ui/react-menubar"
+import React from "react"
+import * as Primitive from "@radix-ui/react-menubar"
 import { Check, ChevronRight, Circle } from "lucide-react"
+import tw from "tailwind-styled-components"
 
 import { cn } from "@/lib/utils"
 
-const MenubarMenu = MenubarPrimitive.Menu
+const Styled = {
+  Root: tw(Primitive.Root)`
+    flex h-10 items-center space-x-1 rounded-md border 
+    border-slate-300 bg-white p-1 
+    dark:border-slate-700 
+    dark:bg-slate-800
+  `,
+  Trigger: tw(Primitive.Trigger)`
+    flex cursor-default select-none items-center rounded-[0.2rem] 
+    py-1.5 px-3 text-sm font-medium outline-none 
+    focus:bg-slate-100 
+    data-[state=open]:bg-slate-100 
+    dark:text-slate-300 
+    dark:focus:bg-slate-700 
+    dark:data-[state=open]:bg-slate-700
+  `,
+  SubTrigger: tw(Primitive.SubTrigger)`
+    flex cursor-default select-none items-center rounded-sm 
+    py-1.5 px-2 text-sm font-medium outline-none 
+    focus:bg-slate-100 
+    data-[state=open]:bg-slate-100 
+    dark:focus:bg-slate-700 
+    dark:data-[state=open]:bg-slate-700
+  `,
+  SubContent: tw(Primitive.SubContent)`
+    z-50 min-w-[8rem] overflow-hidden 
+    rounded-md border border-slate-100 
+    bg-white p-1 shadow-md 
+    animate-in slide-in-from-left-1 
+    dark:border-slate-700 
+    dark:bg-slate-800
+  `,
+  Content: tw(Primitive.Content)`
+    z-50 min-w-[12rem] overflow-hidden rounded-md 
+    border border-slate-100 bg-white p-1 
+    text-slate-700 shadow-md animate-in slide-in-from-top-1 
+    dark:border-slate-800 
+    dark:bg-slate-800 dark:text-slate-400
+  `,
+  Item: tw(Primitive.Item)`
+    relative flex cursor-default select-none items-center 
+    rounded-sm py-1.5 px-2 text-sm font-medium outline-none 
+    focus:bg-slate-100 
+    data-[disabled]:pointer-events-none 
+    data-[disabled]:opacity-50 
+    dark:focus:bg-slate-700
+  `,
+  CheckboxItem: tw(Primitive.CheckboxItem)`
+    relative flex cursor-default select-none items-center 
+    rounded-sm py-1.5 pl-8 pr-2 text-sm font-medium outline-none 
+    focus:bg-slate-100 
+    data-[disabled]:pointer-events-none 
+    data-[disabled]:opacity-50 
+    dark:focus:bg-slate-700
+  `,
+  RadioItem: tw(Primitive.RadioItem)`
+    relative flex cursor-default select-none items-center 
+    rounded-sm py-1.5 pl-8 pr-2 text-sm font-medium outline-none 
+    focus:bg-slate-100 
+    data-[disabled]:pointer-events-none 
+    data-[disabled]:opacity-50 
+    dark:focus:bg-slate-700
+  `,
+  Shortcut: tw.span`
+    ml-auto text-xs tracking-widest text-slate-500
+  `,
+  Separator: tw(Primitive.Separator)`
+    -mx-1 my-1 h-px bg-slate-100 dark:bg-slate-700
+  `,
+}
 
-const MenubarGroup = MenubarPrimitive.Group
+const MenubarMenu = Primitive.Menu
 
-const MenubarPortal = MenubarPrimitive.Portal
+const MenubarGroup = Primitive.Group
 
-const MenubarSub = MenubarPrimitive.Sub
+const MenubarPortal = Primitive.Portal
 
-const MenubarRadioGroup = MenubarPrimitive.RadioGroup
+const MenubarSub = Primitive.Sub
 
-const Menubar = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <MenubarPrimitive.Root
-    ref={ref}
-    className={cn(
-      "flex h-10 items-center space-x-1 rounded-md border border-slate-300 bg-white p-1 dark:border-slate-700 dark:bg-slate-800",
-      className
-    )}
-    {...props}
-  />
-))
-Menubar.displayName = MenubarPrimitive.Root.displayName
+const MenubarRadioGroup = Primitive.RadioGroup
 
-const MenubarTrigger = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Trigger>
->(({ className, ...props }, ref) => (
-  <MenubarPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "flex cursor-default select-none items-center rounded-[0.2rem] py-1.5 px-3 text-sm font-medium outline-none focus:bg-slate-100 data-[state=open]:bg-slate-100 dark:focus:bg-slate-700 dark:data-[state=open]:bg-slate-700",
-      className
-    )}
-    {...props}
-  />
-))
-MenubarTrigger.displayName = MenubarPrimitive.Trigger.displayName
+const MenubarTrigger = Styled.Trigger
 
 const MenubarSubTrigger = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.SubTrigger> & {
+  React.ElementRef<typeof Primitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof Primitive.SubTrigger> & {
     inset?: boolean
   }
 >(({ className, inset, children, ...props }, ref) => (
-  <MenubarPrimitive.SubTrigger
+  <Styled.SubTrigger
     ref={ref}
-    className={cn(
-      "flex cursor-default select-none items-center rounded-sm py-1.5 px-2 text-sm font-medium outline-none focus:bg-slate-100 data-[state=open]:bg-slate-100 dark:focus:bg-slate-700 dark:data-[state=open]:bg-slate-700",
-      inset && "pl-8",
-      className
-    )}
+    className={cn(inset && "pl-8", className)}
     {...props}
   >
     {children}
     <ChevronRight className="ml-auto h-4 w-4" />
-  </MenubarPrimitive.SubTrigger>
+  </Styled.SubTrigger>
 ))
-MenubarSubTrigger.displayName = MenubarPrimitive.SubTrigger.displayName
 
-const MenubarSubContent = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.SubContent>
->(({ className, ...props }, ref) => (
-  <MenubarPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border border-slate-100 bg-white p-1 shadow-md animate-in slide-in-from-left-1 dark:border-slate-700 dark:bg-slate-800",
-      className
-    )}
-    {...props}
-  />
-))
-MenubarSubContent.displayName = MenubarPrimitive.SubContent.displayName
+MenubarSubTrigger.displayName = Primitive.SubTrigger.displayName
+
+const MenubarSubContent = Styled.SubContent
 
 const MenubarContent = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Content>
+  React.ElementRef<typeof Primitive.Content>,
+  React.ComponentPropsWithoutRef<typeof Primitive.Content>
 >(
   (
     { className, align = "start", alignOffset = -4, sideOffset = 8, ...props },
     ref
   ) => (
-    <MenubarPrimitive.Portal>
-      <MenubarPrimitive.Content
+    <Primitive.Portal>
+      <Styled.Content
         ref={ref}
         align={align}
         alignOffset={alignOffset}
         sideOffset={sideOffset}
-        className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border border-slate-100 bg-white p-1 text-slate-700 shadow-md animate-in slide-in-from-top-1 dark:border-slate-800 dark:bg-slate-800 dark:text-slate-400",
-          className
-        )}
+        className={cn(className)}
         {...props}
       />
-    </MenubarPrimitive.Portal>
+    </Primitive.Portal>
   )
 )
-MenubarContent.displayName = MenubarPrimitive.Content.displayName
+
+MenubarContent.displayName = Primitive.Content.displayName
 
 const MenubarItem = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Item> & {
+  React.ElementRef<typeof Primitive.Item>,
+  React.ComponentPropsWithoutRef<typeof Primitive.Item> & {
     inset?: boolean
   }
 >(({ className, inset, ...props }, ref) => (
-  <MenubarPrimitive.Item
+  <Styled.Item
     ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 px-2 text-sm font-medium outline-none focus:bg-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-700",
-      inset && "pl-8",
-      className
-    )}
+    className={cn(inset && "pl-8", className)}
     {...props}
   />
 ))
-MenubarItem.displayName = MenubarPrimitive.Item.displayName
+
+MenubarItem.displayName = Primitive.Item.displayName
 
 const MenubarCheckboxItem = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.CheckboxItem>
+  React.ElementRef<typeof Primitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof Primitive.CheckboxItem>
 >(({ className, children, checked, ...props }, ref) => (
-  <MenubarPrimitive.CheckboxItem
+  <Styled.CheckboxItem
     ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm font-medium outline-none focus:bg-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-700",
-      className
-    )}
+    className={cn(className)}
     checked={checked}
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <MenubarPrimitive.ItemIndicator>
+      <Primitive.ItemIndicator>
         <Check className="h-4 w-4" />
-      </MenubarPrimitive.ItemIndicator>
+      </Primitive.ItemIndicator>
     </span>
     {children}
-  </MenubarPrimitive.CheckboxItem>
+  </Styled.CheckboxItem>
 ))
-MenubarCheckboxItem.displayName = MenubarPrimitive.CheckboxItem.displayName
+
+MenubarCheckboxItem.displayName = Primitive.CheckboxItem.displayName
 
 const MenubarRadioItem = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.RadioItem>
+  React.ElementRef<typeof Primitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof Primitive.RadioItem>
 >(({ className, children, ...props }, ref) => (
-  <MenubarPrimitive.RadioItem
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm font-medium outline-none focus:bg-slate-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-700",
-      className
-    )}
-    {...props}
-  >
+  <Styled.RadioItem ref={ref} className={cn(className)} {...props}>
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <MenubarPrimitive.ItemIndicator>
+      <Primitive.ItemIndicator>
         <Circle className="h-2 w-2 fill-current" />
-      </MenubarPrimitive.ItemIndicator>
+      </Primitive.ItemIndicator>
     </span>
     {children}
-  </MenubarPrimitive.RadioItem>
+  </Styled.RadioItem>
 ))
-MenubarRadioItem.displayName = MenubarPrimitive.RadioItem.displayName
+
+MenubarRadioItem.displayName = Primitive.RadioItem.displayName
 
 const MenubarLabel = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Label> & {
+  React.ElementRef<typeof Primitive.Label>,
+  React.ComponentPropsWithoutRef<typeof Primitive.Label> & {
     inset?: boolean
   }
 >(({ className, inset, ...props }, ref) => (
-  <MenubarPrimitive.Label
+  <Primitive.Label
     ref={ref}
     className={cn(
       "px-2 py-1.5 text-sm font-semibold text-slate-900 dark:text-slate-300",
@@ -186,35 +201,18 @@ const MenubarLabel = React.forwardRef<
     {...props}
   />
 ))
-MenubarLabel.displayName = MenubarPrimitive.Label.displayName
 
-const MenubarSeparator = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <MenubarPrimitive.Separator
-    ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-slate-100 dark:bg-slate-700", className)}
-    {...props}
-  />
-))
-MenubarSeparator.displayName = MenubarPrimitive.Separator.displayName
+MenubarLabel.displayName = Primitive.Label.displayName
 
-const MenubarShortcut = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLSpanElement>) => {
-  return (
-    <span
-      className={cn(
-        "ml-auto text-xs tracking-widest text-slate-500",
-        className
-      )}
-      {...props}
-    />
-  )
-}
-MenubarShortcut.displayname = "MenubarShortcut"
+const MenubarSeparator = Styled.Separator
+
+MenubarSeparator.displayName = Primitive.Separator.displayName
+
+const MenubarShortcut = Styled.Shortcut
+
+MenubarShortcut.displayName = "MenubarShortcut"
+
+const Menubar = Styled.Root
 
 export {
   Menubar,

--- a/templates/next-template/package.json
+++ b/templates/next-template/package.json
@@ -46,6 +46,7 @@
     "react-dom": "^18.2.0",
     "sharp": "^0.31.3",
     "tailwind-merge": "^1.8.0",
+    "tailwind-styled-components": "2.1.6",
     "tailwindcss-animate": "^1.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR proposes an ~arguably~ cleaner pattern for augmenting `radix-ui` primitives.

@shadcn  BTW, really like where this is going. I've been planning on doing something like this for quite a while.

If this new pattern makes sense, I can apply the refactor to the remaining components.