### PR TITLE
fix(app): Remove required id from toast (fixed #721)

### DIFF
--- a/apps/www/registry/default/ui/use-toast.ts
+++ b/apps/www/registry/default/ui/use-toast.ts
@@ -143,7 +143,7 @@ type Toast = Omit<ToasterToast, "id">
 function toast({ ...props }: Toast) {
   const id = genId()
 
-  const update = (props: ToasterToast) =>
+  const update = (props: Omit<ToasterToast, "id">) =>
     dispatch({
       type: "UPDATE_TOAST",
       toast: { ...props, id },

--- a/apps/www/registry/default/ui/use-toast.ts
+++ b/apps/www/registry/default/ui/use-toast.ts
@@ -143,7 +143,7 @@ type Toast = Omit<ToasterToast, "id">
 function toast({ ...props }: Toast) {
   const id = genId()
 
-  const update = (props: Omit<ToasterToast, "id">) =>
+  const update = (props: Toast) =>
     dispatch({
       type: "UPDATE_TOAST",
       toast: { ...props, id },

--- a/apps/www/registry/new-york/ui/use-toast.ts
+++ b/apps/www/registry/new-york/ui/use-toast.ts
@@ -143,7 +143,7 @@ type Toast = Omit<ToasterToast, "id">
 function toast({ ...props }: Toast) {
   const id = genId()
 
-  const update = (props: ToasterToast) =>
+  const update = (props: Toast) =>
     dispatch({
       type: "UPDATE_TOAST",
       toast: { ...props, id },


### PR DESCRIPTION
This PR fixes #721 by removing the unnecessary `id` requirement from the `props` when updating a toast.