### PR TITLE
fix(docs): combobox - language for command

### DIFF
--- a/apps/www/components/examples/combobox/react-hook-form.tsx
+++ b/apps/www/components/examples/combobox/react-hook-form.tsx
@@ -95,8 +95,8 @@ export function ComboboxReactHookForm() {
                 </PopoverTrigger>
                 <PopoverContent className="w-[200px] p-0">
                   <Command>
-                    <CommandInput placeholder="Search framework..." />
-                    <CommandEmpty>No framework found.</CommandEmpty>
+                    <CommandInput placeholder="Search language..." />
+                    <CommandEmpty>No language found.</CommandEmpty>
                     <CommandGroup>
                       {languages.map((language) => (
                         <CommandItem


### PR DESCRIPTION
Show the language as a placeholder and for the CommandEmpty state