### PR TITLE
docs(www): Missing import statement

### DIFF
--- a/apps/www/content/docs/installation/next.mdx
+++ b/apps/www/content/docs/installation/next.mdx
@@ -45,9 +45,10 @@ Here's how I configure Inter for Next.js:
 
 **1. Import the font in the root layout:**
 
-```js showLineNumbers title=app/layout.tsx {2,4-7,15-16}
+```js showLineNumbers title=app/layout.tsx {2,5-8,16-17}
 import "@/styles/globals.css"
 import { Inter as FontSans } from "next/font/google"
+import { cn } from "../@/lib/utils";
 
 export const fontSans = FontSans({
   subsets: ["latin"],


### PR DESCRIPTION
Added missing import statement in fonts example in Next.js installation docs