### PR TITLE
fix(github-card): arrow-down exceed the parent container

### DIFF
--- a/apps/www/app/examples/cards/components/github-card.tsx
+++ b/apps/www/app/examples/cards/components/github-card.tsx
@@ -38,9 +38,7 @@ export function DemoGithub() {
           <Separator orientation="vertical" className="h-[20px]" />
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="secondary" className="px-2">
-                <ChevronDown className="h-4 w-4 text-secondary-foreground" />
-              </Button>
+              <ChevronDown className="h-4 w-4 cursor-pointer text-secondary-foreground" />
             </DropdownMenuTrigger>
             <DropdownMenuContent
               align="end"


### PR DESCRIPTION
if use a button to wrap the arrow-down icon, it may casue these problems.
![image](https://github.com/shadcn/ui/assets/82451257/7f2b253c-8d7e-4875-9685-a830539b3028)
![image](https://github.com/shadcn/ui/assets/82451257/9b8335f3-bee4-4a2e-8097-ff87340433f6)