### PR TITLE
fix(docs): react-hook-form combobox example - clear field errors on change

### DIFF
--- a/apps/www/registry/default/example/combobox-form.tsx
+++ b/apps/www/registry/default/example/combobox-form.tsx
@@ -103,6 +103,7 @@ export default function ComboboxForm() {
                           value={language.value}
                           key={language.value}
                           onSelect={(value) => {
+                            form.clearErrors("language")
                             form.setValue("language", value)
                           }}
                         >


### PR DESCRIPTION
* Fixes #562, whereby the combobox example using React Hook Form would not clear errors for the field after selecting an item. To fix this, we clear the errors for the `language` field when one of the options has been selected.