### PR TITLE
Add Color Theme Generator to docs

### DIFF
--- a/apps/www/content/docs/theming.mdx
+++ b/apps/www/content/docs/theming.mdx
@@ -185,6 +185,6 @@ You can now use the `warning` utility class in your components.
 
 ### Other color formats
 
-I recommend using [HSL colors](https://www.smashingmagazine.com/2021/07/hsl-colors-css/) for theming but you can also use other color formats if you prefer.
+I recommend using [HSL colors](https://www.smashingmagazine.com/2021/07/hsl-colors-css/) for theming but you can also use other color formats if you prefer. You can also automatically color schemes using this [Shadcn UI Theme Generator](https://gradient.page/hex).
 
 See the [Tailwind CSS documentation](https://tailwindcss.com/docs/customizing-colors#using-css-variables) for more information on using `rgb`, `rgba` or `hsl` colors.


### PR DESCRIPTION
This will add a link to the hex code page, where users can select a theme from the list. From that page, they can use the [gradient picker](https://github.com/Illyism/gradient-picker) to set custom HEX or gradients.