### PR TITLE
feat: create form input component

### DIFF
--- a/apps/www/components/react-hook-form/form.tsx
+++ b/apps/www/components/react-hook-form/form.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-hook-form"
 
 import { cn } from "@/lib/utils"
+import { InputProps } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 
 const Form = FormProvider
@@ -100,6 +101,29 @@ const FormLabel = React.forwardRef<
   )
 })
 FormLabel.displayName = "FormLabel"
+
+const FormInput = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => {
+    const { error, formItemId } = useFormField()
+
+    return (
+      <input
+        ref={ref}
+        id={formItemId}
+        className={cn(
+          "flex h-10 w-full rounded-md border px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          error &&
+            "border-destructive text-destructive placeholder:text-destructive focus:ring-destructive",
+          !error &&
+            "border-input bg-transparent  placeholder:text-muted-foreground",
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
+FormInput.displayName = "FormInput"
 
 const FormControl = React.forwardRef<
   React.ElementRef<typeof Slot>,


### PR DESCRIPTION
Create a new `FormInput` component.

In the following example:
```
<Form>
  <FormField
    control={...}
    name="..."
    render={() => (
      <FormItem>
        <FormLabel />
        <FormControl>
          <Input {...form.register('title')} />
        </FormControl>
        <FormDescription />
        <FormMessage />
      </FormItem>
    )}
  />
</Form>
```
We would only be able to see the error for the current `<FormItem />` (in this case for the title input)  appear in the `<FormMessage />` component that sits right under the input.

In many forms, including the ones in Tailwind UI:

<img width="359" alt="image" src="https://github.com/shadcn/ui/assets/21187304/c30740a8-0187-4c27-af0e-4ff12cb8f394">

We often see the border and ring of the current input change color to red/destructive in addition to the error form message appearing below.

This change creates that error styling when an error occurs. The above example can now look like this:

```
<Form>
  <FormField
    control={...}
    name="..."
    render={() => (
      <FormItem>
        <FormLabel />
        <FormControl>
          <FormInput {...form.register('title')} />
        </FormControl>
        <FormDescription />
        <FormMessage />
      </FormItem>
    )}
  />
</Form>
```
