### PR TITLE
Remove class in child that forces left-0 on a centered menu

### DIFF
--- a/templates/next-template/components/ui/navigation-menu.tsx
+++ b/templates/next-template/components/ui/navigation-menu.tsx
@@ -83,7 +83,7 @@ const NavigationMenuViewport = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
 >(({ className, ...props }, ref) => (
-  <div className={cn("absolute left-0 top-full flex justify-center")}>
+  <div className={cn("absolute top-full flex justify-center")}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
         "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border border-slate-200 bg-white shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:zoom-in-90 data-[state=closed]:zoom-out-95 dark:border-slate-700 dark:bg-slate-800 md:w-[var(--radix-navigation-menu-viewport-width)]",


### PR DESCRIPTION
Subject: We should not force the dropdown window of `navigation-menu.tsx` to `position: absolute` and  `left: 0` when the menu itself is center.
Type: Bug

Current behaviour:
![Screenshot 2023-02-20 at 11 44 53 AM](https://user-images.githubusercontent.com/7071812/220165961-07682f3e-4eab-4348-bb3f-1dcffb7789e2.png)

Desired behaviour:
![Screenshot 2023-02-20 at 11 45 09 AM](https://user-images.githubusercontent.com/7071812/220166014-852c0e25-9381-4c9b-8ab7-fcdf633d293b.png)
