### PR TITLE
chore: adjust input default font size to avoid mobile zooming.

### DIFF
--- a/apps/www/registry/default/ui/input.tsx
+++ b/apps/www/registry/default/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-base file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}


### PR DESCRIPTION
This PR simply adjusts the default text size of the input component to avoid the auto zoom on focus in mobile browsers. 

```
By default, all mobile browsers force the form element to work as it is. 
But when a developer sets the font size less than 16 pixels on any form element — 
mobile browsers intervene and force the UI or Page to zoom so that the texts are readable enough.
```
Sources:
https://medium.com/@absqueued/how-to-stop-zoom-in-on-input-focus-on-mobile-devices-835edcaa2ba4#:~:text=By%20default%2C%20all%20mobile%20browsers,the%20texts%20are%20readable%20enough

https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom/