### PR TITLE
docs(dark-mode): add `theme-color` meta tags to Dark Mode documentation

### DIFF
--- a/apps/www/content/docs/dark-mode/next.mdx
+++ b/apps/www/content/docs/dark-mode/next.mdx
@@ -31,25 +31,23 @@ export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
 
 Add the `ThemeProvider` to your root layout, and the two `theme-color` meta tags.
 
-```tsx {1,7-18,20-22} title="app/layout.tsx"
+```tsx {1-2,4-9,17-19} title="app/layout.tsx"
+import { Metadata } from "next"
+
 import { ThemeProvider } from "@/components/theme-provider"
+
+export const metadata: Metadata = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "white" },
+    { media: "(prefers-color-scheme: dark)", color: "black" },
+  ],
+}
 
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <>
       <html lang="en" suppressHydrationWarning>
-        <head>
-          <meta
-            name="theme-color"
-            media="(prefers-color-scheme: light)"
-            content="white"
-          />
-          <meta
-            name="theme-color"
-            media="(prefers-color-scheme: dark)"
-            content="black"
-          />
-        </head>
+        <head />
         <body>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
             {children}

--- a/apps/www/content/docs/dark-mode/next.mdx
+++ b/apps/www/content/docs/dark-mode/next.mdx
@@ -7,9 +7,7 @@ description: Adding dark mode to your next app.
 
 <Steps>
 
-### Install next-themes
-
-Start by installing `next-themes`:
+### Install `next-themes`
 
 ```bash
 npm install next-themes
@@ -31,16 +29,27 @@ export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
 
 ### Wrap your root layout
 
-Add the `ThemeProvider` to your root layout.
+Add the `ThemeProvider` to your root layout, and the two `theme-color` meta tags.
 
-```tsx {1,9-11} title="app/layout.tsx"
+```tsx {1,7-18,20-22} title="app/layout.tsx"
 import { ThemeProvider } from "@/components/theme-provider"
 
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <>
       <html lang="en" suppressHydrationWarning>
-        <head />
+        <head>
+          <meta
+            name="theme-color"
+            media="(prefers-color-scheme: light)"
+            content="white"
+          />
+          <meta
+            name="theme-color"
+            media="(prefers-color-scheme: dark)"
+            content="black"
+          />
+        </head>
         <body>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
             {children}


### PR DESCRIPTION
People regularly encounter an issue when setting up dark mode, see https://github.com/shadcn/ui/issues/313, so I've added the fix to the dark mode's documentation page.

**We could also consider removing `@layer base` from the CSS. It seems unnecessary and it would be easier.**

PS: amazing the work you're doing Shadcn! The popularity of this library shows it. Congrats and thanks a lot :slightly_smiling_face: 

---

### docs(dark-mode): add `theme-color` meta tags to Dark Mode documentation
