### PR TITLE
fix(pagination): wrap PaginationItem in list and fix hydration error

### DIFF
--- a/apps/www/registry/default/ui/pagination.tsx
+++ b/apps/www/registry/default/ui/pagination.tsx
@@ -29,7 +29,11 @@ const PaginationItem = React.forwardRef<
   HTMLLIElement,
   React.ComponentProps<"li">
 >(({ className, ...props }, ref) => (
-  <li ref={ref} className={cn("", className)} {...props} />
+  <React.Fragment>
+    <ul>
+      <li ref={ref} className={cn("", className)} {...props} />
+    </ul>
+  </React.Fragment>
 ))
 PaginationItem.displayName = "PaginationItem"
 


### PR DESCRIPTION
Each PaginationItem within an unordered list for improved accessibility and to adhere to proper HTML semantics, ensuring that individual pagination buttons are recognized as part of a list structure.

This solve this Hydration issue:

![SCR-20240105-mszg](https://github.com/shadcn-ui/ui/assets/8908649/6805265b-d870-4896-9dc1-ef1237a83143)
