### PR TITLE
feat: add disableBackdrop and closeOnClickOutside

### DIFF
--- a/apps/www/registry/default/ui/sheet.tsx
+++ b/apps/www/registry/default/ui/sheet.tsx
@@ -51,17 +51,21 @@ const sheetVariants = cva(
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+      disableBackdrop?: boolean;
+      closeOnClickOutside?: boolean;
+    }
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", className, children, disableBackdrop=false, closeOnClickOutside=true, ...props }, ref) => (
   <SheetPortal>
-    <SheetOverlay />
+    {!disableBackdrop && <SheetOverlay />}
     <SheetPrimitive.Content
       ref={ref}
       className={cn(sheetVariants({ side }), className)}
+      onPointerDownOutside={!closeOnClickOutside ? ((e) => e.preventDefault()) : undefined} 
       {...props}
     >
       {children}


### PR DESCRIPTION
This adds the following features to the Sheet:
1. disableBackdrop: Sometimes, the main content should be visible to users so they can actually make a decision based on the data there (we wouldn't want users going back and forth just because they "forget" something)
2. closeOnClickOutside: Similar to the above, users should be able to copy from and interact with the main content area.

Both features are inspired by [MUI](https://mui.com/material-ui/react-drawer/), this issue -> #212 , and by a project I'm working on.

# Tests
Manually tested. This is how it looks like:

https://github.com/shadcn-ui/ui/assets/51885228/f2d9b81a-7ecf-4d83-8176-c2f8d8358f93




# Problems
1. This does not allow clicks behind the backdrop. Will need to go deeper on how to fix that.
2. Needs examples.
