### PR TITLE
Fix: constructing className conditionally with twMerge and clsx instead of cva

### DIFF
--- a/apps/www/registry/default/ui/button.tsx
+++ b/apps/www/registry/default/ui/button.tsx
@@ -44,7 +44,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const Comp = asChild ? Slot : "button"
     return (
       <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
+        className={cn(buttonVariants({ variant, size }, className))}
         ref={ref}
         {...props}
       />

--- a/apps/www/registry/default/ui/toggle.tsx
+++ b/apps/www/registry/default/ui/toggle.tsx
@@ -35,7 +35,7 @@ const Toggle = React.forwardRef<
 >(({ className, variant, size, ...props }, ref) => (
   <TogglePrimitive.Root
     ref={ref}
-    className={cn(toggleVariants({ variant, size, className }))}
+    className={cn(toggleVariants({ variant, size }, className))}
     {...props}
   />
 ))

--- a/apps/www/registry/new-york/ui/button.tsx
+++ b/apps/www/registry/new-york/ui/button.tsx
@@ -45,7 +45,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const Comp = asChild ? Slot : "button"
     return (
       <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
+        className={cn(buttonVariants({ variant, size }, className))}
         ref={ref}
         {...props}
       />

--- a/apps/www/registry/new-york/ui/toggle.tsx
+++ b/apps/www/registry/new-york/ui/toggle.tsx
@@ -35,7 +35,7 @@ const Toggle = React.forwardRef<
 >(({ className, variant, size, ...props }, ref) => (
   <TogglePrimitive.Root
     ref={ref}
-    className={cn(toggleVariants({ variant, size, className }))}
+    className={cn(toggleVariants({ variant, size }, className))}
     {...props}
   />
 ))

--- a/templates/next-template/components/ui/button.tsx
+++ b/templates/next-template/components/ui/button.tsx
@@ -44,7 +44,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const Comp = asChild ? Slot : "button"
     return (
       <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
+        className={cn(buttonVariants({ variant, size }, className))}
         ref={ref}
         {...props}
       />


### PR DESCRIPTION
Fix: constructing className conditionally with twMerge and clsx@1.2.1 instead of cva@0.4.0

cva@0.4.0 seems not support conditionally constructing className

https://github.com/joe-bell/cva/blob/v0.4.0/src/index.ts#L22-L24
```
export const cx = <T extends CxOptions>(...classes: T): CxReturn =>
  // @ts-ignore
  classes.flat(Infinity).filter(Boolean).join(" ");
```