### PR TITLE
Fix Next Theming docs

### DIFF
--- a/apps/www/content/docs/dark-mode/next.mdx
+++ b/apps/www/content/docs/dark-mode/next.mdx
@@ -18,14 +18,25 @@ npm install next-themes
 ### Create a theme provider
 
 ```tsx title="components/theme-provider.tsx"
-"use client"
+"use client";
 
-import * as React from "react"
-import { ThemeProvider as NextThemesProvider } from "next-themes"
-import { type ThemeProviderProps } from "next-themes/dist/types"
+import * as React from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { type ThemeProviderProps } from "next-themes/dist/types";
+import { useEffect, useState } from "react";
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
+  
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
 }
 ```
 
@@ -39,9 +50,9 @@ import { ThemeProvider } from "@/components/theme-provider"
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <>
-      <html lang="en" suppressHydrationWarning>
+      <html lang="en">
         <head />
-        <body>
+        <body suppressHydrationWarning>
           <ThemeProvider
             attribute="class"
             defaultTheme="system"


### PR DESCRIPTION
Following the current docs always results in hydration errors for me and many others.

I used the solution here https://github.com/pacocoursey/next-themes/issues/169#issuecomment-1539498884 to address it.

I migrated suppressHydrationWarning to the body instead, as it fixed a lot of miscellaneous browser extensions from causing an "Extra attributes from the server" error. This solution: https://github.com/vercel/next.js/discussions/22388#discussioncomment-6370684