### PR TITLE
fix(Pagination): Resolve Hydration Error by Refining Component Structure

### DIFF
--- a/apps/www/content/docs/components/pagination.mdx
+++ b/apps/www/content/docs/components/pagination.mdx
@@ -55,18 +55,12 @@ import {
 ```tsx
 <Pagination>
   <PaginationContent>
-    <PaginationItem>
-      <PaginationPrevious href="#" />
-    </PaginationItem>
-    <PaginationItem>
-      <PaginationLink href="#">1</PaginationLink>
-    </PaginationItem>
+    <PaginationPrevious href="#" />
+    <PaginationLink href="#">1</PaginationLink>
     <PaginationItem>
       <PaginationEllipsis />
     </PaginationItem>
-    <PaginationItem>
-      <PaginationNext href="#" />
-    </PaginationItem>
+    <PaginationNext href="#" />
   </PaginationContent>
 </Pagination>
 ```


### PR DESCRIPTION
I have removed the additional wrapper `<PaginationItem>` from the demo representation of the Pagination component. This adjustment was made as `PaginationPrevious`, `PaginationLink`, and `PaginationNext` already include the necessary `PaginationItem` wrapper internally.

Fixes #2323