### PR TITLE
chore: code preview updated for light mode and scrollbar added for all brows…

### DIFF
--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -14,6 +14,7 @@ import { Toaster as DefaultToaster } from "@/registry/default/ui/toaster"
 import { Toaster as NewYorkToaster } from "@/registry/new-york/ui/toaster"
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://shadcn.com"),
   title: {
     default: siteConfig.name,
     template: `%s - ${siteConfig.name}`,

--- a/apps/www/components/command-menu.tsx
+++ b/apps/www/components/command-menu.tsx
@@ -60,7 +60,7 @@ export function CommandMenu({ ...props }: DialogProps) {
         <span className="hidden lg:inline-flex">Search documentation...</span>
         <span className="inline-flex lg:hidden">Search...</span>
         <kbd className="pointer-events-none absolute right-1.5 top-1.5 hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex">
-          <span className="text-xs">⌘</span>K
+          <span className="text-xs mt-[3px]">⌘</span>K
         </kbd>
       </Button>
       <CommandDialog open={open} onOpenChange={setOpen}>

--- a/apps/www/styles/globals.css
+++ b/apps/www/styles/globals.css
@@ -24,6 +24,18 @@
     --input: 240 5.9% 90%;
     --ring: 240 5% 64.9%;
     --radius: 0.5rem;
+    --code: rgb(0, 0, 0) (255, 0, 0);
+    --code-foreground: #f4f4f5;
+    --code--highlighted: rgb(240, 240, 240);
+    --copy-button-background: rgb(255, 255, 255);
+    --scrollbar-track: rgb(248, 248, 248);
+    --scrollbar-track-border: rgb(242, 242, 242);
+    --scrollbar-track-hover: rgb(240, 240, 240);
+    --scrollbar-track-active: rgb(244, 244, 244);
+    --scrollbar-thumb: rgb(225, 225, 225);
+    --scrollbar-thumb-hover: rgb(220, 220, 220);
+    --scrollbar-thumb-active: rgb(229, 229, 229);
+    --rainbow-background: rgba(0, 0, 0, 0.16);
   }
 
   .dark {
@@ -46,6 +58,17 @@
     --border: 240 3.7% 15.9%;
     --input: 240 3.7% 15.9%;
     --ring: 240 4.9% 83.9%;
+    --code: rgb(255, 255, 255);
+    --code-foreground: #18181b;
+    --code-highlighted: rgb(17, 17, 17);
+    --copy-button-background: rgb(17, 17, 17);
+    --scrollbar-track: #09090b;
+    --scrollbar-track-border: #1b1b1f;
+    --scrollbar-track-hover: #0b0b0c;
+    --scrollbar-track-active: #050507;
+    --scrollbar-thumb: rgb(62, 62, 62);
+    --scrollbar-thumb-hover: rgb(68, 68, 68);
+    --scrollbar-thumb-active: rgb(66, 66, 66);
   }
 }
 
@@ -75,4 +98,77 @@
   .container {
     @apply px-4;
   }
+}
+
+/* Light Theme For Codes */
+span.line span {
+  color: var(--code) !important;
+}
+
+pre {
+  background-color: var(--code-foreground) !important;
+}
+
+span.line--highlighted {
+  background-color: var(--code-foreground) !important;
+}
+div[data-rehype-pretty-code-fragment] button:hover {
+  background-color: var(--copy-button-background) !important;
+}
+
+html.dark div[data-rehype-pretty-code-fragment] button svg {
+  color: rgb(255, 255, 255) !important;
+}
+
+html.light div[data-rehype-pretty-code-fragment] button svg {
+  color: rgb(0, 0, 0) !important;
+}
+
+/* Firefox */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) !important;
+}
+
+/* Chrome, Edge and Safari */
+*::-webkit-scrollbar {
+  width: 7px;
+  width: 7px;
+  height: 7px;
+  height: 7px;
+}
+
+*::-webkit-scrollbar-corner {
+  background-color: var(--scrollbar-track) !important;
+  border: 1px solid var(--scrollbar-track) !important;
+}
+
+*::-webkit-scrollbar-track {
+  background-color: var(--scrollbar-track) !important;
+}
+
+*::-webkit-scrollbar-track {
+  background-color: var(--scrollbar-track-hover) !important;
+  border-left: 1.5px solid var(--scrollbar-track-border) !important;
+  border-right: 1px solid var(--scrollbar-track-border) !important;
+}
+
+*::-webkit-scrollbar-track:active {
+  background-color: var(--scrollbar-track-active) !important;
+  border-left: 1.5px solid var(--scrollbar-track-border) !important;
+  border-right: 1px solid var(--scrollbar-track-border) !important;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb) !important;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb-hover) !important;
+  border-radius: 14px;
+}
+
+*::-webkit-scrollbar-thumb:active {
+  background-color: var(--scrollbar-thumb-active) !important;
+  border-radius: 14px;
 }

