### PR TITLE
fix(cli - init) -  Add `./@/**/*.` to tailwind.config.[js/ts]'s content prop to properly apply styles with default import alias

### DIFF
--- a/packages/cli/src/utils/templates.ts
+++ b/packages/cli/src/utils/templates.ts
@@ -22,6 +22,7 @@ module.exports = {
     './components/**/*.{<%- extension %>,<%- extension %>x}',
     './app/**/*.{<%- extension %>,<%- extension %>x}',
     './src/**/*.{<%- extension %>,<%- extension %>x}',
+    './@/**/*.{<%- extension %>,<%- extension %>x}',
   ],
   theme: {
     container: {
@@ -59,6 +60,7 @@ module.exports = {
     './components/**/*.{<%- extension %>,<%- extension %>x}',
     './app/**/*.{<%- extension %>,<%- extension %>x}',
     './src/**/*.{<%- extension %>,<%- extension %>x}',
+    './@/**/*.{<%- extension %>,<%- extension %>x}',
   ],
   theme: {
     container: {
@@ -137,6 +139,7 @@ const config = {
     './components/**/*.{<%- extension %>,<%- extension %>x}',
     './app/**/*.{<%- extension %>,<%- extension %>x}',
     './src/**/*.{<%- extension %>,<%- extension %>x}',
+    './@/**/*.{<%- extension %>,<%- extension %>x}',
   ],
   theme: {
     container: {
@@ -177,6 +180,7 @@ const config = {
     './components/**/*.{<%- extension %>,<%- extension %>x}',
     './app/**/*.{<%- extension %>,<%- extension %>x}',
     './src/**/*.{<%- extension %>,<%- extension %>x}',
+    './@/**/*.{<%- extension %>,<%- extension %>x}',
 	],
   theme: {
     container: {


### PR DESCRIPTION
Since the default aliases are `@/components` and `@/utils` this change fixes the issue of styling not applying neither in `create t3-app` nor `create next-app` with the default options in `shadcn-ui`.

If accounting for other alias keys are necessary to be added, I can whip up a solution to find how the aliases start with and to use that character i.e: `'./${aliasKey}/**/*.{<%- extension %>,<%- extension %>x},'
around line ~246  in `packages/cli/src/commands/init.ts`.


Thanks,
-8x4
  
  