### PR TITLE
fix: `yarn` copy command for installing components

### DIFF
--- a/apps/www/lib/rehype-npm-command.ts
+++ b/apps/www/lib/rehype-npm-command.ts
@@ -43,7 +43,10 @@ export function rehypeNpmCommand() {
       ) {
         const npmCommand = node.properties?.["__rawString__"]
         node.properties["__npmCommand__"] = npmCommand
-        node.properties["__yarnCommand__"] = npmCommand
+        node.properties["__yarnCommand__"] = npmCommand.replace(
+          "npx",
+          "yarn dlx"
+        )
         node.properties["__pnpmCommand__"] = npmCommand.replace(
           "npx",
           "pnpm dlx"


### PR DESCRIPTION
- [yarn dlx](https://yarnpkg.com/cli/dlx) is the equivalent of `npx` in yarn 2.x

**Edit**: 
Even though this somehow worked for me with yarn `1.22.19`, I think it should be properly tested.

![yarn dlx](https://github.com/shadcn-ui/ui/assets/24194621/1cc39f21-7212-4e46-88d0-32116a51e2c0)



Closes #1109