### PR TITLE
feat(button-group): add new component

### DIFF
--- a/apps/www/app/sink/page.tsx
+++ b/apps/www/app/sink/page.tsx
@@ -18,6 +18,7 @@ import { ButtonLoading } from "@/components/examples/button/loading"
 import { ButtonOutline } from "@/components/examples/button/outline"
 import { ButtonSecondary } from "@/components/examples/button/secondary"
 import { ButtonWithIcon } from "@/components/examples/button/with-icon"
+import { ButtonGroupDemo } from "@/components/examples/button-group/demo"
 import { CardDemo } from "@/components/examples/card/demo"
 import { CheckboxDemo } from "@/components/examples/checkbox/demo"
 import { CollapsibleDemo } from "@/components/examples/collapsible/demo"
@@ -106,6 +107,9 @@ export default function KitchenSinkPage() {
               <div className="flex space-x-2">
                 <ButtonWithIcon />
                 <ButtonLoading />
+              </div>
+              <div>
+                <ButtonGroupDemo />
               </div>
             </ComponentWrapper>
             <ComponentWrapper>

--- a/apps/www/components/examples/button-group/demo.tsx
+++ b/apps/www/components/examples/button-group/demo.tsx
@@ -1,0 +1,11 @@
+import { ButtonGroup, ButtonGroupItem } from "@/components/ui/button-group"
+
+export function ButtonGroupDemo() {
+  return (
+    <ButtonGroup defaultValue="medium">
+      <ButtonGroupItem value="low">Low</ButtonGroupItem>
+      <ButtonGroupItem value="medium">Medium</ButtonGroupItem>
+      <ButtonGroupItem value="high">High</ButtonGroupItem>
+    </ButtonGroup>
+  )
+}

--- a/apps/www/components/examples/button-group/react-hook-form.tsx
+++ b/apps/www/components/examples/button-group/react-hook-form.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import * as z from "zod"
+
+import { Button } from "@/components/ui/button"
+import { ButtonGroup, ButtonGroupItem } from "@/components/ui/button-group"
+import { toast } from "@/components/ui/use-toast"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/react-hook-form/form"
+
+const FormSchema = z.object({
+  type: z.enum(["all", "mentions", "none"], {
+    required_error: "You need to select a notification type.",
+  }),
+})
+
+export function ButtonGroupReactHookForm() {
+  const form = useForm<z.infer<typeof FormSchema>>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      type: "all"
+    }
+  })
+
+  function onSubmit(data: z.infer<typeof FormSchema>) {
+    toast({
+      title: "You submitted the following values:",
+      description: (
+        <pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
+          <code className="text-white">{JSON.stringify(data, null, 2)}</code>
+        </pre>
+      ),
+    })
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="w-2/3 space-y-6">
+        <FormField
+          control={form.control}
+          name="type"
+          render={({ field }) => (
+            <FormItem className="space-y-3">
+              <FormLabel className="block">Notify me about...</FormLabel>
+              <FormControl>
+                <ButtonGroup
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                >
+                  <FormItem>
+                    <FormControl>
+                      <ButtonGroupItem value="all">All</ButtonGroupItem>
+                    </FormControl>
+                  </FormItem>
+                  <FormItem>
+                    <FormControl>
+                      <ButtonGroupItem value="mentions">Mentions</ButtonGroupItem>
+                    </FormControl>
+                  </FormItem>
+                  <FormItem>
+                    <FormControl>
+                      <ButtonGroupItem value="none">None</ButtonGroupItem>
+                    </FormControl>
+                  </FormItem>
+                </ButtonGroup>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit">Submit</Button>
+      </form>
+    </Form>
+  )
+}

--- a/apps/www/components/examples/index.tsx
+++ b/apps/www/components/examples/index.tsx
@@ -17,6 +17,8 @@ import { ButtonLoading } from "@/components/examples/button/loading"
 import { ButtonOutline } from "@/components/examples/button/outline"
 import { ButtonSecondary } from "@/components/examples/button/secondary"
 import { ButtonWithIcon } from "@/components/examples/button/with-icon"
+import { ButtonGroupDemo } from "@/components/examples/button-group/demo"
+import { ButtonGroupReactHookForm } from "@/components/examples/button-group/react-hook-form"
 import { CalendarDemo } from "@/components/examples/calendar/demo"
 import { CalendarReactHookForm } from "@/components/examples/calendar/react-hook-form"
 import { CardDemo } from "@/components/examples/card/demo"
@@ -124,6 +126,8 @@ export const examples = {
   ButtonSecondary,
   ButtonWithIcon,
   ButtonAsChild,
+  ButtonGroupDemo,
+  ButtonGroupReactHookForm,
   CalendarDemo,
   CalendarReactHookForm,
   DataTableDemo,

--- a/apps/www/components/ui/button-group.tsx
+++ b/apps/www/components/ui/button-group.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import * as React from "react"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+
+import { cn } from "@/lib/utils"
+
+const ButtonGroup = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn(
+        "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+        className
+      )}
+      {...props}
+      ref={ref}
+    />
+  )
+})
+ButtonGroup.displayName = RadioGroupPrimitive.Root.displayName
+
+const ButtonGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, children, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=checked]:bg-background data-[state=checked]:text-foreground data-[state=checked]:shadow-sm",
+        className
+      )}
+      {...props}
+      asChild
+    >
+      <button type="button">{children}</button>
+    </RadioGroupPrimitive.Item>
+  )
+})
+ButtonGroupItem.displayName = RadioGroupPrimitive.Item.displayName
+
+export { ButtonGroup, ButtonGroupItem }

