### PR TITLE
fix(a11y): destructive contrast increase

### DIFF
--- a/apps/www/styles/globals.css
+++ b/apps/www/styles/globals.css
@@ -18,7 +18,7 @@
     --muted-foreground: 240 3.8% 46.1%;
     --accent: 240 4.8% 95.9%;
     --accent-foreground: 240 5.9% 10%;
-    --destructive: 0 84.2% 60.2%;
+    --destructive: 0 72.22% 50.59%;
     --destructive-foreground: 0 0% 98%;
     --border: 240 5.9% 90%;
     --input: 240 5.9% 90%;


### PR DESCRIPTION
The default destructive button is failing contrast ratio for WCAG AA standards. 

This substitutes the previous HSL equivalent of `red-500` to `red-600`. This was previous done in another PR: https://github.com/shadcn-ui/ui/pull/79 which looks like it was incorrectly translated to the CSS Variable setup with HSL.