### PR TITLE
Change suggested component dir to ./src/components/ui

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -212,7 +212,7 @@ async function promptForDestinationDir() {
       type: "text",
       name: "dir",
       message: "Where would you like to install the component(s)?",
-      initial: "./components/ui",
+      initial: "./src/components/ui",
     },
   ])
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -212,7 +212,7 @@ async function promptForDestinationDir() {
       type: "text",
       name: "dir",
       message: "Where would you like to install the component(s)?",
-      initial: "./src/components/ui",
+      initial: projectInfo?.srcDir ? "./src/components/ui" : "./components/ui,
     },
   ])
 


### PR DESCRIPTION
# `src` directory is amazing. 
It organizes the project structure. So instead of making the suggested dir `{ROOT}/components/ui` next to `src` dir, I made it in `./src/components/ui`. 

I know that both are available in `Next.js` but I see lots of devs use `src` dir.

Update: In the second commit, it will check if user has already `src` dir then suggest him `./src/components/ui` otherwise `./components/ui`