### PR TITLE
fix(docs): missing form manual installation and aspect-ratio typo

### DIFF
--- a/apps/www/content/docs/components/aspect-ratio.mdx
+++ b/apps/www/content/docs/components/aspect-ratio.mdx
@@ -58,11 +58,7 @@ import { AspectRatio } from "@/components/ui/aspect-ratio"
 ```tsx
 <div className="w-[450px]">
   <AspectRatio ratio={16 / 9}>
-    <Image
-      src="..."
-      alt=Image""
-      className="rounded-md object-cover"
-    />
+    <Image src="..." alt="Image" className="rounded-md object-cover" />
   </AspectRatio>
 </div>
 ```

--- a/apps/www/content/docs/components/form.mdx
+++ b/apps/www/content/docs/components/form.mdx
@@ -73,6 +73,14 @@ const form = useForm()
 
 ## Installation
 
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
 <Steps>
 
 ### Command
@@ -82,6 +90,30 @@ npx shadcn-ui@latest add form
 ```
 
 </Steps>
+
+</TabsContent>
+
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Install the following dependencies:</Step>
+
+```bash
+npm install @radix-ui/react-label @radix-ui/react-slot react-hook-form
+```
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<ComponentSource name="form" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>
 
 ## Usage
 


### PR DESCRIPTION
This PR:
- Fixes #967 
- Fixes #687 (only form docs)
- Fixes typo in aspect-ratio alt prop