### PR TITLE
chore: add `type` in `ClassValue` imports

### DIFF
--- a/apps/www/content/docs/installation.mdx
+++ b/apps/www/content/docs/installation.mdx
@@ -91,7 +91,7 @@ I use icons from [Lucide](https://lucide.dev). You can use any icon library you 
 I use a `cn` helper to make it easier to conditionally add Tailwind CSS classes. Here's how I define it in `lib/utils.ts`:
 
 ```ts
-import { ClassValue, clsx } from "clsx"
+import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {

--- a/apps/www/lib/utils.ts
+++ b/apps/www/lib/utils.ts
@@ -1,4 +1,4 @@
-import { ClassValue, clsx } from "clsx"
+import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {

--- a/examples/playground/lib/utils.ts
+++ b/examples/playground/lib/utils.ts
@@ -1,4 +1,4 @@
-import { ClassValue, clsx } from "clsx"
+import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {

--- a/templates/next-template/lib/utils.ts
+++ b/templates/next-template/lib/utils.ts
@@ -1,6 +1,6 @@
-import { ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }


### PR DESCRIPTION
## Why?

I saw you consistently added the `type` keyword in imports in other files, but missed it in the `ClassValue` import 🙃

Specifically, got this warning while compiling

<img width="493" alt="Screenshot 2023-04-11 at 6 42 51 PM" src="https://user-images.githubusercontent.com/48997634/231173561-affe8226-1a01-4f67-b72e-7e51e258a58e.png">

Hope this is helpful 😊