### PR TITLE
feat: dropdown menu dialog item

### DIFF
--- a/apps/www/components/examples/dropdown-menu/dialog-items.tsx
+++ b/apps/www/components/examples/dropdown-menu/dialog-items.tsx
@@ -1,0 +1,53 @@
+import { Button } from "@/components/ui/button"
+import {
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuDialogItem,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+export function DropdownMenuDialogItemsDemo() {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">Open</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56">
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Dialog items</DropdownMenuLabel>
+          <DropdownMenuDialogItem trigger="Open Dialog">
+            <DialogContent className="sm:max-w-[425px]">
+              <DialogHeader>
+                <DialogTitle>Dialog 1</DialogTitle>
+                <DialogDescription>Hello from Dialog 1</DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button type="submit">Save changes</Button>
+              </DialogFooter>
+            </DialogContent>
+          </DropdownMenuDialogItem>
+          <DropdownMenuDialogItem trigger="Open Dialog 2">
+            <DialogContent className="sm:max-w-[425px]">
+              <DialogHeader>
+                <DialogTitle>Dialog 2</DialogTitle>
+                <DialogDescription>Hello from Dialog 2</DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button type="submit">Save changes</Button>
+              </DialogFooter>
+            </DialogContent>
+          </DropdownMenuDialogItem>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/www/components/ui/dropdown-menu.tsx
+++ b/apps/www/components/ui/dropdown-menu.tsx
@@ -5,6 +5,7 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronRight, Circle } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { Dialog, DialogTrigger } from "./dialog"
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 
@@ -184,6 +185,35 @@ const DropdownMenuShortcut = ({
 }
 DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
 
+const DropdownMenuDialogItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    trigger: React.ReactNode
+    children: React.ReactNode
+    onSelect?: () => void
+    onOpenChange?: (open: boolean) => void
+  }
+>(({ trigger, children, onSelect, onOpenChange, ...props }, ref) => {
+  return (
+    <Dialog onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <DropdownMenuItem
+          ref={ref}
+          onSelect={(event) => {
+            event.preventDefault()
+            onSelect && onSelect()
+          }}
+          {...props}
+        >
+          {trigger}
+        </DropdownMenuItem>
+      </DialogTrigger>
+      {children}
+    </Dialog>
+  )
+})
+DropdownMenuDialogItem.displayName = "DropdownMenuDialogItem"
+
 export {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -200,4 +230,5 @@ export {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuRadioGroup,
+  DropdownMenuDialogItem,
 }

--- a/apps/www/components/ui/dropdown-menu.tsx
+++ b/apps/www/components/ui/dropdown-menu.tsx
@@ -190,12 +190,13 @@ const DropdownMenuDialogItem = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
     trigger: React.ReactNode
     children: React.ReactNode
-    onSelect?: () => void
+    open?: boolean
     onOpenChange?: (open: boolean) => void
+    onSelect?: () => void
   }
->(({ trigger, children, onSelect, onOpenChange, ...props }, ref) => {
+>(({ trigger, children, open, onOpenChange, onSelect, ...props }, ref) => {
   return (
-    <Dialog onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>
         <DropdownMenuItem
           ref={ref}

--- a/apps/www/content/docs/primitives/dropdown-menu.mdx
+++ b/apps/www/content/docs/primitives/dropdown-menu.mdx
@@ -69,3 +69,9 @@ import {
 <ComponentExample src="/components/examples/dropdown-menu/radio-group.tsx">
   <DropdownMenuRadioGroupDemo />
 </ComponentExample>
+
+### Dialog
+
+<ComponentExample src="/components/examples/dropdown-menu/dialog-items.tsx">
+  <DropdownMenuDialogItemsDemo />
+</ComponentExample>


### PR DESCRIPTION
## Description
While building a project of mine and migrating to your components, I encountered an issue where I needed to have a dropdown where several dropdown items open a different dialog. The workaround mentioned in the [notes](https://ui.shadcn.com/docs/primitives/dialog) section of the documentation works for simple cases, but managing the state of a specific dialog programmatically becomes challenging.

## Use Case
RadixUI's documentation on the Dialog component has a good example of such a use case, where the dialog needs to close after an asynchronous form submission, [example](https://www.radix-ui.com/docs/primitives/components/dialog#close-after-asynchronous-form-submission).

## Changes Made
I have created a new component that combines the Dropdown and Dialog components to address this issue. Since this component is used within a dropdown menu, I added it to `@/components/ui/dropdown-menu.tsx`.

Also the example I've addded is rather simple, so let me know if I have to tweak it to show a more "complex" example like the asynchronous form submission thing I mentioned earlier.
