### PR TITLE
Cleanup: remove unused imports in examples

### DIFF
--- a/apps/www/components/command-menu.tsx
+++ b/apps/www/components/command-menu.tsx
@@ -3,7 +3,6 @@
 import * as React from "react"
 import { useRouter } from "next/navigation"
 import { DialogProps } from "@radix-ui/react-alert-dialog"
-import { allDocs } from "contentlayer/generated"
 import { Circle, File, Laptop, Moon, SunMedium } from "lucide-react"
 import { useTheme } from "next-themes"
 

--- a/apps/www/components/examples/alert/demo.tsx
+++ b/apps/www/components/examples/alert/demo.tsx
@@ -1,4 +1,4 @@
-import { Terminal, Waves } from "lucide-react"
+import { Terminal } from "lucide-react"
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 

--- a/apps/www/components/examples/alert/destructive.tsx
+++ b/apps/www/components/examples/alert/destructive.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, FileWarning, Terminal } from "lucide-react"
+import { AlertCircle } from "lucide-react"
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 

--- a/apps/www/components/examples/card/demo.tsx
+++ b/apps/www/components/examples/card/demo.tsx
@@ -10,7 +10,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import { Separator } from "@/components/ui/separator"
 import { Switch } from "@/components/ui/switch"
 
 const notifications = [

--- a/apps/www/components/examples/switch/react-hook-form.tsx
+++ b/apps/www/components/examples/switch/react-hook-form.tsx
@@ -1,13 +1,10 @@
 "use client"
 
-import Link from "next/link"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
 import * as z from "zod"
 
 import { Button } from "@/components/ui/button"
-import { Checkbox } from "@/components/ui/checkbox"
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Switch } from "@/components/ui/switch"
 import { toast } from "@/components/ui/use-toast"
 import {

--- a/apps/www/components/examples/textarea/react-hook-form.tsx
+++ b/apps/www/components/examples/textarea/react-hook-form.tsx
@@ -1,14 +1,10 @@
 "use client"
 
-import Link from "next/link"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
 import * as z from "zod"
 
 import { Button } from "@/components/ui/button"
-import { Checkbox } from "@/components/ui/checkbox"
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
-import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import { toast } from "@/components/ui/use-toast"
 import {


### PR DESCRIPTION
# Cleanup: Removal of Unused Imports

## Summary

This pull request involves cleaning up our code by removing several unused imports across multiple files. The aim is to enhance code readability and maintainability.

## Changes

The following unused imports have been removed or edited:

- `react-hook-form.tsx` in `apps/www/components/examples/switch`:

    ```jsx
    import Link from "next/link";
    import { Checkbox } from "@/components/ui/checkbox";
    import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
    ```

- `react-hook-form.tsx` in `apps/www/components/examples/textarea`:

    ```jsx
    import Link from "next/link";
    import { Checkbox } from "@/components/ui/checkbox";
    import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
    import { Switch } from "@/components/ui/switch";
    ```

- `demo.tsx` in `apps/www/components/examples/data-table`:

    ```jsx
    import { faker } from "@faker-js/faker";
    ```

- `demo.tsx` in `apps/www/components/examples/card`:

    ```jsx
    import { Separator } from "@/components/ui/separator";
    ```

- removed `, Waves` of `demo.tsx` in `apps/www/components/examples/alert`:

    ```jsx
    import { Terminal, Waves } from "lucide-react";
    ```

- removed `, FileWarning, Terminal` of `destructive.tsx` in `apps/www/components/examples/alert`:

    ```jsx
    import { AlertCircle, FileWarning, Terminal } from "lucide-react";
    ```

- `command-menu.tsx` in `apps/www/components`:

    ```jsx
    import { allDocs } from "contentlayer/generated";
    ```

## Impact

Some of these unused imports where in files that were used as examples for people to copy, might be nice to clean that up. 

I welcome any feedback and appreciate your consideration of this PR!
