### PR TITLE
fix(table): horizontal scroll on Chrome

### DIFF
--- a/apps/www/registry/new-york/ui/table.tsx
+++ b/apps/www/registry/new-york/ui/table.tsx
@@ -6,7 +6,7 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="w-full overflow-auto">
+  <div className="relative w-full overflow-auto">
     <table
       ref={ref}
       className={cn("w-full caption-bottom text-sm", className)}


### PR DESCRIPTION
This PR addresses an issue specific to Chrome where overflow isn't handled correctly, especially on mobile devices.

<details>
  <summary>Before</summary>

https://github.com/shadcn-ui/ui/assets/24194621/c00f2e39-7ec1-4a7b-b85d-6a4cdde2f185
</details>

<details>
  <summary>After</summary>

https://github.com/shadcn-ui/ui/assets/24194621/605df73c-ce06-4fde-82d3-e24d8fa903ab
</details>

