### PR TITLE
fix(docs): layout shift by drawer

### DIFF
--- a/apps/www/app/docs/[[...slug]]/page.tsx
+++ b/apps/www/app/docs/[[...slug]]/page.tsx
@@ -87,7 +87,7 @@ export default async function DocPage({ params }: DocPageProps) {
   const toc = await getTableOfContents(doc.body.raw)
 
   return (
-    <main className="relative py-6 lg:gap-10 lg:py-8 xl:grid xl:grid-cols-[1fr_300px]">
+    <main className="relative overflow-hidden py-6 lg:gap-10 lg:py-8 xl:grid xl:grid-cols-[1fr_300px]">
       <div className="mx-auto w-full min-w-0">
         <div className="mb-4 flex items-center space-x-1 text-sm text-muted-foreground">
           <div className="overflow-hidden text-ellipsis whitespace-nowrap">
@@ -132,7 +132,7 @@ export default async function DocPage({ params }: DocPageProps) {
             )}
           </div>
         ) : null}
-        <div className="pb-12 pt-8">
+        <div className="overflow-hidden pb-12 pt-8">
           <Mdx code={doc.body.code} />
         </div>
         <DocsPager doc={doc} />

--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -95,7 +95,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
             disableTransitionOnChange
           >
             <div vaul-drawer-wrapper="">
-              <div className="relative flex min-h-screen flex-col bg-background">
+              <div className="relative flex min-h-screen w-screen flex-col overflow-hidden bg-background">
                 <SiteHeader />
                 <main className="flex-1">{children}</main>
                 <SiteFooter />

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -17,7 +17,7 @@ import MailPage from "@/app/examples/mail/page"
 
 export default function IndexPage() {
   return (
-    <div className="container relative">
+    <div className="container relative overflow-hidden">
       <PageHeader>
         <Announcement />
         <PageHeaderHeading>Build your component library</PageHeaderHeading>


### PR DESCRIPTION
There was a layout shft caused by the newly added drawer. Once you have toggled on the drawer and wish to close it either by swipping it down or pressing anywhere outside the demo component there happens to be a layout shift but now it is fixed on this PR