### PR TITLE
fix: enable input editing in the dialog demo

### DIFF
--- a/apps/www/registry/default/example/dialog-demo.tsx
+++ b/apps/www/registry/default/example/dialog-demo.tsx
@@ -29,13 +29,21 @@ export default function DialogDemo() {
             <Label htmlFor="name" className="text-right">
               Name
             </Label>
-            <Input id="name" value="Pedro Duarte" className="col-span-3" />
+            <Input
+              id="name"
+              defaultValue="Pedro Duarte"
+              className="col-span-3"
+            />
           </div>
           <div className="grid grid-cols-4 items-center gap-4">
             <Label htmlFor="username" className="text-right">
               Username
             </Label>
-            <Input id="username" value="@peduarte" className="col-span-3" />
+            <Input
+              id="username"
+              defaultValue="@peduarte"
+              className="col-span-3"
+            />
           </div>
         </div>
         <DialogFooter>


### PR DESCRIPTION
The dialog demo displays a warning message in development mode, as shown in the following.

_"Warning: You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`."_

<img width="1920" alt="Screenshot 2023-09-02 at 15 13 55" src="https://github.com/shadcn-ui/ui/assets/65852944/cd306305-bd92-4669-aa8f-2f4d42a79681">

Additionally, it renders the input fields "name" and "username" uneditable. This PR aims to address the warning and make these inputs editable.

<img width="1920" alt="Screenshot 2023-09-02 at 15 16 45" src="https://github.com/shadcn-ui/ui/assets/65852944/a386777f-0d5a-4ece-9a34-850a9ecc2bf5">
