### PR TITLE
refactor: update zod imports

### DIFF
--- a/apps/www/app/examples/forms/account/account-form.tsx
+++ b/apps/www/app/examples/forms/account/account-form.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { CalendarIcon, CaretSortIcon, CheckIcon } from "@radix-ui/react-icons"
 import { format } from "date-fns"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/registry/new-york/ui/button"

--- a/apps/www/app/examples/forms/appearance/appearance-form.tsx
+++ b/apps/www/app/examples/forms/appearance/appearance-form.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { ChevronDownIcon } from "@radix-ui/react-icons"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { cn } from "@/lib/utils"
 import { Button, buttonVariants } from "@/registry/new-york/ui/button"

--- a/apps/www/app/examples/forms/display/display-form.tsx
+++ b/apps/www/app/examples/forms/display/display-form.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/registry/new-york/ui/button"
 import { Checkbox } from "@/registry/new-york/ui/checkbox"

--- a/apps/www/app/examples/forms/notifications/notifications-form.tsx
+++ b/apps/www/app/examples/forms/notifications/notifications-form.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/registry/new-york/ui/button"
 import { Checkbox } from "@/registry/new-york/ui/checkbox"

--- a/apps/www/app/examples/forms/profile-form.tsx
+++ b/apps/www/app/examples/forms/profile-form.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useFieldArray, useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/registry/new-york/ui/button"

