### PR TITLE
fix(component): As child example 

### DIFF
--- a/apps/www/registry/default/example/button-as-child.tsx
+++ b/apps/www/registry/default/example/button-as-child.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/registry/default/ui/button"
 export default function ButtonAsChild() {
   return (
     <Button asChild>
-      <Link href="/login">Login</Link>
+      <Link href="/docs">Documentation</Link>
     </Button>
   )
 }

--- a/apps/www/registry/new-york/example/button-as-child.tsx
+++ b/apps/www/registry/new-york/example/button-as-child.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/registry/new-york/ui/button"
 export default function ButtonAsChild() {
   return (
     <Button asChild>
-      <Link href="/login">Login</Link>
+      <Link href="/docs">Documentation</Link>
     </Button>
   )
 }


### PR DESCRIPTION
Previously As child example that attempts redirect to login would throw 404 page.
I've fixed it to redirect to the Documentation page which shows the usage of Next Link and client side routing via the button.