### PR TITLE
fix(cli): support handle src directory for component destination dir

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -144,7 +144,10 @@ async function main() {
         selectedComponents = await promptForComponents(availableComponents)
       }
 
-      const dir = await promptForDestinationDir()
+      const initialDestination = projectInfo?.srcDir
+        ? "./src/components/ui"
+        : "./components/ui"
+      const dir = await promptForDestinationDir(initialDestination)
 
       if (!selectedComponents?.length) {
         logger.warn("No components selected. Nothing to install.")
@@ -206,13 +209,13 @@ async function promptForComponents(components: Component[]) {
   return selectedComponents
 }
 
-async function promptForDestinationDir() {
+async function promptForDestinationDir(initialDestination: string) {
   const { dir } = await prompts([
     {
       type: "text",
       name: "dir",
       message: "Where would you like to install the component(s)?",
-      initial: "./components/ui",
+      initial: initialDestination,
     },
   ])
 


### PR DESCRIPTION
Updating the CLI to handle case where a project is using a `src` directory, so that the initial value of the prompt is set accordingly.