### PR TITLE
feat(cli): Add cli alias

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,10 @@
   ],
   "type": "module",
   "exports": "./dist/index.js",
-  "bin": "./dist/index.js",
+  "bin": {
+    "shadcn-ui": "./dist/index.js",
+    "shui": "./dist/index.js"
+  },
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",


### PR DESCRIPTION
Add `shui` alias for `shadcn-ui` when running cli after global npm installation.