### PR TITLE
fix: typo on carousel import

### DIFF
--- a/apps/www/content/docs/components/carousel.mdx
+++ b/apps/www/content/docs/components/carousel.mdx
@@ -61,7 +61,7 @@ import {
   CarouselItem,
   CarouselNext,
   CarouselPrevious,
-} from "@/registry/new-york/ui/carousel"
+} from "@/components/ui/carousel"
 ```
 
 ```tsx


### PR DESCRIPTION
# What's changed

- [x] Fixed the typo on carousel component

before fix: "@/registry/new-york/ui/carousel"
after fix: "@/components/ui/carousel"

this is ease the user to copy paste without error