### PR TITLE
docs: add Contributing guide for the project

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,0 +1,50 @@
+# Contributing to shadcn/ui Project
+Thank you for considering contributing to shadcn/ui. We appreciate any help, and we are grateful for your time and effort. This document outlines the guidelines for contributing to the project, as well as the process for submitting pull requests.
+## How can I contribute?
+There are many ways you can contribute to this project.
+ - Reporting bugs.
+ - Writting documentation.
+ - Submitting pull requests.
+ - Submitting code changes and bug fixes.
+## Submitting Changes
+ - Ensure that your code follows the style of the project.
+ - Make sure your code is tested.
+ - Make sure your code follows good practices,
+ - Refactor is necessary before submitting changes to improve the quality of your code.
+ - Write any necessary documentation for any changes.
+
+## How to Pull Request
+
+ - Fork the repository and create a new branch for your changes.
+ - Make the necessary changes and commit your code with a clear message.
+ - Push your changes to your fork.
+ - Submit a pull request to the main repository (shadcn/ui)
+ - The repository maintainers will review your pull request and may request changes or improvements.
+ - Once the changes have been made and the pull request has been approved, it will be merged into the main branch.
+ 
+ ## Git commit guide 
+ When writing commit messages, please follow these best practices:
+
+- Use the imperative mood in your commit message. For example, "Fix bug" instead of "Fixed bug" or "Fixes bug".
+- Avoid using exclamation points or question marks in your commit message.
+- Keep your commit message short and concise, ideally no more than 50 characters.
+- Use the commit message body to provide any necessary context or details about the commit.
+- Use prefixes in your commit messages to make them more semantic. Some common prefixes include:
+	- "`feat`" for new features.
+	- "`fix`" for bug fixes.
+	- "`perf`" for performance improvements.
+	- "`build`" for changes to the build system.
+	- "`ci`" for continuous integration - changes,
+	- "`docs`" for documentation changes.
+	- "`refactor`" for refactoring changes.
+	- "`style`" for formatting changes.
+	- "`test`" for changes to tests.
+
+For more information about writing good commit messages, you can refer to [this article](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/).
+
+##  Reporting Bugs
+If you've found a bug in this project, we would appreciate it if you could report it to us. To report a bug, please follow these steps:
+1. Check the existing issues in the repository to see if the bug has already been reported. If it has, you can add your additional information to the existing issue.
+2. If the bug has not been reported, create a new issue and provide a clear and concise description of the problem.
+3. Include any relevant details, such as the version of the API you are using, the platform you are using (e.g. Windows, Mac, Linux), and the steps to reproduce the bug.
+4. If possible, include any error messages or logs that may be relevant to the problem. 


### PR DESCRIPTION
Add a quick contribution guide for devs interested in this project, as well as a quick commit conduct to ensure good practices.