### PR TITLE
Fix: Button outline color correction

### DIFF
--- a/apps/www/registry/default/ui/button.tsx
+++ b/apps/www/registry/default/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-inherit hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",

--- a/apps/www/registry/new-york/ui/button.tsx
+++ b/apps/www/registry/new-york/ui/button.tsx
@@ -14,7 +14,7 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
         outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-inherit shadow-sm hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",


### PR DESCRIPTION
Hi everyone,

This is my first PR so let me know if I did anything wrong. Still learning the ins and outs of things but trying to be more active and notice fixes when I see them.

I made a quick fix to the `<Button variant="outline">` where the background wasn't actually the right color for just an outline. The prime source of error here was when an outlined button sits inside a `<Card>` object, where the button then takes the color of the background rather than the color of the Card it sits on. Switching from `bg-background` to `bg-inherit` handles these two issues.

Sample where `bg-inherit` is used: 
<img width="1130" alt="image" src="https://github.com/shadcn-ui/ui/assets/87681482/778cd6e6-2d5a-4d5f-8a6f-71e4a3f1f8ba">

Sample where `bg-background` is used: 
<img width="1133" alt="image" src="https://github.com/shadcn-ui/ui/assets/87681482/69ba4b3c-6bb3-430b-9d2c-d9dcdfe13d32">

Thanks everyone! I've been loving this library for my website I'm building, and can't wait to see what the final product looks like!