### PR TITLE
feat: remove clsx library and utilize cx feature from cva library

### DIFF
--- a/apps/www/content/docs/installation.mdx
+++ b/apps/www/content/docs/installation.mdx
@@ -61,7 +61,7 @@ This will install dependencies, setup Tailwind CSS, and configure the `cn` utils
 Add the following dependencies to your project:
 
 ```bash
-npm install tailwindcss-animate class-variance-authority clsx tailwind-merge lucide-react
+npm install tailwindcss-animate class-variance-authority tailwind-merge lucide-react
 ```
 
 ### Path Aliases
@@ -257,11 +257,11 @@ Add the following to your `styles/globals.css` file. You can learn more about us
 I use a `cn` helper to make it easier to conditionally add Tailwind CSS classes. Here's how I define it in `lib/utils.ts`:
 
 ```ts title="lib/utils.ts"
-import { clsx, type ClassValue } from "clsx"
+import { cx, CxOptions } from "class-variance-authority"
 import { twMerge } from "tailwind-merge"
 
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+export function cn(...inputs: CxOptions) {
+  return twMerge(cx(inputs))
 }
 ```
 

--- a/apps/www/lib/utils.ts
+++ b/apps/www/lib/utils.ts
@@ -1,8 +1,8 @@
-import { clsx, type ClassValue } from "clsx"
+import { cx, CxOptions } from "class-variance-authority"
 import { twMerge } from "tailwind-merge"
 
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+export function cn(...inputs: CxOptions) {
+  return twMerge(cx(inputs))
 }
 
 export function formatDate(input: string | number): string {

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -50,7 +50,6 @@
     "@vercel/analytics": "^1.0.1",
     "@vercel/og": "^0.0.21",
     "class-variance-authority": "^0.4.0",
-    "clsx": "^1.2.1",
     "cmdk": "^0.2.0",
     "contentlayer": "0.3.0",
     "date-fns": "^2.30.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,7 +20,6 @@ process.on("SIGTERM", () => process.exit(0))
 const PROJECT_DEPENDENCIES = [
   "tailwindcss-animate",
   "class-variance-authority",
-  "clsx",
   "tailwind-merge",
   "lucide-react",
 ]

--- a/packages/cli/src/utils/templates.ts
+++ b/packages/cli/src/utils/templates.ts
@@ -80,11 +80,11 @@ export const STYLES = `@tailwind base;
   }
 }`
 
-export const UTILS = `import { ClassValue, clsx } from "clsx"
+export const UTILS = `import { cx, CxOptions } from "class-variance-authority"
 import { twMerge } from "tailwind-merge"
  
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+export function cn(...inputs: CxOptions) {
+  return twMerge(cx(inputs))
 }
 `
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,9 +196,6 @@ importers:
       class-variance-authority:
         specifier: ^0.4.0
         version: 0.4.0(typescript@4.9.5)
-      clsx:
-        specifier: ^1.2.1
-        version: 1.2.1
       cmdk:
         specifier: ^0.2.0
         version: 0.2.0(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0)
@@ -369,9 +366,6 @@ importers:
       class-variance-authority:
         specifier: ^0.4.0
         version: 0.4.0(typescript@4.9.5)
-      clsx:
-        specifier: ^1.2.1
-        version: 1.2.1
       lucide-react:
         specifier: 0.105.0-alpha.4
         version: 0.105.0-alpha.4(react@18.2.0)
@@ -4393,11 +4387,6 @@ packages:
   /clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
-    dev: false
-
-  /clsx@1.2.1:
-    resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
-    engines: {node: '>=6'}
     dev: false
 
   /cmdk@0.2.0(@types/react@18.2.7)(react-dom@18.2.0)(react@18.2.0):

--- a/templates/next-template/lib/utils.ts
+++ b/templates/next-template/lib/utils.ts
@@ -1,6 +1,6 @@
-import { clsx, type ClassValue } from "clsx"
+import { cx, CxOptions } from "class-variance-authority"
 import { twMerge } from "tailwind-merge"
 
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+export function cn(...inputs: CxOptions) {
+  return twMerge(cx(inputs))
 }

--- a/templates/next-template/package.json
+++ b/templates/next-template/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.4.0",
-    "clsx": "^1.2.1",
     "lucide-react": "0.105.0-alpha.4",
     "next": "^13.4.4",
     "next-themes": "^0.2.1",


### PR DESCRIPTION
Within CVA, they already utilize CLSX and export it as 'cx', eliminating the need for separate installation and allowing for direct usage of the same feature from CVA.

![image](https://github.com/shadcn/ui/assets/31660832/a14b2c41-f814-452e-ad63-04cde0c40e4e)

![image](https://github.com/shadcn/ui/assets/31660832/203605dc-f91d-4d4f-9a28-21afd1faa790)
