### PR TITLE
fix(prompt): update default tailwind configuration file

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -135,8 +135,8 @@ export async function promptForConfig(
     {
       type: "text",
       name: "tailwindConfig",
-      message: `Where is your ${highlight("tailwind.config.js")} located?`,
-      initial: defaultConfig?.tailwind.config ?? DEFAULT_TAILWIND_CONFIG,
+      message: `Where is your ${defaultConfig?.tsx ? highlight("tailwind.config.ts") : highlight("tailwind.config.js")} located?`,
+      initial: defaultConfig?.tailwind.config && defaultConfig?.tsx ? DEFAULT_TAILWIND_CONFIG : "tailwind.config.js",
     },
     {
       type: "text",

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -8,7 +8,7 @@ export const DEFAULT_STYLE = "default"
 export const DEFAULT_COMPONENTS = "@/components"
 export const DEFAULT_UTILS = "@/lib/utils"
 export const DEFAULT_TAILWIND_CSS = "app/globals.css"
-export const DEFAULT_TAILWIND_CONFIG = "tailwind.config.js"
+export const DEFAULT_TAILWIND_CONFIG = "tailwind.config.ts"
 export const DEFAULT_TAILWIND_BASE_COLOR = "slate"
 
 // TODO: Figure out if we want to support all cosmiconfig formats.


### PR DESCRIPTION
Fixes [#1810](https://github.com/shadcn-ui/ui/issues/1810)

- Updates the default value in the `promptForConfig` `tailwind.config.js` or `tailwind.config.ts`.
- Changes the initial value for the `tailwindConfig`.