### PR TITLE
Update alias import path in next.js installation instructions

### DIFF
--- a/apps/www/content/docs/installation/next.mdx
+++ b/apps/www/content/docs/installation/next.mdx
@@ -49,7 +49,7 @@ Here's how I configure Inter for Next.js:
 import "@/styles/globals.css"
 import { Inter as FontSans } from "next/font/google"
 
-import { cn } from "../@/lib/utils"
+import { cn } from "@/lib/utils"
 
 export const fontSans = FontSans({
   subsets: ["latin"],


### PR DESCRIPTION
Assuming the next alias are setup normally, I updated an import that mixed up relative and alias paths