### PR TITLE
fix(example): appearance form 

### DIFF
--- a/apps/www/app/examples/forms/appearance/appearance-form.tsx
+++ b/apps/www/app/examples/forms/appearance/appearance-form.tsx
@@ -1,12 +1,10 @@
 "use client"
 
 import { zodResolver } from "@hookform/resolvers/zod"
-import { ChevronDownIcon } from "@radix-ui/react-icons"
 import { useForm } from "react-hook-form"
 import * as z from "zod"
 
-import { cn } from "@/lib/utils"
-import { Button, buttonVariants } from "@/registry/new-york/ui/button"
+import { Button } from "@/registry/new-york/ui/button"
 import {
   Form,
   FormControl,
@@ -17,6 +15,13 @@ import {
   FormMessage,
 } from "@/registry/new-york/ui/form"
 import { RadioGroup, RadioGroupItem } from "@/registry/new-york/ui/radio-group"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/registry/new-york/ui/select"
 import { toast } from "@/registry/new-york/ui/use-toast"
 
 const appearanceFormSchema = z.object({
@@ -34,6 +39,7 @@ type AppearanceFormValues = z.infer<typeof appearanceFormSchema>
 // This can come from your database or API.
 const defaultValues: Partial<AppearanceFormValues> = {
   theme: "light",
+  font: "inter"
 }
 
 export function AppearanceForm() {
@@ -62,22 +68,18 @@ export function AppearanceForm() {
           render={({ field }) => (
             <FormItem>
               <FormLabel>Font</FormLabel>
-              <div className="relative w-max">
+              <Select defaultValue={field.value} onValueChange={field.onChange}>
                 <FormControl>
-                  <select
-                    className={cn(
-                      buttonVariants({ variant: "outline" }),
-                      "w-[200px] appearance-none bg-transparent font-normal"
-                    )}
-                    {...field}
-                  >
-                    <option value="inter">Inter</option>
-                    <option value="manrope">Manrope</option>
-                    <option value="system">System</option>
-                  </select>
+                  <SelectTrigger className="w-[200px]">
+                    <SelectValue placeholder="Select font" />
+                  </SelectTrigger>
                 </FormControl>
-                <ChevronDownIcon className="absolute right-3 top-2.5 h-4 w-4 opacity-50" />
-              </div>
+                <SelectContent>
+                  <SelectItem value="inter">Inter</SelectItem>
+                  <SelectItem value="manrope">Manrope</SelectItem>
+                  <SelectItem value="system">System</SelectItem>
+                </SelectContent>
+              </Select>
               <FormDescription>
                 Set the font you want to use in the dashboard.
               </FormDescription>

--- a/apps/www/app/examples/forms/appearance/appearance-form.tsx
+++ b/apps/www/app/examples/forms/appearance/appearance-form.tsx
@@ -39,7 +39,7 @@ type AppearanceFormValues = z.infer<typeof appearanceFormSchema>
 // This can come from your database or API.
 const defaultValues: Partial<AppearanceFormValues> = {
   theme: "light",
-  font: "inter"
+  font: "inter",
 }
 
 export function AppearanceForm() {


### PR DESCRIPTION
The appearance form in the example has some bugs.

Firstly, if you dont touch the select component and try to submit, it will error and tell you that you need to select a font, despite inter being shown as default.
![image](https://github.com/shadcn-ui/ui/assets/5064896/73484854-23e0-4b90-b5b1-1d7224bfb11a)

Next, it is not using a shadcn select box. Instead its just a html one. I have switched this out.
![image](https://github.com/shadcn-ui/ui/assets/5064896/3cbd0241-f6f9-4d85-8209-9c6197de17ed)

