### PR TITLE
feat: Add max-height and overflow-y for scrollable dropdown(#1175)

### DIFF
--- a/apps/www/registry/default/ui/select.tsx
+++ b/apps/www/registry/default/ui/select.tsx
@@ -50,7 +50,7 @@ const SelectContent = React.forwardRef<
     >
       <SelectPrimitive.Viewport
         className={cn(
-          "p-1",
+          "p-1 overflow-y-auto max-h-[250px]",
           position === "popper" &&
             "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
         )}


### PR DESCRIPTION
Resolves #1175

Added the necessary styles to enable scrolling for dropdowns with a large number of items. This change ensures that the dropdown content is contained within a maximum height of 250px and becomes scrollable when the content exceeds this limit. Users can now easily navigate through long lists of options without any layout issues.

This enhancement improves the user experience when dealing with extensive dropdown options. It prevents the dropdown from taking up excessive screen space while maintaining usability.

To test the change:
1. Open a dropdown with a large number of items.
2. Verify that the dropdown content is scrollable and contained within the designated height.
3. Check for any visual glitches or layout problems.

Closes #1175