### PR TITLE
Update input.tsx

### DIFF
--- a/apps/www/components/ui/input.tsx
+++ b/apps/www/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent  file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}


### PR DESCRIPTION
If we don't set the text of the file, the `browse` won't so visible on dark mode. By adding `file:text-foreground` it should be good now.

Before
![irsyad-mbp-screenshot-2023-06-22-17 31 48](https://github.com/shadcn/ui/assets/44585532/ace69123-f8cf-41ee-9395-8c349a0e4747)

After
![irsyad-mbp-screenshot-2023-06-22-17 33 16](https://github.com/shadcn/ui/assets/44585532/0db447d5-c6c0-4c25-81fa-bbf14cca252d)
