### PR TITLE
feat: added classname for indicator of progress

### DIFF
--- a/apps/www/components/ui/progress.tsx
+++ b/apps/www/components/ui/progress.tsx
@@ -5,10 +5,14 @@ import * as ProgressPrimitive from "@radix-ui/react-progress"
 
 import { cn } from "@/lib/utils"
 
-const Progress = React.forwardRef<
-  React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+interface ProgressProps extends React.ComponentProps<typeof ProgressPrimitive.Root> {
+  indicatorClassName?: string
+}
+
+const Progress =React.forwardRef<
+React.ElementRef<typeof ProgressPrimitive.Root>,
+ProgressProps
+>(({ className, indicatorClassName, value, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
@@ -18,7 +22,7 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className={cn("h-full w-full flex-1 bg-primary transition-all", indicatorClassName)}
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>


### PR DESCRIPTION
Hello, I don't know how to contribute to the Repository and I couldn't find any documentation.

This is my first time using this pack and I really like it. I fixed the part I found missing in my local. I didn't see anyone making such a request on Issue, but I still wanted to share. I just added the source code for now. If you want an example from the document, I can handle it.

What I do is; In the progress bar, the indicator initially comes as `bg-primary`. This is not something I want. I wanted to change the color of the indicator or something. That's why I defined a props for the indicator. We assign color as we want with indicatorClassName.