### PR TITLE
Updated documentation code to use ctrl key for Windows

### DIFF
--- a/apps/www/content/docs/components/command.mdx
+++ b/apps/www/content/docs/components/command.mdx
@@ -96,7 +96,7 @@ export function CommandMenu() {
 
   React.useEffect(() => {
     const down = (e: KeyboardEvent) => {
-      if (e.key === "k" && e.metaKey) {
+      if (e.key === "k" && (e.ctrlKey || e.metaKey)) {
         setOpen((open) => !open)
       }
     }

--- a/apps/www/content/docs/components/command.mdx
+++ b/apps/www/content/docs/components/command.mdx
@@ -97,6 +97,7 @@ export function CommandMenu() {
   React.useEffect(() => {
     const down = (e: KeyboardEvent) => {
       if (e.key === "k" && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault()
         setOpen((open) => !open)
       }
     }


### PR DESCRIPTION
This PR updates the documentation's code to also open the dialog on Windows. Because on Windows, the <kbd>Ctrl + K</kbd> focuses on the browser's address bar. So it makes sure that the `Ctrl` key is pressed and the browser address bar focus is prevented