### PR TITLE
fix: add missing manual install step for Button component

### DIFF
--- a/apps/www/content/docs/components/button.mdx
+++ b/apps/www/content/docs/components/button.mdx
@@ -20,7 +20,13 @@ npx shadcn-ui add button
     <AccordionTrigger>Manual Installation</AccordionTrigger>
     <AccordionContent>
 
-1. Copy and paste the following code into your project.
+    1. Install the `@radix-ui/react-slot` component from radix-ui:
+
+    ```bash
+    npm install @radix-ui/react-slot
+    ```
+
+    2. Copy and paste the following code into your project.
 
 <ComponentSource src="/components/ui/button.tsx" />
 


### PR DESCRIPTION
The `Button` component now has a dependency of `@radix-ui/react-slot`, but the manual installation steps do not require its installation. This PR adds this to the docs. 