### PR TITLE
feat(www): redirecting to gitHub repo on clicking the library name #1382

### DIFF
--- a/apps/www/app/examples/cards/components/github-card.tsx
+++ b/apps/www/app/examples/cards/components/github-card.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link"
 import {
   ChevronDownIcon,
   CircleIcon,
@@ -28,8 +29,10 @@ export function DemoGithub() {
   return (
     <Card>
       <CardHeader className="grid grid-cols-[1fr_110px] items-start gap-4 space-y-0">
-        <div className="space-y-1">
-          <CardTitle>shadcn/ui</CardTitle>
+        <div className="space-y-1 cursor-pointer">
+          <Link href="https://github.com/shadcn-ui/ui.git">
+            <CardTitle>shadcn/ui</CardTitle>
+          </Link>
           <CardDescription>
             Beautifully designed components built with Radix UI and Tailwind
             CSS.


### PR DESCRIPTION
added a new feature redirecting to the GitHub repo when the name of the library is clicked in [Cards Example Docs](https://ui.shadcn.com/examples/cards)