### PR TITLE
refactor: use `z.nonempty()` instead of `z.refine()` for multiple checkbox forms

### DIFF
--- a/apps/www/app/examples/forms/display/display-form.tsx
+++ b/apps/www/app/examples/forms/display/display-form.tsx
@@ -45,7 +45,7 @@ const items = [
 ] as const
 
 const displayFormSchema = z.object({
-  items: z.array(z.string()).refine((value) => value.some((item) => item), {
+  items: z.array(z.string()).nonempty({
     message: "You have to select at least one item.",
   }),
 })

--- a/apps/www/registry/default/example/checkbox-form-multiple.tsx
+++ b/apps/www/registry/default/example/checkbox-form-multiple.tsx
@@ -45,7 +45,7 @@ const items = [
 ] as const
 
 const FormSchema = z.object({
-  items: z.array(z.string()).refine((value) => value.some((item) => item), {
+  items: z.array(z.string()).nonempty({
     message: "You have to select at least one item.",
   }),
 })

--- a/apps/www/registry/new-york/example/checkbox-form-multiple.tsx
+++ b/apps/www/registry/new-york/example/checkbox-form-multiple.tsx
@@ -45,7 +45,7 @@ const items = [
 ] as const
 
 const FormSchema = z.object({
-  items: z.array(z.string()).refine((value) => value.some((item) => item), {
+  items: z.array(z.string()).nonempty({
     message: "You have to select at least one item.",
   }),
 })


### PR DESCRIPTION
If you want to ensure that an array contains at least one element, use .nonempty().

Zod docs: https://zod.dev/?id=nonempty