### PR TITLE
feat(www): add bun support for installation commands

### DIFF
--- a/.changeset/proud-items-join.md
+++ b/.changeset/proud-items-join.md
@@ -1,0 +1,5 @@
+---
+"shadcn-ui": patch
+---
+
+add bun support to command copying

--- a/.changeset/proud-items-join.md
+++ b/.changeset/proud-items-join.md
@@ -1,5 +1,0 @@
----
-"shadcn-ui": patch
----
-
-add bun support to command copying

--- a/apps/www/components/copy-button.tsx
+++ b/apps/www/components/copy-button.tsx
@@ -151,7 +151,7 @@ export function CopyNpmCommandButton({
   }, [hasCopied])
 
   const copyCommand = React.useCallback(
-    (value: string, pm: "npm" | "pnpm" | "yarn") => {
+    (value: string, pm: "npm" | "pnpm" | "yarn" | "bun") => {
       copyToClipboardWithMeta(value, {
         name: "copy_npm_command",
         properties: {
@@ -198,6 +198,11 @@ export function CopyNpmCommandButton({
           onClick={() => copyCommand(commands.__pnpmCommand__, "pnpm")}
         >
           pnpm
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => copyCommand(commands.__bunCommand__, "bun")}
+        >
+          bun
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/www/components/mdx-components.tsx
+++ b/apps/www/components/mdx-components.tsx
@@ -170,8 +170,9 @@ const components = {
     className,
     __rawString__,
     __npmCommand__,
-    __pnpmCommand__,
     __yarnCommand__,
+    __pnpmCommand__,
+    __bunCommand__,
     __withMeta__,
     __src__,
     __event__,
@@ -201,16 +202,20 @@ const components = {
             className={cn("absolute right-4 top-4", __withMeta__ && "top-16")}
           />
         )}
-        {__npmCommand__ && __yarnCommand__ && __pnpmCommand__ && (
-          <CopyNpmCommandButton
-            commands={{
-              __npmCommand__,
-              __pnpmCommand__,
-              __yarnCommand__,
-            }}
-            className={cn("absolute right-4 top-4", __withMeta__ && "top-16")}
-          />
-        )}
+        {__npmCommand__ &&
+          __yarnCommand__ &&
+          __pnpmCommand__ &&
+          __bunCommand__ && (
+            <CopyNpmCommandButton
+              commands={{
+                __npmCommand__,
+                __yarnCommand__,
+                __pnpmCommand__,
+                __bunCommand__,
+              }}
+              className={cn("absolute right-4 top-4", __withMeta__ && "top-16")}
+            />
+          )}
       </StyleWrapper>
     )
   },

--- a/apps/www/lib/rehype-npm-command.ts
+++ b/apps/www/lib/rehype-npm-command.ts
@@ -20,6 +20,10 @@ export function rehypeNpmCommand() {
           "npm install",
           "pnpm add"
         )
+        node.properties["__bunCommand__"] = npmCommand.replace(
+          "npm install",
+          "bun add"
+        )
       }
 
       // npx create.
@@ -34,6 +38,7 @@ export function rehypeNpmCommand() {
           "npx create-",
           "pnpm create "
         )
+        node.properties["__bunCommand__"] = npmCommand.replace("npx", "bunx")
       }
 
       // npx.
@@ -48,6 +53,7 @@ export function rehypeNpmCommand() {
           "npx",
           "pnpm dlx"
         )
+        node.properties["__bunCommand__"] = npmCommand.replace("npx", "bunx")
       }
     })
   }

--- a/apps/www/types/unist.ts
+++ b/apps/www/types/unist.ts
@@ -27,4 +27,5 @@ export interface NpmCommands {
   __npmCommand__?: string
   __yarnCommand__?: string
   __pnpmCommand__?: string
+  __bunCommand__?: string
 }


### PR DESCRIPTION
The title basically says it all

adding a component:
<img width="766" alt="copying a command with npm, yarn, pnpm, bun as options" src="https://github.com/shadcn-ui/ui/assets/90421212/56056177-b99a-44a6-8f78-fa19219aeccb">

creating an app:
<img width="702" alt="create-next-app with npm, yarn, pnpm, bun" src="https://github.com/shadcn-ui/ui/assets/90421212/80c0be81-0d1d-422e-ad24-9438324d975c">

initing shadcn-ui:
<img width="742" alt="shadcn-ui init with npm, yarn, pnpm, bun" src="https://github.com/shadcn-ui/ui/assets/90421212/cb40059e-4b2a-438b-90db-d0d53ed54a33">
