### PR TITLE
fix(www): vaul drawer wrapper is causing the side bar to break its stickiness 

### DIFF
--- a/apps/www/app/docs/layout.tsx
+++ b/apps/www/app/docs/layout.tsx
@@ -15,7 +15,7 @@ export default function DocsLayout({ children }: DocsLayoutProps) {
             <DocsSidebarNav items={docsConfig.sidebarNav} />
           </ScrollArea>
         </aside>
-        {children}
+        <main vaul-drawer-wrapper="">{children}</main>
       </div>
     </div>
   )

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -94,7 +94,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
             enableSystem
             disableTransitionOnChange
           >
-            <div vaul-drawer-wrapper="">
+            <div>
               <div className="relative flex min-h-screen flex-col bg-background">
                 <SiteHeader />
                 <main className="flex-1">{children}</main>


### PR DESCRIPTION
https://github.com/shadcn-ui/ui/assets/86073083/082b90a2-d37c-4e75-bce0-746da1f7a6ba

The sidebar stickiness breaks when you open and close the vaul drawer. This happens because the wrapper adds overflow:hidden to the parent element and doesn't remove it after the drawer is closed. There could be another solution to remove the overflow completely, but instead, this scopes the vaul wrapper to only affect the main document so that the sidebar remains unaffected.