### PR TITLE
fix: stop unnecessary rerenders from useFormField

### DIFF
--- a/apps/www/registry/default/ui/form.tsx
+++ b/apps/www/registry/default/ui/form.tsx
@@ -42,9 +42,9 @@ const FormField = <
 const useFormField = () => {
   const fieldContext = React.useContext(FormFieldContext)
   const itemContext = React.useContext(FormItemContext)
-  const { getFieldState, formState } = useFormContext()
+  const { formState } = useFormContext()
 
-  const fieldState = getFieldState(fieldContext.name, formState)
+  const error = formState.errors[fieldContext.name]
 
   if (!fieldContext) {
     throw new Error("useFormField should be used within <FormField>")
@@ -58,7 +58,7 @@ const useFormField = () => {
     formItemId: `${id}-form-item`,
     formDescriptionId: `${id}-form-item-description`,
     formMessageId: `${id}-form-item-message`,
-    ...fieldState,
+    error,
   }
 }
 

--- a/apps/www/registry/new-york/ui/form.tsx
+++ b/apps/www/registry/new-york/ui/form.tsx
@@ -42,9 +42,9 @@ const FormField = <
 const useFormField = () => {
   const fieldContext = React.useContext(FormFieldContext)
   const itemContext = React.useContext(FormItemContext)
-  const { getFieldState, formState } = useFormContext()
+  const { formState } = useFormContext()
 
-  const fieldState = getFieldState(fieldContext.name, formState)
+  const error = formState.errors[fieldContext.name]
 
   if (!fieldContext) {
     throw new Error("useFormField should be used within <FormField>")
@@ -58,7 +58,7 @@ const useFormField = () => {
     formItemId: `${id}-form-item`,
     formDescriptionId: `${id}-form-item-description`,
     formMessageId: `${id}-form-item-message`,
-    ...fieldState,
+    error,
   }
 }
 


### PR DESCRIPTION
Hi, I noticed that when using `<Checkbox />` and `<RadioButtonGroup />` every time a button is clicked, the whole form re-renders because getFieldState() causes the re-render. In this PR I derive error from formState instead so that getFieldState() isn't called. This removes re-renders when using checkboxes, but not for radio buttons.

I'm not really sure if this is the way to go about it, but I wanted to get it to your attention. I think ideally, when using radio buttons, checkboxes, or switches, when an input is changed there isn't any rerenders.

 Thanks!