### PR TITLE
Add first and last page buttons to Pagination

### DIFF
--- a/apps/www/content/docs/components/pagination.mdx
+++ b/apps/www/content/docs/components/pagination.mdx
@@ -45,7 +45,9 @@ import {
   Pagination,
   PaginationContent,
   PaginationEllipsis,
+  PaginationFirst,
   PaginationItem,
+  PaginationLast,
   PaginationLink,
   PaginationNext,
   PaginationPrevious,
@@ -55,6 +57,7 @@ import {
 ```tsx
 <Pagination>
   <PaginationContent>
+    <PaginationFirst href="#" />
     <PaginationItem>
       <PaginationPrevious href="#" />
     </PaginationItem>
@@ -67,6 +70,7 @@ import {
     <PaginationItem>
       <PaginationNext href="#" />
     </PaginationItem>
+    <PaginationLast href="#" />
   </PaginationContent>
 </Pagination>
 ```

--- a/apps/www/registry/default/example/pagination-demo.tsx
+++ b/apps/www/registry/default/example/pagination-demo.tsx
@@ -2,7 +2,9 @@ import {
   Pagination,
   PaginationContent,
   PaginationEllipsis,
+  PaginationFirst,
   PaginationItem,
+  PaginationLast,
   PaginationLink,
   PaginationNext,
   PaginationPrevious,
@@ -12,6 +14,7 @@ export default function PaginationDemo() {
   return (
     <Pagination>
       <PaginationContent>
+        <PaginationFirst href="#" />
         <PaginationItem>
           <PaginationPrevious href="#" />
         </PaginationItem>
@@ -32,6 +35,7 @@ export default function PaginationDemo() {
         <PaginationItem>
           <PaginationNext href="#" />
         </PaginationItem>
+        <PaginationLast href="#" />
       </PaginationContent>
     </Pagination>
   )

--- a/apps/www/registry/default/ui/pagination.tsx
+++ b/apps/www/registry/default/ui/pagination.tsx
@@ -1,5 +1,11 @@
 import * as React from "react"
-import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
+import {
+  ChevronFirst,
+  ChevronLast,
+  ChevronLeft,
+  ChevronRight,
+  MoreHorizontal,
+} from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { ButtonProps, buttonVariants } from "@/registry/default/ui/button"
@@ -60,6 +66,22 @@ const PaginationLink = ({
 )
 PaginationLink.displayName = "PaginationLink"
 
+const PaginationFirst = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to first page"
+    size="default"
+    className={cn("gap-1 pl-2.5", className)}
+    {...props}
+  >
+    <ChevronFirst className="h-4 w-4" />
+    <span>First</span>
+  </PaginationLink>
+)
+PaginationFirst.displayName = "PaginationFirst"
+
 const PaginationPrevious = ({
   className,
   ...props
@@ -91,6 +113,22 @@ const PaginationNext = ({
   </PaginationLink>
 )
 
+const PaginationLast = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to last page"
+    size="default"
+    className={cn("gap-1 pr-2.5", className)}
+    {...props}
+  >
+    <span>Last</span>
+    <ChevronLast className="h-4 w-4" />
+  </PaginationLink>
+)
+PaginationLast.displayName = "PaginationLast"
+
 const PaginationEllipsis = ({
   className,
   ...props
@@ -113,4 +151,6 @@ export {
   PaginationLink,
   PaginationNext,
   PaginationPrevious,
+  PaginationFirst,
+  PaginationLast,
 }

--- a/apps/www/registry/new-york/example/pagination-demo.tsx
+++ b/apps/www/registry/new-york/example/pagination-demo.tsx
@@ -2,7 +2,9 @@ import {
   Pagination,
   PaginationContent,
   PaginationEllipsis,
+  PaginationFirst,
   PaginationItem,
+  PaginationLast,
   PaginationLink,
   PaginationNext,
   PaginationPrevious,
@@ -12,6 +14,7 @@ export default function PaginationDemo() {
   return (
     <Pagination>
       <PaginationContent>
+        <PaginationFirst href="#" />
         <PaginationItem>
           <PaginationPrevious href="#" />
         </PaginationItem>
@@ -32,6 +35,7 @@ export default function PaginationDemo() {
         <PaginationItem>
           <PaginationNext href="#" />
         </PaginationItem>
+        <PaginationLast href="#" />
       </PaginationContent>
     </Pagination>
   )

--- a/apps/www/registry/new-york/ui/pagination.tsx
+++ b/apps/www/registry/new-york/ui/pagination.tsx
@@ -3,6 +3,8 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   DotsHorizontalIcon,
+  DoubleArrowLeftIcon,
+  DoubleArrowRightIcon,
 } from "@radix-ui/react-icons"
 
 import { cn } from "@/lib/utils"
@@ -80,6 +82,22 @@ const PaginationPrevious = ({
 )
 PaginationPrevious.displayName = "PaginationPrevious"
 
+const PaginationFirst = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to first page"
+    size="default"
+    className={cn("gap-1 pl-2.5", className)}
+    {...props}
+  >
+    <DoubleArrowLeftIcon className="h-4 w-4" />
+    <span>First</span>
+  </PaginationLink>
+)
+PaginationFirst.displayName = "PaginationFirst"
+
 const PaginationNext = ({
   className,
   ...props
@@ -94,6 +112,22 @@ const PaginationNext = ({
     <ChevronRightIcon className="h-4 w-4" />
   </PaginationLink>
 )
+
+const PaginationLast = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to last page"
+    size="default"
+    className={cn("gap-1 pr-2.5", className)}
+    {...props}
+  >
+    <span>Last</span>
+    <DoubleArrowRightIcon className="h-4 w-4" />
+  </PaginationLink>
+)
+PaginationLast.displayName = "PaginationLast"
 
 const PaginationEllipsis = ({
   className,
@@ -117,4 +151,6 @@ export {
   PaginationPrevious,
   PaginationNext,
   PaginationEllipsis,
+  PaginationFirst,
+  PaginationLast,
 }


### PR DESCRIPTION
It's quite common for pagination elements to have first and last page buttons. It's okay to keep 1 button and last page visible all the time as well. With these two components shadcnui pagination can give the user the flexibility to decide how they'll handle first and last page.