### PR TITLE
fix: identical interface and function name

### DIFF
--- a/apps/www/app/examples/tasks/components/data-table-faceted-filter.tsx
+++ b/apps/www/app/examples/tasks/components/data-table-faceted-filter.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/registry/new-york/ui/popover"
 import { Separator } from "@/registry/new-york/ui/separator"
 
-interface DataTableFacetedFilter<TData, TValue> {
+interface DataTableFacetedFilterProps<TData, TValue> {
   column?: Column<TData, TValue>
   title?: string
   options: {
@@ -35,7 +35,7 @@ export function DataTableFacetedFilter<TData, TValue>({
   column,
   title,
   options,
-}: DataTableFacetedFilter<TData, TValue>) {
+}: DataTableFacetedFilterProps<TData, TValue>) {
   const facets = column?.getFacetedUniqueValues()
   const selectedValues = new Set(column?.getFilterValue() as string[])
 


### PR DESCRIPTION
VSCode is shouting at me for this identical interface and function name:

<img width="560" alt="Screenshot 2023-09-03 at 7 48 09 PM" src="https://github.com/shadcn-ui/ui/assets/13049130/b7ccf5bd-b9a2-40f2-9762-9582298aadac">

This PR just renames the interface to a more sensible one.