### PR TITLE
fix(docs): add missing files in toast manual installation and data-table

### DIFF
--- a/apps/www/content/docs/components/toast.mdx
+++ b/apps/www/content/docs/components/toast.mdx
@@ -61,7 +61,17 @@ npm install @radix-ui/react-toast
 
 <Step>Copy and paste the following code into your project.</Step>
 
+`toast.tsx`
+
 <ComponentSource name="toast" />
+
+`toaster.tsx`
+
+<ComponentSource name="toast" fileName="toaster" />
+
+`use-toast.tsx`
+
+<ComponentSource name="toast" fileName="use-toast" />
 
 <Step>Update the import paths to match your project setup.</Step>
 

--- a/apps/www/lib/rehype-component.ts
+++ b/apps/www/lib/rehype-component.ts
@@ -10,19 +10,41 @@ import { styles } from "../registry/styles"
 export function rehypeComponent() {
   return async (tree: UnistTree) => {
     visit(tree, (node: UnistNode) => {
-      const { value: src } = getNodeAttributeByName(node, "src") || {}
+      // src prop overrides both name and fileName.
+      const { value: srcPath } =
+        (getNodeAttributeByName(node, "src") as {
+          name: string
+          value?: string
+          type?: string
+        }) || {}
 
       if (node.name === "ComponentSource") {
         const name = getNodeAttributeByName(node, "name")?.value as string
+        const fileName = getNodeAttributeByName(node, "fileName")?.value as
+          | string
+          | undefined
 
-        if (!name) {
+        if (!name && !srcPath) {
           return null
         }
 
         try {
           for (const style of styles) {
-            const component = Index[style.name][name]
-            const src = component.files[0]
+            let src: string
+
+            if (srcPath) {
+              src = srcPath
+            } else {
+              const component = Index[style.name][name]
+              src = fileName
+                ? component.files.find((file: string) => {
+                    return (
+                      file.endsWith(`${fileName}.tsx`) ||
+                      file.endsWith(`${fileName}.ts`)
+                    )
+                  }) || component.files[0]
+                : component.files[0]
+            }
 
             // Read the source file.
             const filePath = path.join(process.cwd(), src)


### PR DESCRIPTION
This PR:
- Fixes #780 
- Fixes #687 (only toast docs)