### PR TITLE
docs: use NextLink for internal links

### DIFF
--- a/apps/www/components/mdx-components.tsx
+++ b/apps/www/components/mdx-components.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import Image from "next/image"
-import Link, { LinkProps } from "next/link"
+import Link from "next/link"
 import { useMDXComponent } from "next-contentlayer/hooks"
 import { NpmCommands } from "types/unist"
 
@@ -291,6 +291,12 @@ const components = {
     ...props
   }: React.ComponentProps<typeof FrameworkDocs>) => (
     <FrameworkDocs className={cn(className)} {...props} />
+  ),
+  Link: ({ className, ...props }: React.ComponentProps<typeof Link>) => (
+    <Link
+      className={cn("font-medium underline underline-offset-4", className)}
+      {...props}
+    />
   ),
   LinkedCard: ({ className, ...props }: React.ComponentProps<typeof Link>) => (
     <Link

--- a/apps/www/content/docs/changelog.mdx
+++ b/apps/www/content/docs/changelog.mdx
@@ -8,7 +8,7 @@ toc: false
 
 This project and the components are written in TypeScript. **We recommend using TypeScript for your project as well**.
 
-However we provide a JavaScript version of the components, available via the [cli](/docs/cli).
+However we provide a JavaScript version of the components, available via the <Link href="/docs/cli">CLI</Link>.
 
 ```txt
 Would you like to use TypeScript (recommended)? no

--- a/apps/www/content/docs/components/calendar.mdx
+++ b/apps/www/content/docs/components/calendar.mdx
@@ -75,7 +75,7 @@ See the [React DayPicker](https://react-day-picker.js.org) documentation for mor
 
 ## Date Picker
 
-You can use the `<Calendar>` component to build a date picker. See the [Date Picker](/docs/components/date-picker) page for more information.
+You can use the `<Calendar>` component to build a date picker. See the <Link href="/docs/components/date-picker">Date Picker</Link> page for more information.
 
 ## Examples
 

--- a/apps/www/content/docs/components/combobox.mdx
+++ b/apps/www/content/docs/components/combobox.mdx
@@ -10,7 +10,7 @@ component: true
 
 The Combobox is built using a composition of the `<Popover />` and the `<Command />` components.
 
-See installation instructions for the [Popover](/docs/components/popover#installation) and the [Command](/docs/components/command#installation) components.
+See installation instructions for the <Link href="/docs/components/popover#installation">Popover</Link> and the <Link href="/docs/components/command#installation">Command</Link> components.
 
 ## Usage
 

--- a/apps/www/content/docs/components/command.mdx
+++ b/apps/www/content/docs/components/command.mdx
@@ -127,4 +127,4 @@ export function CommandMenu() {
 
 ### Combobox
 
-You can use the `<Command />` component as a combobox. See the [Combobox](/docs/components/combobox) page for more information.
+You can use the `<Command />` component as a combobox. See the <Link href="/docs/components/combobox">Combobox</Link> page for more information.

--- a/apps/www/content/docs/components/data-table.mdx
+++ b/apps/www/content/docs/components/data-table.mdx
@@ -825,7 +825,7 @@ You can show the number of selected rows using the `table.getFilteredSelectedRow
 
 ## Reusable Components
 
-Here are some components you can use to build your data tables. This is from the [Tasks](/examples/tasks) demo.
+Here are some components you can use to build your data tables. This is from the <Link href="/examples/tasks">Tasks</Link> demo.
 
 ### Column header
 

--- a/apps/www/content/docs/components/date-picker.mdx
+++ b/apps/www/content/docs/components/date-picker.mdx
@@ -10,7 +10,7 @@ component: true
 
 The Date Picker is built using a composition of the `<Popover />` and the `<Calendar />` components.
 
-See installation instructions for the [Popover](/docs/components/popover#installation) and the [Calendar](/docs/components/calendar#installation) components.
+See installation instructions for the <Link href="/docs/components/popover#installation">Popover</Link> and the <Link href="/docs/components/calendar#installation">Calendar</Link> components.
 
 ## Usage
 

--- a/apps/www/content/docs/components/form.mdx
+++ b/apps/www/content/docs/components/form.mdx
@@ -212,11 +212,11 @@ That's it. You now have a fully accessible form that is type-safe with client-si
 
 See the following links for more examples on how to use the `<Form />` component with other components:
 
-- [Checkbox](/docs/components/checkbox#form)
-- [Date Picker](/docs/components/date-picker#form)
-- [Input](/docs/components/input#form)
-- [Radio Group](/docs/components/radio-group#form)
-- [Select](/docs/components/select#form)
-- [Switch](/docs/components/switch#form)
-- [Textarea](/docs/components/textarea#form)
-- [Combobox](/docs/components/combobox#form)
+- <Link href="/docs/components/checkbox#form">Checkbox</Link>
+- <Link href="/docs/components/date-picker#form">Date Picker</Link>
+- <Link href="/docs/components/input#form">Input</Link>
+- <Link href="/docs/components/radio-group#form">Radio Group</Link>
+- <Link href="/docs/components/select#form">Select</Link>
+- <Link href="/docs/components/switch#form">Switch</Link>
+- <Link href="/docs/components/textarea#form">Textarea</Link>
+- <Link href="/docs/components/combobox#form">Combobox</Link>

--- a/apps/www/content/docs/components/table.mdx
+++ b/apps/www/content/docs/components/table.mdx
@@ -78,6 +78,6 @@ import {
 
 You can use the `<Table />` component to build more complex data tables. Combine it with [@tanstack/react-table](https://tanstack.com/table/v8) to create tables with sorting, filtering and pagination.
 
-See the [Data Table](/docs/components/data-table) documentation for more information.
+See the <Link href="/docs/components/data-table">Data Table</Link> documentation for more information.
 
-You can also see an example of a data table in the [Tasks](/examples/tasks) demo.
+You can also see an example of a data table in the <Link href="/examples/tasks">Tasks</Link> demo.

--- a/apps/www/content/docs/installation/index.mdx
+++ b/apps/www/content/docs/installation/index.mdx
@@ -93,7 +93,7 @@ description: How to install dependencies and structure your app.
 
 This project and the components are written in TypeScript. We recommend using TypeScript for your project as well.
 
-However we provide a JavaScript version of the components as well. The JavaScript version is available via the [cli](/docs/cli).
+However we provide a JavaScript version of the components as well. The JavaScript version is available via the <Link href="/docs/cli">CLI</Link>.
 
 To opt-out of TypeScript, you can use the `tsx` flag in your `components.json` file.
 

--- a/apps/www/content/docs/installation/manual.mdx
+++ b/apps/www/content/docs/installation/manual.mdx
@@ -137,7 +137,7 @@ module.exports = {
 
 ### Configure styles
 
-Add the following to your styles/globals.css file. You can learn more about using CSS variables for theming in the [theming section](/docs/theming).
+Add the following to your styles/globals.css file. You can learn more about using CSS variables for theming in the <Link href="/docs/theming">theming section</Link>.
 
 ```css title="styles.css"
 @tailwind base;


### PR DESCRIPTION
When an internal link in the documentation (mdx files) is clicked, the browser does a full page load. This pull request uses the next router to handle internal links.