### PR TITLE
fix: rounded corners to first and last selected days in range selection date picker

### DIFF
--- a/apps/www/registry/default/ui/calendar.tsx
+++ b/apps/www/registry/default/ui/calendar.tsx
@@ -36,11 +36,18 @@ function Calendar({
         head_cell:
           "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
         row: "flex w-full mt-2",
-        cell: "text-center text-sm p-0 relative [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+        cell: cn(
+          "[&:has([aria-selected])]:bg-accent relative p-0 text-center text-sm",
+          props.mode === "range"
+            ? "[&:has(>.day-range-end)]:rounded-l-none [&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-none [&:has(>.day-range-start)]:rounded-l-md"
+            : "[&:has([aria-selected])]:rounded-md"
+        ),
         day: cn(
           buttonVariants({ variant: "ghost" }),
           "h-9 w-9 p-0 font-normal aria-selected:opacity-100"
         ),
+        day_range_start: "day-range-start",
+        day_range_end: "day-range-end",
         day_selected:
           "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
         day_today: "bg-accent text-accent-foreground",


### PR DESCRIPTION
fixes: #1957 

Using the same approach made on New York style.

---

## Behavior on browsers with support to has selector before this fix
![Screenshot 2023-11-26 at 23 21 54](https://github.com/shadcn-ui/ui/assets/13812512/b7152e60-2409-4723-ac52-2d940ce718d5)

## with fix
![Screenshot 2023-11-26 at 23 23 01](https://github.com/shadcn-ui/ui/assets/13812512/32a3dba5-a10a-4d68-a51e-122b5b32e22b)


## Behavior in browser without support to has selector

Firefox[ has a bug open to solve problem with has + pseudo class](https://bugzilla.mozilla.org/show_bug.cgi?id=418039), this fix not change how this is present, it can be fixed if we stop to use has operator, if you guys want, I can make a new solution in both styles, without has selector in a new PR.

![Screenshot 2023-11-26 at 23 24 42](https://github.com/shadcn-ui/ui/assets/13812512/99682c72-721b-4bb0-818f-726654c39d1c)
