### PR TITLE
fix(cli): tailwindcss config in ts project

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -135,8 +135,13 @@ export async function promptForConfig(
     {
       type: "text",
       name: "tailwindConfig",
-      message: `Where is your ${highlight("tailwind.config.js")} located?`,
-      initial: defaultConfig?.tailwind.config ?? DEFAULT_TAILWIND_CONFIG,
+      message: (_, values) =>
+        `Where is your ${highlight(
+          `tailwind.config.${values.typescript ? "ts" : "js"}`
+        )} located?`,
+      initial: (_, values) =>
+        defaultConfig?.tailwind.config ||
+        `tailwind.config.${values.typescript ? "ts" : "js"}`,
     },
     {
       type: "text",


### PR DESCRIPTION
fixed issue by @p7uverma  which is reported by @josuejs23.
Issue: #1740 
issue context: When im adding shadcn-ui to my nextjs project that is created with Typecript it ask me if my tailwind config file is TS or JS, it would be graat if by default is TypeSscipt if my project is created with TypeScript?

I fixed this issue by checking typescript value given by user.
And reflecting changes to 'tailwindConfig' accounding to that. 

```typescript
{
      type: "text",
      name: "tailwindConfig",
      message: (_, values) =>
        `Where is your ${highlight(
          `tailwind.config.${values.typescript ? "ts" : "js"}`
        )} located?`,
      initial: (_, values) =>
        defaultConfig?.tailwind.config ||
        `tailwind.config.${values.typescript ? "ts" : "js"}`,
},
```
@shadcn Please Review my Pull request.. 