### PR TITLE
docs(www): Fix typo

### DIFF
--- a/apps/www/app/examples/music/components/menu.tsx
+++ b/apps/www/app/examples/music/components/menu.tsx
@@ -190,7 +190,7 @@ export function Menu() {
             <MenubarRadioItem value="Luis">Luis</MenubarRadioItem>
           </MenubarRadioGroup>
           <MenubarSeparator />
-          <MenubarItem inset>Manage Famliy...</MenubarItem>
+          <MenubarItem inset>Manage Family...</MenubarItem>
           <MenubarSeparator />
           <MenubarItem inset>Add Account...</MenubarItem>
         </MenubarContent>


### PR DESCRIPTION
Fixed typo from 'Famliy' to 'Family' in music example.