### PR TITLE
fix(combobox): search language by label in examples

### DIFF
--- a/apps/www/app/examples/forms/account/account-form.tsx
+++ b/apps/www/app/examples/forms/account/account-form.tsx
@@ -184,10 +184,10 @@ export function AccountForm() {
                     <CommandGroup>
                       {languages.map((language) => (
                         <CommandItem
-                          value={language.value}
+                          value={language.label}
                           key={language.value}
-                          onSelect={(value) => {
-                            form.setValue("language", value)
+                          onSelect={() => {
+                            form.setValue("language", language.value)
                           }}
                         >
                           <CheckIcon

--- a/apps/www/registry/default/example/combobox-form.tsx
+++ b/apps/www/registry/default/example/combobox-form.tsx
@@ -100,10 +100,10 @@ export default function ComboboxForm() {
                     <CommandGroup>
                       {languages.map((language) => (
                         <CommandItem
-                          value={language.value}
+                          value={language.label}
                           key={language.value}
-                          onSelect={(value) => {
-                            form.setValue("language", value)
+                          onSelect={() => {
+                            form.setValue("language", language.value)
                           }}
                         >
                           <Check

--- a/apps/www/registry/new-york/example/combobox-form.tsx
+++ b/apps/www/registry/new-york/example/combobox-form.tsx
@@ -103,10 +103,10 @@ export default function ComboboxForm() {
                     <CommandGroup>
                       {languages.map((language) => (
                         <CommandItem
-                          value={language.value}
+                          value={language.label}
                           key={language.value}
-                          onSelect={(value) => {
-                            form.setValue("language", value)
+                          onSelect={() => {
+                            form.setValue("language", language.value)
                           }}
                         >
                           {language.label}


### PR DESCRIPTION
**Description:**
- The search in the `Combobox` for languages is done by language value instead of label.
  - https://ui.shadcn.com/docs/components/combobox#form
  - https://ui.shadcn.com/examples/forms/account

**Related Issues:**
- #933 
- #1072 

**Video:**

https://github.com/shadcn-ui/ui/assets/24194621/0cac67f9-01c1-4fc2-b906-7ad83c60e3df

closes #933, closes #1072
