### PR TITLE
feat(cli): add optional components prefix

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -63,6 +63,17 @@ export const add = new Command()
         process.exit(1)
       }
 
+      // Check if the prefix is invalid
+      if (
+        config.prefix &&
+        !/^(?![0-9])[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(config.prefix)
+      ) {
+        logger.warn(
+          `Invalid prefix "${config.prefix}". Prefix must be a valid identifier.`
+        )
+        process.exit(1)
+      }
+
       const registryIndex = await getRegistryIndex()
 
       let selectedComponents = options.components

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -23,6 +23,7 @@ export const rawConfigSchema = z
     style: z.string(),
     rsc: z.coerce.boolean().default(false),
     tsx: z.coerce.boolean().default(true),
+    prefix: z.string().optional(),
     tailwind: z.object({
       config: z.string(),
       css: z.string(),

--- a/packages/cli/src/utils/transformers/index.ts
+++ b/packages/cli/src/utils/transformers/index.ts
@@ -6,6 +6,7 @@ import { registryBaseColorSchema } from "@/src/utils/registry/schema"
 import { transformCssVars } from "@/src/utils/transformers/transform-css-vars"
 import { transformImport } from "@/src/utils/transformers/transform-import"
 import { transformJsx } from "@/src/utils/transformers/transform-jsx"
+import { transformPrefix } from "@/src/utils/transformers/transform-prefix"
 import { transformRsc } from "@/src/utils/transformers/transform-rsc"
 import { Project, ScriptKind, type SourceFile } from "ts-morph"
 import * as z from "zod"
@@ -27,6 +28,7 @@ const transformers: Transformer[] = [
   transformImport,
   transformRsc,
   transformCssVars,
+  transformPrefix,
 ]
 
 const project = new Project({

--- a/packages/cli/src/utils/transformers/transform-prefix.ts
+++ b/packages/cli/src/utils/transformers/transform-prefix.ts
@@ -1,0 +1,58 @@
+import { Transformer } from "@/src/utils/transformers"
+
+export const transformPrefix: Transformer = async ({ sourceFile, config }) => {
+  if (!config.prefix) {
+    return sourceFile
+  }
+
+  const exportDeclaration = sourceFile.getExportDeclarations()[0]
+
+  if (!exportDeclaration) {
+    return sourceFile
+  }
+
+  // Add alias to named exports
+  const namedExports = exportDeclaration.getNamedExports()
+  if (namedExports.length) {
+    namedExports.forEach((namedExport) => {
+      // Skip type only exports
+      if (namedExport.isTypeOnly()) return
+
+      const componentName = namedExport.getNameNode().getText()
+
+      // Skip lowercase exports
+      if (componentName[0] === componentName[0].toLowerCase()) return
+
+      const newComponentName = `${config.prefix}${componentName}`
+      namedExport.renameAlias(newComponentName)
+    })
+  }
+
+  // Add prefix to types
+  const typeAliases = sourceFile
+    .getTypeAliases()
+    .filter((typeAlias) => typeAlias.isExported())
+
+  if (typeAliases.length) {
+    typeAliases.forEach((typeAlias) => {
+      const typeName = typeAlias.getNameNode().getText()
+      const newTypeName = `${config.prefix}${typeName}`
+      typeAlias.rename(newTypeName)
+    })
+  }
+
+  // Add prefix to interfaces
+  const interfaces = sourceFile
+    .getInterfaces()
+    .filter((interfaceDeclaration) => interfaceDeclaration.isExported())
+
+  if (interfaces.length) {
+    interfaces.forEach((interfaceDeclaration) => {
+      const interfaceName = interfaceDeclaration.getNameNode().getText()
+      const newInterfaceName = `${config.prefix}${interfaceName}`
+      interfaceDeclaration.rename(newInterfaceName)
+    })
+  }
+
+  return sourceFile
+}

--- a/packages/cli/test/utils/__snapshots__/transform-prefix.test.ts.snap
+++ b/packages/cli/test/utils/__snapshots__/transform-prefix.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`transform prefix 1`] = `
+"import * as React from \\"react\\"
+function NoPrefixFunc() {}
+const NoPrefixConst = () => {}
+type NoPrefixType = {}
+interface NoPrefixInterface {}
+
+function lowerFoo() {}
+const Foo = () => {}
+type FooType = {}
+export { Foo, type FooType, lowerFoo }
+
+export function Bar() {}
+export const Bar2 = () => {}
+export type Baz = {}
+export interface Qux {}
+\\"
+    "
+`;
+
+exports[`transform prefix 2`] = `
+"import * as React from \\"react\\"
+function NoPrefixFunc() {}
+const NoPrefixConst = () => {}
+type NoPrefixType = {}
+interface NoPrefixInterface {}
+
+function lowerFoo() {}
+const Foo = () => {}
+type ShFooType = {}
+export { Foo as ShFoo, type ShFooType, lowerFoo }
+
+export function Bar() {}
+export const Bar2 = () => {}
+export type ShBaz = {}
+export interface ShQux {}
+\\"
+    "
+`;

--- a/packages/cli/test/utils/transform-prefix.test.ts
+++ b/packages/cli/test/utils/transform-prefix.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "vitest"
+
+import { transform } from "../../src/utils/transformers"
+
+test("transform prefix", async () => {
+  expect(
+    await transform({
+      filename: "test.ts",
+      raw: `import * as React from "react"
+function NoPrefixFunc() {}
+const NoPrefixConst = () => {}
+type NoPrefixType = {}
+interface NoPrefixInterface {}
+
+function lowerFoo() {}
+const Foo = () => {}
+type FooType = {}
+export { Foo, type FooType, lowerFoo }
+
+export function Bar() {}
+export const Bar2 = () => {}
+export type Baz = {}
+export interface Qux {}
+"
+    `,
+      config: {
+        tsx: true,
+        prefix: "",
+      },
+    })
+  ).toMatchSnapshot()
+
+  expect(
+    await transform({
+      filename: "test.ts",
+      raw: `import * as React from "react"
+function NoPrefixFunc() {}
+const NoPrefixConst = () => {}
+type NoPrefixType = {}
+interface NoPrefixInterface {}
+
+function lowerFoo() {}
+const Foo = () => {}
+type FooType = {}
+export { Foo, type FooType, lowerFoo }
+
+export function Bar() {}
+export const Bar2 = () => {}
+export type Baz = {}
+export interface Qux {}
+"
+    `,
+      config: {
+        tsx: true,
+        prefix: "Sh",
+      },
+    })
+  ).toMatchSnapshot()
+})


### PR DESCRIPTION
Add an option to prefix components exports. Closes #850.

## Features
- disabled by default
- lowercase exports are ignored
- types and interfaces names are replaced (other exports are aliased)

## Usage
Add the `prefix` option in your `components.json` file.

```js
// components.json
{
  // ...
  "prefix": "Sh",
  // ...
}
```

## Example
This example uses the `Badge` component.

```tsx
import * as React from "react"
import { cva, type VariantProps } from "class-variance-authority"

import { cn } from "@/lib/utils"

const badgeVariants = cva(
  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
  {
    variants: {
      variant: {
        default:
          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
        secondary:
          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
        destructive:
          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
        outline: "text-foreground",
      },
    },
    defaultVariants: {
      variant: "default",
    },
  }
)

export interface ShBadgeProps
  extends React.HTMLAttributes<HTMLDivElement>,
    VariantProps<typeof badgeVariants> {}

function Badge({ className, variant, ...props }: ShBadgeProps) {
  return (
    <div className={cn(badgeVariants({ variant }), className)} {...props} />
  )
}

export { Badge as ShBadge, badgeVariants }
```
