### PR TITLE
Fix command menu bottom padding

### DIFF
--- a/apps/www/components/command-menu.tsx
+++ b/apps/www/components/command-menu.tsx
@@ -65,7 +65,7 @@ export function CommandMenu({ ...props }: DialogProps) {
       </Button>
       <CommandDialog open={open} onOpenChange={setOpen}>
         <CommandInput placeholder="Type a command or search..." />
-        <CommandList>
+        <CommandList className="pb-1">
           <CommandEmpty>No results found.</CommandEmpty>
           <CommandGroup heading="Links">
             {docsConfig.mainNav


### PR DESCRIPTION
The last item of command menu has a smaller padding at the bottom than its sides. 

**Chrome**
![Padding shadcn chrome](https://github.com/shadcn-ui/ui/assets/35405382/8f8117fb-252c-42f7-a09f-d0bea0d26681)

**Safari**
![Padding shadcn mac](https://github.com/shadcn-ui/ui/assets/35405382/2966be1e-e1ac-42f1-ab10-c48b6704a2bc)

