### PR TITLE
fix(cli): change the default path for tailwind globals css

### DIFF
--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -7,7 +7,7 @@ import * as z from "zod"
 export const DEFAULT_STYLE = "default"
 export const DEFAULT_COMPONENTS = "@/components"
 export const DEFAULT_UTILS = "@/lib/utils"
-export const DEFAULT_TAILWIND_CSS = "app/globals.css"
+export const DEFAULT_TAILWIND_CSS = "src/app/globals.css"
 export const DEFAULT_TAILWIND_CONFIG = "tailwind.config.js"
 export const DEFAULT_TAILWIND_BASE_COLOR = "slate"
 


### PR DESCRIPTION
Fixes shadcn-ui/ui#1821 
Fixes shadcn-ui/ui#2302

TODO:
- [x] change default path for tailwind globals css file
- [ ] update in all the docs ([cli docs](https://github.com/shadcn-ui/ui/blob/main/apps/www/content/docs/cli.mdx), [astro docs](https://github.com/shadcn-ui/ui/blob/main/apps/www/content/docs/installation/astro.mdx), [gatsby docs](https://github.com/shadcn-ui/ui/blob/main/apps/www/content/docs/installation/gatsby.mdx), [laravel docs](https://github.com/shadcn-ui/ui/blob/main/apps/www/content/docs/installation/laravel.mdx), [next docs](https://github.com/shadcn-ui/ui/blob/main/apps/www/content/docs/installation/next.mdx), [remix docs](https://github.com/shadcn-ui/ui/blob/main/apps/www/content/docs/installation/remix.mdx), [vite docs](https://github.com/shadcn-ui/ui/blob/main/apps/www/content/docs/installation/vite.mdx))