### PR TITLE
fix(badge): requires ref for certain scenarios like usage as a trigger

### DIFF
--- a/apps/www/registry/default/ui/badge.tsx
+++ b/apps/www/registry/default/ui/badge.tsx
@@ -27,10 +27,17 @@ export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
-function Badge({ className, variant, ...props }: BadgeProps) {
-  return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
-  )
-}
+const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
+  ({ className, variant, ...props }, ref) => {
+    return (
+      <div
+        className={cn(badgeVariants({ variant }), className)}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Badge.displayName = "Badge"
 
 export { Badge, badgeVariants }


### PR DESCRIPTION
When I was using it with hover card I received some react errors. After exposing ref it was fine.