### PR TITLE
chore(docs): fixed a typo in dark-mode doc

### DIFF
--- a/apps/www/content/docs/dark-mode/index.mdx
+++ b/apps/www/content/docs/dark-mode/index.mdx
@@ -34,4 +34,4 @@ description: Adding dark mode to your site.
 
 ## Other frameworks
 
-I'm looking for help writing guides for other frameworks. Help me write guides for Remix, Astro and Vite by [opening an PR](https://github.com/shadcn/ui).
+I'm looking for help writing guides for other frameworks. Help me write guides for Remix, Astro and Vite by [opening a PR](https://github.com/shadcn/ui).


### PR DESCRIPTION
There is a typo in docs/dark-mode.
![image](https://github.com/shadcn-ui/ui/assets/102830723/04c7eb46-e3de-49cc-b401-6f119a0e7a6f)
It says "opening an PR". 

Fix:
![image](https://github.com/shadcn-ui/ui/assets/102830723/3ec39c2a-ce4f-44e7-809d-679b71562a88)
