### PR TITLE
Fix/react hook form docs

### DIFF
--- a/apps/www/content/docs/forms/react-hook-form.mdx
+++ b/apps/www/content/docs/forms/react-hook-form.mdx
@@ -99,7 +99,6 @@ Define the shape of your form using a Zod schema. You can read more about using 
 ```tsx showLineNumbers {4,6-8}
 "use client"
 
-import Link from "next/link"
 import * as z from "zod"
 
 const formSchema = z.object({
@@ -114,7 +113,6 @@ Use the `useForm` hook from `react-hook-form` to create a form.
 ```tsx showLineNumbers {4,14-20,22-27}
 "use client"
 
-import Link from "next/link"
 import { zodResolver } from "@hookform/resolvers/zod"
 import * as z from "zod"
 
@@ -151,7 +149,6 @@ We can now use the `<Form />` components to build our form.
 ```tsx showLineNumbers {7-17,28-50}
 "use client"
 
-import Link from "next/link"
 import { zodResolver } from "@hookform/resolvers/zod"
 import * as z from "zod"
 

--- a/apps/www/content/docs/forms/react-hook-form.mdx
+++ b/apps/www/content/docs/forms/react-hook-form.mdx
@@ -76,7 +76,7 @@ const form = useForm()
 1. Install the following dependencies:
 
 ```sh
-npm install react-hook-form zod @hookform/resolvers @radix-ui/react-slot
+npm install react-hook-form zod @hookform/resolvers @radix-ui/react-slot @radix-ui/react-label
 ```
 
 2. Copy and paste the following `<Form />` component to your app.
@@ -114,6 +114,7 @@ Use the `useForm` hook from `react-hook-form` to create a form.
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
 import * as z from "zod"
 
 const formSchema = z.object({
@@ -150,6 +151,7 @@ We can now use the `<Form />` components to build our form.
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
 import * as z from "zod"
 
 import { Button } from "@/components/ui/button"


### PR DESCRIPTION
- Removed Link component in the example that is not used.
- Added missing useForm import in docs
- Added missing dependency in installation command