### PR TITLE
feat(cli): detect package manager based on lockfiles

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,9 +25,11 @@ const PROJECT_DEPENDENCIES = [
 ]
 
 async function main() {
-  const packageInfo = await getPackageInfo()
-  const projectInfo = await getProjectInfo()
-  const packageManager = getPackageManager()
+  const [packageInfo, projectInfo, packageManager] = await Promise.all([
+    getPackageInfo(),
+    getProjectInfo(),
+    getPackageManager(),
+  ])
 
   const program = new Command()
     .name("shadcn-ui")

--- a/packages/cli/src/utils/get-package-manager.ts
+++ b/packages/cli/src/utils/get-package-manager.ts
@@ -1,4 +1,38 @@
-export function getPackageManager() {
+import { promises as fs } from "fs"
+import path from "path"
+
+async function fileExists(path: string) {
+  try {
+    await fs.access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function getPackageManager(
+  cwd = "."
+): Promise<"yarn" | "pnpm" | "npm"> {
+  // match based on lockfile
+  const [yarnLock, npmLock, pnpmLock] = await Promise.all([
+    fileExists(path.resolve(cwd, "yarn.lock")),
+    fileExists(path.resolve(cwd, "package-lock.json")),
+    fileExists(path.resolve(cwd, "pnpm-lock.yaml")),
+  ])
+
+  if (yarnLock) {
+    return "yarn"
+  }
+
+  if (pnpmLock) {
+    return "pnpm"
+  }
+
+  if (npmLock) {
+    return "npm"
+  }
+
+  // match based on used package manager
   const userAgent = process.env.npm_config_user_agent
 
   if (!userAgent) {


### PR DESCRIPTION
When invoking `shadcn-ui` via `npx`, the CLI will always assume NPM even though the project uses a different package manager, creating a `package-lock.json` even though a different PM is used.

The logic is inspired by https://github.com/egoist/detect-package-manager, checking for a lockfile in current working directory.

Note: an additional change has been added to `Promise.all` async functions. 