### PR TITLE
fix(toast): type error title when using reactnode

### DIFF
--- a/apps/www/registry/default/ui/use-toast.ts
+++ b/apps/www/registry/default/ui/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 const TOAST_LIMIT = 1
 const TOAST_REMOVE_DELAY = 1000000
 
-type ToasterToast = ToastProps & {
+type ToasterToast = Omit<ToastProps, 'id' | 'title' | 'description' | 'action'> & {
   id: string
   title?: React.ReactNode
   description?: React.ReactNode

--- a/apps/www/registry/new-york/ui/use-toast.ts
+++ b/apps/www/registry/new-york/ui/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 const TOAST_LIMIT = 1
 const TOAST_REMOVE_DELAY = 1000000
 
-type ToasterToast = ToastProps & {
+type ToasterToast = Omit<ToastProps, 'id' | 'title' | 'description' | 'action'> & {
   id: string
   title?: React.ReactNode
   description?: React.ReactNode


### PR DESCRIPTION
This PR will close issue #896 to enable toast title with `ReactNode`. Here's the preview

| Before | After |
|--------|--------|
| <img width="1225" alt="image" src="https://github.com/shadcn-ui/ui/assets/58651943/fc38bf6c-6c8d-4bc3-ab1d-7330e10dbe2b"> | <img width="448" alt="image" src="https://github.com/shadcn-ui/ui/assets/58651943/43dd0884-8d83-4d2d-bfad-d15f847f66de"> |


