### PR TITLE
docs: Fix typo in aspect-ratio example

### DIFF
--- a/apps/www/content/docs/components/aspect-ratio.mdx
+++ b/apps/www/content/docs/components/aspect-ratio.mdx
@@ -60,7 +60,7 @@ import { AspectRatio } from "@/components/ui/aspect-ratio"
   <AspectRatio ratio={16 / 9}>
     <Image
       src="..."
-      alt=Image""
+      alt="Image"
       className="rounded-md object-cover"
     />
   </AspectRatio>


### PR DESCRIPTION
Fixed typo in aspect-ratio docs example.