### PR TITLE
Update the default `app` location of `app/globals.css`

### DIFF
--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -1,4 +1,5 @@
 import path from "path"
+import { existsSync } from 'fs';
 import { resolveImport } from "@/src/utils/resolve-import"
 import { cosmiconfig } from "cosmiconfig"
 import { loadConfig } from "tsconfig-paths"
@@ -7,7 +8,7 @@ import * as z from "zod"
 export const DEFAULT_STYLE = "default"
 export const DEFAULT_COMPONENTS = "@/components"
 export const DEFAULT_UTILS = "@/lib/utils"
-export const DEFAULT_TAILWIND_CSS = "app/globals.css"
+export const DEFAULT_TAILWIND_CSS = existsSync('app') ? "app/globals.css" : "src/app/globals.css"
 export const DEFAULT_TAILWIND_CONFIG = "tailwind.config.js"
 export const DEFAULT_TAILWIND_BASE_COLOR = "slate"
 


### PR DESCRIPTION
Update the default location of `app/globals.css` dynamically to `src/app/globals.css`
The current nextjs default is `src/app` directory 
When we create an `app` directory outside of `src` we break the route of the project.