### PR TITLE
feat(toast): add example of promise toast and add shake animation

### DIFF
--- a/apps/www/components/examples/index.tsx
+++ b/apps/www/components/examples/index.tsx
@@ -52,6 +52,7 @@ import { TextareaWithLabel } from "@/components/examples/textarea/with-label"
 import { TextareaWithText } from "@/components/examples/textarea/with-text"
 import { ToastDemo } from "@/components/examples/toast/demo"
 import { ToastDestructive } from "@/components/examples/toast/destructive"
+import { ToastWithPromise } from "@/components/examples/toast/promise"
 import { ToastSimple } from "@/components/examples/toast/simple"
 import { ToastWithAction } from "@/components/examples/toast/with-action"
 import { ToastWithTitle } from "@/components/examples/toast/with-title"
@@ -132,6 +133,7 @@ export const examples = {
   TextareaWithText,
   ToastDemo,
   ToastDestructive,
+  ToastWithPromise,
   ToastSimple,
   ToastWithTitle,
   ToastWithAction,

--- a/apps/www/components/examples/toast/promise.tsx
+++ b/apps/www/components/examples/toast/promise.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { useToast } from "@/hooks/use-toast"
+
+import { Button } from "@/components/ui/button"
+
+export function ToastWithPromise() {
+  const { toast } = useToast()
+
+  const handleToast = async () => {
+    const progress = toast({
+      title: "Saving...",
+      description: "Your message is being sent.",
+    })
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+    progress.update({
+      title: "Error",
+      description: "Failed to send message.",
+      variant: "destructive",
+    })
+  }
+
+  return (
+    <Button variant="outline" onClick={handleToast}>
+      Show Toast
+    </Button>
+  )
+}

--- a/apps/www/components/examples/toast/promise.tsx
+++ b/apps/www/components/examples/toast/promise.tsx
@@ -36,7 +36,7 @@ export function ToastWithPromise() {
 
   return (
     <Button variant="outline" onClick={handleToast}>
-      Show Toast
+      Trigger promise that might reject
     </Button>
   )
 }

--- a/apps/www/components/examples/toast/promise.tsx
+++ b/apps/www/components/examples/toast/promise.tsx
@@ -5,10 +5,10 @@ import { useToast } from "@/hooks/use-toast"
 import { Button } from "@/components/ui/button"
 
 export function ToastWithPromise() {
-  const toaster = useToast()
+  const { toast } = useToast()
 
   const handleToast = async () => {
-    const progress = toaster.toast({
+    const progress = toast({
       title: "Sending...",
       description: "Your message is being sent.",
     })

--- a/apps/www/components/examples/toast/promise.tsx
+++ b/apps/www/components/examples/toast/promise.tsx
@@ -4,12 +4,6 @@ import { useToast } from "@/hooks/use-toast"
 
 import { Button } from "@/components/ui/button"
 
-const promiseThatMightReject = () => {
-  return new Promise((res, rej) =>
-    setTimeout(Math.random() < 0.5 ? res : rej, 2000)
-  )
-}
-
 export function ToastWithPromise() {
   const toaster = useToast()
 
@@ -38,5 +32,11 @@ export function ToastWithPromise() {
     <Button variant="outline" onClick={handleToast}>
       Trigger promise that might reject
     </Button>
+  )
+}
+
+function promiseThatMightReject() {
+  return new Promise((res, rej) =>
+    setTimeout(Math.random() < 0.5 ? res : rej, 2000)
   )
 }

--- a/apps/www/components/examples/toast/promise.tsx
+++ b/apps/www/components/examples/toast/promise.tsx
@@ -4,20 +4,34 @@ import { useToast } from "@/hooks/use-toast"
 
 import { Button } from "@/components/ui/button"
 
+const promiseThatMightReject = () => {
+  return new Promise((res, rej) =>
+    setTimeout(Math.random() < 0.5 ? res : rej, 2000)
+  )
+}
+
 export function ToastWithPromise() {
-  const { toast } = useToast()
+  const toaster = useToast()
 
   const handleToast = async () => {
-    const progress = toast({
-      title: "Saving...",
+    const progress = toaster.toast({
+      title: "Sending...",
       description: "Your message is being sent.",
     })
-    await new Promise((resolve) => setTimeout(resolve, 2000))
-    progress.update({
-      title: "Error",
-      description: "Failed to send message.",
-      variant: "destructive",
-    })
+    await promiseThatMightReject()
+      .then(() => {
+        progress.update({
+          title: "Success",
+          description: "Message sent.",
+        })
+      })
+      .catch(() => {
+        progress.update({
+          title: "Error",
+          description: "Failed to send message.",
+          variant: "destructive",
+        })
+      })
   }
 
   return (

--- a/apps/www/components/mdx.tsx
+++ b/apps/www/components/mdx.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 import Image from "next/image"
 import { useMDXComponent } from "next-contentlayer/hooks"

--- a/apps/www/components/ui/toast.tsx
+++ b/apps/www/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:top-auto sm:bottom-0 sm:right-0 sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
       className
     )}
     {...props}
@@ -76,7 +76,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute top-2 right-2 rounded-md p-1 text-slate-500 opacity-0 transition-opacity hover:text-slate-900 focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600 dark:hover:text-slate-50",
+      "absolute right-2 top-2 rounded-md p-1 text-slate-500 opacity-0 transition-opacity hover:text-slate-900 focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600 dark:hover:text-slate-50",
       className
     )}
     toast-close=""

--- a/apps/www/components/ui/toaster.tsx
+++ b/apps/www/components/ui/toaster.tsx
@@ -16,9 +16,9 @@ export function Toaster() {
 
   return (
     <ToastProvider>
-      {toasts.map(function ({ id, title, description, action, ...props }) {
+      {toasts.map(function ({ id, title, description, action, ref, ...props }) {
         return (
-          <Toast key={id} {...props}>
+          <Toast key={id} {...props} ref={ref}>
             <div className="grid gap-1">
               {title && <ToastTitle>{title}</ToastTitle>}
               {description && (

--- a/apps/www/content/docs/primitives/toast.mdx
+++ b/apps/www/content/docs/primitives/toast.mdx
@@ -123,7 +123,9 @@ Use `toast({ variant: "destructive" }})` to display a destructive toast.
   <ToastDestructive />
 </ComponentExample>
 
-### Using promises
+### Updating a toast
+
+You can update your toast using the `update` method returned from the `toast` function. This can be used in conjunction with a promise to update the toast when the promise resolves or rejects.
 
 <ComponentExample src="/components/examples/toast/promise.tsx">
   <ToastWithPromise />

--- a/apps/www/content/docs/primitives/toast.mdx
+++ b/apps/www/content/docs/primitives/toast.mdx
@@ -122,3 +122,9 @@ Use `toast({ variant: "destructive" }})` to display a destructive toast.
 <ComponentExample src="/components/examples/toast/destructive.tsx">
   <ToastDestructive />
 </ComponentExample>
+
+### Using promises
+
+<ComponentExample src="/components/examples/toast/promise.tsx">
+  <ToastWithPromise />
+</ComponentExample>

--- a/apps/www/hooks/use-toast.ts
+++ b/apps/www/hooks/use-toast.ts
@@ -140,7 +140,7 @@ interface Toast extends Omit<ToasterToast, "id"> {}
 function toast({ ...props }: Toast) {
   const id = genId()
 
-  const update = (props: ToasterToast) =>
+  const update = (props: Toast) =>
     dispatch({
       type: "UPDATE_TOAST",
       toast: { ...props, id },

--- a/apps/www/hooks/use-toast.ts
+++ b/apps/www/hooks/use-toast.ts
@@ -8,6 +8,7 @@ const TOAST_REMOVE_DELAY = 1000
 
 type ToasterToast = ToastProps & {
   id: string
+  ref?: React.RefObject<HTMLLIElement>
   title?: React.ReactNode
   description?: React.ReactNode
   action?: ToastActionElement
@@ -78,6 +79,28 @@ export const reducer = (state: State, action: Action): State => {
       }
 
     case "UPDATE_TOAST":
+      const toast = state.toasts.find((t) => t.id === action.toast.id)
+      if (
+        toast?.variant !== "destructive" &&
+        action.toast.variant === "destructive" &&
+        toast?.ref?.current
+      ) {
+        toast.ref.current.animate(
+          [
+            { transform: "translateX(-30px)" },
+            { transform: "translateX(30px)" },
+            { transform: "translateX(-20px)" },
+            { transform: "translateX(20px)" },
+            { transform: "translateX(-10px)" },
+            { transform: "translateX(10px)" },
+            { transform: "translateX(0)" },
+          ],
+          {
+            duration: 400,
+            iterations: 1,
+          }
+        )
+      }
       return {
         ...state,
         toasts: state.toasts.map((t) =>
@@ -151,6 +174,7 @@ function toast({ ...props }: Toast) {
     type: "ADD_TOAST",
     toast: {
       ...props,
+      ref: props.ref ?? React.createRef(),
       id,
       open: true,
       onOpenChange: (open) => {


### PR DESCRIPTION
Thought I'd add an example of a promise-based toaster.

Adds a shake animation if a toast is updated to destructive:

https://user-images.githubusercontent.com/51714798/232233219-2fc00303-2a31-4546-a4d9-17b790f2dfc4.mp4

