### PR TITLE
feat(docs): added external link button to ComponentPreview component's Code tab

### DIFF
--- a/apps/www/components/external-file-link-button.tsx
+++ b/apps/www/components/external-file-link-button.tsx
@@ -3,17 +3,17 @@
 import * as React from "react"
 import { ExternalLinkIcon } from "@radix-ui/react-icons"
 
+import { siteConfig } from "@/config/site"
 import { Event, trackEvent } from "@/lib/events"
 import { cn } from "@/lib/utils"
 import { Button } from "@/registry/new-york/ui/button"
-import { siteConfig } from "@/config/site"
 
-interface ExternalFileLinkButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
+interface ExternalFileLinkButtonProps
+  extends React.HTMLAttributes<HTMLButtonElement> {
   value: string
   src?: string
   event?: Event["name"]
 }
-
 
 export function ExternalFileLinkButton({
   value,
@@ -22,9 +22,8 @@ export function ExternalFileLinkButton({
   event,
   ...props
 }: ExternalFileLinkButtonProps) {
-
   const redirectToExternalLink = React.useCallback(() => {
-    const prefix = `${siteConfig.links.github}${siteConfig.demoCodeSlug}`;
+    const prefix = `${siteConfig.links.github}${siteConfig.demoCodeSlug}`
     if (event) {
       trackEvent({
         name: event,
@@ -33,7 +32,7 @@ export function ExternalFileLinkButton({
         },
       })
     }
-    window.open(prefix+src, "_blank")
+    window.open(prefix + src, "_blank")
   }, [src, value, event])
   return (
     <Button

--- a/apps/www/components/external-file-link-button.tsx
+++ b/apps/www/components/external-file-link-button.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import * as React from "react"
+import { ExternalLinkIcon } from "@radix-ui/react-icons"
+
+import { Event, trackEvent } from "@/lib/events"
+import { cn } from "@/lib/utils"
+import { Button } from "@/registry/new-york/ui/button"
+import { siteConfig } from "@/config/site"
+
+interface ExternalFileLinkButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
+  value: string
+  src?: string
+  event?: Event["name"]
+}
+
+
+export function ExternalFileLinkButton({
+  value,
+  className,
+  src,
+  event,
+  ...props
+}: ExternalFileLinkButtonProps) {
+
+  const redirectToExternalLink = React.useCallback(() => {
+    const prefix = `${siteConfig.links.github}${siteConfig.demoCodeSlug}`;
+    if (event) {
+      trackEvent({
+        name: event,
+        properties: {
+          code: value,
+        },
+      })
+    }
+    window.open(prefix+src, "_blank")
+  }, [src, value, event])
+  return (
+    <Button
+      size="icon"
+      variant="ghost"
+      className={cn(
+        "relative z-10 h-6 w-6 text-zinc-50 hover:bg-zinc-700 hover:text-zinc-50",
+        className
+      )}
+      onClick={redirectToExternalLink}
+      {...props}
+    >
+      <span className="sr-only">External Link</span>
+      <ExternalLinkIcon className="h-3 w-3" />
+    </Button>
+  )
+}

--- a/apps/www/components/mdx-components.tsx
+++ b/apps/www/components/mdx-components.tsx
@@ -208,7 +208,10 @@ const components = {
                 value={__rawString__}
                 src={__src__}
                 event={__event__}
-                className={cn("absolute right-10 top-4", __withMeta__ && "top-16")}
+                className={cn(
+                  "absolute right-10 top-4",
+                  __withMeta__ && "top-16"
+                )}
                 title="Link to code"
               />
             )}

--- a/apps/www/components/mdx-components.tsx
+++ b/apps/www/components/mdx-components.tsx
@@ -15,6 +15,7 @@ import { ComponentExample } from "@/components/component-example"
 import { ComponentPreview } from "@/components/component-preview"
 import { ComponentSource } from "@/components/component-source"
 import { CopyButton, CopyNpmCommandButton } from "@/components/copy-button"
+import { ExternalFileLinkButton } from "@/components/external-file-link-button"
 import { FrameworkDocs } from "@/components/framework-docs"
 import { StyleWrapper } from "@/components/style-wrapper"
 import {
@@ -195,12 +196,23 @@ const components = {
           {...props}
         />
         {__rawString__ && !__npmCommand__ && (
-          <CopyButton
-            value={__rawString__}
-            src={__src__}
-            event={__event__}
-            className={cn("absolute right-4 top-4", __withMeta__ && "top-16")}
-          />
+          <>
+            <CopyButton
+              value={__rawString__}
+              src={__src__}
+              event={__event__}
+              className={cn("absolute right-4 top-4", __withMeta__ && "top-16")}
+            />
+            {__src__ && (
+              <ExternalFileLinkButton
+                value={__rawString__}
+                src={__src__}
+                event={__event__}
+                className={cn("absolute right-10 top-4", __withMeta__ && "top-16")}
+                title="Link to code"
+              />
+            )}
+          </>
         )}
         {__npmCommand__ &&
           __yarnCommand__ &&

--- a/apps/www/config/site.ts
+++ b/apps/www/config/site.ts
@@ -8,6 +8,7 @@ export const siteConfig = {
     twitter: "https://twitter.com/shadcn",
     github: "https://github.com/shadcn-ui/ui",
   },
+  demoCodeSlug: "/blob/main/apps/www/",
 }
 
 export type SiteConfig = typeof siteConfig


### PR DESCRIPTION
In response to issue https://github.com/shadcn-ui/ui/issues/2386, this correction introduces an external link icon button in the ComponentPreview component's Code tab, alongside the copy icon button. This button will redirect the user to the GitHub repository file link of the demo code.

<img width="1440" alt="image" src="https://github.com/shadcn-ui/ui/assets/98891987/8272dd84-0e49-4bce-93db-ae1529df5a6f">
<img width="1440" alt="image" src="https://github.com/shadcn-ui/ui/assets/98891987/23b9ca59-d6bc-456d-b26f-ef4cdbcf1591">
