### PR TITLE
fix: update installation guide for yarn command

### DIFF
--- a/apps/www/lib/rehype-npm-command.ts
+++ b/apps/www/lib/rehype-npm-command.ts
@@ -30,10 +30,9 @@ export function rehypeNpmCommand() {
       if (node.properties?.["__rawString__"]?.startsWith("npx create-")) {
         const npmCommand = node.properties?.["__rawString__"]
         node.properties["__npmCommand__"] = npmCommand
-        node.properties["__yarnCommand__"] = npmCommand.replace(
-          "npx create-",
-          "yarn create "
-        )
+        node.properties["__yarnCommand__"] = npmCommand
+          .replace("npx create-", "yarn create ")
+          .replace("@latest", "")
         node.properties["__pnpmCommand__"] = npmCommand.replace(
           "npx create-",
           "pnpm create "


### PR DESCRIPTION
Replace `@latest` keyword with an empty string to copy the correct command line for `yarn` package manager.

This pull request resolves #2076
