### PR TITLE
fix(www): 404 page incompatible with light mode (#2348)

### DIFF
--- a/apps/www/app/not-found.tsx
+++ b/apps/www/app/not-found.tsx
@@ -1,0 +1,14 @@
+export default async function NotFound() {
+  return (
+    <main className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2">
+      <div className="flex items-center justify-center">
+        <h2 className="mr-6 pr-6 text-2xl font-semibold align-top leading-49 text-primary border-r border-solid border-muted-foreground">
+          404
+        </h2>
+        <p className="text-primary font-normal leading-49 m-0">
+          This page could not be found.
+        </p>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
Fixes the [issue #2348](https://github.com/shadcn-ui/ui/issues/2348) by adding a not-found template page in the root of the app directory to properly handle a 404 Not Found. The message is no longer invisible in light mode.

Note: I mirrored the default template page as best I could but a custom error page could be a plus!