### PR TITLE
chore: remove `clsx`

### DIFF
--- a/apps/www/content/docs/installation/manual.mdx
+++ b/apps/www/content/docs/installation/manual.mdx
@@ -16,7 +16,7 @@ Components are styled using Tailwind CSS. You need to install Tailwind CSS in yo
 Add the following dependencies to your project:
 
 ```bash
-npm install tailwindcss-animate class-variance-authority clsx tailwind-merge
+npm install tailwindcss-animate class-variance-authority tailwind-merge
 ```
 
 ### Add icon library
@@ -228,11 +228,10 @@ Add the following to your styles/globals.css file. You can learn more about usin
 I use a `cn` helper to make it easier to conditionally add Tailwind CSS classes. Here's how I define it in `lib/utils.ts`:
 
 ```ts title="lib/utils.ts"
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { ClassNameValue, twJoin } from "tailwind-merge"
 
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+export function cn(...inputs: ClassNameValue[]) {
+  return twJoin(...inputs)
 }
 ```
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -30,7 +30,6 @@ import * as z from "zod"
 const PROJECT_DEPENDENCIES = [
   "tailwindcss-animate",
   "class-variance-authority",
-  "clsx",
   "tailwind-merge",
 ]
 

--- a/packages/cli/src/utils/templates.ts
+++ b/packages/cli/src/utils/templates.ts
@@ -1,16 +1,14 @@
-export const UTILS = `import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
- 
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+export const UTILS = `import { ClassNameValue, twJoin } from "tailwind-merge"
+
+export function cn(...inputs: ClassNameValue[]) {
+  return twJoin(...inputs)
 }
 `
 
-export const UTILS_JS = `import { clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
- 
+export const UTILS_JS = `import { twJoin } from "tailwind-merge"
+
 export function cn(...inputs) {
-  return twMerge(clsx(inputs))
+  return twJoin(...inputs)
 }
 `
 

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -1,12 +1,15 @@
-import fs from "fs"
-import path from "path"
-import { execa } from "execa"
-import { afterEach, expect, test, vi } from "vitest"
+import fs from "fs";
+import path from "path";
+import { execa } from "execa";
+import { afterEach, expect, test, vi } from "vitest";
 
-import { runInit } from "../../src/commands/init"
-import { getConfig } from "../../src/utils/get-config"
-import * as getPackageManger from "../../src/utils/get-package-manager"
-import * as registry from "../../src/utils/registry"
+
+
+import { runInit } from "../../src/commands/init";
+import { getConfig } from "../../src/utils/get-config";
+import * as getPackageManger from "../../src/utils/get-package-manager";
+import * as registry from "../../src/utils/registry";
+
 
 vi.mock("execa")
 vi.mock("fs/promises", () => ({
@@ -69,7 +72,9 @@ test("init config-full", async () => {
   expect(mockWriteFile).toHaveBeenNthCalledWith(
     3,
     expect.stringMatching(/src\/lib\/utils.ts$/),
-    expect.stringContaining(`import { type ClassValue, clsx } from "clsx"`),
+    expect.stringContaining(
+      `import { ClassNameValue, twJoin } from "tailwind-merge"`
+    ),
     "utf8"
   )
   expect(execa).toHaveBeenCalledWith(
@@ -78,7 +83,6 @@ test("init config-full", async () => {
       "add",
       "tailwindcss-animate",
       "class-variance-authority",
-      "clsx",
       "tailwind-merge",
       "@radix-ui/react-icons",
     ],
@@ -139,7 +143,9 @@ test("init config-partial", async () => {
   expect(mockWriteFile).toHaveBeenNthCalledWith(
     3,
     expect.stringMatching(/utils.ts$/),
-    expect.stringContaining(`import { type ClassValue, clsx } from "clsx"`),
+    expect.stringContaining(
+      `import { ClassNameValue, twJoin } from "tailwind-merge"`
+    ),
     "utf8"
   )
   expect(execa).toHaveBeenCalledWith(
@@ -148,7 +154,6 @@ test("init config-partial", async () => {
       "install",
       "tailwindcss-animate",
       "class-variance-authority",
-      "clsx",
       "tailwind-merge",
       "lucide-react",
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,9 +433,6 @@ importers:
       class-variance-authority:
         specifier: ^0.4.0
         version: 0.4.0(typescript@4.9.5)
-      clsx:
-        specifier: ^1.2.1
-        version: 1.2.1
       lucide-react:
         specifier: 0.105.0-alpha.4
         version: 0.105.0-alpha.4(react@18.2.0)
@@ -502,7 +499,7 @@ importers:
         version: 2.8.8
       tailwindcss:
         specifier: ^3.3.2
-        version: 3.3.2(ts-node@10.9.1)
+        version: 3.3.2
       typescript:
         specifier: ^4.9.5
         version: 4.9.5
@@ -6151,7 +6148,7 @@ packages:
     dependencies:
       fast-glob: 3.3.0
       postcss: 8.4.24
-      tailwindcss: 3.3.2(ts-node@10.9.1)
+      tailwindcss: 3.3.2
     dev: true
 
   /eslint-plugin-turbo@1.9.9(eslint@8.41.0):
@@ -9167,6 +9164,22 @@ packages:
       yaml: 1.10.2
     dev: true
 
+  /postcss-load-config@4.0.1(postcss@8.4.24):
+    resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.1.0
+      postcss: 8.4.24
+      yaml: 2.3.1
+
   /postcss-load-config@4.0.1(postcss@8.4.24)(ts-node@10.9.1):
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
@@ -10452,8 +10465,39 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders'
     dependencies:
-      tailwindcss: 3.3.2(ts-node@10.9.1)
+      tailwindcss: 3.3.2
     dev: false
+
+  /tailwindcss@3.3.2:
+    resolution: {integrity: sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.5.3
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.2.12
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.18.2
+      lilconfig: 2.1.0
+      micromatch: 4.0.5
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.24
+      postcss-import: 15.1.0(postcss@8.4.24)
+      postcss-js: 4.0.1(postcss@8.4.24)
+      postcss-load-config: 4.0.1(postcss@8.4.24)
+      postcss-nested: 6.0.1(postcss@8.4.24)
+      postcss-selector-parser: 6.0.13
+      postcss-value-parser: 4.2.0
+      resolve: 1.22.2
+      sucrase: 3.32.0
+    transitivePeerDependencies:
+      - ts-node
 
   /tailwindcss@3.3.2(ts-node@10.9.1):
     resolution: {integrity: sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==}

--- a/templates/next-template/lib/utils.ts
+++ b/templates/next-template/lib/utils.ts
@@ -1,6 +1,5 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { ClassNameValue, twJoin } from "tailwind-merge"
 
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+export function cn(...inputs: ClassNameValue[]) {
+  return twJoin(...inputs)
 }

--- a/templates/next-template/package.json
+++ b/templates/next-template/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.4.0",
-    "clsx": "^1.2.1",
     "lucide-react": "0.105.0-alpha.4",
     "next": "^13.4.8",
     "next-themes": "^0.2.1",


### PR DESCRIPTION
`tailwind-merge` already have a build-in function `twJoin` to do the same thing with `twMerge(clsx([]))`.

But this will be a breaking change, because `twJoin` didn't support object syntax like this:
```ts
import clsx from 'clsx'

const c = clsx({ 'h-full': true })
```
The author of `tailwind-merge` explained here: https://github.com/dcastil/tailwind-merge/discussions/137#discussioncomment-3481605

So, I think use `twJoin` is enough, we don't need `clsx`