### PR TITLE
fix(toast): replace MAX_VALUE with MAX_SAFE_INTEGER

### DIFF
--- a/apps/www/registry/default/ui/use-toast.ts
+++ b/apps/www/registry/default/ui/use-toast.ts
@@ -26,7 +26,7 @@ const actionTypes = {
 let count = 0
 
 function genId() {
-  count = (count + 1) % Number.MAX_VALUE
+  count = (count + 1) % Number.MAX_SAFE_INTEGER
   return count.toString()
 }
 

--- a/apps/www/registry/new-york/ui/use-toast.ts
+++ b/apps/www/registry/new-york/ui/use-toast.ts
@@ -26,7 +26,7 @@ const actionTypes = {
 let count = 0
 
 function genId() {
-  count = (count + 1) % Number.MAX_VALUE
+  count = (count + 1) % Number.MAX_SAFE_INTEGER
   return count.toString()
 }
 


### PR DESCRIPTION
This PR replaces the maximum id from `Number.MAX_VALUE` to `Number.MAX_SAFE_INTEGER` in `use-toast.ts`. Considering how JS stores numbers, it's unsafe to plus one if the number is larger than `Number.MAX_SAFE_INTEGER`. Here is an example:

```js 
> let num

> num = Number.MAX_VALUE - 1
> num + 1 === num
true

> num = Number.MAX_SAFE_INTEGER - 1
> num + 1 === num
false
```