### PR TITLE
build(components): downgrade version of `zod`

### DIFF
--- a/apps/www/content/docs/components/form.mdx
+++ b/apps/www/content/docs/components/form.mdx
@@ -123,7 +123,7 @@ npm install @radix-ui/react-label @radix-ui/react-slot react-hook-form @hookform
 
 Define the shape of your form using a Zod schema. You can read more about using Zod in the [Zod documentation](https://zod.dev).
 
-```tsx showLineNumbers {4,6-8}
+```tsx showLineNumbers {3,5-7}
 "use client"
 
 import * as z from "zod"
@@ -137,10 +137,11 @@ const formSchema = z.object({
 
 Use the `useForm` hook from `react-hook-form` to create a form.
 
-```tsx showLineNumbers {4,14-20,22-27}
+```tsx showLineNumbers {3-4,14-20,22-27}
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
 import * as z from "zod"
 
 const formSchema = z.object({
@@ -177,6 +178,7 @@ We can now use the `<Form />` components to build our form.
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
 import * as z from "zod"
 
 import { Button } from "@/components/ui/button"

--- a/apps/www/registry/registry.ts
+++ b/apps/www/registry/registry.ts
@@ -98,7 +98,7 @@ const ui: Registry = [
       "@radix-ui/react-label",
       "@radix-ui/react-slot",
       "@hookform/resolvers",
-      "zod",
+      "zod@3.21.4",
       "react-hook-form",
     ],
     registryDependencies: ["button", "label"],


### PR DESCRIPTION
Downgrade the version of `zod`, which is the dependency of the `Form` component, to `3.21.4`.

The following problem occurs in the latest version of zod.

<img width="990" alt="scr" src="https://github.com/shadcn-ui/ui/assets/39112954/637d4a60-abd0-416a-95f0-25211317eeb5">

As you can see, an error occurs if you pass the schema as an argument to the `zodResolver` method.
This problem can be neatly solved using `zod@3.21.4`.

Information regarding this issue can be found at the link below.
https://github.com/colinhacks/zod/issues/2663
