### PR TITLE
fix(textarea): fix textarea-form zod schema bio max length

### DIFF
--- a/apps/www/registry/default/example/textarea-form.tsx
+++ b/apps/www/registry/default/example/textarea-form.tsx
@@ -28,7 +28,7 @@ const FormSchema = z.object({
       message: "Bio must be at least 10 characters.",
     })
     .max(160, {
-      message: "Bio must not be longer than 30 characters.",
+      message: "Bio must not be longer than 160 characters.",
     }),
 })
 

--- a/apps/www/registry/new-york/example/textarea-form.tsx
+++ b/apps/www/registry/new-york/example/textarea-form.tsx
@@ -28,7 +28,7 @@ const FormSchema = z.object({
       message: "Bio must be at least 10 characters.",
     })
     .max(160, {
-      message: "Bio must not be longer than 30 characters.",
+      message: "Bio must not be longer than 160 characters.",
     }),
 })
 


### PR DESCRIPTION
#### Description

The Zod schema for the `textarea-form` example has a wrong message for the max-length condition.