### PR TITLE
fix: added gap instead of space

### DIFF
--- a/apps/www/registry/default/ui/dialog.tsx
+++ b/apps/www/registry/default/ui/dialog.tsx
@@ -73,7 +73,7 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
       className
     )}
     {...props}


### PR DESCRIPTION
fixes #2447

I removed space-x-2 and added gap-2 as we were using flex box.

Also it is not given to specific breakpoint so it will also give gap to every viewpoint which was the main objective of the pull request.