### PR TITLE
feat: add dropdown menu with react hook forms (which enables multi select and can can be an alternative for multi-select)

### DIFF
--- a/apps/www/__registry__/index.tsx
+++ b/apps/www/__registry__/index.tsx
@@ -586,6 +586,13 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/default/example/dropdown-menu-radio-group")),
       files: ["registry/default/example/dropdown-menu-radio-group.tsx"],
     },
+    "dropdown-menu-form":{
+      name: "dropdown-menu-form",
+      type: "components:example",
+      registryDependencies: ["dropdown-menu", "checkbox", "form"],
+      component: React.lazy(() => import("@/registry/default/example/dropdown-menu-form")),
+      files: ["registry/default/example/dropdown-menu-form.tsx"],
+    },
     "hover-card-demo": {
       name: "hover-card-demo",
       type: "components:example",
@@ -1594,6 +1601,13 @@ export const Index: Record<string, any> = {
       registryDependencies: ["dropdown-menu","radio-group"],
       component: React.lazy(() => import("@/registry/new-york/example/dropdown-menu-radio-group")),
       files: ["registry/new-york/example/dropdown-menu-radio-group.tsx"],
+    },
+    "dropdown-menu-form":{
+      name: "dropdown-menu-form",
+      type: "components:example",
+      registryDependencies: ["dropdown-menu", "checkbox", "form"],
+      component: React.lazy(() => import("@/registry/new-york/example/dropdown-menu-form")),
+      files: ["registry/new-york/example/dropdown-menu-form.tsx"],
     },
     "hover-card-demo": {
       name: "hover-card-demo",

--- a/apps/www/content/docs/components/dropdown-menu.mdx
+++ b/apps/www/content/docs/components/dropdown-menu.mdx
@@ -84,3 +84,7 @@ import {
 ### Radio Group
 
 <ComponentPreview name="dropdown-menu-radio-group" />
+
+### Form
+
+<ComponentPreview name="dropdown-menu-form" />

--- a/apps/www/registry/default/example/dropdown-menu-form.tsx
+++ b/apps/www/registry/default/example/dropdown-menu-form.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import * as z from "zod"
+
+import { Button } from "@/registry/default/ui/button"
+import {
+    Form,
+    FormDescription,
+    FormField,
+    FormLabel,
+} from "@/registry/default/ui/form"
+import { toast } from "@/registry/default/ui/use-toast"
+import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from "@/registry/default/ui/dropdown-menu"
+import { ChevronDown } from "lucide-react"
+
+
+const regions = [
+    {
+        value: "allRegions",
+        label: "All Regions"
+    },
+    {
+        value: "india",
+        label: "India"
+    },
+    {
+        value: "usa",
+        label: "USA"
+    },
+    {
+        value: "europe",
+        label: "Europe"
+    },
+    {
+        value: "apac",
+        label: "APAC"
+    },
+] as const
+
+
+const FormSchema = z.object({
+    regions: z.array(z.string()).refine((value) => value.some((item) => item), {
+        message: "You have to select at least one region.",
+    }),
+})
+
+
+export default function DropdownMenuReactHookForm() {
+    const form = useForm<z.infer<typeof FormSchema>>({
+        resolver: zodResolver(FormSchema),
+        defaultValues: {
+            regions: ["india", "usa"]
+        }
+    })
+
+
+    function onSubmit(data: z.infer<typeof FormSchema>) {
+        toast({
+            title: "You submitted the following values:",
+            description: (
+                <pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
+                    <code className="text-white">{JSON.stringify(data, null, 2)}</code>
+                </pre>
+            ),
+        })
+    }
+
+    return (
+        <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+                <div className="mb-4">
+                    <FormLabel className="text-base">Regions</FormLabel>
+                    <FormDescription>
+                        Select the regions.
+                    </FormDescription>
+                </div>
+                <FormField
+                    control={form.control}
+                    name="regions"
+                    render={({ field }) => {
+                        return <DropdownMenu >
+                            <DropdownMenuTrigger asChild>
+                                <Button variant="outline" className="flex flex-row gap-2">All Regions
+                                    <ChevronDown />
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent className="w-56">
+                                {
+                                    regions.map((region) => {
+                                        return <DropdownMenuCheckboxItem
+                                            key={region.value}
+                                            checked={field.value?.includes(region.value)}
+                                            onCheckedChange={(checked) => {
+                                                return checked ? field.onChange([...field.value, region.value]) : field.onChange(field.value?.filter((value) => value != region.value))
+                                            }}
+                                        >
+                                            {region.label}
+                                        </DropdownMenuCheckboxItem>
+                                    })
+                                }
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    }}
+                />
+                <Button type="submit">Submit</Button>
+            </form>
+        </Form >
+    )
+}

--- a/apps/www/registry/new-york/example/dropdown-menu-form.tsx
+++ b/apps/www/registry/new-york/example/dropdown-menu-form.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import * as z from "zod"
+
+import { Button } from "@/registry/new-york/ui/button"
+import {
+    Form,
+    FormDescription,
+    FormField,
+    FormLabel,
+} from "@/registry/new-york/ui/form"
+import { toast } from "@/registry/new-york/ui/use-toast"
+import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from "@/registry/new-york/ui/dropdown-menu"
+import { ChevronDown } from "lucide-react"
+
+
+const regions = [
+    {
+        value: "allRegions",
+        label: "All Regions"
+    },
+    {
+        value: "india",
+        label: "India"
+    },
+    {
+        value: "usa",
+        label: "USA"
+    },
+    {
+        value: "europe",
+        label: "Europe"
+    },
+    {
+        value: "apac",
+        label: "APAC"
+    },
+] as const
+
+
+const FormSchema = z.object({
+    regions: z.array(z.string()).refine((value) => value.some((item) => item), {
+        message: "You have to select at least one region.",
+    }),
+})
+
+
+export default function DropdownMenuReactHookForm() {
+    const form = useForm<z.infer<typeof FormSchema>>({
+        resolver: zodResolver(FormSchema),
+        defaultValues: {
+            regions: ["india", "usa"]
+        }
+    })
+
+
+    function onSubmit(data: z.infer<typeof FormSchema>) {
+        toast({
+            title: "You submitted the following values:",
+            description: (
+                <pre className="mt-2 w-[340px] rounded-md bg-slate-950 p-4">
+                    <code className="text-white">{JSON.stringify(data, null, 2)}</code>
+                </pre>
+            ),
+        })
+    }
+
+    return (
+        <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+                <div className="mb-4">
+                    <FormLabel className="text-base">Regions</FormLabel>
+                    <FormDescription>
+                        Select the regions.
+                    </FormDescription>
+                </div>
+                <FormField
+                    control={form.control}
+                    name="regions"
+                    render={({ field }) => {
+                        return <DropdownMenu >
+                            <DropdownMenuTrigger asChild>
+                                <Button variant="outline" className="flex flex-row gap-2">All Regions
+                                    <ChevronDown />
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent className="w-56">
+                                {
+                                    regions.map((region) => {
+                                        return <DropdownMenuCheckboxItem
+                                            key={region.value}
+                                            checked={field.value?.includes(region.value)}
+                                            onCheckedChange={(checked) => {
+                                                return checked ? field.onChange([...field.value, region.value]) : field.onChange(field.value?.filter((value) => value != region.value))
+                                            }}
+                                        >
+                                            {region.label}
+                                        </DropdownMenuCheckboxItem>
+                                    })
+                                }
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    }}
+                />
+                <Button type="submit">Submit</Button>
+            </form>
+        </Form >
+    )
+}

--- a/apps/www/registry/registry.ts
+++ b/apps/www/registry/registry.ts
@@ -510,6 +510,12 @@ const example: Registry = [
     files: ["example/dropdown-menu-radio-group.tsx"],
   },
   {
+    name: "dropdown-menu-form",
+    type: "components:example",
+    registryDependencies: ["dropdown-menu", "checkbox", "form"],
+    files: ["example/dropdown-menu-form.tsx"],
+  },
+  {
     name: "hover-card-demo",
     type: "components:example",
     registryDependencies: ["hover-card"],


### PR DESCRIPTION
Hi @shadcn 
I hope this message finds you well. 

In this pull request, I've added a much-needed feature to the repository's example, specifically focusing on incorporating a dropdown menu using React Hook Forms. 

I've thoroughly tested the changes to ensure they integrate smoothly and maintain the project's overall stability. Your feedback and insights on this implementation would be greatly appreciated.

Thank you for considering my contribution. Looking forward to your feedback and the opportunity to merge this enhancement into the main branch.

