### PR TITLE
feat(data-table): dont show page count if zero

### DIFF
--- a/apps/www/app/examples/tasks/components/data-table-pagination.tsx
+++ b/apps/www/app/examples/tasks/components/data-table-pagination.tsx
@@ -49,10 +49,12 @@ export function DataTablePagination<TData>({
             </SelectContent>
           </Select>
         </div>
-        <div className="flex w-[100px] items-center justify-center text-sm font-medium">
-          Page {table.getState().pagination.pageIndex + 1} of{" "}
-          {table.getPageCount()}
-        </div>
+        {table.getPageCount() !== 0 && (
+          <div className="flex w-[100px] items-center justify-center text-sm font-medium">
+            Page {table.getState().pagination.pageIndex + 1} of{" "}
+            {table.getPageCount()}
+          </div>
+        )}
         <div className="flex items-center space-x-2">
           <Button
             variant="outline"


### PR DESCRIPTION
Conditionally render current page of page count. (Page 2 of 12)

When filtering the data-table to a state where there are no results, Page 1 of 0 is displayed which makes no sense.

If you would rather keep displaying page count and do something like `{table.getPageCount() === 0 ? 1 : table.getPageCount()}`. Let me know and I will make changes.

**Before:**
<img width="1344" alt="Screenshot 2023-12-02 at 17 46 11" src="https://github.com/shadcn-ui/ui/assets/55989505/afb0dacf-a104-42b6-87ea-275f7fa90348">

**After:**
<img width="1344" alt="Screenshot 2023-12-02 at 17 46 52" src="https://github.com/shadcn-ui/ui/assets/55989505/1e1f3775-1970-4d1f-bdd9-8776fe5535c2">
