### PR TITLE
fix(docs): Resizable panel direction should be horizontal

### DIFF
--- a/apps/www/content/docs/components/resizable.mdx
+++ b/apps/www/content/docs/components/resizable.mdx
@@ -110,7 +110,7 @@ import {
 
 export default function Example() {
   return (
-    <ResizablePanelGroup direction="vertical">
+    <ResizablePanelGroup direction="horizontal">
       <ResizablePanel>One</ResizablePanel>
       <ResizableHandle withHandle />
       <ResizablePanel>Two</ResizablePanel>


### PR DESCRIPTION
In the [resizable documentation](https://ui.shadcn.com/docs/components/resizable) the handle example shows a horizontal handle but the code example has `direction="vertical"` when it should be `direction="horizontal"`

<img width="745" alt="Screenshot 2024-01-05 at 9 34 43 AM" src="https://github.com/shadcn-ui/ui/assets/7241069/68c21241-e0c7-41b1-81d7-579306149520">
