### PR TITLE
docs: removed unnecessary link of github - navbar

### DIFF
--- a/apps/www/components/main-nav.tsx
+++ b/apps/www/components/main-nav.tsx
@@ -63,14 +63,6 @@ export function MainNav() {
         >
           Examples
         </Link>
-        <Link
-          href={siteConfig.links.github}
-          className={cn(
-            "hidden text-foreground/60 transition-colors hover:text-foreground/80 lg:block"
-          )}
-        >
-          GitHub
-        </Link>
       </nav>
     </div>
   )


### PR DESCRIPTION
fixes #2490 

There were two links in navigation bar.
This pull request has one link removed from nav links and github icon link is still there.

Note: only removed from larger than sm breakpoint.