### PR TITLE
fix(cli-nextjs-bug): 404 error on next after init command

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,9 +1,9 @@
-import { existsSync, promises as fs } from "fs"
-import path from "path"
+import { existsSync, promises as fs } from "fs";
+import path from "path";
 import {
   DEFAULT_COMPONENTS,
+  DEFAULT_GLOBAL_CSS,
   DEFAULT_TAILWIND_CONFIG,
-  DEFAULT_TAILWIND_CSS,
   DEFAULT_UTILS,
   getConfig,
   rawConfigSchema,
@@ -120,7 +120,7 @@ export async function promptForConfig(
       type: "text",
       name: "tailwindCss",
       message: `Where is your ${highlight("global CSS")} file?`,
-      initial: defaultConfig?.tailwind.css ?? DEFAULT_TAILWIND_CSS,
+      initial: defaultConfig?.tailwind.css ?? DEFAULT_GLOBAL_CSS,
     },
     {
       type: "toggle",

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -7,7 +7,7 @@ import * as z from "zod"
 export const DEFAULT_STYLE = "default"
 export const DEFAULT_COMPONENTS = "@/components"
 export const DEFAULT_UTILS = "@/lib/utils"
-export const DEFAULT_TAILWIND_CSS = "app/globals.css"
+export const DEFAULT_GLOBAL_CSS = "src/app/globals.css"
 export const DEFAULT_TAILWIND_CONFIG = "tailwind.config.js"
 export const DEFAULT_TAILWIND_BASE_COLOR = "slate"
 


### PR DESCRIPTION
- [X] Fix #755 - on init command it points to the wrong global.css file path. This points to the correct src/app/global.css file