### PR TITLE
Fixing Persistent Error Message in ComboBox Form Even After Option Selection

### DIFF
--- a/apps/www/registry/default/example/combobox-form.tsx
+++ b/apps/www/registry/default/example/combobox-form.tsx
@@ -104,6 +104,7 @@ export default function ComboboxForm() {
                           key={language.value}
                           onSelect={() => {
                             form.setValue("language", language.value)
+                            form.trigger("language");
                           }}
                         >
                           <Check

--- a/apps/www/registry/new-york/example/combobox-form.tsx
+++ b/apps/www/registry/new-york/example/combobox-form.tsx
@@ -107,6 +107,7 @@ export default function ComboboxForm() {
                           key={language.value}
                           onSelect={() => {
                             form.setValue("language", language.value)
+                            form.trigger("language");
                           }}
                         >
                           {language.label}


### PR DESCRIPTION

When submitting the combobox form without selecting an option, the error validation is triggered. However, soon after selecting an option, the error message still persists, despite setting `mode: 'onChange'` in the `useForm` hook. This PR addresses the issue by explicitly triggering with `form.trigger(name);` after selection, ensuring the removal of the error message when an option is selected.