### PR TITLE
fix(docs): set incorrect values in the combobox

### DIFF
--- a/apps/www/content/docs/components/combobox.mdx
+++ b/apps/www/content/docs/components/combobox.mdx
@@ -85,8 +85,8 @@ export function ComboboxDemo() {
             {frameworks.map((framework) => (
               <CommandItem
                 key={framework.value}
-                onSelect={(currentValue) => {
-                  setValue(currentValue === value ? "" : currentValue)
+                onSelect={() => {
+                  setValue(framework.value === value ? "" : framework.value)
                   setOpen(false)
                 }}
               >

--- a/apps/www/registry/default/example/combobox-demo.tsx
+++ b/apps/www/registry/default/example/combobox-demo.tsx
@@ -68,8 +68,8 @@ export default function ComboboxDemo() {
             {frameworks.map((framework) => (
               <CommandItem
                 key={framework.value}
-                onSelect={(currentValue) => {
-                  setValue(currentValue === value ? "" : currentValue)
+                onSelect={() => {
+                  setValue(framework.value === value ? "" : framework.value)
                   setOpen(false)
                 }}
               >

--- a/apps/www/registry/default/example/combobox-popover.tsx
+++ b/apps/www/registry/default/example/combobox-popover.tsx
@@ -95,10 +95,11 @@ export default function ComboboxPopover() {
                 {statuses.map((status) => (
                   <CommandItem
                     key={status.value}
-                    onSelect={(value) => {
+                    onSelect={() => {
                       setSelectedStatus(
-                        statuses.find((priority) => priority.value === value) ||
-                          null
+                        statuses.find(
+                          (priority) => priority.value === status.value
+                        ) || null
                       )
                       setOpen(false)
                     }}

--- a/apps/www/registry/new-york/example/combobox-demo.tsx
+++ b/apps/www/registry/new-york/example/combobox-demo.tsx
@@ -68,8 +68,8 @@ export default function ComboboxDemo() {
             {frameworks.map((framework) => (
               <CommandItem
                 key={framework.value}
-                onSelect={(currentValue) => {
-                  setValue(currentValue === value ? "" : currentValue)
+                onSelect={() => {
+                  setValue(framework.value === value ? "" : framework.value)
                   setOpen(false)
                 }}
               >

--- a/apps/www/registry/new-york/example/combobox-popover.tsx
+++ b/apps/www/registry/new-york/example/combobox-popover.tsx
@@ -69,10 +69,11 @@ export default function ComboboxPopover() {
                 {statuses.map((status) => (
                   <CommandItem
                     key={status.value}
-                    onSelect={(value) => {
+                    onSelect={() => {
                       setSelectedStatus(
-                        statuses.find((priority) => priority.value === value) ||
-                          null
+                        statuses.find(
+                          (priority) => priority.value === status.value
+                        ) || null
                       )
                       setOpen(false)
                     }}


### PR DESCRIPTION
Current examples are working well because the value and label are the same although the label starts with uppercase. When you change the value(different from the label text) and select any item the combobox will be empty. 

```
 const frameworks = [ {
    value: "next.js",
    label: "Next.js",
  }]

    <CommandItem
                key={frameworks.value}
                onSelect={(currentValue) => {
                // currentValue is label value
                }}
              >
              ```