### PR TITLE
Update: Rename 'ResizableGroup' to 'ResizablePanelGroup' in Documentation

### DIFF
--- a/apps/www/content/docs/components/resizable.mdx
+++ b/apps/www/content/docs/components/resizable.mdx
@@ -62,11 +62,11 @@ import {
 ```
 
 ```tsx
-<ResizableGroup direction="horizontal">
+<ResizablePanelGroup direction="horizontal">
   <ResizablePanel>One</ResizablePanel>
   <ResizableHandle />
   <ResizablePanel>Two</ResizablePanel>
-</ResizableGroup>
+</ResizablePanelGroup>
 ```
 
 ## Examples
@@ -86,11 +86,11 @@ import {
 
 export default function Example() {
   return (
-    <ResizableGroup direction="vertical">
+    <ResizablePanelGroup direction="vertical">
       <ResizablePanel>One</ResizablePanel>
       <ResizableHandle />
       <ResizablePanel>Two</ResizablePanel>
-    </ResizableGroup>
+    </ResizablePanelGroup>
   )
 }
 ```
@@ -110,11 +110,11 @@ import {
 
 export default function Example() {
   return (
-    <ResizableGroup direction="vertical">
+    <ResizablePanelGroup direction="vertical">
       <ResizablePanel>One</ResizablePanel>
       <ResizableHandle withHandle />
       <ResizablePanel>Two</ResizablePanel>
-    </ResizableGroup>
+    </ResizablePanelGroup>
   )
 }
 ```


### PR DESCRIPTION
### Overview
This pull request updates the documentation to reflect the correct component name, changing `ResizableGroup` to `ResizablePanelGroup`. This change ensures consistency and correctness in the documentation, aiding developers in correctly implementing the component.

### Changes Made
- In the code examples within the documentation, `ResizableGroup` has been renamed to `ResizablePanelGroup`.
- This change is applied to both horizontal and vertical orientation examples.

### Additional Information
- These changes are confined to documentation and do not alter the actual implementation or functionality of the components in question.

Please review the changes for accuracy and merge if appropriate. Thanks!