### PR TITLE
docs(www): add note on file input with react hook form

### DIFF
--- a/apps/www/content/docs/components/input.mdx
+++ b/apps/www/content/docs/components/input.mdx
@@ -58,6 +58,32 @@ import { Input } from "@/components/ui/input"
 
 <ComponentPreview name="input-file" className="[&_input]:max-w-xs" />
 
+When utilizing `<Input type="file" />` alongside [React Hook Form](https://www.react-hook-form.com/), it is important to have an uncontrolled input. You can achieve this by simply passing the `onChange` handler to the `onChange` prop of the input element.
+
+```tsx
+<FormField
+  control={form.control}
+  name="picture"
+  render={({ field: { value, onChange, ...fieldProps } }) => (
+    <FormItem>
+      <FormLabel>Picture</FormLabel>
+      <FormControl>
+        <Input
+          {...fieldProps}
+          placeholder="Picture"
+          type="file"
+          accept="image/*, application/pdf"
+          onChange={(event) =>
+            onChange(event.target.files && event.target.files[0])
+          }
+        />
+      </FormControl>
+      <FormMessage />
+    </FormItem>
+  )}
+/>
+```
+
 ### Disabled
 
 <ComponentPreview name="input-disabled" className="[&_input]:max-w-xs" />


### PR DESCRIPTION
Hey there! 👋🏻

Thank you so much for creating this amazing content! 😍 This is my first PR in this repository, so please let me know if anything is missing or can be improved.

**Intention**
While all the components worked perfectly, I encountered some difficulties when using the `<Input />` component with `type="file"` and react hook forms. In my search for a solution, I came across these helpful discussions:
-  [Issue 443](https://github.com/shadcn-ui/ui/issues/443)
-  [Issue 884](https://github.com/shadcn-ui/ui/issues/884)
-  [Issue 1085](https://github.com/shadcn-ui/ui/issues/1085)
-  [React Hook Form Discussion](https://github.com/orgs/react-hook-form/discussions/5394)
-  [Stack Overflow Question](https://stackoverflow.com/questions/68038076/react-hook-form-with-file-just-submitting-fakepath)

It seems that I'm not the first one to have these questions.

**Solution**
I made a small addition to the `<Input />` file example and included a tiny code snippet. I didn't include zod, as it was straightforward to use `z.instanceof(File)`.

I hope this is valuable. Please let me know if there's anything else I can do to make changes.