### PR TITLE
Fix: Adding `whitespace: nowrap` property to `Badge` component

### DIFF
--- a/apps/www/registry/default/ui/badge.tsx
+++ b/apps/www/registry/default/ui/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 whitespace-nowrap",
   {
     variants: {
       variant: {

--- a/apps/www/registry/new-york/ui/badge.tsx
+++ b/apps/www/registry/new-york/ui/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 whitespace-nowrap",
   {
     variants: {
       variant: {


### PR DESCRIPTION
# Problem
Currently, the `Badge` component lacks the `whitespace: nowrap` property, resulting in situations where(https://github.com/shadcn-ui/ui/assets/24266984/3d716826-6c7f-4286-ba5c-6c32cb9e1223) a single badge containing two words may wrap to the next line
[Screenshot 2023-08-01 at 1 23 16 PM](https://github.com/shadcn-ui/ui/assets/24266984/3d716826-6c7f-4286-ba5c-6c32cb9e1223)

# Proposed Solution
I believe that in most cases, users would prefer the `Badge` component to appear on a single line. Therefore, I suggest adding the `nowrap` property by default. Users who need a different behavior, such as breaking it into two or more lines, can explicitly set the `wrap` property.

# Changes Made
To address this, I have added the `whitespace: nowrap` property to the `Badge` component by default.

# Benefits
- Consistent appearance: Badges will be displayed on a single line, improving visual consistency across the application.
- Simplicity: Developers won't need to manually specify `nowrap` for each badge, reducing boilerplate code.
- Improved user experience: Two-line badges can be avoided in most scenarios, resulting in a cleaner UI.

I have tested this change extensively, and it works seamlessly with existing components.

Please review this pull request, and I'm open to any feedback or suggestions.

Thank you for your time and consideration!