### PR TITLE
docs(drawer): div with [vaul-drawer-wrapper] is missing

### DIFF
--- a/apps/www/content/docs/components/drawer.mdx
+++ b/apps/www/content/docs/components/drawer.mdx
@@ -30,7 +30,7 @@ Drawer is built on top of [Vaul](https://github.com/emilkowalski/vaul) by [emilk
 npx shadcn-ui@latest add drawer
 ```
 
-<Step>Add <div> with [vaul-drawer-wrapper] data attribute</Step>
+<Step>Add div with [vaul-drawer-wrapper] data attribute</Step>
 
 ```tsx title="app/layout.tsx" {6}
 export default function RootLayout({ children }) {
@@ -67,7 +67,7 @@ npm install vaul
 
 <Step>Update the import paths to match your project setup.</Step>
 
-<Step>Add <div> with [vaul-drawer-wrapper] data attribute</Step>
+<Step>Add div with [vaul-drawer-wrapper] data attribute</Step>
 
 ```tsx title="app/layout.tsx" {6}
 export default function RootLayout({ children }) {

--- a/apps/www/content/docs/components/drawer.mdx
+++ b/apps/www/content/docs/components/drawer.mdx
@@ -30,7 +30,9 @@ Drawer is built on top of [Vaul](https://github.com/emilkowalski/vaul) by [emilk
 npx shadcn-ui@latest add drawer
 ```
 
-<Step>Add div with [vaul-drawer-wrapper] data attribute</Step>
+<Step>Add `[vaul-drawer-wrapper]` data attribute</Step>
+
+If you want to scale the background when the drawer is open i.e `shouldScaleBackground`, add `vaul-drawer-wrapper=""` to the background/root element.
 
 ```tsx title="app/layout.tsx" {6}
 export default function RootLayout({ children }) {

--- a/apps/www/content/docs/components/drawer.mdx
+++ b/apps/www/content/docs/components/drawer.mdx
@@ -22,9 +22,32 @@ Drawer is built on top of [Vaul](https://github.com/emilkowalski/vaul) by [emilk
 </TabsList>
 <TabsContent value="cli">
 
+<Steps>
+
+<Step>Run the following command:</Step>
+
 ```bash
 npx shadcn-ui@latest add drawer
 ```
+
+<Step>Add <div> with [vaul-drawer-wrapper] data attribute</Step>
+
+```tsx title="app/layout.tsx" {6}
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <head />
+      <body>
+        <div vaul-drawer-wrapper="">
+          <main>{children}</main>
+        </div>
+      </body>
+    </html>
+  )
+}
+```
+
+</Steps>
 
 </TabsContent>
 
@@ -43,6 +66,23 @@ npm install vaul
 <ComponentSource name="drawer" />
 
 <Step>Update the import paths to match your project setup.</Step>
+
+<Step>Add <div> with [vaul-drawer-wrapper] data attribute</Step>
+
+```tsx title="app/layout.tsx" {6}
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <head />
+      <body>
+        <div vaul-drawer-wrapper="">
+          <main>{children}</main>
+        </div>
+      </body>
+    </html>
+  )
+}
+```
 
 </Steps>
 

--- a/apps/www/content/docs/components/drawer.mdx
+++ b/apps/www/content/docs/components/drawer.mdx
@@ -69,7 +69,9 @@ npm install vaul
 
 <Step>Update the import paths to match your project setup.</Step>
 
-<Step>Add div with [vaul-drawer-wrapper] data attribute</Step>
+<Step>Add `[vaul-drawer-wrapper]` data attribute</Step>
+
+If you want to scale the background when the drawer is open i.e `shouldScaleBackground`, add `vaul-drawer-wrapper=""` to the background/root element.
 
 ```tsx title="app/layout.tsx" {6}
 export default function RootLayout({ children }) {


### PR DESCRIPTION
A div with [vaul-drawer-wrapper] is required to enable background scaling.
This change is required so that passing **shouldScaleBackground** prop to the Drawer component takes effect.

[It is documented here!](https://github.com/emilkowalski/vaul#api-reference)

Thanks!