### PR TITLE
fix(toast): local variable name shadows variable in outer scope (see line 140)

### DIFF
--- a/apps/www/components/ui/use-toast.ts
+++ b/apps/www/components/ui/use-toast.ts
@@ -93,8 +93,8 @@ export const reducer = (state: State, action: Action): State => {
       if (toastId) {
         addToRemoveQueue(toastId)
       } else {
-        state.toasts.forEach((toast) => {
-          addToRemoveQueue(toast.id)
+        state.toasts.forEach((stateToast) => {
+          addToRemoveQueue(stateToast.id)
         })
       }
 


### PR DESCRIPTION
Hello 👋🏻 

I propose this very tiny PR that corrects a local variable name that shadows a variable in the outer scope.

On L.96, `toast` is used in the forEach, knowing that `toast` is already a named function on L140.

It is very tiny and makes sense in terms of readability to keep `toast` if you feel like so feel free to disregard and close this PR. 

Best regards,