--- a/apps/www/styles/globals.css
+++ b/apps/www/styles/globals.css
@@ -25,8 +25,8 @@
     --ring: 240 5% 64.9%;
     --radius: 0.5rem;
     --code: rgb(0, 0, 0) (255, 0, 0);
-    --code-foreground: #f4f4f5;
-    --code--highlighted: rgb(240, 240, 240);
+    --code-foreground: rgb(244, 244, 245);
+    --code-highlighted: rgb(234, 234, 235);
     --copy-button-background: rgb(255, 255, 255);
     --scrollbar-track: rgb(248, 248, 248);
     --scrollbar-track-border: rgb(207, 207, 207);
@@ -58,8 +58,8 @@
     --input: 240 3.7% 15.9%;
     --ring: 240 4.9% 83.9%;
     --code: rgb(255, 255, 255);
-    --code-foreground: #18181b;
-    --code-highlighted: rgb(17, 17, 17);
+    --code-foreground: rgb(24, 24, 27);
+    --code-highlighted: rgb(20, 20, 25);
     --copy-button-background: rgb(17, 17, 17);
     --scrollbar-track: #09090b;
     --scrollbar-track-border: #1b1b1f;
@@ -99,28 +99,29 @@
   }
 }
 
-/* Light Theme For Code Preview */
+/* Light Theme For Code Preview (!important is important here cause some of this values are already definded in data-rehype-pretty-code-fragment at mdx.css by default)*/
 span.line span {
-  color: var(--code);
+  color: var(--code) !important;
 }
 
 pre {
-  background-color: var(--code-foreground);
+  background-color: var(--code-foreground) !important;
 }
 
 span.line--highlighted {
-  background-color: var(--code-foreground);
+  background-color: var(--code-highlighted) !important;
 }
+
 div[data-rehype-pretty-code-fragment] button:hover {
-  background-color: var(--copy-button-background);
+  background-color: var(--copy-button-background) !important;
 }
 
 html.dark div[data-rehype-pretty-code-fragment] button svg {
-  color: rgb(255, 255, 255);
+  color: rgb(255, 255, 255) !important;
 }
 
 html.light div[data-rehype-pretty-code-fragment] button svg {
-  color: rgb(0, 0, 0);
+  color: rgb(0, 0, 0) !important;
 }
 
 /* Firefox Scrollbar */

--- a/apps/www/styles/globals.css
+++ b/apps/www/styles/globals.css
@@ -29,13 +29,12 @@
     --code--highlighted: rgb(240, 240, 240);
     --copy-button-background: rgb(255, 255, 255);
     --scrollbar-track: rgb(248, 248, 248);
-    --scrollbar-track-border: rgb(242, 242, 242);
+    --scrollbar-track-border: rgb(207, 207, 207);
     --scrollbar-track-hover: rgb(240, 240, 240);
     --scrollbar-track-active: rgb(244, 244, 244);
-    --scrollbar-thumb: rgb(225, 225, 225);
-    --scrollbar-thumb-hover: rgb(220, 220, 220);
-    --scrollbar-thumb-active: rgb(229, 229, 229);
-    --rainbow-background: rgba(0, 0, 0, 0.16);
+    --scrollbar-thumb: rgb(213.5, 213.5, 213.5);
+    --scrollbar-thumb-hover:  rgb(220, 220, 220);
+    --scrollbar-thumb-active: rgb(205, 205, 205);
   }
 
   .dark {
@@ -66,9 +65,9 @@
     --scrollbar-track-border: #1b1b1f;
     --scrollbar-track-hover: #0b0b0c;
     --scrollbar-track-active: #050507;
-    --scrollbar-thumb: rgb(62, 62, 62);
-    --scrollbar-thumb-hover: rgb(68, 68, 68);
-    --scrollbar-thumb-active: rgb(66, 66, 66);
+    --scrollbar-thumb: rgb(65, 65, 65);
+    --scrollbar-thumb-hover: rgb(60, 60, 60);
+    --scrollbar-thumb-active: rgb(50, 50, 50);
   }
 }
 
