### PR TITLE
fix: `initialFocus` breaks date-picker on firefox and ios-chrome

### DIFF
--- a/apps/www/app/examples/dashboard/components/date-range-picker.tsx
+++ b/apps/www/app/examples/dashboard/components/date-range-picker.tsx
@@ -51,7 +51,6 @@ export function CalendarDateRangePicker({
         </PopoverTrigger>
         <PopoverContent className="w-auto p-0" align="end">
           <Calendar
-            initialFocus
             mode="range"
             defaultMonth={date?.from}
             selected={date}

--- a/apps/www/app/examples/forms/account/account-form.tsx
+++ b/apps/www/app/examples/forms/account/account-form.tsx
@@ -140,7 +140,6 @@ export function AccountForm() {
                     disabled={(date) =>
                       date > new Date() || date < new Date("1900-01-01")
                     }
-                    initialFocus
                   />
                 </PopoverContent>
               </Popover>

--- a/apps/www/content/docs/components/date-picker.mdx
+++ b/apps/www/content/docs/components/date-picker.mdx
@@ -52,7 +52,6 @@ export function DatePickerDemo() {
           mode="single"
           selected={date}
           onSelect={setDate}
-          initialFocus
         />
       </PopoverContent>
     </Popover>

--- a/apps/www/registry/default/example/calendar-form.tsx
+++ b/apps/www/registry/default/example/calendar-form.tsx
@@ -83,7 +83,6 @@ export default function CalendarForm() {
                     disabled={(date) =>
                       date > new Date() || date < new Date("1900-01-01")
                     }
-                    initialFocus
                   />
                 </PopoverContent>
               </Popover>

--- a/apps/www/registry/default/example/calendar-react-hook-form.tsx
+++ b/apps/www/registry/default/example/calendar-react-hook-form.tsx
@@ -83,7 +83,6 @@ export default function CalendarForm() {
                     disabled={(date) =>
                       date > new Date() || date < new Date("1900-01-01")
                     }
-                    initialFocus
                   />
                 </PopoverContent>
               </Popover>

--- a/apps/www/registry/default/example/date-picker-demo.tsx
+++ b/apps/www/registry/default/example/date-picker-demo.tsx
@@ -35,7 +35,6 @@ export default function DatePickerDemo() {
           mode="single"
           selected={date}
           onSelect={setDate}
-          initialFocus
         />
       </PopoverContent>
     </Popover>

--- a/apps/www/registry/default/example/date-picker-form.tsx
+++ b/apps/www/registry/default/example/date-picker-form.tsx
@@ -83,7 +83,6 @@ export default function DatePickerForm() {
                     disabled={(date) =>
                       date > new Date() || date < new Date("1900-01-01")
                     }
-                    initialFocus
                   />
                 </PopoverContent>
               </Popover>

--- a/apps/www/registry/default/example/date-picker-with-range.tsx
+++ b/apps/www/registry/default/example/date-picker-with-range.tsx
@@ -51,7 +51,6 @@ export default function DatePickerWithRange({
         </PopoverTrigger>
         <PopoverContent className="w-auto p-0" align="start">
           <Calendar
-            initialFocus
             mode="range"
             defaultMonth={date?.from}
             selected={date}

--- a/apps/www/registry/new-york/example/calendar-form.tsx
+++ b/apps/www/registry/new-york/example/calendar-form.tsx
@@ -83,7 +83,6 @@ export default function CalendarForm() {
                     disabled={(date) =>
                       date > new Date() || date < new Date("1900-01-01")
                     }
-                    initialFocus
                   />
                 </PopoverContent>
               </Popover>

--- a/apps/www/registry/new-york/example/date-picker-demo.tsx
+++ b/apps/www/registry/new-york/example/date-picker-demo.tsx
@@ -35,7 +35,6 @@ export default function DatePickerDemo() {
           mode="single"
           selected={date}
           onSelect={setDate}
-          initialFocus
         />
       </PopoverContent>
     </Popover>

--- a/apps/www/registry/new-york/example/date-picker-form.tsx
+++ b/apps/www/registry/new-york/example/date-picker-form.tsx
@@ -83,7 +83,6 @@ export default function DatePickerForm() {
                     disabled={(date) =>
                       date > new Date() || date < new Date("1900-01-01")
                     }
-                    initialFocus
                   />
                 </PopoverContent>
               </Popover>

--- a/apps/www/registry/new-york/example/date-picker-with-range.tsx
+++ b/apps/www/registry/new-york/example/date-picker-with-range.tsx
@@ -51,7 +51,6 @@ export default function DatePickerWithRange({
         </PopoverTrigger>
         <PopoverContent className="w-auto p-0" align="start">
           <Calendar
-            initialFocus
             mode="range"
             defaultMonth={date?.from}
             selected={date}


### PR DESCRIPTION
`initialFocus` leads to the popover not opening on firefox and ios chrome.

i couldnt find any difference in accessibility with this change.

closes https://github.com/shadcn-ui/ui/issues/910