### PR TITLE
resolveConfigPaths shouldn't expect tsconfig.json unless config.tsx is true

### DIFF
--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -63,7 +63,7 @@ export async function resolveConfigPaths(cwd: string, config: RawConfig) {
   // Read tsconfig.json.
   const tsConfig = await loadConfig(cwd)
 
-  if (tsConfig.resultType === "failed") {
+  if (config.tsx && tsConfig.resultType === "failed") {
     throw new Error(
       `Failed to load tsconfig.json. ${tsConfig.message ?? ""}`.trim()
     )


### PR DESCRIPTION
The current experience is it logs an error for anyone who declines to use Typescript in `init`. (Don't tell DHH! 😛)