### PR TITLE
feat: Add loading state to the Button

### DIFF
--- a/templates/next-template/components/ui/button.tsx
+++ b/templates/next-template/components/ui/button.tsx
@@ -1,7 +1,9 @@
 import * as React from "react"
-import { VariantProps, cva } from "class-variance-authority"
+import type { VariantProps } from "class-variance-authority"
+import { cva } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
+import { Loader2 } from "lucide-react"
 
 const buttonVariants = cva(
   "active:scale-95 inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 dark:hover:bg-slate-800 dark:hover:text-slate-100 disabled:opacity-50 dark:focus:ring-slate-400 disabled:pointer-events-none dark:focus:ring-offset-slate-900 data-[state=open]:bg-slate-100 dark:data-[state=open]:bg-slate-800",
@@ -25,6 +27,10 @@ const buttonVariants = cva(
         sm: "h-9 px-2 rounded-md",
         lg: "h-11 px-8 rounded-md",
       },
+
+      modifiers: {
+        loading: "opacity-50 animate-pulse pointer-events-none",
+      },
     },
     defaultVariants: {
       variant: "default",
@@ -35,19 +41,43 @@ const buttonVariants = cva(
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {}
+    VariantProps<typeof buttonVariants> {
+  loading?: boolean
+}
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, ...props }, ref) => {
+  ({ className, variant, size, loading, children, ...props }, ref) => {
     return (
       <button
-        className={cn(buttonVariants({ variant, size, className }))}
+        className={cn(
+          buttonVariants({
+            variant,
+            size,
+            ...(loading && { modifiers: "loading" }),
+            className,
+          })
+        )}
         ref={ref}
         {...props}
-      />
+      >
+        {!loading && children}
+        {/* Maintain same width of element */}
+        {loading && <LoadingIndicator>{children}</LoadingIndicator>}
+      </button>
     )
   }
 )
 Button.displayName = "Button"
 
 export { Button, buttonVariants }
+
+const LoadingIndicator = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div className="relative flex items-center justify-center">
+      <div className="absolute top-0 left-0 flex h-full w-full transform items-center justify-center">
+        <Loader2 className="animate-spin animate-pulse" />
+      </div>
+      <div className="invisible">{children}</div>
+    </div>
+  )
+}


### PR DESCRIPTION
This PR adds simple handling for the loading state: the original content becomes **invisible** to ensure that the element's width is not changed; the loading indicator is shown instead of the original content with pulse animation. Later on it other handlers can be added, such as custom loading indicator/icon/text.