### PR TITLE
fix(cli): add ability to diff JavaScript files

### DIFF
--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -66,7 +66,12 @@ export const diff = new Command()
         const projectComponents = registryIndex.filter((item) => {
           for (const file of item.files) {
             const filePath = path.resolve(targetDir, file)
-            if (existsSync(filePath)) {
+            if (
+              existsSync(filePath) ||
+              existsSync(
+                filePath.replace(/\.tsx$/, ".jsx").replace(/\.ts$/, ".js")
+              )
+            ) {
               return true
             }
           }
@@ -151,10 +156,13 @@ async function diffComponent(
     }
 
     for (const file of item.files) {
-      const filePath = path.resolve(targetDir, file.name)
+      let filePath = path.resolve(targetDir, file.name)
 
       if (!existsSync(filePath)) {
-        continue
+        filePath = filePath.replace(/\.tsx$/, ".jsx").replace(/\.ts$/, ".js")
+        if (!existsSync(filePath)) {
+          continue
+        }
       }
 
       const fileContent = await fs.readFile(filePath, "utf8")


### PR DESCRIPTION
Closes #1513

I chose to make the diff command check for both TypeScript and JavaScript files. I did not use the `tsx` value in `components.json` to search for only TS or only JS files because if the diff command only used the `tsx` value to look for files, it wouldn't diff the `use-toast.ts` file when `tsx` is false due to an issue where .ts files aren't renamed to .js files, which is fixed by this PR https://github.com/shadcn-ui/ui/pull/1466.