### PR TITLE
fix(ui): max height for select viewport

### DIFF
--- a/apps/www/registry/default/ui/select.tsx
+++ b/apps/www/registry/default/ui/select.tsx
@@ -52,7 +52,7 @@ const SelectContent = React.forwardRef<
         className={cn(
           "p-1",
           position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+            "h-[var(--radix-select-trigger-height)] max-h-[var(--radix-popper-available-height)] w-full min-w-[var(--radix-select-trigger-width)]"
         )}
       >
         {children}


### PR DESCRIPTION
Today if a Select component has so many options that it takes more than the viewport in height, it hides them and makes them inaccessible. Limiting the viewport to the available height provided to us by radix makes it scroll internally and simply works.