--- a/apps/www/content/docs/components/form.mdx
+++ b/apps/www/content/docs/components/form.mdx
@@ -128,7 +128,7 @@ Define the shape of your form using a Zod schema. You can read more about using 
 ```tsx showLineNumbers {3,5-7}
 "use client"
 
-import * as z from "zod"
+import { z } from "zod"
 
 const formSchema = z.object({
   username: z.string().min(2).max(50),
@@ -144,7 +144,7 @@ Use the `useForm` hook from `react-hook-form` to create a form.
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 const formSchema = z.object({
   username: z.string().min(2, {
@@ -181,7 +181,7 @@ We can now use the `<Form />` components to build our form.
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/components/ui/button"
 import {

--- a/apps/www/lib/validations/log.ts
+++ b/apps/www/lib/validations/log.ts
@@ -1,4 +1,4 @@
-import * as z from "zod"
+import { z } from "zod"
 
 export const logSchema = z.object({
   event: z.enum(["copy_primitive"]),

--- a/apps/www/lib/validations/og.ts
+++ b/apps/www/lib/validations/og.ts
@@ -1,4 +1,4 @@
-import * as z from "zod"
+import { z } from "zod"
 
 export const ogImageSchema = z.object({
   heading: z.string(),

--- a/apps/www/registry/default/example/calendar-form.tsx
+++ b/apps/www/registry/default/example/calendar-form.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { format } from "date-fns"
 import { CalendarIcon } from "lucide-react"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/registry/default/ui/button"

--- a/apps/www/registry/default/example/calendar-react-hook-form.tsx
+++ b/apps/www/registry/default/example/calendar-react-hook-form.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { format } from "date-fns"
 import { CalendarIcon } from "lucide-react"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/registry/default/ui/button"

--- a/apps/www/registry/default/example/checkbox-form-multiple.tsx
+++ b/apps/www/registry/default/example/checkbox-form-multiple.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/registry/default/ui/button"
 import { Checkbox } from "@/registry/default/ui/checkbox"

--- a/apps/www/registry/default/example/checkbox-form-single.tsx
+++ b/apps/www/registry/default/example/checkbox-form-single.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/registry/default/ui/button"
 import { Checkbox } from "@/registry/default/ui/checkbox"

--- a/apps/www/registry/default/example/combobox-form.tsx
+++ b/apps/www/registry/default/example/combobox-form.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Check, ChevronsUpDown } from "lucide-react"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/registry/default/ui/button"

--- a/apps/www/registry/default/example/date-picker-form.tsx
+++ b/apps/www/registry/default/example/date-picker-form.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { format } from "date-fns"
 import { CalendarIcon } from "lucide-react"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/registry/default/ui/button"

--- a/apps/www/registry/default/example/input-form.tsx
+++ b/apps/www/registry/default/example/input-form.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/registry/default/ui/button"
 import {

--- a/apps/www/registry/default/example/radio-group-form.tsx
+++ b/apps/www/registry/default/example/radio-group-form.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/registry/default/ui/button"
 import {

--- a/apps/www/registry/default/example/select-form.tsx
+++ b/apps/www/registry/default/example/select-form.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/registry/default/ui/button"
 import {

--- a/apps/www/registry/default/example/switch-form.tsx
+++ b/apps/www/registry/default/example/switch-form.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/registry/default/ui/button"
 import {

--- a/apps/www/registry/default/example/textarea-form.tsx
+++ b/apps/www/registry/default/example/textarea-form.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/registry/default/ui/button"
 import {

--- a/apps/www/registry/new-york/example/calendar-form.tsx
+++ b/apps/www/registry/new-york/example/calendar-form.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { CalendarIcon } from "@radix-ui/react-icons"
 import { format } from "date-fns"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/registry/new-york/ui/button"

--- a/apps/www/registry/new-york/example/checkbox-form-multiple.tsx
+++ b/apps/www/registry/new-york/example/checkbox-form-multiple.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/registry/new-york/ui/button"
 import { Checkbox } from "@/registry/new-york/ui/checkbox"

--- a/apps/www/registry/new-york/example/checkbox-form-single.tsx
+++ b/apps/www/registry/new-york/example/checkbox-form-single.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/registry/new-york/ui/button"
 import { Checkbox } from "@/registry/new-york/ui/checkbox"

--- a/apps/www/registry/new-york/example/combobox-form.tsx
+++ b/apps/www/registry/new-york/example/combobox-form.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { CaretSortIcon, CheckIcon } from "@radix-ui/react-icons"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/registry/new-york/ui/button"

--- a/apps/www/registry/new-york/example/date-picker-form.tsx
+++ b/apps/www/registry/new-york/example/date-picker-form.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { CalendarIcon } from "@radix-ui/react-icons"
 import { format } from "date-fns"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/registry/new-york/ui/button"

--- a/apps/www/registry/new-york/example/input-form.tsx
+++ b/apps/www/registry/new-york/example/input-form.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/registry/new-york/ui/button"
 import {

--- a/apps/www/registry/new-york/example/radio-group-form.tsx
+++ b/apps/www/registry/new-york/example/radio-group-form.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/registry/new-york/ui/button"
 import {

--- a/apps/www/registry/new-york/example/select-form.tsx
+++ b/apps/www/registry/new-york/example/select-form.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/registry/new-york/ui/button"
 import {

--- a/apps/www/registry/new-york/example/switch-form.tsx
+++ b/apps/www/registry/new-york/example/switch-form.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/registry/new-york/ui/button"
 import {

--- a/apps/www/registry/new-york/example/textarea-form.tsx
+++ b/apps/www/registry/new-york/example/textarea-form.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import * as z from "zod"
+import { z } from "zod"
 
 import { Button } from "@/registry/new-york/ui/button"
 import {

--- a/apps/www/registry/schema.ts
+++ b/apps/www/registry/schema.ts
@@ -1,4 +1,4 @@
-import * as z from "zod"
+import { z } from "zod"
 
 export const registrySchema = z.array(
   z.object({


### PR DESCRIPTION
As of v3 of zod, using `import * as z from "zod"` is no longer required, [see here](https://github.com/colinhacks/zod/blob/dd849254d1149bc1f2ef0f47f0f7607955e4db85/MIGRATION.md?plain=1#L30).

This PR aligns all zod imports to match `import { z } from "zod"`
Both methods are already used in the project.

This also aligns imports to match zod documentation.
<img width="756" alt="Screenshot 2024-01-17 at 10 57 38" src="https://github.com/shadcn-ui/ui/assets/55989505/e339019e-4ebd-4ae1-ac8c-5dc74bb4b1d3">
