### PR TITLE
docs: add import useForm

### DIFF
--- a/apps/www/content/docs/components/form.mdx
+++ b/apps/www/content/docs/components/form.mdx
@@ -123,7 +123,7 @@ npm install @radix-ui/react-label @radix-ui/react-slot react-hook-form @hookform
 
 Define the shape of your form using a Zod schema. You can read more about using Zod in the [Zod documentation](https://zod.dev).
 
-```tsx showLineNumbers {4,6-8}
+```tsx showLineNumbers {3,5-7}
 "use client"
 
 import * as z from "zod"
@@ -137,11 +137,12 @@ const formSchema = z.object({
 
 Use the `useForm` hook from `react-hook-form` to create a form.
 
-```tsx showLineNumbers {4,14-20,22-27}
+```tsx showLineNumbers {4-5,14-20,22-27}
 "use client"
 
-import { zodResolver } from "@hookform/resolvers/zod"
 import * as z from "zod"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
 
 const formSchema = z.object({
   username: z.string().min(2, {
@@ -176,8 +177,9 @@ We can now use the `<Form />` components to build our form.
 ```tsx showLineNumbers {7-17,28-50}
 "use client"
 
-import { zodResolver } from "@hookform/resolvers/zod"
 import * as z from "zod"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
 
 import { Button } from "@/components/ui/button"
 import {


### PR DESCRIPTION
Add `import { useForm } from "react-hook-form"` to make the example code more complete.

![CleanShot 2023-08-29 at 00 24 34@2x](https://github.com/shadcn-ui/ui/assets/75478661/d4adce1d-891a-4f81-a971-cd76bfd2e8c6)
