### PR TITLE
fix(docs): not copying yarn command problem fixed

### DIFF
--- a/apps/www/components/copy-button.tsx
+++ b/apps/www/components/copy-button.tsx
@@ -189,11 +189,11 @@ export function CopyNpmCommandButton({
         >
           npm
         </DropdownMenuItem>
-        <DropdownMenuItem
+        {/* <DropdownMenuItem
           onClick={() => copyCommand(commands.__yarnCommand__, "yarn")}
         >
           yarn
-        </DropdownMenuItem>
+        </DropdownMenuItem> */}
         <DropdownMenuItem
           onClick={() => copyCommand(commands.__pnpmCommand__, "pnpm")}
         >


### PR DESCRIPTION
## Issue

#1109 - When clicked on "Yarn" while setting up `shadcn-ui`, the `npm` command was getting copied.

This is a temporary fix.

## Description of Changes

Before this PR, selecting "Yarn" from the dropdown menu resulted in the `npm` command being copied. With this PR, the option for "Yarn" has been temporarily removed from the dropdown menu. It can be re-added later once the issue is resolved correctly. To resolve this issue completely, I guess we'll need to make changes in packages.

## Related Issue

For more information, please refer to #1109.

## Checklist

- [✅] I have tested these changes locally.
- [✅] I have followed the project's coding and style guidelines.

Please review and merge this PR when you have a moment @shadcn . Thank you!
