### PR TITLE
feat(cli-init): show link to preview base colors

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -110,7 +110,7 @@ export async function promptForConfig(
       name: "tailwindBaseColor",
       message: `Which color would you like to use as ${highlight(
         "base color"
-      )}?`,
+      )}? You can preview the colors here: https://tailwindcss.com/docs/customizing-colors`,
       choices: baseColors.map((color) => ({
         title: color.label,
         value: color.name,


### PR DESCRIPTION
shows a link to preview base colors when initializing shadcn-ui with CLI

this is the preview link: https://tailwindcss.com/docs/customizing-colors

closes #961 