### PR TITLE
perf(form): scoped field subscription state

### DIFF
--- a/apps/www/registry/default/ui/form.tsx
+++ b/apps/www/registry/default/ui/form.tsx
@@ -8,6 +8,7 @@ import {
   FieldValues,
   FormProvider,
   useFormContext,
+  useFormState,
 } from "react-hook-form"
 
 import { cn } from "@/lib/utils"
@@ -42,7 +43,8 @@ const FormField = <
 const useFormField = () => {
   const fieldContext = React.useContext(FormFieldContext)
   const itemContext = React.useContext(FormItemContext)
-  const { getFieldState, formState } = useFormContext()
+  const { getFieldState } = useFormContext()
+  const formState = useFormState({ name: fieldContext.name })
 
   const fieldState = getFieldState(fieldContext.name, formState)
 

--- a/apps/www/registry/new-york/ui/form.tsx
+++ b/apps/www/registry/new-york/ui/form.tsx
@@ -8,6 +8,7 @@ import {
   FieldValues,
   FormProvider,
   useFormContext,
+  useFormState,
 } from "react-hook-form"
 
 import { cn } from "@/lib/utils"
@@ -42,7 +43,8 @@ const FormField = <
 const useFormField = () => {
   const fieldContext = React.useContext(FormFieldContext)
   const itemContext = React.useContext(FormItemContext)
-  const { getFieldState, formState } = useFormContext()
+  const { getFieldState } = useFormContext()
+  const formState = useFormState({ name: fieldContext.name })
 
   const fieldState = getFieldState(fieldContext.name, formState)
 


### PR DESCRIPTION
# Improve react hook form rerenders

using [useFormState](https://react-hook-form.com/docs/useformstate) to scope `fieldState` subscription at field level to avoid unnecessary rerender for other fields

## Before
https://www.loom.com/share/4b5b78b4efe14d7b947c8b5de13da678

## After
https://www.loom.com/share/7620fe449325438a8270f68f86ee5111