### PR TITLE
Fix pagination import path in docs

### DIFF
--- a/apps/www/content/docs/components/pagination.mdx
+++ b/apps/www/content/docs/components/pagination.mdx
@@ -49,7 +49,7 @@ import {
   PaginationLink,
   PaginationNext,
   PaginationPrevious,
-} from "@/components/ui/resizable"
+} from "@/components/ui/pagination"
 ```
 
 ```tsx


### PR DESCRIPTION
Fix the import path from for the pagination component from `"@/components/ui/resizable"` to `"@/components/ui/pagination"` in the documentation.