@@ -100,75 +99,73 @@
   }
 }
 
-/* Light Theme For Codes */
+/* Light Theme For Code Preview */
 span.line span {
-  color: var(--code) !important;
+  color: var(--code);
 }
 
 pre {
-  background-color: var(--code-foreground) !important;
+  background-color: var(--code-foreground);
 }
 
 span.line--highlighted {
-  background-color: var(--code-foreground) !important;
+  background-color: var(--code-foreground);
 }
 div[data-rehype-pretty-code-fragment] button:hover {
-  background-color: var(--copy-button-background) !important;
+  background-color: var(--copy-button-background);
 }
 
 html.dark div[data-rehype-pretty-code-fragment] button svg {
-  color: rgb(255, 255, 255) !important;
+  color: rgb(255, 255, 255);
 }
 
 html.light div[data-rehype-pretty-code-fragment] button svg {
-  color: rgb(0, 0, 0) !important;
+  color: rgb(0, 0, 0);
 }
 
-/* Firefox */
+/* Firefox Scrollbar */
 * {
   scrollbar-width: thin;
-  scrollbar-color: var(--scrollbar-thumb) !important;
+  scrollbar-color: var(--scrollbar-thumb);
 }
 
-/* Chrome, Edge and Safari */
+/* Chrome, Edge and Safari Scrollbar */
 *::-webkit-scrollbar {
-  width: 7px;
-  width: 7px;
-  height: 7px;
-  height: 7px;
+  width: 7.5px;
+  height: 7.5px;
 }
 
 *::-webkit-scrollbar-corner {
-  background-color: var(--scrollbar-track) !important;
-  border: 1px solid var(--scrollbar-track) !important;
+  background-color: var(--scrollbar-track);
+  border: 1px solid var(--scrollbar-track);
 }
 
 *::-webkit-scrollbar-track {
-  background-color: var(--scrollbar-track) !important;
+  background-color: var(--scrollbar-track);
 }
 
 *::-webkit-scrollbar-track {
-  background-color: var(--scrollbar-track-hover) !important;
-  border-left: 1.5px solid var(--scrollbar-track-border) !important;
-  border-right: 1px solid var(--scrollbar-track-border) !important;
+  background-color: var(--scrollbar-track-hover);
+  border-left: 1.5px solid var(--scrollbar-track-border);
+  border-right: 1px solid var(--scrollbar-track-border);
 }
 
 *::-webkit-scrollbar-track:active {
-  background-color: var(--scrollbar-track-active) !important;
-  border-left: 1.5px solid var(--scrollbar-track-border) !important;
-  border-right: 1px solid var(--scrollbar-track-border) !important;
+  background-color: var(--scrollbar-track-active);
+  border-left: 1.5px solid var(--scrollbar-track-border);
+  border-right: 1px solid var(--scrollbar-track-border);
 }
 
 *::-webkit-scrollbar-thumb {
-  background-color: var(--scrollbar-thumb) !important;
+  background-color: var(--scrollbar-thumb);
 }
 
 *::-webkit-scrollbar-thumb {
-  background-color: var(--scrollbar-thumb-hover) !important;
+  background-color: var(--scrollbar-thumb-hover);
   border-radius: 14px;
 }
 
 *::-webkit-scrollbar-thumb:active {
-  background-color: var(--scrollbar-thumb-active) !important;
+  background-color: var(--scrollbar-thumb-active);
   border-radius: 14px;
 }


### PR DESCRIPTION
![new_recording_-_10_24_2023,_1_41_26_pm (Original)](https://github.com/shadcn-ui/ui/assets/103621682/aecd7670-00b1-455f-9636-b029cd1c90c1)
![new_recording_-_10_26_2023,_8_58_31_am (Original)](https://github.com/shadcn-ui/ui/assets/103621682/ce1a144b-0197-4d7c-b0a0-cb781576511b)


hello again!!!
in my code I have:
1. searhbar ⌘ button is center at command menu appps/www/components/command-menu.tsx.
2. fixed opengraph wanring which was occuring for not using metadataBase in metadata apps/www/app/layout.tsx
3. fixed the code preview was not using any light theme colors in light mode at apps/www/styles/global.css
4. scrollbar added for chrome,firefox,edge and all chromium browsers