### PR TITLE
feat(docs): add dark mode support for remix

### DIFF
--- a/apps/www/content/docs/dark-mode/index.mdx
+++ b/apps/www/content/docs/dark-mode/index.mdx
@@ -30,8 +30,22 @@ description: Adding dark mode to your site.
     </svg>
     <p className="font-medium mt-2">Vite</p>
   </LinkedCard>
+  <LinkedCard href="/docs/dark-mode/remix">
+    <svg
+      role="img"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      className="w-10 h-10"
+      fill="currentColor"
+    >
+      <title>Remix</title>      
+      <path fillRule="evenodd" clipRule="evenodd" d="M17.6384 15.833C17.766 17.4725 17.766 18.2411 17.766 19.08H13.9727C13.9727 18.8973 13.9759 18.7301 13.9792 18.5606C13.9895 18.0337 14.0002 17.4842 13.9148 16.3746C13.802 14.75 13.1024 14.389 11.8161 14.389H10.6765H5.85V11.4333H11.9967C13.6215 11.4333 14.4339 10.939 14.4339 9.63033C14.4339 8.47962 13.6215 7.7823 11.9967 7.7823H5.85V4.89H12.6737C16.3521 4.89 18.18 6.62736 18.18 9.4026C18.18 11.4784 16.8937 12.8322 15.156 13.0578C16.6229 13.3511 17.4804 14.1859 17.6384 15.833Z" />
+      <path d="M5.85 19.08V16.8766H9.86091C10.5309 16.8766 10.6763 17.3735 10.6763 17.6698V19.08H5.85Z" />
+      </svg>
+    <p className="font-medium mt-2">Remix</p>
+  </LinkedCard>
 </div>
 
 ## Other frameworks
 
-I'm looking for help writing guides for other frameworks. Help me write guides for Remix, Astro and Vite by [opening an PR](https://github.com/shadcn/ui).
+I'm looking for help writing guides for other frameworks. Help me write guides for Astro by [opening an PR](https://github.com/shadcn/ui).

--- a/apps/www/content/docs/dark-mode/remix.mdx
+++ b/apps/www/content/docs/dark-mode/remix.mdx
@@ -1,0 +1,122 @@
+---
+title: Remix
+description: Adding dark mode to your remix app.
+---
+
+## Dark mode
+
+<Steps>
+
+### Create your session storage and themeSessionResolver
+
+```tsx title="sessions.server.tsx"
+import { createThemeSessionResolver } from 'remix-themes'
+
+const sessionStorage = createCookieSessionStorage({
+  cookie: {
+    name: '__remix-themes',
+    // domain: 'remix.run',
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax',
+    secrets: ['s3cr3t'],
+    // secure: true,
+  },
+})
+
+export const themeSessionResolver = createThemeSessionResolver(sessionStorage)
+```
+
+### Update your root layout
+
+Create a new component with the `ThemeProvider` to wrap the `App` component.
+
+```tsx {1-9,12-13,21,34-41} title="root.tsx"
+import { ThemeProvider, useTheme, PreventFlashOnWrongTheme } from 'remix-themes'
+import { themeSessionResolver } from './sessions.server'
+
+export const loader: LoaderFunction = async ({request}) => {
+  const {getTheme} = await themeSessionResolver(request)
+  return {
+    theme: getTheme(),
+  }
+}
+
+function App() {
+  const data = useLoaderData()
+  const [theme] = useTheme()
+
+  return (
+    <html lang="en" className={theme ?? ''}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <Meta />
+        <PreventFlashOnWrongTheme ssrTheme={Boolean(data.theme)} />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        {process.env.NODE_ENV === 'development' && <LiveReload />}
+      </body>
+    </html>
+  )
+}
+
+export default function AppWithProviders() {
+  const data = useLoaderData()
+  return (
+    <ThemeProvider specifiedTheme={data.theme} themeAction="/action/set-theme">
+      <App />
+    </ThemeProvider>
+  )
+}
+```
+
+### Add the action route
+Create a file in `/routes/action.set-theme.ts` with the content below. Ensure that you pass the filename to the ThemeProvider component.
+
+```tsx title="app/routes/action.set-theme.tsx"
+import {createThemeAction} from 'remix-themes'
+import { themeSessionResolver } from '~/sessions.server'
+
+export const action = createThemeAction(themeSessionResolver)
+```
+
+### Add mode toggle
+Place a mode toggle on your site to toggle between light and dark mode.
+
+```tsx title="app/components/mode-toggle.tsx"
+import { MoonIcon, SunIcon } from "@radix-ui/react-icons"
+import { Theme, useTheme } from "remix-themes"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./ui/dropdown-menu"
+import { Button } from "./ui/button"
+
+export function ModeToggle() {
+  const [, setTheme] = useTheme()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon">
+          <SunIcon className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <MoonIcon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme(Theme.LIGHT)}>
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme(Theme.DARK)}>
+          Dark
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+```
+
+</Steps>


### PR DESCRIPTION
Add dark mode support for remix

Let me know if there is a problem with the PR.

For some reason the variables in the `tailwind.css` file like
```css
@layer base {
  :root {
   /* */
  }
  .dark {
     /* */
  }

@layer base{
  * {
    @apply border-border;
  }
  body {
    @apply bg-background text-foreground;
  }
}
```
The code above doesn't work. For the dark mode to work i have to modify the file and delete the layer and put the content in the root of the file
```css
:root {
 /* */
}
.dark {
   /* */
}
* {
  @apply border-border;
}
body {
  @apply bg-background text-foreground;
}
```

I didn't include that in the remix doc because i don't think that is a correct behavior so i guess it should be a fix in the core package or something like, i'm not sure.

Let know what do you think. Thanks