### PR TITLE
Add cn() util in Astro installation steps

### DIFF
--- a/apps/www/content/docs/installation/astro.mdx
+++ b/apps/www/content/docs/installation/astro.mdx
@@ -109,6 +109,19 @@ import '@/styles/globals.css'
 ---
 ```
 
+### Add a cn helper
+
+We use `cn` helper to make it easier to conditionally add Tailwind CSS classes. Define it in `@/lib/utils.ts`:
+
+```ts title="@/lib/utils.ts"
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+```
+
 ### That's it
 
 You can now start adding components to your project.


### PR DESCRIPTION
Astro installation guide is missing the cn() utility setup. Without it,  after running `npx shadcn-ui@latest add button` button fails to render.