### PR TITLE
fix: context menu example in mobile device

### DIFF
--- a/apps/www/components/examples/context-menu/demo.tsx
+++ b/apps/www/components/examples/context-menu/demo.tsx
@@ -39,7 +39,7 @@ import {
 export function ContextMenuDemo() {
   return (
     <ContextMenu>
-      <ContextMenuTrigger className="flex h-[150px] w-[300px] items-center justify-center rounded-md border border-dashed border-slate-200 text-sm dark:border-slate-700">
+      <ContextMenuTrigger className="flex h-[150px] w-[300px] select-none items-center justify-center rounded-md border border-dashed border-slate-200 text-sm dark:border-slate-700">
         Right click here
       </ContextMenuTrigger>
       <ContextMenuContent className="w-64">


### PR DESCRIPTION
@radix-ui/react-context-menu supports "Triggers with a long-press on touch devices"
when long-press the click area in the example, there will be unexpected situations,
set the text in context area with "select none" could avoid this.
you can checkout [radix-ui docs](https://www.radix-ui.com/docs/primitives/components/context-menu) to confirm.