### PR TITLE
(fix) Updated the Date Picker doc to fix CalendarIcon import

### DIFF
--- a/apps/www/components/examples/date-picker/react-hook-form.tsx
+++ b/apps/www/components/examples/date-picker/react-hook-form.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { format } from "date-fns"
-import { CalendarIcon } from "lucide-react"
+import { Calendar as CalendarIcon } from "lucide-react"
 import { useForm } from "react-hook-form"
 import * as z from "zod"
 


### PR DESCRIPTION
The react-hook-form example of the Date Picker had an error for the CalendarIcon import. Import has been updated so that the icon is imported correctly.