### PR TITLE
fix(www/combobox-demo): add `value` prop to code demo

### DIFF
--- a/apps/www/registry/default/example/combobox-demo.tsx
+++ b/apps/www/registry/default/example/combobox-demo.tsx
@@ -72,6 +72,7 @@ export default function ComboboxDemo() {
                   setValue(currentValue === value ? "" : currentValue)
                   setOpen(false)
                 }}
+                value={framework.value}
               >
                 <Check
                   className={cn(


### PR DESCRIPTION
Potentially fixes https://github.com/shadcn-ui/ui/issues/1754

Upon investigating the issue, seems like the `cmdk input` infers the value from whatever is provided above. However, here's a scenario where that ends up being an issue:

- visit `components/combobox`
- search for 'Next.js'
- now add a `whitespace` at the end
- see how it returns `no results`
- remove the `whitespace`
- see that the search doesn't return `next.js` and you need to delete the entire value for it to work

So this solution fixes the demo by providing a `value` to `CommandItem` so its value is not inferred
```javascript
<CommandItem
  key={framework.value}
  onSelect={(currentValue) => {
    setValue(currentValue === value ? "" : currentValue)
    setOpen(false)
  }}
  value={framework.value}
>
```

However, an issue with this: this solution doesn't work, for example, to the `TeamSwitcher` since the `value` currently provided inside the content array doesn't match what the user sees (i.e., if you search for `Alicia Koch` but you've added
```javascript
<CommandItem
  key={team.value}
  onSelect={() => {
    setSelectedTeam(team)
    setOpen(false)
  }}
  className="text-sm"
  value={team.value}
>
```
It won't return any results since the `alicia koch` object looks like this:
```javascript
{
  label: "Alicia Koch",
  value: "personal",
},
```
