### PR TITLE
fix(www): copy button won't change correctly when code copied

### DIFF
--- a/apps/www/components/copy-button.tsx
+++ b/apps/www/components/copy-button.tsx
@@ -38,9 +38,10 @@ export function CopyButton({
   const [hasCopied, setHasCopied] = React.useState(false)
 
   React.useEffect(() => {
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       setHasCopied(false)
     }, 2000)
+    return () => clearTimeout(timer)
   }, [hasCopied])
 
   return (


### PR DESCRIPTION
A setTimeout timer should be cleared in `useEffect` to prevent adverse side effects.