### PR TITLE
fix(Command): remove invalid `data-[disabled]` attribute

### DIFF
--- a/apps/www/registry/default/ui/command.tsx
+++ b/apps/www/registry/default/ui/command.tsx
@@ -117,7 +117,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[selected]:bg-accent data-[selected]:text-accent-foreground",
       className
     )}
     {...props}

--- a/apps/www/registry/new-york/ui/command.tsx
+++ b/apps/www/registry/new-york/ui/command.tsx
@@ -117,7 +117,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[selected]:bg-accent data-[selected]:text-accent-foreground",
       className
     )}
     {...props}


### PR DESCRIPTION
[cmdk's README.md](https://github.com/pacocoursey/cmdk#readme) states that `[data-disabled]` is available on `<Command.Item />`. However since the PR that made this data attribute available, there has been no releases. As a result the styling using this data attribute is not being applied. 

While making these changes I realised `aria-selected` is also being used for styling, so I switched this to use the data attribute, `data-selected`, which **is** applied by cmdk.

I created an issue on cmdk repo here, https://github.com/pacocoursey/cmdk/issues/192 and will follow this but there is no indication when this will be addressed or if there will be a new release.


**Before** w/ Calendar CommandItem disabled:
<img width="709" alt="Screenshot 2023-11-19 at 21 05 33" src="https://github.com/shadcn-ui/ui/assets/55989505/b5046ba5-0509-45dc-8993-adbce578bf64">

**After** w/ Calendar CommandItem disabled:
<img width="710" alt="Screenshot 2023-11-19 at 21 04 17" src="https://github.com/shadcn-ui/ui/assets/55989505/f9cebcb6-a342-422e-ad9e-4ed56c034c12">

