### PR TITLE
Increase the spacing

### DIFF
--- a/apps/www/app/examples/cards/components/create-account.tsx
+++ b/apps/www/app/examples/cards/components/create-account.tsx
@@ -24,11 +24,11 @@ export function DemoCreateAccount() {
       </CardHeader>
       <CardContent className="grid gap-4">
         <div className="grid grid-cols-2 gap-6">
-          <Button variant="outline">
+          <Button variant="outline" className="mb-4">
             <Icons.gitHub className="mr-2 h-4 w-4" />
             Github
           </Button>
-          <Button variant="outline">
+          <Button variant="outline" className="mb-4">
             <Icons.google className="mr-2 h-4 w-4" />
             Google
           </Button>


### PR DESCRIPTION
Increase the spacing between the _Google and Github button_ with the _'or continue with' text_ below by adding `className="mb-4"` on both buttons.