### PR TITLE
fix(cli): match tailwind config extension with ts or js

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -85,17 +85,18 @@ export async function promptForConfig(
   const styles = await getRegistryStyles()
   const baseColors = await getRegistryBaseColors()
 
+  const tsxOption = await prompts({
+    type: "toggle",
+    name: "typescript",
+    message: `Would you like to use ${highlight("TypeScript")} (recommended)?`,
+    initial: defaultConfig?.tsx ?? true,
+    active: "yes",
+    inactive: "no",
+  })
+
+  const configExtension = tsxOption.typescript ? "ts" : "js";
+
   const options = await prompts([
-    {
-      type: "toggle",
-      name: "typescript",
-      message: `Would you like to use ${highlight(
-        "TypeScript"
-      )} (recommended)?`,
-      initial: defaultConfig?.tsx ?? true,
-      active: "yes",
-      inactive: "no",
-    },
     {
       type: "select",
       name: "style",
@@ -135,8 +136,12 @@ export async function promptForConfig(
     {
       type: "text",
       name: "tailwindConfig",
-      message: `Where is your ${highlight("tailwind.config.js")} located?`,
-      initial: defaultConfig?.tailwind.config ?? DEFAULT_TAILWIND_CONFIG,
+      message: `Where is your ${highlight(
+        `tailwind.config.${configExtension}`
+      )} file?`,
+      initial:
+        defaultConfig?.tailwind.config ??
+        `${DEFAULT_TAILWIND_CONFIG}.${configExtension}`,
     },
     {
       type: "text",
@@ -170,7 +175,7 @@ export async function promptForConfig(
       cssVariables: options.tailwindCssVariables,
     },
     rsc: options.rsc,
-    tsx: options.typescript,
+    tsx: tsxOption.typescript,
     aliases: {
       utils: options.utils,
       components: options.components,

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -8,7 +8,7 @@ export const DEFAULT_STYLE = "default"
 export const DEFAULT_COMPONENTS = "@/components"
 export const DEFAULT_UTILS = "@/lib/utils"
 export const DEFAULT_TAILWIND_CSS = "app/globals.css"
-export const DEFAULT_TAILWIND_CONFIG = "tailwind.config.js"
+export const DEFAULT_TAILWIND_CONFIG = "tailwind.config"
 export const DEFAULT_TAILWIND_BASE_COLOR = "slate"
 
 // TODO: Figure out if we want to support all cosmiconfig formats.


### PR DESCRIPTION
Added .ts or .js extension to tailwind.config on CLI prompt

![image](https://github.com/shadcn-ui/ui/assets/3497950/613a3954-97be-43d2-a67a-d49cb2379517)

Fixes #1620 