### PR TITLE
docs(drawer): missing drawer footer import in drawer usage example

### DIFF
--- a/apps/www/content/docs/components/drawer.mdx
+++ b/apps/www/content/docs/components/drawer.mdx
@@ -61,6 +61,7 @@ import {
   DrawerHeader,
   DrawerTitle,
   DrawerTrigger,
+  DrawerFooter,
 } from "@/components/ui/drawer"
 ```
 


### PR DESCRIPTION
This PR:

- Fixes:  #2168 