--- a/apps/www/config/components.ts
+++ b/apps/www/config/components.ts
@@ -40,6 +40,12 @@ export const components = [
     files: ["components/ui/button.tsx"],
   },
   {
+    component: "button-group",
+    name: "Button Group",
+    dependencies: ["@radix-ui/react-radio-group"],
+    files: ["components/ui/button-group.tsx"],
+  },
+  {
     component: "card",
     name: "Card",
     files: ["components/ui/card.tsx"],

--- a/apps/www/config/docs.ts
+++ b/apps/www/config/docs.ts
@@ -132,6 +132,12 @@ export const docsConfig: DocsConfig = {
           items: [],
         },
         {
+          title: "Button Group",
+          href: "/docs/components/button-group",
+          items: [],
+          label: "New",
+        },
+        {
           title: "Calendar",
           href: "/docs/components/calendar",
           items: [],

--- a/apps/www/content/docs/components/button-group.mdx
+++ b/apps/www/content/docs/components/button-group.mdx
@@ -30,7 +30,7 @@ npm install @radix-ui/react-radio-group
 
 2. Copy and paste the following code into your project.
 
-<ComponentSource src="/components/ui/radio-group.tsx" />
+<ComponentSource src="/components/ui/button-group.tsx" />
 
 <Callout>
   This is the `<ButtonGroup />` primitive. You can place it in a file at

--- a/apps/www/content/docs/components/button-group.mdx
+++ b/apps/www/content/docs/components/button-group.mdx
@@ -1,0 +1,71 @@
+---
+title: Button Group
+description: A set of checkable buttons—known as button groups—where no more than one of the buttons can be checked at a time.
+component: true
+radix:
+  link: https://www.radix-ui.com/docs/primitives/components/radio-group
+  api: https://www.radix-ui.com/docs/primitives/components/radio-group#api-reference
+---
+
+<ComponentExample src="/components/examples/button-group/demo.tsx">
+  <ButtonGroupDemo />
+</ComponentExample>
+
+## Installation
+
+```bash
+npx shadcn-ui add button-group
+```
+
+<Accordion type="single" collapsible>
+  <AccordionItem value="manual-installation">
+    <AccordionTrigger>Manual Installation</AccordionTrigger>
+    <AccordionContent>
+
+1. Install the `@radix-ui/react-radio-group` component from radix-ui:
+
+```bash
+npm install @radix-ui/react-radio-group
+```
+
+2. Copy and paste the following code into your project.
+
+<ComponentSource src="/components/ui/radio-group.tsx" />
+
+<Callout>
+  This is the `<ButtonGroup />` primitive. You can place it in a file at
+  `components/ui/button-group.tsx`.
+</Callout>
+
+    </AccordionContent>
+
+  </AccordionItem>
+</Accordion>
+
+## Usage
+
+```tsx
+import { Label } from "@/components/ui/label"
+import { ButtonGroup, ButtonGroupItem } from "@/components/ui/button-group"
+```
+
+```tsx
+<ButtonGroup defaultValue="medium">
+  <ButtonGroupItem value="low">Low</ButtonGroupItem>
+  <ButtonGroupItem value="medium">Medium</ButtonGroupItem>
+  <ButtonGroupItem value="high">High</ButtonGroupItem>
+</ButtonGroup>
+```
+
+## React Hook form
+
+<Alert className="mt-4">
+  <AlertDescription>
+    **Note**: Learn more about using React Hook Form on the
+    [docs](/docs/forms/react-hook-form) page.
+  </AlertDescription>
+</Alert>
+
+<ComponentExample src="/components/examples/button-group/react-hook-form.tsx">
+  <ButtonGroupReactHookForm />
+</ComponentExample>


### PR DESCRIPTION
I created a new button group component that uses `@radix-ui/react-radio-group` but looks like the tabs list + triggers components:
![image](https://github.com/shadcn/ui/assets/16118391/c6439ff7-3042-4a5f-9b66-508238565498)

Check it out at:
`http://localhost:3001/docs/components/button-group` or `http://localhost:3001/sink`

I use it for use cases like this:
![image](https://github.com/shadcn/ui/assets/16118391/4e542e0e-e1bb-4cf6-89fc-50eccfad0f86)
