### PR TITLE
chore: add link to tool to easily copy HSL values of Tailwind colors

### DIFF
--- a/apps/www/content/docs/theming.mdx
+++ b/apps/www/content/docs/theming.mdx
@@ -7,6 +7,8 @@ We use CSS variables for styling. This allows you to easily change the colors of
 
 **CSS variables must be defined without color space function**. See the [Tailwind CSS documentation](https://tailwindcss.com/docs/customizing-colors#using-css-variables) for more information.
 
+If you want to easily find and copy HSL values of different TailwindCSS colors, you can use this little utility at [https://translate-tailwind-colors.vercel.app/](https://translate-tailwind-colors.vercel.app/).
+
 ## Convention
 
 We use a simple `background` and `foreground` convention for colors. The `background` variable is used for the background color of the component and the `foreground` variable is used for the text color.


### PR DESCRIPTION
Thank you for putting this wonderful thing together.

I made this little tool: https://translate-tailwind-colors.vercel.app/ to quickly copy HSL values of different Tailwind colors. Made it specifically because I wanted to customize some of the default colors used and there wasn't a tool readily available to do this.