### PR TITLE
www(astro): little global style path correction

### DIFF
--- a/apps/www/content/docs/installation/astro.mdx
+++ b/apps/www/content/docs/installation/astro.mdx
@@ -91,7 +91,7 @@ You will be asked a few questions to configure `components.json`:
 Would you like to use TypeScript (recommended)? no / yes
 Which style would you like to use? › Default
 Which color would you like to use as base color? › Slate
-Where is your global CSS file? › › ./src/styles/globals.css
+Where is your global CSS file? › › ./src/styles/global.css
 Do you want to use CSS variables for colors? › no / yes
 Where is your tailwind.config.js located? › tailwind.config.cjs
 Configure the import alias for components: › @/components


### PR DESCRIPTION
Global styles are not applied if you specify the path as specified in the documentation. I spent some time trying to figure it out and want to warn others.

Here is the link to the documentation, where it says that the path should be exactly like this `src/styles/global.css` ("s" is superfluous): [https://docs.astro.build/en/tutorial/2-pages/5/](https://docs.astro.build/en/tutorial/2-pages/5/)