### PR TITLE
fix(card): eslint error `jsx-a11y/heading-has-content`

### DIFF
--- a/apps/www/registry/default/ui/card.tsx
+++ b/apps/www/registry/default/ui/card.tsx
@@ -32,7 +32,7 @@ CardHeader.displayName = "CardHeader"
 const CardTitle = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
+>(({ className, children, ...props }, ref) => (
   <div
     ref={ref}
     className={cn(
@@ -40,7 +40,9 @@ const CardTitle = React.forwardRef<
       className
     )}
     {...props}
-  />
+  >
+    {children}
+  </div>
 ))
 CardTitle.displayName = "CardTitle"
 


### PR DESCRIPTION
> Enforce that heading elements (h1, h2, etc.) have content and that the content is accessible to screen readers.

Rule documentation can be found [here](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/1635dccc8106a774ae58010381771099664e32b4/docs/rules/heading-has-content.md#jsx-a11yheading-has-content)

**Fix:** taking the children out from the props.