### PR TITLE
perf(registry): avoid fetch if base color doesn't exists in the registry

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -101,7 +101,7 @@ export async function promptForConfig(
   const highlight = (text: string) => chalk.cyan(text)
 
   const styles = await getRegistryStyles()
-  const baseColors = await getRegistryBaseColors()
+  const baseColors = getRegistryBaseColors()
 
   const options = await prompts([
     {

--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -36,7 +36,7 @@ export async function getRegistryStyles() {
   }
 }
 
-export async function getRegistryBaseColors() {
+export function getRegistryBaseColors() {
   return [
     {
       name: "slate",

--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -62,6 +62,11 @@ export function getRegistryBaseColors() {
 }
 
 export async function getRegistryBaseColor(baseColor: string) {
+  const baseColors = getRegistryBaseColors().map((item) => item.name)
+  if (!baseColors.includes(baseColor)) {
+    throw new Error(`Base color ${baseColor} is not found.`)
+  }
+
   try {
     const [result] = await fetchRegistry([`colors/${baseColor}.json`])
 

--- a/packages/cli/test/commands/get-config.test.ts
+++ b/packages/cli/test/commands/get-config.test.ts
@@ -1,0 +1,9 @@
+import { expect, test, vi } from "vitest"
+import { getRegistryBaseColor } from "../../src/utils/registry"
+
+test("should throw error when baseColor not found in the registry", async () => {
+  const baseColor = "not-found"
+  await expect(getRegistryBaseColor(baseColor)).rejects.toThrow(
+    `Base color ${baseColor} is not found.`
+  )
+});


### PR DESCRIPTION
Hi folks!

This PR aims to solve problem #2373 by adding a check if the base color exists in the local registry. Also, I removed the Promise from `getRegistryBaseColors` since it was useless.