### PR TITLE
 removed padding and height from button with variant "link"

### DIFF
--- a/templates/next-template/components/ui/button.tsx
+++ b/templates/next-template/components/ui/button.tsx
@@ -26,6 +26,12 @@ const buttonVariants = cva(
         icon: "h-10 w-10",
       },
     },
+    compoundVariants: [
+      {
+        variant: "link",
+        className: "p-0 h-auto",
+      },
+    ],
     defaultVariants: {
       variant: "default",
       size: "default",


### PR DESCRIPTION
Removed padding and height from button with variant 'link.' Padding and height are good with other variants, but they don't make sense with the link type because it doesn't matter here. This was causing a bad UX since the hover event was being emitted outside of the actual text placement.