### PR TITLE
dark mode button(in the vite docs) bug fix

### DIFF
--- a/apps/www/content/docs/dark-mode/vite.mdx
+++ b/apps/www/content/docs/dark-mode/vite.mdx
@@ -125,7 +125,7 @@ export function ModeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon">
+        <Button variant="outline" size="icon" className="relative">
           <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
           <span className="sr-only">Toggle theme</span>


### PR DESCRIPTION
this PR fixes the issue discussed in #2237 

[Screencast from 03-01-24 06:18:00 PM IST.webm](https://github.com/shadcn-ui/ui/assets/91429557/89358fd8-732c-4fc9-871b-2f4925d62143)


For the dark mode moon icon is staying and not moving with the navbar on scrolling. For light mode everything is fine.
I changed the position of button to relative so that moon icon absolute positioning use button as ancestor. this fix will make this component independent component and developers will be able to copy and paste it to there application without thinking about the positioning for the component.
I am new to open source contribution, so please let me know if there's anything I can improve.