### PR TITLE
docs(form-component): add missing `useForm` import to example

### DIFF
--- a/apps/www/content/docs/components/form.mdx
+++ b/apps/www/content/docs/components/form.mdx
@@ -106,11 +106,12 @@ const formSchema = z.object({
 
 Use the `useForm` hook from `react-hook-form` to create a form.
 
-```tsx showLineNumbers {4,14-20,22-27}
+```tsx showLineNumbers {4-5,14-20,22-27}
 "use client"
 
 import Link from "next/link"
 import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
 import * as z from "zod"
 
 const formSchema = z.object({
@@ -148,6 +149,7 @@ We can now use the `<Form />` components to build our form.
 
 import Link from "next/link"
 import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
 import * as z from "zod"
 
 import { Button } from "@/components/ui/button"


### PR DESCRIPTION
Closes: #1223 

Updated the Form component doc to include the missing `useForm` import in the example code for better clarity.