### PR TITLE
Bugfix/#1632 radio group horizontal orientation not working

### DIFF
--- a/apps/www/registry/default/ui/radio-group.tsx
+++ b/apps/www/registry/default/ui/radio-group.tsx
@@ -12,7 +12,7 @@ const RadioGroup = React.forwardRef<
 >(({ className, ...props }, ref) => {
   return (
     <RadioGroupPrimitive.Root
-      className={cn("grid gap-2", className)}
+      className={cn(`${props.orientation === "horizontal" ? "flex" : "grid"} gap-2`, className)}
       {...props}
       ref={ref}
     />

--- a/apps/www/registry/new-york/ui/radio-group.tsx
+++ b/apps/www/registry/new-york/ui/radio-group.tsx
@@ -12,7 +12,7 @@ const RadioGroup = React.forwardRef<
 >(({ className, ...props }, ref) => {
   return (
     <RadioGroupPrimitive.Root
-      className={cn("grid gap-2", className)}
+      className={cn(`${props.orientation === "horizontal" ? "flex" : "grid"} gap-2`, className)}
       {...props}
       ref={ref}
     />


### PR DESCRIPTION
By using a ternary if statement, we are able to detect if the orientation attribute was horizontal and then apply the flex tailwind class. If not, the orientation attribute would be set to grid as the default.