### PR TITLE
Added new label for mobile navigation

### DIFF
--- a/apps/www/components/mobile-nav.tsx
+++ b/apps/www/components/mobile-nav.tsx
@@ -94,6 +94,11 @@ export function MobileNav() {
                             className="text-muted-foreground"
                           >
                             {item.title}
+                            {item.label && (
+                              <span className="ml-2 rounded-md bg-[#adfa1d] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
+                                {item.label}
+                              </span>
+                            )}
                           </MobileLink>
                         ) : (
                           item.title


### PR DESCRIPTION
- Update the `mobile-nav` component and added `new` label if `item.label` is present in the `docsConfig.sidebarNav`.

![image](https://github.com/shadcn-ui/ui/assets/70029024/e19eddf4-22bb-4afe-8158-ea795ea0c5c0)