### PR TITLE
fix(tasks): only show table header hide button when hiding enabled

### DIFF
--- a/apps/www/app/examples/tasks/components/data-table-column-header.tsx
+++ b/apps/www/app/examples/tasks/components/data-table-column-header.tsx
@@ -59,11 +59,15 @@ export function DataTableColumnHeader<TData, TValue>({
             <ArrowDownIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
             Desc
           </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => column.toggleVisibility(false)}>
-            <EyeNoneIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
-            Hide
-          </DropdownMenuItem>
+          {column.getCanHide() ? (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => column.toggleVisibility(false)}>
+                <EyeNoneIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
+                Hide
+              </DropdownMenuItem>
+            </>
+          ) : null}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>


### PR DESCRIPTION
When `enableHiding` is set to `false` on a table, the button would still show but clicking is has no effect. This makes sure to only show the button if hiding is actually enabled.