### PR TITLE
fix(www): extend tailwind supports-backdrop-blur

### DIFF
--- a/apps/www/components/site-header.tsx
+++ b/apps/www/components/site-header.tsx
@@ -11,7 +11,7 @@ import { buttonVariants } from "@/registry/new-york/ui/button"
 
 export function SiteHeader() {
   return (
-    <header className="supports-backdrop-blur:bg-background/60 sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur">
+    <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-backdrop-blur:bg-background/60">
       <div className="container flex h-14 items-center">
         <MainNav />
         <MobileNav />

--- a/apps/www/tailwind.config.cjs
+++ b/apps/www/tailwind.config.cjs
@@ -1,5 +1,11 @@
 const baseConfig = require("../../tailwind.config.cjs")
 
+/** @type {import('tailwindcss/types/config').ResolvableTo<Record<string, string>>} */
+const baseConfigThemeExtendSupports = (utils) =>
+  typeof baseConfig.theme.extend.supports === "function"
+    ? baseConfig.theme.extend.supports(utils)
+    : baseConfig.theme.extend.supports
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   ...baseConfig,
@@ -8,4 +14,14 @@ module.exports = {
     "content/**/*.mdx",
     "registry/**/*.{ts,tsx}",
   ],
+  theme: {
+    ...baseConfig.theme,
+    extend: {
+      ...baseConfig.theme.extend,
+      supports: {
+        ...baseConfigThemeExtendSupports(),
+        "backdrop-blur": "backdrop-filter: blur(var(--tw-backdrop-blur))",
+      },
+    }
+  }
 }


### PR DESCRIPTION
Tailwind doesn't have `supports-backdrop-blur` rule, witch is used in `site-header.tsx` so `supports-backdrop-blur:bg-background/60` is never applied.

Extended it only for `app/www` as it's not used over ui components.