### PR TITLE
Feat(docs): Added preset to Date Range Picker

### DIFF
--- a/apps/www/content/docs/components/date-picker.mdx
+++ b/apps/www/content/docs/components/date-picker.mdx
@@ -68,13 +68,17 @@ See the [React DayPicker](https://react-day-picker.js.org) documentation for mor
 
 <ComponentPreview name="date-picker-demo" />
 
+### With Presets
+
+<ComponentPreview name="date-picker-with-presets" />
+
 ### Date Range Picker
 
 <ComponentPreview name="date-picker-with-range" />
 
-### With Presets
+### With Presets <small>- internal</small>
 
-<ComponentPreview name="date-picker-with-presets" />
+<ComponentPreview name="date-picker-with-range-presets-internal" />
 
 ### Form
 

--- a/apps/www/content/docs/components/date-picker.mdx
+++ b/apps/www/content/docs/components/date-picker.mdx
@@ -80,6 +80,10 @@ See the [React DayPicker](https://react-day-picker.js.org) documentation for mor
 
 <ComponentPreview name="date-picker-with-range-presets-internal" />
 
+### With Presets <small>- external</small>
+
+<ComponentPreview name="date-picker-with-range-presets-external" />
+
 ### Form
 
 <ComponentPreview name="date-picker-form" />

--- a/apps/www/registry/default/example/date-picker-with-range-presets-external.tsx
+++ b/apps/www/registry/default/example/date-picker-with-range-presets-external.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import * as React from "react"
+import { addDays, format } from "date-fns"
+import { Calendar as CalendarIcon } from "lucide-react"
+import { DateRange } from "react-day-picker"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/registry/default/ui/button"
+import { Calendar } from "@/registry/default/ui/calendar"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/registry/default/ui/popover"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/registry/default/ui/select"
+
+export default function DatePickerWithRange({
+  className,
+}: React.HTMLAttributes<HTMLDivElement>) {
+  const [date, setDate] = React.useState<DateRange | undefined>({
+    from: new Date(2022, 0, 20),
+    to: addDays(new Date(2022, 0, 20), 20),
+  })
+
+  const handlePresetSelect = (value: string) => {
+    switch (value) {
+      case "last7Days":
+        setDate({
+          from: addDays(new Date(), -7),
+          to: new Date(),
+        })
+        break
+      case "last30Days":
+        setDate({
+          from: addDays(new Date(), -30),
+          to: new Date(),
+        })
+        break
+      case "monthToDate":
+        setDate({
+          from: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
+          to: new Date(),
+        })
+        break
+      case "yearToDate":
+        setDate({
+          from: new Date(new Date().getFullYear(), 0, 1),
+          to: new Date(),
+        })
+        break
+      default:
+        break
+    }
+  }
+
+  return (
+    <div className={cn("inline-flex", className)}>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            id="date"
+            variant={"outline"}
+            className={cn(
+              "w-[250px] justify-start text-left font-normal border-r-0 rounded-r-none",
+              !date && "text-muted-foreground"
+            )}
+          >
+            <CalendarIcon className="mr-2 h-4 w-4" />
+            {date?.from ? (
+              date.to ? (
+                <>
+                  {format(date.from, "LLL dd, y")} -{" "}
+                  {format(date.to, "LLL dd, y")}
+                </>
+              ) : (
+                format(date.from, "LLL dd, y")
+              )
+            ) : (
+              <span>Pick a date</span>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            initialFocus
+            mode="range"
+            defaultMonth={date?.from}
+            selected={date}
+            onSelect={setDate}
+            numberOfMonths={2}
+          />
+        </PopoverContent>
+      </Popover>
+      <Select
+        onValueChange={(value) => {
+          setDate(undefined) // Reset range when a preset is selected
+          handlePresetSelect(value)
+        }}
+      >
+        <SelectTrigger className="w-[140px] rounded-l-none">
+          <SelectValue placeholder="Select Range" />
+        </SelectTrigger>
+        <SelectContent position="popper">
+          <SelectItem value="last7Days">Last 7 Days</SelectItem>
+          <SelectItem value="last30Days">Last 30 Days</SelectItem>
+          <SelectItem value="monthToDate">Month to Date</SelectItem>
+          <SelectItem value="yearToDate">Year to Date</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/apps/www/registry/default/example/date-picker-with-range-presets-internal.tsx
+++ b/apps/www/registry/default/example/date-picker-with-range-presets-internal.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import * as React from "react"
+import { addDays, format } from "date-fns"
+import { Calendar as CalendarIcon } from "lucide-react"
+import { DateRange } from "react-day-picker"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/registry/default/ui/button"
+import { Calendar } from "@/registry/default/ui/calendar"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/registry/default/ui/popover"
+
+export default function DatePickerWithRange({
+  className,
+}: React.HTMLAttributes<HTMLDivElement>) {
+  const [date, setDate] = React.useState<DateRange | undefined>({
+    from: new Date(2022, 0, 20),
+    to: addDays(new Date(2022, 0, 20), 20),
+  })
+
+  const handlePresetSelect = (value: string) => {
+    switch (value) {
+      case "last7Days":
+        setDate({
+          from: addDays(new Date(), -7),
+          to: new Date(),
+        })
+        break
+      case "last30Days":
+        setDate({
+          from: addDays(new Date(), -30),
+          to: new Date(),
+        })
+        break
+      case "monthToDate":
+        setDate({
+          from: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
+          to: new Date(),
+        })
+        break
+      case "yearToDate":
+        setDate({
+          from: new Date(new Date().getFullYear(), 0, 1),
+          to: new Date(),
+        })
+        break
+      default:
+        break
+    }
+  }
+
+  return (
+    <div className={cn("inline-flex", className)}>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            id="date"
+            variant={"outline"}
+            className={cn(
+              "w-[300px] justify-start text-left font-normal",
+              !date && "text-muted-foreground"
+            )}
+          >
+            <CalendarIcon className="mr-2 h-4 w-4" />
+            {date?.from ? (
+              date.to ? (
+                <>
+                  {format(date.from, "LLL dd, y")} -{" "}
+                  {format(date.to, "LLL dd, y")}
+                </>
+              ) : (
+                format(date.from, "LLL dd, y")
+              )
+            ) : (
+              <span>Pick a date</span>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <div className="w-full flex justify-evenly p-2">
+            <Button
+              variant={"outline"}
+              onClick={() => handlePresetSelect("last7Days")}
+            >
+              Last 7 Days
+            </Button>
+            <Button
+              variant={"outline"}
+              onClick={() => handlePresetSelect("last30Days")}
+            >
+              Last 30 Days
+            </Button>
+            <Button
+              variant={"outline"}
+              onClick={() => handlePresetSelect("monthToDate")}
+            >
+              Month to Date
+            </Button>
+            <Button
+              variant={"outline"}
+              onClick={() => handlePresetSelect("yearToDate")}
+            >
+              Year to Date
+            </Button>
+          </div>
+          <div className="border-t">
+            <Calendar
+              initialFocus
+              mode="range"
+              defaultMonth={date?.from}
+              selected={date}
+              onSelect={setDate}
+              numberOfMonths={2}
+            />
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/apps/www/registry/new-york/example/date-picker-with-range-presets-external.tsx
+++ b/apps/www/registry/new-york/example/date-picker-with-range-presets-external.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import * as React from "react"
+import { addDays, format } from "date-fns"
+import { Calendar as CalendarIcon } from "lucide-react"
+import { DateRange } from "react-day-picker"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/registry/new-york/ui/button"
+import { Calendar } from "@/registry/new-york/ui/calendar"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/registry/new-york/ui/popover"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/registry/new-york/ui/select"
+
+export default function DatePickerWithRange({
+  className,
+}: React.HTMLAttributes<HTMLDivElement>) {
+  const [date, setDate] = React.useState<DateRange | undefined>({
+    from: new Date(2022, 0, 20),
+    to: addDays(new Date(2022, 0, 20), 20),
+  })
+
+  const handlePresetSelect = (value: string) => {
+    switch (value) {
+      case "last7Days":
+        setDate({
+          from: addDays(new Date(), -7),
+          to: new Date(),
+        })
+        break
+      case "last30Days":
+        setDate({
+          from: addDays(new Date(), -30),
+          to: new Date(),
+        })
+        break
+      case "monthToDate":
+        setDate({
+          from: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
+          to: new Date(),
+        })
+        break
+      case "yearToDate":
+        setDate({
+          from: new Date(new Date().getFullYear(), 0, 1),
+          to: new Date(),
+        })
+        break
+      default:
+        break
+    }
+  }
+
+  return (
+    <div className={cn("inline-flex", className)}>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            id="date"
+            variant={"outline"}
+            className={cn(
+              "w-[250px] justify-start text-left font-normal border-r-0 rounded-r-none",
+              !date && "text-muted-foreground"
+            )}
+          >
+            <CalendarIcon className="mr-2 h-4 w-4" />
+            {date?.from ? (
+              date.to ? (
+                <>
+                  {format(date.from, "LLL dd, y")} -{" "}
+                  {format(date.to, "LLL dd, y")}
+                </>
+              ) : (
+                format(date.from, "LLL dd, y")
+              )
+            ) : (
+              <span>Pick a date</span>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            initialFocus
+            mode="range"
+            defaultMonth={date?.from}
+            selected={date}
+            onSelect={setDate}
+            numberOfMonths={2}
+          />
+        </PopoverContent>
+      </Popover>
+      <Select
+        onValueChange={(value) => {
+          setDate(undefined) // Reset range when a preset is selected
+          handlePresetSelect(value)
+        }}
+      >
+        <SelectTrigger className="w-[140px] rounded-l-none">
+          <SelectValue placeholder="Select Range" />
+        </SelectTrigger>
+        <SelectContent position="popper">
+          <SelectItem value="last7Days">Last 7 Days</SelectItem>
+          <SelectItem value="last30Days">Last 30 Days</SelectItem>
+          <SelectItem value="monthToDate">Month to Date</SelectItem>
+          <SelectItem value="yearToDate">Year to Date</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/apps/www/registry/new-york/example/date-picker-with-range-presets-internal.tsx
+++ b/apps/www/registry/new-york/example/date-picker-with-range-presets-internal.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import * as React from "react"
+import { addDays, format } from "date-fns"
+import { Calendar as CalendarIcon } from "lucide-react"
+import { DateRange } from "react-day-picker"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/registry/new-york/ui/button"
+import { Calendar } from "@/registry/new-york/ui/calendar"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/registry/new-york/ui/popover"
+
+export default function DatePickerWithRange({
+  className,
+}: React.HTMLAttributes<HTMLDivElement>) {
+  const [date, setDate] = React.useState<DateRange | undefined>({
+    from: new Date(2022, 0, 20),
+    to: addDays(new Date(2022, 0, 20), 20),
+  })
+
+  const handlePresetSelect = (value: string) => {
+    switch (value) {
+      case "last7Days":
+        setDate({
+          from: addDays(new Date(), -7),
+          to: new Date(),
+        })
+        break
+      case "last30Days":
+        setDate({
+          from: addDays(new Date(), -30),
+          to: new Date(),
+        })
+        break
+      case "monthToDate":
+        setDate({
+          from: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
+          to: new Date(),
+        })
+        break
+      case "yearToDate":
+        setDate({
+          from: new Date(new Date().getFullYear(), 0, 1),
+          to: new Date(),
+        })
+        break
+      default:
+        break
+    }
+  }
+
+  return (
+    <div className={cn("inline-flex", className)}>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            id="date"
+            variant={"outline"}
+            className={cn(
+              "w-[300px] justify-start text-left font-normal",
+              !date && "text-muted-foreground"
+            )}
+          >
+            <CalendarIcon className="mr-2 h-4 w-4" />
+            {date?.from ? (
+              date.to ? (
+                <>
+                  {format(date.from, "LLL dd, y")} -{" "}
+                  {format(date.to, "LLL dd, y")}
+                </>
+              ) : (
+                format(date.from, "LLL dd, y")
+              )
+            ) : (
+              <span>Pick a date</span>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <div className="w-full flex justify-start p-2">
+            <Button
+              variant={"outline"}
+              onClick={() => handlePresetSelect("last7Days")}
+            >
+              Last 7 Days
+            </Button>
+            <Button
+              variant={"outline"}
+              onClick={() => handlePresetSelect("last30Days")}
+            >
+              Last 30 Days
+            </Button>
+            <Button
+              variant={"outline"}
+              onClick={() => handlePresetSelect("monthToDate")}
+            >
+              Month to Date
+            </Button>
+            <Button
+              variant={"outline"}
+              onClick={() => handlePresetSelect("yearToDate")}
+            >
+              Year to Date
+            </Button>
+          </div>
+          <div className="border-t">
+            <Calendar
+              initialFocus
+              mode="range"
+              defaultMonth={date?.from}
+              selected={date}
+              onSelect={setDate}
+              numberOfMonths={2}
+            />
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/apps/www/registry/registry.ts
+++ b/apps/www/registry/registry.ts
@@ -573,6 +573,13 @@ const example: Registry = [
     dependencies: ["date-fns"],
   },
   {
+    name: "date-picker-with-range-presets-external",
+    type: "components:example",
+    registryDependencies: ["button", "calendar", "popover", "select"],
+    files: ["example/date-picker-with-range-presets-external.tsx"],
+    dependencies: ["date-fns"],
+  },
+  {
     name: "dialog-demo",
     type: "components:example",
     registryDependencies: ["dialog"],

--- a/apps/www/registry/registry.ts
+++ b/apps/www/registry/registry.ts
@@ -566,6 +566,13 @@ const example: Registry = [
     dependencies: ["date-fns"],
   },
   {
+    name: "date-picker-with-range-presets-internal",
+    type: "components:example",
+    registryDependencies: ["button", "calendar", "popover"],
+    files: ["example/date-picker-with-range-presets-internal.tsx"],
+    dependencies: ["date-fns"],
+  },
+  {
     name: "dialog-demo",
     type: "components:example",
     registryDependencies: ["dialog"],


### PR DESCRIPTION
1. **Internal Presets:** Integrated internal presets into the date-range picker, accessible through buttons.

2. **External Presets:** Introduced external presets for the date-range picker, available via a select popover.

3. **Changed Arrangement:**
    - Date Picker
    - Date Picker with Internal Presets
    - Date-Range Picker
    - Date-Range Picker with Internal Presets
    - Date-Range Picker with External Presets
    
### Images
- ![image](https://github.com/shadcn-ui/ui/assets/68627196/9c08dc78-5816-4600-9da9-347805650454)

- ![image](https://github.com/shadcn-ui/ui/assets/68627196/1f861f62-bb0c-4635-9485-9c5bb0a499b3)

