### PR TITLE
fix(examples): command not searching properly in examples

### DIFF
--- a/apps/www/registry/default/example/command-demo.tsx
+++ b/apps/www/registry/default/example/command-demo.tsx
@@ -25,32 +25,32 @@ export default function CommandDemo() {
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>
         <CommandGroup heading="Suggestions">
-          <CommandItem>
+          <CommandItem value="Calendar">
             <Calendar className="mr-2 h-4 w-4" />
             <span>Calendar</span>
           </CommandItem>
-          <CommandItem>
+          <CommandItem value="Search Emoji">
             <Smile className="mr-2 h-4 w-4" />
             <span>Search Emoji</span>
           </CommandItem>
-          <CommandItem>
+          <CommandItem value="Calculator">
             <Calculator className="mr-2 h-4 w-4" />
             <span>Calculator</span>
           </CommandItem>
         </CommandGroup>
         <CommandSeparator />
         <CommandGroup heading="Settings">
-          <CommandItem>
+          <CommandItem value="Profile">
             <User className="mr-2 h-4 w-4" />
             <span>Profile</span>
             <CommandShortcut>⌘P</CommandShortcut>
           </CommandItem>
-          <CommandItem>
+          <CommandItem value="Billing">
             <CreditCard className="mr-2 h-4 w-4" />
             <span>Billing</span>
             <CommandShortcut>⌘B</CommandShortcut>
           </CommandItem>
-          <CommandItem>
+          <CommandItem value="Settings">
             <Settings className="mr-2 h-4 w-4" />
             <span>Settings</span>
             <CommandShortcut>⌘S</CommandShortcut>

--- a/apps/www/registry/default/example/command-dialog.tsx
+++ b/apps/www/registry/default/example/command-dialog.tsx
@@ -49,32 +49,32 @@ export default function CommandDialogDemo() {
         <CommandList>
           <CommandEmpty>No results found.</CommandEmpty>
           <CommandGroup heading="Suggestions">
-            <CommandItem>
+            <CommandItem value="Calendar">
               <Calendar className="mr-2 h-4 w-4" />
               <span>Calendar</span>
             </CommandItem>
-            <CommandItem>
+            <CommandItem value="Search Emoji">
               <Smile className="mr-2 h-4 w-4" />
               <span>Search Emoji</span>
             </CommandItem>
-            <CommandItem>
+            <CommandItem value="Calculator">
               <Calculator className="mr-2 h-4 w-4" />
               <span>Calculator</span>
             </CommandItem>
           </CommandGroup>
           <CommandSeparator />
           <CommandGroup heading="Settings">
-            <CommandItem>
+            <CommandItem value="Profile">
               <User className="mr-2 h-4 w-4" />
               <span>Profile</span>
               <CommandShortcut>⌘P</CommandShortcut>
             </CommandItem>
-            <CommandItem>
+            <CommandItem value="Billing">
               <CreditCard className="mr-2 h-4 w-4" />
               <span>Billing</span>
               <CommandShortcut>⌘B</CommandShortcut>
             </CommandItem>
-            <CommandItem>
+            <CommandItem value="Settings">
               <Settings className="mr-2 h-4 w-4" />
               <span>Settings</span>
               <CommandShortcut>⌘S</CommandShortcut>

--- a/apps/www/registry/new-york/example/command-demo.tsx
+++ b/apps/www/registry/new-york/example/command-demo.tsx
@@ -25,32 +25,32 @@ export default function CommandDemo() {
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>
         <CommandGroup heading="Suggestions">
-          <CommandItem>
+          <CommandItem value="Calendar">
             <CalendarIcon className="mr-2 h-4 w-4" />
             <span>Calendar</span>
           </CommandItem>
-          <CommandItem>
+          <CommandItem value="Search Emoji">
             <FaceIcon className="mr-2 h-4 w-4" />
             <span>Search Emoji</span>
           </CommandItem>
-          <CommandItem>
+          <CommandItem value="Launch">
             <RocketIcon className="mr-2 h-4 w-4" />
             <span>Launch</span>
           </CommandItem>
         </CommandGroup>
         <CommandSeparator />
         <CommandGroup heading="Settings">
-          <CommandItem>
+          <CommandItem value="Profile">
             <PersonIcon className="mr-2 h-4 w-4" />
             <span>Profile</span>
             <CommandShortcut>⌘P</CommandShortcut>
           </CommandItem>
-          <CommandItem>
+          <CommandItem value="Mail">
             <EnvelopeClosedIcon className="mr-2 h-4 w-4" />
             <span>Mail</span>
             <CommandShortcut>⌘B</CommandShortcut>
           </CommandItem>
-          <CommandItem>
+          <CommandItem value="Settings">
             <GearIcon className="mr-2 h-4 w-4" />
             <span>Settings</span>
             <CommandShortcut>⌘S</CommandShortcut>

--- a/apps/www/registry/new-york/example/command-dialog.tsx
+++ b/apps/www/registry/new-york/example/command-dialog.tsx
@@ -49,32 +49,32 @@ export default function CommandDialogDemo() {
         <CommandList>
           <CommandEmpty>No results found.</CommandEmpty>
           <CommandGroup heading="Suggestions">
-            <CommandItem>
+            <CommandItem value="Calendar">
               <CalendarIcon className="mr-2 h-4 w-4" />
               <span>Calendar</span>
             </CommandItem>
-            <CommandItem>
+            <CommandItem value="Search Emoji">
               <FaceIcon className="mr-2 h-4 w-4" />
               <span>Search Emoji</span>
             </CommandItem>
-            <CommandItem>
+            <CommandItem value="Launch">
               <RocketIcon className="mr-2 h-4 w-4" />
               <span>Launch</span>
             </CommandItem>
           </CommandGroup>
           <CommandSeparator />
           <CommandGroup heading="Settings">
-            <CommandItem>
+            <CommandItem value="Profile">
               <PersonIcon className="mr-2 h-4 w-4" />
               <span>Profile</span>
               <CommandShortcut>⌘P</CommandShortcut>
             </CommandItem>
-            <CommandItem>
+            <CommandItem value="Mail">
               <EnvelopeClosedIcon className="mr-2 h-4 w-4" />
               <span>Mail</span>
               <CommandShortcut>⌘B</CommandShortcut>
             </CommandItem>
-            <CommandItem>
+            <CommandItem value="Settings">
               <GearIcon className="mr-2 h-4 w-4" />
               <span>Settings</span>
               <CommandShortcut>⌘S</CommandShortcut>


### PR DESCRIPTION
The examples are missing the value for each command item, which causes unexpected behaviours when searching (i.e. empty results when results should be found).

Fixes #1695