### PR TITLE
Fix example combobox-form hovering issue

### DIFF
--- a/apps/www/registry/default/example/combobox-form.tsx
+++ b/apps/www/registry/default/example/combobox-form.tsx
@@ -100,7 +100,7 @@ export default function ComboboxForm() {
                     <CommandGroup>
                       {languages.map((language) => (
                         <CommandItem
-                          value={language.label}
+                          value={language.value}
                           key={language.value}
                           onSelect={() => {
                             form.setValue("language", language.value)

--- a/apps/www/registry/new-york/example/combobox-form.tsx
+++ b/apps/www/registry/new-york/example/combobox-form.tsx
@@ -103,7 +103,7 @@ export default function ComboboxForm() {
                     <CommandGroup>
                       {languages.map((language) => (
                         <CommandItem
-                          value={language.label}
+                          value={language.value}
                           key={language.value}
                           onSelect={() => {
                             form.setValue("language", language.value)


### PR DESCRIPTION
In the example for ComboBox Form there is a issue when there are multiple labels in the languages array the hover will be activated for all items with that label. My solution was to update the value of the CommandItem to the value of the language instead of the label.

![CleanShot 2023-08-27 at 00 44 10](https://github.com/shadcn-ui/ui/assets/25036645/d012a4db-7da3-43dd-a0e9-c8dd8b9adf9d)
