### PR TITLE
fix(switch): switch size fixed with rem

### DIFF
--- a/apps/www/components/ui/switch.tsx
+++ b/apps/www/components/ui/switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-[24px] w-[44px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      "peer inline-flex h-7 w-12 shrink-0 cursor-pointer items-center rounded-full border-[0.25rem] border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
       className
     )}
     {...props}


### PR DESCRIPTION
Problem:
When the browser font size change, preview is broken

Old (small size):
![CleanShot 2023-05-22 23 43 21](https://github.com/shadcn/ui/assets/8670548/d81a6523-3ebb-4eec-a4e2-b8ba563e8f34)
New (small size):
![CleanShot 2023-05-22 23 43 33](https://github.com/shadcn/ui/assets/8670548/68721aaf-f8a5-4edf-affa-960054b601fd)

Old (bigger size):
![CleanShot 2023-05-22 23 45 43](https://github.com/shadcn/ui/assets/8670548/c314c38f-f1cb-40da-bc32-46cc10c57da6)
New (bigger size):
![CleanShot 2023-05-22 23 45 58](https://github.com/shadcn/ui/assets/8670548/8c81755a-b4bb-4187-b1ea-b0a51abc86f1)
