### PR TITLE
docs(www): add remix dark mode docs

### DIFF
--- a/apps/www/config/docs.ts
+++ b/apps/www/config/docs.ts
@@ -152,6 +152,11 @@ export const docsConfig: DocsConfig = {
           href: "/docs/dark-mode/astro",
           items: [],
         },
+        {
+          title: "Remix",
+          href: "/docs/dark-mode/remix",
+          items: [],
+        },
       ],
     },
     {

--- a/apps/www/content/docs/dark-mode/index.mdx
+++ b/apps/www/content/docs/dark-mode/index.mdx
@@ -43,6 +43,19 @@ description: Adding dark mode to your site.
     </svg>
     <p className="font-medium mt-2">Astro</p>
   </LinkedCard>
+  <LinkedCard href="/docs/dark-mode/remix">
+    <svg
+      role="img"
+      viewBox="0 0 24 24"      
+      xmlns="http://www.w3.org/2000/svg"
+      className="w-10 h-10"
+      fill="currentColor"
+    >
+      <title>Remix</title>
+      <path d="M21.511 18.508c.216 2.773.216 4.073.216 5.492H15.31c0-.309.006-.592.011-.878.018-.892.036-1.821-.109-3.698-.19-2.747-1.374-3.358-3.55-3.358H1.574v-5h10.396c2.748 0 4.122-.835 4.122-3.049 0-1.946-1.374-3.125-4.122-3.125H1.573V0h11.541c6.221 0 9.313 2.938 9.313 7.632 0 3.511-2.176 5.8-5.114 6.182 2.48.497 3.93 1.909 4.198 4.694ZM1.573 24v-3.727h6.784c1.133 0 1.379.84 1.379 1.342V24Z" />
+    </svg>
+    <p className="font-medium mt-2">Remix</p>
+  </LinkedCard>
 </div>
 
 ## Other frameworks

--- a/apps/www/content/docs/dark-mode/remix.mdx
+++ b/apps/www/content/docs/dark-mode/remix.mdx
@@ -1,0 +1,147 @@
+---
+title: Remix
+description: Adding dark mode to your remix app.
+---
+
+## Dark mode
+
+<Steps>
+
+### Install remix-themes
+
+Start by installing `remix-themes`:
+
+```bash
+npm install remix-themes
+```
+
+### Create a session storage and theme session resolver
+
+```tsx title="app/sessions.server.tsx"
+import { createThemeSessionResolver } from 'remix-themes'
+
+// You can default to 'development' if process.env.NODE_ENV is not set
+const isProduction = process.env.NODE_ENV === 'production';
+
+const sessionStorage = createCookieSessionStorage({
+  cookie: {
+    name: 'theme',
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax',
+    secrets: ['s3cr3t'],
+    // Set domain and secure only if in production
+    ...(isProduction
+      ? { domain: 'your-production-domain.com', secure: true }
+      : {}),
+  },
+})
+
+export const themeSessionResolver = createThemeSessionResolver(sessionStorage)
+```
+
+### Set up Remix Themes
+
+Add the `ThemeProvider` to your root layout.
+
+```tsx {1-3,6-11,15-22,25-26,28,33} title="app/root.tsx"
+import { ThemeProvider, useTheme, PreventFlashOnWrongTheme } from 'remix-themes';
+import { themeSessionResolver } from './sessions.server';
+import clsx from 'clsx';
+
+// Return the theme from the session storage using the loader
+export async function loader({ request }: LoaderFunctionArgs) {
+  const { getTheme } = await themeSessionResolver(request);
+  return {
+    theme: getTheme(),
+  };
+}
+// Wrap your app with ThemeProvider.
+// `specifiedTheme` is the stored theme in the session storage.
+// `themeAction` is the action name that's used to change the theme in the session storage.
+export default function AppWithProviders() {
+  const data = useLoaderData<typeof loader>();
+  return (
+    <ThemeProvider specifiedTheme={data.theme} themeAction="/action/set-theme">
+      <App />
+    </ThemeProvider>
+  );
+}
+
+export function App() {
+  const data = useLoaderData<typeof loader>();
+  const [theme] = useTheme();
+  return (
+    <html lang="en" className={clsx(theme)}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <Meta />
+        <PreventFlashOnWrongTheme ssrTheme={Boolean(data.theme)} />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+
+```
+
+### Add an action route
+
+Create a file in `/routes/action.set-theme.ts`. Ensure that you pass the filename to the ThemeProvider component. This route it's used to store the preferred theme in the session storage when the user changes it.
+
+```tsx title="app/routes/action.set-theme.ts"
+import { createThemeAction } from 'remix-themes'
+import { themeSessionResolver } from './sessions.server'
+
+export const action = createThemeAction(themeSessionResolver)
+```
+
+### Add a mode toggle
+
+Place a mode toggle on your site to toggle between light and dark mode.
+
+```tsx title="components/mode-toggle.tsx"
+import { Moon, Sun } from 'lucide-react';
+
+import { Button } from './ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from './ui/dropdown-menu';
+import { useTheme, Theme } from 'remix-themes';
+
+export function ModeToggle() {
+  const [, setTheme] = useTheme();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon">
+          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme(Theme.LIGHT)}>
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme(Theme.DARK)}>
+          Dark
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+```
+
+</Steps>

--- a/apps/www/content/docs/dark-mode/remix.mdx
+++ b/apps/www/content/docs/dark-mode/remix.mdx
@@ -7,6 +7,16 @@ description: Adding dark mode to your remix app.
 
 <Steps>
 
+### Modify your tailwind.css file
+Add `:root[class~="dark"]` to your tailwind.css file. This will allow you to use the `dark` class on your html element to apply dark mode styles.
+
+```css {2} title="app/tailwind.css"
+  .dark,
+  :root[class~="dark"] {
+    ...
+  }
+```
+
 ### Install remix-themes
 
 Start by installing `remix-themes`:


### PR DESCRIPTION
I added documentation to support dark mode for Remix.

## Dependencies
- remix-themes is required

## Showcase
https://github.com/shadcn-ui/ui/assets/48875246/457f8e99-24e1-479e-bbdc-88048d58502f

