### PR TITLE
fix: use tilde instead of at sign for remix install

### DIFF
--- a/apps/www/content/docs/installation/remix.mdx
+++ b/apps/www/content/docs/installation/remix.mdx
@@ -102,7 +102,7 @@ npx shadcn-ui@latest add button
 The command above will add the `Button` component to your project. You can then import it like this:
 
 ```tsx {1,6} showLineNumbers
-import { Button } from "@/components/ui"
+import { Button } from "~/components/ui"
 
 export default function Home() {
   return (


### PR DESCRIPTION
👋🏻 

Noticed a minor typo. This will use the remix default import path, which is also the one used elsewhere in the installation guide.