### PR TITLE
fix (sheet): extend SheetContentProps types

### DIFF
--- a/apps/www/registry/default/ui/sheet.tsx
+++ b/apps/www/registry/default/ui/sheet.tsx
@@ -51,7 +51,10 @@ const sheetVariants = cva(
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+  children?: React.ReactNode;
+  className?: string;
+}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,


### PR DESCRIPTION
Fix interface SheetContentProps to extend React.ComponentPropsWithoutRef and VariantProps

This change enables the SheetContentProps to accept any valid props for React components and variants, such as style, className, id, etc.

@shadcn, please review the code and type definitions of the SheetContentProps interface.