### PR TITLE
feat(textarea): auto resizable

### DIFF
--- a/apps/www/registry/default/ui/textarea.tsx
+++ b/apps/www/registry/default/ui/textarea.tsx
@@ -1,28 +1,29 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { useRef, useEffect} from 'react'
+import { useRef, useEffect } from 'react'
 import { mergeRefs } from "react-merge-refs";
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> { }
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {
-const texteAreaRef = useRef<HTMLTextAreaElement>(null);
+    const texteAreaRef = useRef<HTMLTextAreaElement>(null);
 
-  useEffect(() => {
-    const ref = texteAreaRef?.current;
+    useEffect(() => {
+      const ref = texteAreaRef?.current;
 
-    const updateTextareaHeight = () => {
-      if(ref) {
-        ref.style.height = "auto";
-        ref.style.height = ref?.scrollHeight + "px";
-      }
-    };
+      const updateTextareaHeight = () => {
+        if (ref) {
+          ref.style.height = "auto";
+          ref.style.height = ref?.scrollHeight + "px";
+        }
+      };
 
-    updateTextareaHeight();
-    ref?.addEventListener("input", updateTextareaHeight);
+      updateTextareaHeight();
+      ref?.addEventListener("input", updateTextareaHeight);
 
-    return () => ref?.removeEventListener("input", updateTextareaHeight);
-  }, []);
+      return () => ref?.removeEventListener("input", updateTextareaHeight);
+    }, []);
+
     return (
       <textarea
         className={cn(

--- a/apps/www/registry/default/ui/textarea.tsx
+++ b/apps/www/registry/default/ui/textarea.tsx
@@ -1,24 +1,41 @@
-import * as React from "react"
-
-import { cn } from "@/lib/utils"
-
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { useRef, useEffect} from 'react'
+import { mergeRefs } from "react-merge-refs";
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {
+const texteAreaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const ref = texteAreaRef?.current;
+
+    const updateTextareaHeight = () => {
+      if(ref) {
+        ref.style.height = "auto";
+        ref.style.height = ref?.scrollHeight + "px";
+      }
+    };
+
+    updateTextareaHeight();
+    ref?.addEventListener("input", updateTextareaHeight);
+
+    return () => ref?.removeEventListener("input", updateTextareaHeight);
+  }, []);
     return (
       <textarea
         className={cn(
           "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
-        ref={ref}
+        ref={mergeRefs([texteAreaRef, ref])}
         {...props}
       />
-    )
+    );
   }
-)
-Textarea.displayName = "Textarea"
+);
 
-export { Textarea }
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/apps/www/registry/new-york/ui/textarea.tsx
+++ b/apps/www/registry/new-york/ui/textarea.tsx
@@ -1,42 +1,24 @@
-import * as React from "react";
-import { cn } from "@/lib/utils";
-import { useRef, useEffect } from 'react'
-import { mergeRefs } from "react-merge-refs";
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> { }
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {
-    const texteAreaRef = useRef<HTMLTextAreaElement>(null);
-
-    useEffect(() => {
-      const ref = texteAreaRef?.current;
-
-      const updateTextareaHeight = () => {
-        if (ref) {
-          ref.style.height = "auto";
-          ref.style.height = ref?.scrollHeight + "px";
-        }
-      };
-
-      updateTextareaHeight();
-      ref?.addEventListener("input", updateTextareaHeight);
-
-      return () => ref?.removeEventListener("input", updateTextareaHeight);
-    }, []);
-
     return (
       <textarea
         className={cn(
           "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
-        ref={mergeRefs([texteAreaRef, ref])}
+        ref={ref}
         {...props}
       />
-    );
+    )
   }
-);
+)
+Textarea.displayName = "Textarea"
 
-Textarea.displayName = "Textarea";
-
-export { Textarea };
+export { Textarea }

--- a/apps/www/registry/new-york/ui/textarea.tsx
+++ b/apps/www/registry/new-york/ui/textarea.tsx
@@ -1,24 +1,42 @@
-import * as React from "react"
-
-import { cn } from "@/lib/utils"
-
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { useRef, useEffect } from 'react'
+import { mergeRefs } from "react-merge-refs";
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> { }
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {
+    const texteAreaRef = useRef<HTMLTextAreaElement>(null);
+
+    useEffect(() => {
+      const ref = texteAreaRef?.current;
+
+      const updateTextareaHeight = () => {
+        if (ref) {
+          ref.style.height = "auto";
+          ref.style.height = ref?.scrollHeight + "px";
+        }
+      };
+
+      updateTextareaHeight();
+      ref?.addEventListener("input", updateTextareaHeight);
+
+      return () => ref?.removeEventListener("input", updateTextareaHeight);
+    }, []);
+
     return (
       <textarea
         className={cn(
           "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
-        ref={ref}
+        ref={mergeRefs([texteAreaRef, ref])}
         {...props}
       />
-    )
+    );
   }
-)
-Textarea.displayName = "Textarea"
+);
 
-export { Textarea }
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "postcss": "^8.4.24",
     "prettier": "^2.8.8",
     "pretty-quick": "^3.1.3",
+    "react-merge-refs": "^2.1.1",
     "tailwindcss": "^3.3.2",
     "tailwindcss-animate": "^1.0.5",
     "ts-node": "^10.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       pretty-quick:
         specifier: ^3.1.3
         version: 3.1.3(prettier@2.8.8)
+      react-merge-refs:
+        specifier: ^2.1.1
+        version: 2.1.1
       tailwindcss:
         specifier: ^3.3.2
         version: 3.3.2(ts-node@10.9.1)
@@ -9371,6 +9374,10 @@ packages:
 
   /react-lifecycles-compat@3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
+    dev: false
+
+  /react-merge-refs@2.1.1:
+    resolution: {integrity: sha512-jLQXJ/URln51zskhgppGJ2ub7b2WFKGq3cl3NYKtlHoTG+dN2q7EzWrn3hN3EgPsTMvpR9tpq5ijdp7YwFZkag==}
     dev: false
 
   /react-remove-scroll-bar@2.3.4(@types/react@18.2.7)(react@18.2.0):


### PR DESCRIPTION
https://github.com/shadcn-ui/ui/assets/79323963/5afc0cc3-d80e-4c2b-9ea0-124569f33ff8

In my opinion, an auto-resizable textarea brings a great user experience, and I would like to see it included in this UI library. I discarded the changes in New Yorker because of Server Components. What do you think?