### PR TITLE
docs(pagination): wrong import path of components in pagination usage

### DIFF
--- a/apps/www/content/docs/components/pagination.mdx
+++ b/apps/www/content/docs/components/pagination.mdx
@@ -49,7 +49,7 @@ import {
   PaginationLink,
   PaginationNext,
   PaginationPrevious,
-} from "@/components/ui/resizable"
+} from "@/components/ui/pagination"
 ```
 
 ```tsx


### PR DESCRIPTION
This PR:

Fixes: #2150 