### PR TITLE
fix: bug related to tab display when inactive

### DIFF
--- a/apps/www/registry/default/ui/tabs.tsx
+++ b/apps/www/registry/default/ui/tabs.tsx
@@ -44,7 +44,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=inactive]:hidden",
       className
     )}
     {...props}

--- a/apps/www/registry/new-york/ui/tabs.tsx
+++ b/apps/www/registry/new-york/ui/tabs.tsx
@@ -44,7 +44,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=inactive]:hidden",
       className
     )}
     {...props}


### PR DESCRIPTION
This pull request addresses a bug where tabs that were not currently active were not being hidden.

I have fixed this issue by adjusting the logic responsible for determining tab visibility when they are in the inactive state. Tabs that are inactive will be hidden using tailwind `hidden` class applied to them, and the `data-[state=inactive]` property will be handled correctly to ensure proper tab rendering.

Please review the changes and let me know if there are any concerns or questions. This fix should resolve the problem and improve the overall user experience when interacting with tabs.
