### PR TITLE
feat(carousel): navigation dots

### DIFF
--- a/apps/www/__registry__/index.tsx
+++ b/apps/www/__registry__/index.tsx
@@ -502,6 +502,13 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/default/example/carousel-orientation")),
       files: ["registry/default/example/carousel-orientation.tsx"],
     },
+    "carousel-dots": {
+      name: "carousel-dots",
+      type: "components:example",
+      registryDependencies: ["carousel"],
+      component: React.lazy(() => import("@/registry/default/example/carousel-dots")),
+      files: ["registry/default/example/carousel-dots.tsx"],
+    },
     "carousel-api": {
       name: "carousel-api",
       type: "components:example",
@@ -1720,6 +1727,13 @@ export const Index: Record<string, any> = {
       registryDependencies: ["carousel"],
       component: React.lazy(() => import("@/registry/new-york/example/carousel-orientation")),
       files: ["registry/new-york/example/carousel-orientation.tsx"],
+    },
+    "carousel-dots": {
+      name: "carousel-dots",
+      type: "components:example",
+      registryDependencies: ["carousel"],
+      component: React.lazy(() => import("@/registry/new-york/example/carousel-dots")),
+      files: ["registry/new-york/example/carousel-dots.tsx"],
     },
     "carousel-api": {
       name: "carousel-api",

--- a/apps/www/content/docs/components/carousel.mdx
+++ b/apps/www/content/docs/components/carousel.mdx
@@ -158,6 +158,23 @@ Use the `orientation` prop to set the orientation of the carousel.
 </Carousel>
 ```
 
+### Dots
+
+You can use the `<CarouselDots />` component to enable slides pagination.
+
+<ComponentPreview name="carousel-dots" />
+
+```tsx showLineNumbers /vertical | horizontal/
+<Carousel>
+  <CarouselContent>
+    <CarouselItem>...</CarouselItem>
+    <CarouselItem>...</CarouselItem>
+    <CarouselItem>...</CarouselItem>
+  </CarouselContent>
+  <CarouselDots />
+</Carousel>
+```
+
 ## Options
 
 You can pass options to the carousel using the `opts` prop. See the [Embla Carousel docs](https://www.embla-carousel.com/api/options/) for more information.

--- a/apps/www/registry/default/example/carousel-dots.tsx
+++ b/apps/www/registry/default/example/carousel-dots.tsx
@@ -1,0 +1,37 @@
+import * as React from "react"
+
+import { Card, CardContent } from "@/registry/default/ui/card"
+import {
+  Carousel,
+  CarouselContent,
+  CarouselDots,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/registry/default/ui/carousel"
+
+export default function CarouselDotsExample() {
+  return (
+    <Carousel className="w-full max-w-sm">
+      <CarouselContent className="-ml-1">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <CarouselItem
+            key={index}
+            className="pl-1 md:basis-1/2 lg:basis-1/3   "
+          >
+            <div className="p-1">
+              <Card>
+                <CardContent className="flex aspect-square items-center justify-center p-6">
+                  <span className="text-2xl font-semibold">{index + 1}</span>
+                </CardContent>
+              </Card>
+            </div>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+      <CarouselDots />
+    </Carousel>
+  )
+}

--- a/apps/www/registry/default/ui/carousel.tsx
+++ b/apps/www/registry/default/ui/carousel.tsx
@@ -252,6 +252,35 @@ const CarouselNext = React.forwardRef<
 })
 CarouselNext.displayName = "CarouselNext"
 
+const CarouselDots = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { api } = useCarousel()
+  const isCurrent = (index: number) => index === api?.selectedScrollSnap()
+  const length = api?.scrollSnapList().length ?? 1
+
+  return (
+    <div
+      ref={ref}
+      className={cn("my-2 flex justify-center gap-1", className)}
+      {...props}
+    >
+      {Array.from({ length }).map((_, index) => (
+        <button
+          className={cn(
+            "h-2.5 w-2.5 rounded-full transition-all duration-300",
+            isCurrent(index) ? "bg-primary" : "bg-primary/50"
+          )}
+          key={index}
+          onClick={() => api?.scrollTo(index)}
+        />
+      ))}
+    </div>
+  )
+})
+CarouselDots.displayName = "CarouselDots"
+
 export {
   type CarouselApi,
   Carousel,
@@ -259,4 +288,5 @@ export {
   CarouselItem,
   CarouselPrevious,
   CarouselNext,
+  CarouselDots,
 }

--- a/apps/www/registry/new-york/example/carousel-dots.tsx
+++ b/apps/www/registry/new-york/example/carousel-dots.tsx
@@ -1,0 +1,34 @@
+import * as React from "react"
+
+import { Card, CardContent } from "@/registry/new-york/ui/card"
+import {
+  Carousel,
+  CarouselContent,
+  CarouselDots,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/registry/new-york/ui/carousel"
+
+export default function CarouselDotsExample() {
+  return (
+    <Carousel className="w-full max-w-sm">
+      <CarouselContent className="-ml-1">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <CarouselItem key={index} className="pl-1 md:basis-1/2 lg:basis-1/3">
+            <div className="p-1">
+              <Card>
+                <CardContent className="flex aspect-square items-center justify-center p-6">
+                  <span className="text-2xl font-semibold">{index + 1}</span>
+                </CardContent>
+              </Card>
+            </div>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+      <CarouselDots />
+    </Carousel>
+  )
+}

--- a/apps/www/registry/new-york/ui/carousel.tsx
+++ b/apps/www/registry/new-york/ui/carousel.tsx
@@ -28,6 +28,7 @@ type CarouselContextProps = {
   scrollNext: () => void
   canScrollPrev: boolean
   canScrollNext: boolean
+  currentSlide: number
 } & CarouselProps
 
 const CarouselContext = React.createContext<CarouselContextProps | null>(null)
@@ -67,12 +68,14 @@ const Carousel = React.forwardRef<
     )
     const [canScrollPrev, setCanScrollPrev] = React.useState(false)
     const [canScrollNext, setCanScrollNext] = React.useState(false)
+    const [currentSlide, setCurrentSlide] = React.useState(api?.selectedScrollSnap() ?? 0)
 
     const onSelect = React.useCallback((api: CarouselApi) => {
       if (!api) {
         return
       }
 
+      setCurrentSlide(api?.selectedScrollSnap())
       setCanScrollPrev(api.canScrollPrev())
       setCanScrollNext(api.canScrollNext())
     }, [])
@@ -132,6 +135,7 @@ const Carousel = React.forwardRef<
           scrollNext,
           canScrollPrev,
           canScrollNext,
+          currentSlide
         }}
       >
         <div
@@ -252,6 +256,38 @@ const CarouselNext = React.forwardRef<
 })
 CarouselNext.displayName = "CarouselNext"
 
+const CarouselDots = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { api, currentSlide } = useCarousel()
+  const length = api?.scrollSnapList().length ?? 1
+
+  return (
+    <div
+      ref={ref}
+      role="tablist"
+      className={cn("my-2 flex justify-center gap-1", className)}
+      {...props}
+    >
+      {Array.from({ length }).map((_, index) => (
+        <button
+          key={index}
+          role="tab"
+          aria-selected={index === currentSlide ? 'true' : 'false'}
+          aria-label={`Slide ${index + 1}`}
+          onClick={() => api?.scrollTo(index)}
+          className={cn(
+            "h-2.5 w-2.5 rounded-full transition-all duration-300",
+            index === currentSlide ? "bg-primary" : "bg-primary/50"
+          )}
+        />
+      ))}
+    </div>
+  )
+})
+CarouselDots.displayName = "CarouselDots"
+
 export {
   type CarouselApi,
   Carousel,
@@ -259,4 +295,5 @@ export {
   CarouselItem,
   CarouselPrevious,
   CarouselNext,
+  CarouselDots,
 }

--- a/apps/www/registry/registry.ts
+++ b/apps/www/registry/registry.ts
@@ -436,6 +436,12 @@ const example: Registry = [
     files: ["example/carousel-orientation.tsx"],
   },
   {
+    name: "carousel-dots",
+    type: "components:example",
+    registryDependencies: ["carousel"],
+    files: ["example/carousel-dots.tsx"],
+  },
+  {
     name: "carousel-api",
     type: "components:example",
     registryDependencies: ["carousel"],


### PR DESCRIPTION
As I was using `Carousel` component, I needed to implement Dots Pagination in my project. They are pretty common in many Carousel/Slider libraries, such as [slick](https://kenwheeler.github.io/slick/), [Keen-Slider](https://keen-slider.io/examples), [Swiper](https://swiperjs.com/demos) and etc.

This pull request adds a `CarouselDots` component to improve the current `Carousel`.

![image](https://github.com/shadcn-ui/ui/assets/61247833/4153bb17-8b84-4a06-b3f9-63ff4d3c9e98)
