### PR TITLE
feat(kbd-component): new kbd tag component proposal

### DIFF
--- a/apps/www/__registry__/index.tsx
+++ b/apps/www/__registry__/index.tsx
@@ -47,6 +47,13 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/default/ui/badge")),
       files: ["registry/default/ui/badge.tsx"],
     },
+    "kbd": {
+      name: "kbd",
+      type: "components:ui",
+      registryDependencies: undefined,
+      component: React.lazy(() => import("@/registry/default/ui/kbd")),
+      files: ["registry/default/ui/kbd.tsx"],
+    },
     "button": {
       name: "button",
       type: "components:ui",
@@ -333,6 +340,13 @@ export const Index: Record<string, any> = {
       registryDependencies: ["badge"],
       component: React.lazy(() => import("@/registry/default/example/badge-secondary")),
       files: ["registry/default/example/badge-secondary.tsx"],
+    },
+    "kbd-demo": {
+      name: "kbd-demo",
+      type: "components:example",
+      registryDependencies: ["kbd"],
+      component: React.lazy(() => import("@/registry/default/example/kbd-demo")),
+      files: ["registry/default/example/kbd-demo.tsx"],
     },
     "button-demo": {
       name: "button-demo",
@@ -1056,6 +1070,13 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/new-york/ui/badge")),
       files: ["registry/new-york/ui/badge.tsx"],
     },
+    "kbd": {
+      name: "kbd",
+      type: "components:ui",
+      registryDependencies: undefined,
+      component: React.lazy(() => import("@/registry/new-york/ui/kbd")),
+      files: ["registry/new-york/ui/kbd.tsx"],
+    },
     "button": {
       name: "button",
       type: "components:ui",
@@ -1342,6 +1363,13 @@ export const Index: Record<string, any> = {
       registryDependencies: ["badge"],
       component: React.lazy(() => import("@/registry/new-york/example/badge-secondary")),
       files: ["registry/new-york/example/badge-secondary.tsx"],
+    },
+    "kbd-demo": {
+      name: "kbd-demo",
+      type: "components:example",
+      registryDependencies: ["kbd"],
+      component: React.lazy(() => import("@/registry/new-york/example/kbd-demo")),
+      files: ["registry/new-york/example/kbd-demo.tsx"],
     },
     "button-demo": {
       name: "button-demo",

--- a/apps/www/config/docs.ts
+++ b/apps/www/config/docs.ts
@@ -258,6 +258,11 @@ export const docsConfig: DocsConfig = {
           items: [],
         },
         {
+          title: "Kbd",
+          href: "/docs/components/kbd",
+          items: [],
+        },
+        {
           title: "Label",
           href: "/docs/components/label",
           items: [],

--- a/apps/www/content/docs/components/kbd.mdx
+++ b/apps/www/content/docs/components/kbd.mdx
@@ -1,0 +1,55 @@
+---
+title: Kbd
+description: Displays a kbd tag.
+component: true
+---
+
+<ComponentPreview name="kbd-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn-ui@latest add kbd
+```
+
+</TabsContent>
+
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<ComponentSource name="kbd" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>
+
+## Usage
+
+```tsx
+import { Kbd } from "@/components/ui/kbd"
+```
+
+```tsx
+<Kbd>Alt</Kbd>
+```
+
+## Examples
+
+### Default
+
+<ComponentPreview name="kbd-demo" />

--- a/apps/www/pages/api/components.json
+++ b/apps/www/pages/api/components.json
@@ -70,6 +70,17 @@
     "type": "ui"
   },
   {
+    "name": "kbd",
+    "files": [
+      {
+        "name": "kbd.tsx",
+        "dir": "components/ui",
+        "content": "import * as React from \"react\"\nimport { cva, type VariantProps } from \"class-variance-authority\"\n\nimport { cn } from \"@/lib/utils\"\n\nconst kbdVariants = cva(\n  \"h-5 rounded border-x-[1px] border-b-[3px] border-t-[1px] px-1.5 font-mono text-xs font-semibold\",\n  {\n    variants: {\n      variant: {\n        default: \"bg-muted\",\n      },\n    },\n    defaultVariants: {\n      variant: \"default\",\n    },\n  }\n)\n\nexport interface KbdProps\n  extends React.HTMLAttributes<HTMLDivElement>,\n    VariantProps<typeof kbdVariants> {}\n\nfunction Kbd({ className, variant, ...props }: KbdProps) {\n  return <kbd className={cn(kbdVariants({ variant }), className)} {...props} />\n}\n\nexport { Kbd, kbdVariants }\n"
+      }
+    ],
+    "type": "ui"
+  },
+  {
     "name": "button",
     "dependencies": ["@radix-ui/react-slot"],
     "files": [

--- a/apps/www/public/registry/index.json
+++ b/apps/www/public/registry/index.json
@@ -57,6 +57,13 @@
     "type": "components:ui"
   },
   {
+    "name": "kbd",
+    "files": [
+      "ui/kbd.tsx"
+    ],
+    "type": "components:ui"
+  },
+  {
     "name": "button",
     "dependencies": [
       "@radix-ui/react-slot"

--- a/apps/www/public/registry/styles/default/kbd.json
+++ b/apps/www/public/registry/styles/default/kbd.json
@@ -1,0 +1,10 @@
+{
+  "name": "kbd",
+  "files": [
+    {
+      "name": "kbd.tsx",
+      "content": "import * as React from \"react\"\nimport { cva, type VariantProps } from \"class-variance-authority\"\n\nimport { cn } from \"@/lib/utils\"\n\nconst kbdVariants = cva(\n  \"h-5 rounded border-x-[1px] border-b-[3px] border-t-[1px] px-1.5 font-mono text-xs font-semibold\",\n  {\n    variants: {\n      variant: {\n        default: \"bg-muted\",\n      },\n    },\n    defaultVariants: {\n      variant: \"default\",\n    },\n  }\n)\n\nexport interface KbdProps\n  extends React.HTMLAttributes<HTMLDivElement>,\n    VariantProps<typeof kbdVariants> {}\n\nfunction Kbd({ className, variant, ...props }: KbdProps) {\n  return <kbd className={cn(kbdVariants({ variant }), className)} {...props} />\n}\n\nexport { Kbd, kbdVariants }\n"
+    }
+  ],
+  "type": "components:ui"
+}

--- a/apps/www/registry/default/example/kbd-demo.tsx
+++ b/apps/www/registry/default/example/kbd-demo.tsx
@@ -1,0 +1,9 @@
+import { Kbd } from "@/registry/default/ui/kbd"
+
+export default function KbdDemo() {
+  return (
+    <span>
+      <Kbd>Alt</Kbd> + <Kbd>F4</Kbd>
+    </span>
+  )
+}

--- a/apps/www/registry/default/ui/kbd.tsx
+++ b/apps/www/registry/default/ui/kbd.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const kbdVariants = cva(
+  "h-5 rounded border-x-[1px] border-b-[3px] border-t-[1px] px-1.5 font-mono text-xs font-semibold shadow-sm",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface KbdProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof kbdVariants> {}
+
+function Kbd({ className, variant, ...props }: KbdProps) {
+  return <kbd className={cn(kbdVariants({ variant }), className)} {...props} />
+}
+
+export { Kbd, kbdVariants }

--- a/apps/www/registry/new-york/example/kbd-demo.tsx
+++ b/apps/www/registry/new-york/example/kbd-demo.tsx
@@ -1,0 +1,9 @@
+import { Kbd } from "@/registry/new-york/ui/kbd"
+
+export default function KbdDemo() {
+  return (
+    <span>
+      <Kbd>Alt</Kbd> + <Kbd>F4</Kbd>
+    </span>
+  )
+}

--- a/apps/www/registry/new-york/ui/kbd.tsx
+++ b/apps/www/registry/new-york/ui/kbd.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const kbdVariants = cva(
+  "h-4 rounded border-x-[1px] border-b-[3px] border-t-[1px] px-1 font-mono text-xs font-semibold",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface KbdProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof kbdVariants> {}
+
+function Kbd({ className, variant, ...props }: KbdProps) {
+  return <kbd className={cn(kbdVariants({ variant }), className)} {...props} />
+}
+
+export { Kbd, kbdVariants }

--- a/apps/www/registry/registry.ts
+++ b/apps/www/registry/registry.ts
@@ -37,6 +37,11 @@ const ui: Registry = [
     files: ["ui/badge.tsx"],
   },
   {
+    name: "kbd",
+    type: "components:ui",
+    files: ["ui/kbd.tsx"],
+  },
+  {
     name: "button",
     type: "components:ui",
     dependencies: ["@radix-ui/react-slot"],
@@ -288,6 +293,12 @@ const example: Registry = [
     type: "components:example",
     registryDependencies: ["badge"],
     files: ["example/badge-secondary.tsx"],
+  },
+  {
+    name: "kbd-demo",
+    type: "components:example",
+    registryDependencies: ["kbd"],
+    files: ["example/kbd-demo.tsx"],
   },
   {
     name: "button-demo",


### PR DESCRIPTION
I was working on a personal project and reached a point where I required a styled `<kbd>` tag. Considering this need, I believed it would be a valuable addition to create a proposal for a new component within this repository. Here, I'm presenting the new Kbd component along with visual representations:

**Light Mode**
![image](https://github.com/shadcn-ui/ui/assets/11697697/c45b7e2c-e23c-4cb5-b402-3d03ff9c6eb9)

**Dark Mode**
![image](https://github.com/shadcn-ui/ui/assets/11697697/8434bd69-5003-4533-a115-d4a37a89171f)

The Kbd component is designed for simplicity and ease of use. Incorporating it into your project is straightforward. You can import the Kbd component either by directly copying the code or utilizing the provided CLI. Once imported, you can employ it as shown in the example below:

```tsx
    <span>
      <Kbd>Alt</Kbd> + <Kbd>F4</Kbd>
    </span>
```

