### PR TITLE
Toggle Group Component! 🚀 

### DIFF
--- a/apps/www/config/docs.ts
+++ b/apps/www/config/docs.ts
@@ -348,6 +348,11 @@ export const docsConfig: DocsConfig = {
           items: [],
         },
         {
+          title: "Toggle Group",
+          href: "/docs/components/toggle-group",
+          items: [],
+        },
+        {
           title: "Tooltip",
           href: "/docs/components/tooltip",
           items: [],

--- a/apps/www/content/docs/components/toggle-group.mdx
+++ b/apps/www/content/docs/components/toggle-group.mdx
@@ -1,0 +1,68 @@
+---
+title: Toggle Group
+description: A set of two-state buttons that can be toggled on or off.
+component: true
+radix:
+  link: https://www.radix-ui.com/primitives/docs/components/toggle-group
+  api: https://www.radix-ui.com/primitives/docs/components/toggle-group#api-reference
+---
+
+<ComponentPreview name="toggle-group-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn-ui@latest add toggle-group
+```
+
+</TabsContent>
+
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Install the following dependencies:</Step>
+
+```bash
+npm install @radix-ui/react-toggle-group
+```
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<ComponentSource name="toggle-group" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>
+
+## Usage
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+```
+
+```tsx
+<ToggleGroup type="single" defaultValue="left">
+  <ToggleGroupItem value="left">Left</ToggleGroupItem>
+  <ToggleGroupItem value="center">Center</ToggleGroupItem>
+  <ToggleGroupItem value="right">Right</ToggleGroupItem>
+</ToggleGroup>
+```
+
+## Examples
+
+### Default
+
+<ComponentPreview name="toggle-group-demo" />

--- a/apps/www/registry/default/example/toggle-group-demo.tsx
+++ b/apps/www/registry/default/example/toggle-group-demo.tsx
@@ -1,0 +1,14 @@
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@/registry/default/ui/toggle-group"
+
+export default function ToggleGroupDemo() {
+  return (
+    <ToggleGroup type="single" defaultValue="left">
+      <ToggleGroupItem value="left">Left</ToggleGroupItem>
+      <ToggleGroupItem value="center">Center</ToggleGroupItem>
+      <ToggleGroupItem value="right">Right</ToggleGroupItem>
+    </ToggleGroup>
+  )
+}

--- a/apps/www/registry/default/ui/toggle-group.tsx
+++ b/apps/www/registry/default/ui/toggle-group.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import * as React from "react"
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const ToggleGroup = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <ToggleGroupPrimitive.Root
+    ref={ref}
+    className={cn(
+      "inline-flex space-x-px rounded bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName
+
+const toggleGroupItemVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm",
+  {
+    variants: {
+      variant: {
+        default: "ring-offset-background",
+      },
+      size: {
+        default: "rounded-sm px-3 py-1.5 text-sm",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+const ToggleGroupItem = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
+    VariantProps<typeof toggleGroupItemVariants>
+>(({ className, variant, size, ...props }, ref) => (
+  <ToggleGroupPrimitive.Item
+    ref={ref}
+    className={cn(toggleGroupItemVariants({ variant, size, className }))}
+    {...props}
+  />
+))
+
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName
+
+export { ToggleGroup, ToggleGroupItem, toggleGroupItemVariants }

--- a/apps/www/registry/new-york/example/toggle-group-demo.tsx
+++ b/apps/www/registry/new-york/example/toggle-group-demo.tsx
@@ -1,0 +1,14 @@
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@/registry/new-york/ui/toggle-group"
+
+export default function ToggleGroupDemo() {
+  return (
+    <ToggleGroup type="single" defaultValue="left">
+      <ToggleGroupItem value="left">Left</ToggleGroupItem>
+      <ToggleGroupItem value="center">Center</ToggleGroupItem>
+      <ToggleGroupItem value="right">Right</ToggleGroupItem>
+    </ToggleGroup>
+  )
+}

--- a/apps/www/registry/new-york/ui/toggle-group.tsx
+++ b/apps/www/registry/new-york/ui/toggle-group.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import * as React from "react"
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const ToggleGroup = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <ToggleGroupPrimitive.Root
+    ref={ref}
+    className={cn(
+      "inline-flex space-x-px rounded bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName
+
+const toggleGroupItemVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm",
+  {
+    variants: {
+      variant: {
+        default: "ring-offset-background",
+      },
+      size: {
+        default: "rounded-sm px-3 py-1.5 text-sm",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+const ToggleGroupItem = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
+    VariantProps<typeof toggleGroupItemVariants>
+>(({ className, variant, size, ...props }, ref) => (
+  <ToggleGroupPrimitive.Item
+    ref={ref}
+    className={cn(toggleGroupItemVariants({ variant, size, className }))}
+    {...props}
+  />
+))
+
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName
+
+export { ToggleGroup, ToggleGroupItem, toggleGroupItemVariants }


### PR DESCRIPTION
This PR creates a new `toggle-group` component, based on [Radix](https://www.radix-ui.com/primitives/docs/components/toggle-group) implementation. The component is unstyled and uses the CVA library. Also works on dark mode.

![CleanShot 2023-09-25 at 20 09 18](https://github.com/shadcn-ui/ui/assets/810642/e9d88660-9339-48db-b232-c45ebdb43857)
![CleanShot 2023-09-25 at 20 09 25](https://github.com/shadcn-ui/ui/assets/810642/33890f08-a08d-403f-b543-c8b9f2401171)

This PR can replace the https://github.com/shadcn-ui/ui/pull/570 button group implementation, following the Radix implementation.