### PR TITLE
docs: Dialog static backdrop

### DIFF
--- a/apps/www/__registry__/index.tsx
+++ b/apps/www/__registry__/index.tsx
@@ -4,15 +4,15 @@
 import * as React from "react"
 
 export const Index: Record<string, any> = {
-  "default": {
-    "accordion": {
+  default: {
+    accordion: {
       name: "accordion",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/accordion")),
       files: ["registry/default/ui/accordion.tsx"],
     },
-    "alert": {
+    alert: {
       name: "alert",
       type: "components:ui",
       registryDependencies: undefined,
@@ -33,63 +33,63 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/default/ui/aspect-ratio")),
       files: ["registry/default/ui/aspect-ratio.tsx"],
     },
-    "avatar": {
+    avatar: {
       name: "avatar",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/avatar")),
       files: ["registry/default/ui/avatar.tsx"],
     },
-    "badge": {
+    badge: {
       name: "badge",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/badge")),
       files: ["registry/default/ui/badge.tsx"],
     },
-    "button": {
+    button: {
       name: "button",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/button")),
       files: ["registry/default/ui/button.tsx"],
     },
-    "calendar": {
+    calendar: {
       name: "calendar",
       type: "components:ui",
       registryDependencies: ["button"],
       component: React.lazy(() => import("@/registry/default/ui/calendar")),
       files: ["registry/default/ui/calendar.tsx"],
     },
-    "card": {
+    card: {
       name: "card",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/card")),
       files: ["registry/default/ui/card.tsx"],
     },
-    "carousel": {
+    carousel: {
       name: "carousel",
       type: "components:ui",
       registryDependencies: ["button"],
       component: React.lazy(() => import("@/registry/default/ui/carousel")),
       files: ["registry/default/ui/carousel.tsx"],
     },
-    "checkbox": {
+    checkbox: {
       name: "checkbox",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/checkbox")),
       files: ["registry/default/ui/checkbox.tsx"],
     },
-    "collapsible": {
+    collapsible: {
       name: "collapsible",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/collapsible")),
       files: ["registry/default/ui/collapsible.tsx"],
     },
-    "command": {
+    command: {
       name: "command",
       type: "components:ui",
       registryDependencies: ["dialog"],
@@ -103,14 +103,14 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/default/ui/context-menu")),
       files: ["registry/default/ui/context-menu.tsx"],
     },
-    "dialog": {
+    dialog: {
       name: "dialog",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/dialog")),
       files: ["registry/default/ui/dialog.tsx"],
     },
-    "drawer": {
+    drawer: {
       name: "drawer",
       type: "components:ui",
       registryDependencies: undefined,
@@ -121,13 +121,15 @@ export const Index: Record<string, any> = {
       name: "dropdown-menu",
       type: "components:ui",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/ui/dropdown-menu")),
+      component: React.lazy(
+        () => import("@/registry/default/ui/dropdown-menu")
+      ),
       files: ["registry/default/ui/dropdown-menu.tsx"],
     },
-    "form": {
+    form: {
       name: "form",
       type: "components:ui",
-      registryDependencies: ["button","label"],
+      registryDependencies: ["button", "label"],
       component: React.lazy(() => import("@/registry/default/ui/form")),
       files: ["registry/default/ui/form.tsx"],
     },
@@ -138,21 +140,21 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/default/ui/hover-card")),
       files: ["registry/default/ui/hover-card.tsx"],
     },
-    "input": {
+    input: {
       name: "input",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/input")),
       files: ["registry/default/ui/input.tsx"],
     },
-    "label": {
+    label: {
       name: "label",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/label")),
       files: ["registry/default/ui/label.tsx"],
     },
-    "menubar": {
+    menubar: {
       name: "menubar",
       type: "components:ui",
       registryDependencies: undefined,
@@ -163,24 +165,26 @@ export const Index: Record<string, any> = {
       name: "navigation-menu",
       type: "components:ui",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/ui/navigation-menu")),
+      component: React.lazy(
+        () => import("@/registry/default/ui/navigation-menu")
+      ),
       files: ["registry/default/ui/navigation-menu.tsx"],
     },
-    "pagination": {
+    pagination: {
       name: "pagination",
       type: "components:ui",
       registryDependencies: ["button"],
       component: React.lazy(() => import("@/registry/default/ui/pagination")),
       files: ["registry/default/ui/pagination.tsx"],
     },
-    "popover": {
+    popover: {
       name: "popover",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/popover")),
       files: ["registry/default/ui/popover.tsx"],
     },
-    "progress": {
+    progress: {
       name: "progress",
       type: "components:ui",
       registryDependencies: undefined,
@@ -194,7 +198,7 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/default/ui/radio-group")),
       files: ["registry/default/ui/radio-group.tsx"],
     },
-    "resizable": {
+    resizable: {
       name: "resizable",
       type: "components:ui",
       registryDependencies: undefined,
@@ -208,84 +212,88 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/default/ui/scroll-area")),
       files: ["registry/default/ui/scroll-area.tsx"],
     },
-    "select": {
+    select: {
       name: "select",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/select")),
       files: ["registry/default/ui/select.tsx"],
     },
-    "separator": {
+    separator: {
       name: "separator",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/separator")),
       files: ["registry/default/ui/separator.tsx"],
     },
-    "sheet": {
+    sheet: {
       name: "sheet",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/sheet")),
       files: ["registry/default/ui/sheet.tsx"],
     },
-    "skeleton": {
+    skeleton: {
       name: "skeleton",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/skeleton")),
       files: ["registry/default/ui/skeleton.tsx"],
     },
-    "slider": {
+    slider: {
       name: "slider",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/slider")),
       files: ["registry/default/ui/slider.tsx"],
     },
-    "sonner": {
+    sonner: {
       name: "sonner",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/sonner")),
       files: ["registry/default/ui/sonner.tsx"],
     },
-    "switch": {
+    switch: {
       name: "switch",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/switch")),
       files: ["registry/default/ui/switch.tsx"],
     },
-    "table": {
+    table: {
       name: "table",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/table")),
       files: ["registry/default/ui/table.tsx"],
     },
-    "tabs": {
+    tabs: {
       name: "tabs",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/tabs")),
       files: ["registry/default/ui/tabs.tsx"],
     },
-    "textarea": {
+    textarea: {
       name: "textarea",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/textarea")),
       files: ["registry/default/ui/textarea.tsx"],
     },
-    "toast": {
+    toast: {
       name: "toast",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/ui/toast")),
-      files: ["registry/default/ui/toast.tsx","registry/default/ui/use-toast.ts","registry/default/ui/toaster.tsx"],
+      files: [
+        "registry/default/ui/toast.tsx",
+        "registry/default/ui/use-toast.ts",
+        "registry/default/ui/toaster.tsx",
+      ],
     },
-    "toggle": {
+    toggle: {
       name: "toggle",
       type: "components:ui",
       registryDependencies: undefined,
@@ -299,7 +307,7 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/default/ui/toggle-group")),
       files: ["registry/default/ui/toggle-group.tsx"],
     },
-    "tooltip": {
+    tooltip: {
       name: "tooltip",
       type: "components:ui",
       registryDependencies: undefined,
@@ -310,928 +318,1198 @@ export const Index: Record<string, any> = {
       name: "accordion-demo",
       type: "components:example",
       registryDependencies: ["accordion"],
-      component: React.lazy(() => import("@/registry/default/example/accordion-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/accordion-demo")
+      ),
       files: ["registry/default/example/accordion-demo.tsx"],
     },
     "alert-demo": {
       name: "alert-demo",
       type: "components:example",
       registryDependencies: ["alert"],
-      component: React.lazy(() => import("@/registry/default/example/alert-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/alert-demo")
+      ),
       files: ["registry/default/example/alert-demo.tsx"],
     },
     "alert-destructive": {
       name: "alert-destructive",
       type: "components:example",
       registryDependencies: ["alert"],
-      component: React.lazy(() => import("@/registry/default/example/alert-destructive")),
+      component: React.lazy(
+        () => import("@/registry/default/example/alert-destructive")
+      ),
       files: ["registry/default/example/alert-destructive.tsx"],
     },
     "alert-dialog-demo": {
       name: "alert-dialog-demo",
       type: "components:example",
-      registryDependencies: ["alert-dialog","button"],
-      component: React.lazy(() => import("@/registry/default/example/alert-dialog-demo")),
+      registryDependencies: ["alert-dialog", "button"],
+      component: React.lazy(
+        () => import("@/registry/default/example/alert-dialog-demo")
+      ),
       files: ["registry/default/example/alert-dialog-demo.tsx"],
     },
     "aspect-ratio-demo": {
       name: "aspect-ratio-demo",
       type: "components:example",
       registryDependencies: ["aspect-ratio"],
-      component: React.lazy(() => import("@/registry/default/example/aspect-ratio-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/aspect-ratio-demo")
+      ),
       files: ["registry/default/example/aspect-ratio-demo.tsx"],
     },
     "avatar-demo": {
       name: "avatar-demo",
       type: "components:example",
       registryDependencies: ["avatar"],
-      component: React.lazy(() => import("@/registry/default/example/avatar-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/avatar-demo")
+      ),
       files: ["registry/default/example/avatar-demo.tsx"],
     },
     "badge-demo": {
       name: "badge-demo",
       type: "components:example",
       registryDependencies: ["badge"],
-      component: React.lazy(() => import("@/registry/default/example/badge-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/badge-demo")
+      ),
       files: ["registry/default/example/badge-demo.tsx"],
     },
     "badge-destructive": {
       name: "badge-destructive",
       type: "components:example",
       registryDependencies: ["badge"],
-      component: React.lazy(() => import("@/registry/default/example/badge-destructive")),
+      component: React.lazy(
+        () => import("@/registry/default/example/badge-destructive")
+      ),
       files: ["registry/default/example/badge-destructive.tsx"],
     },
     "badge-outline": {
       name: "badge-outline",
       type: "components:example",
       registryDependencies: ["badge"],
-      component: React.lazy(() => import("@/registry/default/example/badge-outline")),
+      component: React.lazy(
+        () => import("@/registry/default/example/badge-outline")
+      ),
       files: ["registry/default/example/badge-outline.tsx"],
     },
     "badge-secondary": {
       name: "badge-secondary",
       type: "components:example",
       registryDependencies: ["badge"],
-      component: React.lazy(() => import("@/registry/default/example/badge-secondary")),
+      component: React.lazy(
+        () => import("@/registry/default/example/badge-secondary")
+      ),
       files: ["registry/default/example/badge-secondary.tsx"],
     },
     "button-demo": {
       name: "button-demo",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/default/example/button-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/button-demo")
+      ),
       files: ["registry/default/example/button-demo.tsx"],
     },
     "button-secondary": {
       name: "button-secondary",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/default/example/button-secondary")),
+      component: React.lazy(
+        () => import("@/registry/default/example/button-secondary")
+      ),
       files: ["registry/default/example/button-secondary.tsx"],
     },
     "button-destructive": {
       name: "button-destructive",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/default/example/button-destructive")),
+      component: React.lazy(
+        () => import("@/registry/default/example/button-destructive")
+      ),
       files: ["registry/default/example/button-destructive.tsx"],
     },
     "button-outline": {
       name: "button-outline",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/default/example/button-outline")),
+      component: React.lazy(
+        () => import("@/registry/default/example/button-outline")
+      ),
       files: ["registry/default/example/button-outline.tsx"],
     },
     "button-ghost": {
       name: "button-ghost",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/default/example/button-ghost")),
+      component: React.lazy(
+        () => import("@/registry/default/example/button-ghost")
+      ),
       files: ["registry/default/example/button-ghost.tsx"],
     },
     "button-link": {
       name: "button-link",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/default/example/button-link")),
+      component: React.lazy(
+        () => import("@/registry/default/example/button-link")
+      ),
       files: ["registry/default/example/button-link.tsx"],
     },
     "button-with-icon": {
       name: "button-with-icon",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/default/example/button-with-icon")),
+      component: React.lazy(
+        () => import("@/registry/default/example/button-with-icon")
+      ),
       files: ["registry/default/example/button-with-icon.tsx"],
     },
     "button-loading": {
       name: "button-loading",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/default/example/button-loading")),
+      component: React.lazy(
+        () => import("@/registry/default/example/button-loading")
+      ),
       files: ["registry/default/example/button-loading.tsx"],
     },
     "button-icon": {
       name: "button-icon",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/default/example/button-icon")),
+      component: React.lazy(
+        () => import("@/registry/default/example/button-icon")
+      ),
       files: ["registry/default/example/button-icon.tsx"],
     },
     "button-as-child": {
       name: "button-as-child",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/default/example/button-as-child")),
+      component: React.lazy(
+        () => import("@/registry/default/example/button-as-child")
+      ),
       files: ["registry/default/example/button-as-child.tsx"],
     },
     "calendar-demo": {
       name: "calendar-demo",
       type: "components:example",
       registryDependencies: ["calendar"],
-      component: React.lazy(() => import("@/registry/default/example/calendar-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/calendar-demo")
+      ),
       files: ["registry/default/example/calendar-demo.tsx"],
     },
     "calendar-form": {
       name: "calendar-form",
       type: "components:example",
-      registryDependencies: ["calendar","form","popover"],
-      component: React.lazy(() => import("@/registry/default/example/calendar-form")),
+      registryDependencies: ["calendar", "form", "popover"],
+      component: React.lazy(
+        () => import("@/registry/default/example/calendar-form")
+      ),
       files: ["registry/default/example/calendar-form.tsx"],
     },
     "card-demo": {
       name: "card-demo",
       type: "components:example",
-      registryDependencies: ["card","button","switch"],
-      component: React.lazy(() => import("@/registry/default/example/card-demo")),
+      registryDependencies: ["card", "button", "switch"],
+      component: React.lazy(
+        () => import("@/registry/default/example/card-demo")
+      ),
       files: ["registry/default/example/card-demo.tsx"],
     },
     "card-with-form": {
       name: "card-with-form",
       type: "components:example",
-      registryDependencies: ["button","card","input","label","select"],
-      component: React.lazy(() => import("@/registry/default/example/card-with-form")),
+      registryDependencies: ["button", "card", "input", "label", "select"],
+      component: React.lazy(
+        () => import("@/registry/default/example/card-with-form")
+      ),
       files: ["registry/default/example/card-with-form.tsx"],
     },
     "carousel-demo": {
       name: "carousel-demo",
       type: "components:example",
       registryDependencies: ["carousel"],
-      component: React.lazy(() => import("@/registry/default/example/carousel-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/carousel-demo")
+      ),
       files: ["registry/default/example/carousel-demo.tsx"],
     },
     "carousel-size": {
       name: "carousel-size",
       type: "components:example",
       registryDependencies: ["carousel"],
-      component: React.lazy(() => import("@/registry/default/example/carousel-size")),
+      component: React.lazy(
+        () => import("@/registry/default/example/carousel-size")
+      ),
       files: ["registry/default/example/carousel-size.tsx"],
     },
     "carousel-spacing": {
       name: "carousel-spacing",
       type: "components:example",
       registryDependencies: ["carousel"],
-      component: React.lazy(() => import("@/registry/default/example/carousel-spacing")),
+      component: React.lazy(
+        () => import("@/registry/default/example/carousel-spacing")
+      ),
       files: ["registry/default/example/carousel-spacing.tsx"],
     },
     "carousel-orientation": {
       name: "carousel-orientation",
       type: "components:example",
       registryDependencies: ["carousel"],
-      component: React.lazy(() => import("@/registry/default/example/carousel-orientation")),
+      component: React.lazy(
+        () => import("@/registry/default/example/carousel-orientation")
+      ),
       files: ["registry/default/example/carousel-orientation.tsx"],
     },
     "carousel-api": {
       name: "carousel-api",
       type: "components:example",
       registryDependencies: ["carousel"],
-      component: React.lazy(() => import("@/registry/default/example/carousel-api")),
+      component: React.lazy(
+        () => import("@/registry/default/example/carousel-api")
+      ),
       files: ["registry/default/example/carousel-api.tsx"],
     },
     "carousel-plugin": {
       name: "carousel-plugin",
       type: "components:example",
       registryDependencies: ["carousel"],
-      component: React.lazy(() => import("@/registry/default/example/carousel-plugin")),
+      component: React.lazy(
+        () => import("@/registry/default/example/carousel-plugin")
+      ),
       files: ["registry/default/example/carousel-plugin.tsx"],
     },
     "checkbox-demo": {
       name: "checkbox-demo",
       type: "components:example",
       registryDependencies: ["checkbox"],
-      component: React.lazy(() => import("@/registry/default/example/checkbox-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/checkbox-demo")
+      ),
       files: ["registry/default/example/checkbox-demo.tsx"],
     },
     "checkbox-disabled": {
       name: "checkbox-disabled",
       type: "components:example",
       registryDependencies: ["checkbox"],
-      component: React.lazy(() => import("@/registry/default/example/checkbox-disabled")),
+      component: React.lazy(
+        () => import("@/registry/default/example/checkbox-disabled")
+      ),
       files: ["registry/default/example/checkbox-disabled.tsx"],
     },
     "checkbox-form-multiple": {
       name: "checkbox-form-multiple",
       type: "components:example",
-      registryDependencies: ["checkbox","form"],
-      component: React.lazy(() => import("@/registry/default/example/checkbox-form-multiple")),
+      registryDependencies: ["checkbox", "form"],
+      component: React.lazy(
+        () => import("@/registry/default/example/checkbox-form-multiple")
+      ),
       files: ["registry/default/example/checkbox-form-multiple.tsx"],
     },
     "checkbox-form-single": {
       name: "checkbox-form-single",
       type: "components:example",
-      registryDependencies: ["checkbox","form"],
-      component: React.lazy(() => import("@/registry/default/example/checkbox-form-single")),
+      registryDependencies: ["checkbox", "form"],
+      component: React.lazy(
+        () => import("@/registry/default/example/checkbox-form-single")
+      ),
       files: ["registry/default/example/checkbox-form-single.tsx"],
     },
     "checkbox-with-text": {
       name: "checkbox-with-text",
       type: "components:example",
       registryDependencies: ["checkbox"],
-      component: React.lazy(() => import("@/registry/default/example/checkbox-with-text")),
+      component: React.lazy(
+        () => import("@/registry/default/example/checkbox-with-text")
+      ),
       files: ["registry/default/example/checkbox-with-text.tsx"],
     },
     "collapsible-demo": {
       name: "collapsible-demo",
       type: "components:example",
       registryDependencies: ["collapsible"],
-      component: React.lazy(() => import("@/registry/default/example/collapsible-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/collapsible-demo")
+      ),
       files: ["registry/default/example/collapsible-demo.tsx"],
     },
     "combobox-demo": {
       name: "combobox-demo",
       type: "components:example",
       registryDependencies: ["command"],
-      component: React.lazy(() => import("@/registry/default/example/combobox-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/combobox-demo")
+      ),
       files: ["registry/default/example/combobox-demo.tsx"],
     },
     "combobox-dropdown-menu": {
       name: "combobox-dropdown-menu",
       type: "components:example",
-      registryDependencies: ["command","dropdown-menu","button"],
-      component: React.lazy(() => import("@/registry/default/example/combobox-dropdown-menu")),
+      registryDependencies: ["command", "dropdown-menu", "button"],
+      component: React.lazy(
+        () => import("@/registry/default/example/combobox-dropdown-menu")
+      ),
       files: ["registry/default/example/combobox-dropdown-menu.tsx"],
     },
     "combobox-form": {
       name: "combobox-form",
       type: "components:example",
-      registryDependencies: ["command","form"],
-      component: React.lazy(() => import("@/registry/default/example/combobox-form")),
+      registryDependencies: ["command", "form"],
+      component: React.lazy(
+        () => import("@/registry/default/example/combobox-form")
+      ),
       files: ["registry/default/example/combobox-form.tsx"],
     },
     "combobox-popover": {
       name: "combobox-popover",
       type: "components:example",
-      registryDependencies: ["combobox","popover"],
-      component: React.lazy(() => import("@/registry/default/example/combobox-popover")),
+      registryDependencies: ["combobox", "popover"],
+      component: React.lazy(
+        () => import("@/registry/default/example/combobox-popover")
+      ),
       files: ["registry/default/example/combobox-popover.tsx"],
     },
     "combobox-responsive": {
       name: "combobox-responsive",
       type: "components:example",
-      registryDependencies: ["combobox","popover","drawer"],
-      component: React.lazy(() => import("@/registry/default/example/combobox-responsive")),
+      registryDependencies: ["combobox", "popover", "drawer"],
+      component: React.lazy(
+        () => import("@/registry/default/example/combobox-responsive")
+      ),
       files: ["registry/default/example/combobox-responsive.tsx"],
     },
     "command-demo": {
       name: "command-demo",
       type: "components:example",
       registryDependencies: ["command"],
-      component: React.lazy(() => import("@/registry/default/example/command-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/command-demo")
+      ),
       files: ["registry/default/example/command-demo.tsx"],
     },
     "command-dialog": {
       name: "command-dialog",
       type: "components:example",
-      registryDependencies: ["command","dialog"],
-      component: React.lazy(() => import("@/registry/default/example/command-dialog")),
+      registryDependencies: ["command", "dialog"],
+      component: React.lazy(
+        () => import("@/registry/default/example/command-dialog")
+      ),
       files: ["registry/default/example/command-dialog.tsx"],
     },
     "context-menu-demo": {
       name: "context-menu-demo",
       type: "components:example",
       registryDependencies: ["context-menu"],
-      component: React.lazy(() => import("@/registry/default/example/context-menu-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/context-menu-demo")
+      ),
       files: ["registry/default/example/context-menu-demo.tsx"],
     },
     "data-table-demo": {
       name: "data-table-demo",
       type: "components:example",
       registryDependencies: ["data-table"],
-      component: React.lazy(() => import("@/registry/default/example/data-table-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/data-table-demo")
+      ),
       files: ["registry/default/example/data-table-demo.tsx"],
     },
     "date-picker-demo": {
       name: "date-picker-demo",
       type: "components:example",
-      registryDependencies: ["button","calendar","popover"],
-      component: React.lazy(() => import("@/registry/default/example/date-picker-demo")),
+      registryDependencies: ["button", "calendar", "popover"],
+      component: React.lazy(
+        () => import("@/registry/default/example/date-picker-demo")
+      ),
       files: ["registry/default/example/date-picker-demo.tsx"],
     },
     "date-picker-form": {
       name: "date-picker-form",
       type: "components:example",
-      registryDependencies: ["button","calendar","form","popover"],
-      component: React.lazy(() => import("@/registry/default/example/date-picker-form")),
+      registryDependencies: ["button", "calendar", "form", "popover"],
+      component: React.lazy(
+        () => import("@/registry/default/example/date-picker-form")
+      ),
       files: ["registry/default/example/date-picker-form.tsx"],
     },
     "date-picker-with-presets": {
       name: "date-picker-with-presets",
       type: "components:example",
-      registryDependencies: ["button","calendar","popover","select"],
-      component: React.lazy(() => import("@/registry/default/example/date-picker-with-presets")),
+      registryDependencies: ["button", "calendar", "popover", "select"],
+      component: React.lazy(
+        () => import("@/registry/default/example/date-picker-with-presets")
+      ),
       files: ["registry/default/example/date-picker-with-presets.tsx"],
     },
     "date-picker-with-range": {
       name: "date-picker-with-range",
       type: "components:example",
-      registryDependencies: ["button","calendar","popover"],
-      component: React.lazy(() => import("@/registry/default/example/date-picker-with-range")),
+      registryDependencies: ["button", "calendar", "popover"],
+      component: React.lazy(
+        () => import("@/registry/default/example/date-picker-with-range")
+      ),
       files: ["registry/default/example/date-picker-with-range.tsx"],
     },
     "dialog-demo": {
       name: "dialog-demo",
       type: "components:example",
       registryDependencies: ["dialog"],
-      component: React.lazy(() => import("@/registry/default/example/dialog-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/dialog-demo")
+      ),
       files: ["registry/default/example/dialog-demo.tsx"],
     },
     "dialog-close-button": {
       name: "dialog-close-button",
       type: "components:example",
-      registryDependencies: ["dialog","button"],
-      component: React.lazy(() => import("@/registry/default/example/dialog-close-button")),
+      registryDependencies: ["dialog", "button"],
+      component: React.lazy(
+        () => import("@/registry/default/example/dialog-close-button")
+      ),
       files: ["registry/default/example/dialog-close-button.tsx"],
+    },
+    "dialog-static-backdrop": {
+      name: "dialog-static-backdrop",
+      type: "components:example",
+      registryDependencies: ["dialog", "button"],
+      component: React.lazy(
+        () => import("@/registry/default/example/dialog-static-backdrop")
+      ),
+      files: ["registry/default/example/dialog-static-backdrop.tsx"],
     },
     "drawer-demo": {
       name: "drawer-demo",
       type: "components:example",
       registryDependencies: ["drawer"],
-      component: React.lazy(() => import("@/registry/default/example/drawer-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/drawer-demo")
+      ),
       files: ["registry/default/example/drawer-demo.tsx"],
     },
     "drawer-dialog": {
       name: "drawer-dialog",
       type: "components:example",
-      registryDependencies: ["drawer","dialog"],
-      component: React.lazy(() => import("@/registry/default/example/drawer-dialog")),
+      registryDependencies: ["drawer", "dialog"],
+      component: React.lazy(
+        () => import("@/registry/default/example/drawer-dialog")
+      ),
       files: ["registry/default/example/drawer-dialog.tsx"],
     },
     "dropdown-menu-demo": {
       name: "dropdown-menu-demo",
       type: "components:example",
       registryDependencies: ["dropdown-menu"],
-      component: React.lazy(() => import("@/registry/default/example/dropdown-menu-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/dropdown-menu-demo")
+      ),
       files: ["registry/default/example/dropdown-menu-demo.tsx"],
     },
     "dropdown-menu-checkboxes": {
       name: "dropdown-menu-checkboxes",
       type: "components:example",
-      registryDependencies: ["dropdown-menu","checkbox"],
-      component: React.lazy(() => import("@/registry/default/example/dropdown-menu-checkboxes")),
+      registryDependencies: ["dropdown-menu", "checkbox"],
+      component: React.lazy(
+        () => import("@/registry/default/example/dropdown-menu-checkboxes")
+      ),
       files: ["registry/default/example/dropdown-menu-checkboxes.tsx"],
     },
     "dropdown-menu-radio-group": {
       name: "dropdown-menu-radio-group",
       type: "components:example",
-      registryDependencies: ["dropdown-menu","radio-group"],
-      component: React.lazy(() => import("@/registry/default/example/dropdown-menu-radio-group")),
+      registryDependencies: ["dropdown-menu", "radio-group"],
+      component: React.lazy(
+        () => import("@/registry/default/example/dropdown-menu-radio-group")
+      ),
       files: ["registry/default/example/dropdown-menu-radio-group.tsx"],
     },
     "hover-card-demo": {
       name: "hover-card-demo",
       type: "components:example",
       registryDependencies: ["hover-card"],
-      component: React.lazy(() => import("@/registry/default/example/hover-card-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/hover-card-demo")
+      ),
       files: ["registry/default/example/hover-card-demo.tsx"],
     },
     "input-demo": {
       name: "input-demo",
       type: "components:example",
       registryDependencies: ["input"],
-      component: React.lazy(() => import("@/registry/default/example/input-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/input-demo")
+      ),
       files: ["registry/default/example/input-demo.tsx"],
     },
     "input-disabled": {
       name: "input-disabled",
       type: "components:example",
       registryDependencies: ["input"],
-      component: React.lazy(() => import("@/registry/default/example/input-disabled")),
+      component: React.lazy(
+        () => import("@/registry/default/example/input-disabled")
+      ),
       files: ["registry/default/example/input-disabled.tsx"],
     },
     "input-file": {
       name: "input-file",
       type: "components:example",
       registryDependencies: ["input"],
-      component: React.lazy(() => import("@/registry/default/example/input-file")),
+      component: React.lazy(
+        () => import("@/registry/default/example/input-file")
+      ),
       files: ["registry/default/example/input-file.tsx"],
     },
     "input-form": {
       name: "input-form",
       type: "components:example",
-      registryDependencies: ["input","button","form"],
-      component: React.lazy(() => import("@/registry/default/example/input-form")),
+      registryDependencies: ["input", "button", "form"],
+      component: React.lazy(
+        () => import("@/registry/default/example/input-form")
+      ),
       files: ["registry/default/example/input-form.tsx"],
     },
     "input-with-button": {
       name: "input-with-button",
       type: "components:example",
-      registryDependencies: ["input","button"],
-      component: React.lazy(() => import("@/registry/default/example/input-with-button")),
+      registryDependencies: ["input", "button"],
+      component: React.lazy(
+        () => import("@/registry/default/example/input-with-button")
+      ),
       files: ["registry/default/example/input-with-button.tsx"],
     },
     "input-with-label": {
       name: "input-with-label",
       type: "components:example",
-      registryDependencies: ["input","button","label"],
-      component: React.lazy(() => import("@/registry/default/example/input-with-label")),
+      registryDependencies: ["input", "button", "label"],
+      component: React.lazy(
+        () => import("@/registry/default/example/input-with-label")
+      ),
       files: ["registry/default/example/input-with-label.tsx"],
     },
     "input-with-text": {
       name: "input-with-text",
       type: "components:example",
-      registryDependencies: ["input","button","label"],
-      component: React.lazy(() => import("@/registry/default/example/input-with-text")),
+      registryDependencies: ["input", "button", "label"],
+      component: React.lazy(
+        () => import("@/registry/default/example/input-with-text")
+      ),
       files: ["registry/default/example/input-with-text.tsx"],
     },
     "label-demo": {
       name: "label-demo",
       type: "components:example",
       registryDependencies: ["label"],
-      component: React.lazy(() => import("@/registry/default/example/label-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/label-demo")
+      ),
       files: ["registry/default/example/label-demo.tsx"],
     },
     "menubar-demo": {
       name: "menubar-demo",
       type: "components:example",
       registryDependencies: ["menubar"],
-      component: React.lazy(() => import("@/registry/default/example/menubar-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/menubar-demo")
+      ),
       files: ["registry/default/example/menubar-demo.tsx"],
     },
     "navigation-menu-demo": {
       name: "navigation-menu-demo",
       type: "components:example",
       registryDependencies: ["navigation-menu"],
-      component: React.lazy(() => import("@/registry/default/example/navigation-menu-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/navigation-menu-demo")
+      ),
       files: ["registry/default/example/navigation-menu-demo.tsx"],
     },
     "pagination-demo": {
       name: "pagination-demo",
       type: "components:example",
       registryDependencies: ["pagination"],
-      component: React.lazy(() => import("@/registry/default/example/pagination-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/pagination-demo")
+      ),
       files: ["registry/default/example/pagination-demo.tsx"],
     },
     "popover-demo": {
       name: "popover-demo",
       type: "components:example",
       registryDependencies: ["popover"],
-      component: React.lazy(() => import("@/registry/default/example/popover-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/popover-demo")
+      ),
       files: ["registry/default/example/popover-demo.tsx"],
     },
     "progress-demo": {
       name: "progress-demo",
       type: "components:example",
       registryDependencies: ["progress"],
-      component: React.lazy(() => import("@/registry/default/example/progress-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/progress-demo")
+      ),
       files: ["registry/default/example/progress-demo.tsx"],
     },
     "radio-group-demo": {
       name: "radio-group-demo",
       type: "components:example",
       registryDependencies: ["radio-group"],
-      component: React.lazy(() => import("@/registry/default/example/radio-group-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/radio-group-demo")
+      ),
       files: ["registry/default/example/radio-group-demo.tsx"],
     },
     "radio-group-form": {
       name: "radio-group-form",
       type: "components:example",
-      registryDependencies: ["radio-group","form"],
-      component: React.lazy(() => import("@/registry/default/example/radio-group-form")),
+      registryDependencies: ["radio-group", "form"],
+      component: React.lazy(
+        () => import("@/registry/default/example/radio-group-form")
+      ),
       files: ["registry/default/example/radio-group-form.tsx"],
     },
     "resizable-demo": {
       name: "resizable-demo",
       type: "components:example",
       registryDependencies: ["resizable"],
-      component: React.lazy(() => import("@/registry/default/example/resizable-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/resizable-demo")
+      ),
       files: ["registry/default/example/resizable-demo.tsx"],
     },
     "resizable-demo-with-handle": {
       name: "resizable-demo-with-handle",
       type: "components:example",
       registryDependencies: ["resizable"],
-      component: React.lazy(() => import("@/registry/default/example/resizable-demo-with-handle")),
+      component: React.lazy(
+        () => import("@/registry/default/example/resizable-demo-with-handle")
+      ),
       files: ["registry/default/example/resizable-demo-with-handle.tsx"],
     },
     "resizable-vertical": {
       name: "resizable-vertical",
       type: "components:example",
       registryDependencies: ["resizable"],
-      component: React.lazy(() => import("@/registry/default/example/resizable-vertical")),
+      component: React.lazy(
+        () => import("@/registry/default/example/resizable-vertical")
+      ),
       files: ["registry/default/example/resizable-vertical.tsx"],
     },
     "resizable-handle": {
       name: "resizable-handle",
       type: "components:example",
       registryDependencies: ["resizable"],
-      component: React.lazy(() => import("@/registry/default/example/resizable-handle")),
+      component: React.lazy(
+        () => import("@/registry/default/example/resizable-handle")
+      ),
       files: ["registry/default/example/resizable-handle.tsx"],
     },
     "scroll-area-demo": {
       name: "scroll-area-demo",
       type: "components:example",
       registryDependencies: ["scroll-area"],
-      component: React.lazy(() => import("@/registry/default/example/scroll-area-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/scroll-area-demo")
+      ),
       files: ["registry/default/example/scroll-area-demo.tsx"],
     },
     "scroll-area-horizontal-demo": {
       name: "scroll-area-horizontal-demo",
       type: "components:example",
       registryDependencies: ["scroll-area"],
-      component: React.lazy(() => import("@/registry/default/example/scroll-area-horizontal-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/scroll-area-horizontal-demo")
+      ),
       files: ["registry/default/example/scroll-area-horizontal-demo.tsx"],
     },
     "select-demo": {
       name: "select-demo",
       type: "components:example",
       registryDependencies: ["select"],
-      component: React.lazy(() => import("@/registry/default/example/select-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/select-demo")
+      ),
       files: ["registry/default/example/select-demo.tsx"],
     },
     "select-scrollable": {
       name: "select-scrollable",
       type: "components:example",
       registryDependencies: ["select"],
-      component: React.lazy(() => import("@/registry/default/example/select-scrollable")),
+      component: React.lazy(
+        () => import("@/registry/default/example/select-scrollable")
+      ),
       files: ["registry/default/example/select-scrollable.tsx"],
     },
     "select-form": {
       name: "select-form",
       type: "components:example",
       registryDependencies: ["select"],
-      component: React.lazy(() => import("@/registry/default/example/select-form")),
+      component: React.lazy(
+        () => import("@/registry/default/example/select-form")
+      ),
       files: ["registry/default/example/select-form.tsx"],
     },
     "separator-demo": {
       name: "separator-demo",
       type: "components:example",
       registryDependencies: ["separator"],
-      component: React.lazy(() => import("@/registry/default/example/separator-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/separator-demo")
+      ),
       files: ["registry/default/example/separator-demo.tsx"],
     },
     "sheet-demo": {
       name: "sheet-demo",
       type: "components:example",
       registryDependencies: ["sheet"],
-      component: React.lazy(() => import("@/registry/default/example/sheet-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/sheet-demo")
+      ),
       files: ["registry/default/example/sheet-demo.tsx"],
     },
     "sheet-side": {
       name: "sheet-side",
       type: "components:example",
       registryDependencies: ["sheet"],
-      component: React.lazy(() => import("@/registry/default/example/sheet-side")),
+      component: React.lazy(
+        () => import("@/registry/default/example/sheet-side")
+      ),
       files: ["registry/default/example/sheet-side.tsx"],
     },
     "skeleton-demo": {
       name: "skeleton-demo",
       type: "components:example",
       registryDependencies: ["skeleton"],
-      component: React.lazy(() => import("@/registry/default/example/skeleton-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/skeleton-demo")
+      ),
       files: ["registry/default/example/skeleton-demo.tsx"],
     },
     "slider-demo": {
       name: "slider-demo",
       type: "components:example",
       registryDependencies: ["slider"],
-      component: React.lazy(() => import("@/registry/default/example/slider-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/slider-demo")
+      ),
       files: ["registry/default/example/slider-demo.tsx"],
     },
     "sonner-demo": {
       name: "sonner-demo",
       type: "components:example",
       registryDependencies: ["sonner"],
-      component: React.lazy(() => import("@/registry/default/example/sonner-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/sonner-demo")
+      ),
       files: ["registry/default/example/sonner-demo.tsx"],
     },
     "switch-demo": {
       name: "switch-demo",
       type: "components:example",
       registryDependencies: ["switch"],
-      component: React.lazy(() => import("@/registry/default/example/switch-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/switch-demo")
+      ),
       files: ["registry/default/example/switch-demo.tsx"],
     },
     "switch-form": {
       name: "switch-form",
       type: "components:example",
-      registryDependencies: ["switch","form"],
-      component: React.lazy(() => import("@/registry/default/example/switch-form")),
+      registryDependencies: ["switch", "form"],
+      component: React.lazy(
+        () => import("@/registry/default/example/switch-form")
+      ),
       files: ["registry/default/example/switch-form.tsx"],
     },
     "table-demo": {
       name: "table-demo",
       type: "components:example",
       registryDependencies: ["table"],
-      component: React.lazy(() => import("@/registry/default/example/table-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/table-demo")
+      ),
       files: ["registry/default/example/table-demo.tsx"],
     },
     "tabs-demo": {
       name: "tabs-demo",
       type: "components:example",
       registryDependencies: ["tabs"],
-      component: React.lazy(() => import("@/registry/default/example/tabs-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/tabs-demo")
+      ),
       files: ["registry/default/example/tabs-demo.tsx"],
     },
     "textarea-demo": {
       name: "textarea-demo",
       type: "components:example",
       registryDependencies: ["textarea"],
-      component: React.lazy(() => import("@/registry/default/example/textarea-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/textarea-demo")
+      ),
       files: ["registry/default/example/textarea-demo.tsx"],
     },
     "textarea-disabled": {
       name: "textarea-disabled",
       type: "components:example",
       registryDependencies: ["textarea"],
-      component: React.lazy(() => import("@/registry/default/example/textarea-disabled")),
+      component: React.lazy(
+        () => import("@/registry/default/example/textarea-disabled")
+      ),
       files: ["registry/default/example/textarea-disabled.tsx"],
     },
     "textarea-form": {
       name: "textarea-form",
       type: "components:example",
-      registryDependencies: ["textarea","form"],
-      component: React.lazy(() => import("@/registry/default/example/textarea-form")),
+      registryDependencies: ["textarea", "form"],
+      component: React.lazy(
+        () => import("@/registry/default/example/textarea-form")
+      ),
       files: ["registry/default/example/textarea-form.tsx"],
     },
     "textarea-with-button": {
       name: "textarea-with-button",
       type: "components:example",
-      registryDependencies: ["textarea","button"],
-      component: React.lazy(() => import("@/registry/default/example/textarea-with-button")),
+      registryDependencies: ["textarea", "button"],
+      component: React.lazy(
+        () => import("@/registry/default/example/textarea-with-button")
+      ),
       files: ["registry/default/example/textarea-with-button.tsx"],
     },
     "textarea-with-label": {
       name: "textarea-with-label",
       type: "components:example",
-      registryDependencies: ["textarea","label"],
-      component: React.lazy(() => import("@/registry/default/example/textarea-with-label")),
+      registryDependencies: ["textarea", "label"],
+      component: React.lazy(
+        () => import("@/registry/default/example/textarea-with-label")
+      ),
       files: ["registry/default/example/textarea-with-label.tsx"],
     },
     "textarea-with-text": {
       name: "textarea-with-text",
       type: "components:example",
-      registryDependencies: ["textarea","label"],
-      component: React.lazy(() => import("@/registry/default/example/textarea-with-text")),
+      registryDependencies: ["textarea", "label"],
+      component: React.lazy(
+        () => import("@/registry/default/example/textarea-with-text")
+      ),
       files: ["registry/default/example/textarea-with-text.tsx"],
     },
     "toast-demo": {
       name: "toast-demo",
       type: "components:example",
       registryDependencies: ["toast"],
-      component: React.lazy(() => import("@/registry/default/example/toast-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toast-demo")
+      ),
       files: ["registry/default/example/toast-demo.tsx"],
     },
     "toast-destructive": {
       name: "toast-destructive",
       type: "components:example",
       registryDependencies: ["toast"],
-      component: React.lazy(() => import("@/registry/default/example/toast-destructive")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toast-destructive")
+      ),
       files: ["registry/default/example/toast-destructive.tsx"],
     },
     "toast-simple": {
       name: "toast-simple",
       type: "components:example",
       registryDependencies: ["toast"],
-      component: React.lazy(() => import("@/registry/default/example/toast-simple")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toast-simple")
+      ),
       files: ["registry/default/example/toast-simple.tsx"],
     },
     "toast-with-action": {
       name: "toast-with-action",
       type: "components:example",
       registryDependencies: ["toast"],
-      component: React.lazy(() => import("@/registry/default/example/toast-with-action")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toast-with-action")
+      ),
       files: ["registry/default/example/toast-with-action.tsx"],
     },
     "toast-with-title": {
       name: "toast-with-title",
       type: "components:example",
       registryDependencies: ["toast"],
-      component: React.lazy(() => import("@/registry/default/example/toast-with-title")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toast-with-title")
+      ),
       files: ["registry/default/example/toast-with-title.tsx"],
     },
     "toggle-group-demo": {
       name: "toggle-group-demo",
       type: "components:example",
       registryDependencies: ["toggle-group"],
-      component: React.lazy(() => import("@/registry/default/example/toggle-group-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toggle-group-demo")
+      ),
       files: ["registry/default/example/toggle-group-demo.tsx"],
     },
     "toggle-group-disabled": {
       name: "toggle-group-disabled",
       type: "components:example",
       registryDependencies: ["toggle-group"],
-      component: React.lazy(() => import("@/registry/default/example/toggle-group-disabled")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toggle-group-disabled")
+      ),
       files: ["registry/default/example/toggle-group-disabled.tsx"],
     },
     "toggle-group-lg": {
       name: "toggle-group-lg",
       type: "components:example",
       registryDependencies: ["toggle-group"],
-      component: React.lazy(() => import("@/registry/default/example/toggle-group-lg")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toggle-group-lg")
+      ),
       files: ["registry/default/example/toggle-group-lg.tsx"],
     },
     "toggle-group-outline": {
       name: "toggle-group-outline",
       type: "components:example",
       registryDependencies: ["toggle-group"],
-      component: React.lazy(() => import("@/registry/default/example/toggle-group-outline")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toggle-group-outline")
+      ),
       files: ["registry/default/example/toggle-group-outline.tsx"],
     },
     "toggle-group-sm": {
       name: "toggle-group-sm",
       type: "components:example",
       registryDependencies: ["toggle-group"],
-      component: React.lazy(() => import("@/registry/default/example/toggle-group-sm")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toggle-group-sm")
+      ),
       files: ["registry/default/example/toggle-group-sm.tsx"],
     },
     "toggle-group-single": {
       name: "toggle-group-single",
       type: "components:example",
       registryDependencies: ["toggle-group"],
-      component: React.lazy(() => import("@/registry/default/example/toggle-group-single")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toggle-group-single")
+      ),
       files: ["registry/default/example/toggle-group-single.tsx"],
     },
     "toggle-demo": {
       name: "toggle-demo",
       type: "components:example",
       registryDependencies: ["toggle"],
-      component: React.lazy(() => import("@/registry/default/example/toggle-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toggle-demo")
+      ),
       files: ["registry/default/example/toggle-demo.tsx"],
     },
     "toggle-disabled": {
       name: "toggle-disabled",
       type: "components:example",
       registryDependencies: ["toggle"],
-      component: React.lazy(() => import("@/registry/default/example/toggle-disabled")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toggle-disabled")
+      ),
       files: ["registry/default/example/toggle-disabled.tsx"],
     },
     "toggle-lg": {
       name: "toggle-lg",
       type: "components:example",
       registryDependencies: ["toggle"],
-      component: React.lazy(() => import("@/registry/default/example/toggle-lg")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toggle-lg")
+      ),
       files: ["registry/default/example/toggle-lg.tsx"],
     },
     "toggle-outline": {
       name: "toggle-outline",
       type: "components:example",
       registryDependencies: ["toggle"],
-      component: React.lazy(() => import("@/registry/default/example/toggle-outline")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toggle-outline")
+      ),
       files: ["registry/default/example/toggle-outline.tsx"],
     },
     "toggle-sm": {
       name: "toggle-sm",
       type: "components:example",
       registryDependencies: ["toggle"],
-      component: React.lazy(() => import("@/registry/default/example/toggle-sm")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toggle-sm")
+      ),
       files: ["registry/default/example/toggle-sm.tsx"],
     },
     "toggle-with-text": {
       name: "toggle-with-text",
       type: "components:example",
       registryDependencies: ["toggle"],
-      component: React.lazy(() => import("@/registry/default/example/toggle-with-text")),
+      component: React.lazy(
+        () => import("@/registry/default/example/toggle-with-text")
+      ),
       files: ["registry/default/example/toggle-with-text.tsx"],
     },
     "tooltip-demo": {
       name: "tooltip-demo",
       type: "components:example",
       registryDependencies: ["tooltip"],
-      component: React.lazy(() => import("@/registry/default/example/tooltip-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/tooltip-demo")
+      ),
       files: ["registry/default/example/tooltip-demo.tsx"],
     },
     "typography-blockquote": {
       name: "typography-blockquote",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/example/typography-blockquote")),
+      component: React.lazy(
+        () => import("@/registry/default/example/typography-blockquote")
+      ),
       files: ["registry/default/example/typography-blockquote.tsx"],
     },
     "typography-demo": {
       name: "typography-demo",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/example/typography-demo")),
+      component: React.lazy(
+        () => import("@/registry/default/example/typography-demo")
+      ),
       files: ["registry/default/example/typography-demo.tsx"],
     },
     "typography-h1": {
       name: "typography-h1",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/example/typography-h1")),
+      component: React.lazy(
+        () => import("@/registry/default/example/typography-h1")
+      ),
       files: ["registry/default/example/typography-h1.tsx"],
     },
     "typography-h2": {
       name: "typography-h2",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/example/typography-h2")),
+      component: React.lazy(
+        () => import("@/registry/default/example/typography-h2")
+      ),
       files: ["registry/default/example/typography-h2.tsx"],
     },
     "typography-h3": {
       name: "typography-h3",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/example/typography-h3")),
+      component: React.lazy(
+        () => import("@/registry/default/example/typography-h3")
+      ),
       files: ["registry/default/example/typography-h3.tsx"],
     },
     "typography-h4": {
       name: "typography-h4",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/example/typography-h4")),
+      component: React.lazy(
+        () => import("@/registry/default/example/typography-h4")
+      ),
       files: ["registry/default/example/typography-h4.tsx"],
     },
     "typography-inline-code": {
       name: "typography-inline-code",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/example/typography-inline-code")),
+      component: React.lazy(
+        () => import("@/registry/default/example/typography-inline-code")
+      ),
       files: ["registry/default/example/typography-inline-code.tsx"],
     },
     "typography-large": {
       name: "typography-large",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/example/typography-large")),
+      component: React.lazy(
+        () => import("@/registry/default/example/typography-large")
+      ),
       files: ["registry/default/example/typography-large.tsx"],
     },
     "typography-lead": {
       name: "typography-lead",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/example/typography-lead")),
+      component: React.lazy(
+        () => import("@/registry/default/example/typography-lead")
+      ),
       files: ["registry/default/example/typography-lead.tsx"],
     },
     "typography-list": {
       name: "typography-list",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/example/typography-list")),
+      component: React.lazy(
+        () => import("@/registry/default/example/typography-list")
+      ),
       files: ["registry/default/example/typography-list.tsx"],
     },
     "typography-muted": {
       name: "typography-muted",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/example/typography-muted")),
+      component: React.lazy(
+        () => import("@/registry/default/example/typography-muted")
+      ),
       files: ["registry/default/example/typography-muted.tsx"],
     },
     "typography-p": {
       name: "typography-p",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/example/typography-p")),
+      component: React.lazy(
+        () => import("@/registry/default/example/typography-p")
+      ),
       files: ["registry/default/example/typography-p.tsx"],
     },
     "typography-small": {
       name: "typography-small",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/example/typography-small")),
+      component: React.lazy(
+        () => import("@/registry/default/example/typography-small")
+      ),
       files: ["registry/default/example/typography-small.tsx"],
     },
     "typography-table": {
       name: "typography-table",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/example/typography-table")),
+      component: React.lazy(
+        () => import("@/registry/default/example/typography-table")
+      ),
       files: ["registry/default/example/typography-table.tsx"],
     },
     "mode-toggle": {
       name: "mode-toggle",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/default/example/mode-toggle")),
+      component: React.lazy(
+        () => import("@/registry/default/example/mode-toggle")
+      ),
       files: ["registry/default/example/mode-toggle.tsx"],
     },
-    "cards": {
+    cards: {
       name: "cards",
       type: "components:example",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/default/example/cards")),
       files: ["registry/default/example/cards/cards.tsx"],
     },
-  },  "new-york": {
-    "accordion": {
+  },
+  "new-york": {
+    accordion: {
       name: "accordion",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/accordion")),
       files: ["registry/new-york/ui/accordion.tsx"],
     },
-    "alert": {
+    alert: {
       name: "alert",
       type: "components:ui",
       registryDependencies: undefined,
@@ -1242,73 +1520,77 @@ export const Index: Record<string, any> = {
       name: "alert-dialog",
       type: "components:ui",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/new-york/ui/alert-dialog")),
+      component: React.lazy(
+        () => import("@/registry/new-york/ui/alert-dialog")
+      ),
       files: ["registry/new-york/ui/alert-dialog.tsx"],
     },
     "aspect-ratio": {
       name: "aspect-ratio",
       type: "components:ui",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/ui/aspect-ratio")),
+      component: React.lazy(
+        () => import("@/registry/new-york/ui/aspect-ratio")
+      ),
       files: ["registry/new-york/ui/aspect-ratio.tsx"],
     },
-    "avatar": {
+    avatar: {
       name: "avatar",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/avatar")),
       files: ["registry/new-york/ui/avatar.tsx"],
     },
-    "badge": {
+    badge: {
       name: "badge",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/badge")),
       files: ["registry/new-york/ui/badge.tsx"],
     },
-    "button": {
+    button: {
       name: "button",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/button")),
       files: ["registry/new-york/ui/button.tsx"],
     },
-    "calendar": {
+    calendar: {
       name: "calendar",
       type: "components:ui",
       registryDependencies: ["button"],
       component: React.lazy(() => import("@/registry/new-york/ui/calendar")),
       files: ["registry/new-york/ui/calendar.tsx"],
     },
-    "card": {
+    card: {
       name: "card",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/card")),
       files: ["registry/new-york/ui/card.tsx"],
     },
-    "carousel": {
+    carousel: {
       name: "carousel",
       type: "components:ui",
       registryDependencies: ["button"],
       component: React.lazy(() => import("@/registry/new-york/ui/carousel")),
       files: ["registry/new-york/ui/carousel.tsx"],
     },
-    "checkbox": {
+    checkbox: {
       name: "checkbox",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/checkbox")),
       files: ["registry/new-york/ui/checkbox.tsx"],
     },
-    "collapsible": {
+    collapsible: {
       name: "collapsible",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/collapsible")),
       files: ["registry/new-york/ui/collapsible.tsx"],
     },
-    "command": {
+    command: {
       name: "command",
       type: "components:ui",
       registryDependencies: ["dialog"],
@@ -1319,17 +1601,19 @@ export const Index: Record<string, any> = {
       name: "context-menu",
       type: "components:ui",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/ui/context-menu")),
+      component: React.lazy(
+        () => import("@/registry/new-york/ui/context-menu")
+      ),
       files: ["registry/new-york/ui/context-menu.tsx"],
     },
-    "dialog": {
+    dialog: {
       name: "dialog",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/dialog")),
       files: ["registry/new-york/ui/dialog.tsx"],
     },
-    "drawer": {
+    drawer: {
       name: "drawer",
       type: "components:ui",
       registryDependencies: undefined,
@@ -1340,13 +1624,15 @@ export const Index: Record<string, any> = {
       name: "dropdown-menu",
       type: "components:ui",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/ui/dropdown-menu")),
+      component: React.lazy(
+        () => import("@/registry/new-york/ui/dropdown-menu")
+      ),
       files: ["registry/new-york/ui/dropdown-menu.tsx"],
     },
-    "form": {
+    form: {
       name: "form",
       type: "components:ui",
-      registryDependencies: ["button","label"],
+      registryDependencies: ["button", "label"],
       component: React.lazy(() => import("@/registry/new-york/ui/form")),
       files: ["registry/new-york/ui/form.tsx"],
     },
@@ -1357,21 +1643,21 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/new-york/ui/hover-card")),
       files: ["registry/new-york/ui/hover-card.tsx"],
     },
-    "input": {
+    input: {
       name: "input",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/input")),
       files: ["registry/new-york/ui/input.tsx"],
     },
-    "label": {
+    label: {
       name: "label",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/label")),
       files: ["registry/new-york/ui/label.tsx"],
     },
-    "menubar": {
+    menubar: {
       name: "menubar",
       type: "components:ui",
       registryDependencies: undefined,
@@ -1382,24 +1668,26 @@ export const Index: Record<string, any> = {
       name: "navigation-menu",
       type: "components:ui",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/ui/navigation-menu")),
+      component: React.lazy(
+        () => import("@/registry/new-york/ui/navigation-menu")
+      ),
       files: ["registry/new-york/ui/navigation-menu.tsx"],
     },
-    "pagination": {
+    pagination: {
       name: "pagination",
       type: "components:ui",
       registryDependencies: ["button"],
       component: React.lazy(() => import("@/registry/new-york/ui/pagination")),
       files: ["registry/new-york/ui/pagination.tsx"],
     },
-    "popover": {
+    popover: {
       name: "popover",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/popover")),
       files: ["registry/new-york/ui/popover.tsx"],
     },
-    "progress": {
+    progress: {
       name: "progress",
       type: "components:ui",
       registryDependencies: undefined,
@@ -1413,7 +1701,7 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/new-york/ui/radio-group")),
       files: ["registry/new-york/ui/radio-group.tsx"],
     },
-    "resizable": {
+    resizable: {
       name: "resizable",
       type: "components:ui",
       registryDependencies: undefined,
@@ -1427,84 +1715,88 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/new-york/ui/scroll-area")),
       files: ["registry/new-york/ui/scroll-area.tsx"],
     },
-    "select": {
+    select: {
       name: "select",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/select")),
       files: ["registry/new-york/ui/select.tsx"],
     },
-    "separator": {
+    separator: {
       name: "separator",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/separator")),
       files: ["registry/new-york/ui/separator.tsx"],
     },
-    "sheet": {
+    sheet: {
       name: "sheet",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/sheet")),
       files: ["registry/new-york/ui/sheet.tsx"],
     },
-    "skeleton": {
+    skeleton: {
       name: "skeleton",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/skeleton")),
       files: ["registry/new-york/ui/skeleton.tsx"],
     },
-    "slider": {
+    slider: {
       name: "slider",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/slider")),
       files: ["registry/new-york/ui/slider.tsx"],
     },
-    "sonner": {
+    sonner: {
       name: "sonner",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/sonner")),
       files: ["registry/new-york/ui/sonner.tsx"],
     },
-    "switch": {
+    switch: {
       name: "switch",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/switch")),
       files: ["registry/new-york/ui/switch.tsx"],
     },
-    "table": {
+    table: {
       name: "table",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/table")),
       files: ["registry/new-york/ui/table.tsx"],
     },
-    "tabs": {
+    tabs: {
       name: "tabs",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/tabs")),
       files: ["registry/new-york/ui/tabs.tsx"],
     },
-    "textarea": {
+    textarea: {
       name: "textarea",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/textarea")),
       files: ["registry/new-york/ui/textarea.tsx"],
     },
-    "toast": {
+    toast: {
       name: "toast",
       type: "components:ui",
       registryDependencies: undefined,
       component: React.lazy(() => import("@/registry/new-york/ui/toast")),
-      files: ["registry/new-york/ui/toast.tsx","registry/new-york/ui/use-toast.ts","registry/new-york/ui/toaster.tsx"],
+      files: [
+        "registry/new-york/ui/toast.tsx",
+        "registry/new-york/ui/use-toast.ts",
+        "registry/new-york/ui/toaster.tsx",
+      ],
     },
-    "toggle": {
+    toggle: {
       name: "toggle",
       type: "components:ui",
       registryDependencies: undefined,
@@ -1515,10 +1807,12 @@ export const Index: Record<string, any> = {
       name: "toggle-group",
       type: "components:ui",
       registryDependencies: ["toggle"],
-      component: React.lazy(() => import("@/registry/new-york/ui/toggle-group")),
+      component: React.lazy(
+        () => import("@/registry/new-york/ui/toggle-group")
+      ),
       files: ["registry/new-york/ui/toggle-group.tsx"],
     },
-    "tooltip": {
+    tooltip: {
       name: "tooltip",
       type: "components:ui",
       registryDependencies: undefined,
@@ -1529,913 +1823,1182 @@ export const Index: Record<string, any> = {
       name: "accordion-demo",
       type: "components:example",
       registryDependencies: ["accordion"],
-      component: React.lazy(() => import("@/registry/new-york/example/accordion-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/accordion-demo")
+      ),
       files: ["registry/new-york/example/accordion-demo.tsx"],
     },
     "alert-demo": {
       name: "alert-demo",
       type: "components:example",
       registryDependencies: ["alert"],
-      component: React.lazy(() => import("@/registry/new-york/example/alert-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/alert-demo")
+      ),
       files: ["registry/new-york/example/alert-demo.tsx"],
     },
     "alert-destructive": {
       name: "alert-destructive",
       type: "components:example",
       registryDependencies: ["alert"],
-      component: React.lazy(() => import("@/registry/new-york/example/alert-destructive")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/alert-destructive")
+      ),
       files: ["registry/new-york/example/alert-destructive.tsx"],
     },
     "alert-dialog-demo": {
       name: "alert-dialog-demo",
       type: "components:example",
-      registryDependencies: ["alert-dialog","button"],
-      component: React.lazy(() => import("@/registry/new-york/example/alert-dialog-demo")),
+      registryDependencies: ["alert-dialog", "button"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/alert-dialog-demo")
+      ),
       files: ["registry/new-york/example/alert-dialog-demo.tsx"],
     },
     "aspect-ratio-demo": {
       name: "aspect-ratio-demo",
       type: "components:example",
       registryDependencies: ["aspect-ratio"],
-      component: React.lazy(() => import("@/registry/new-york/example/aspect-ratio-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/aspect-ratio-demo")
+      ),
       files: ["registry/new-york/example/aspect-ratio-demo.tsx"],
     },
     "avatar-demo": {
       name: "avatar-demo",
       type: "components:example",
       registryDependencies: ["avatar"],
-      component: React.lazy(() => import("@/registry/new-york/example/avatar-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/avatar-demo")
+      ),
       files: ["registry/new-york/example/avatar-demo.tsx"],
     },
     "badge-demo": {
       name: "badge-demo",
       type: "components:example",
       registryDependencies: ["badge"],
-      component: React.lazy(() => import("@/registry/new-york/example/badge-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/badge-demo")
+      ),
       files: ["registry/new-york/example/badge-demo.tsx"],
     },
     "badge-destructive": {
       name: "badge-destructive",
       type: "components:example",
       registryDependencies: ["badge"],
-      component: React.lazy(() => import("@/registry/new-york/example/badge-destructive")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/badge-destructive")
+      ),
       files: ["registry/new-york/example/badge-destructive.tsx"],
     },
     "badge-outline": {
       name: "badge-outline",
       type: "components:example",
       registryDependencies: ["badge"],
-      component: React.lazy(() => import("@/registry/new-york/example/badge-outline")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/badge-outline")
+      ),
       files: ["registry/new-york/example/badge-outline.tsx"],
     },
     "badge-secondary": {
       name: "badge-secondary",
       type: "components:example",
       registryDependencies: ["badge"],
-      component: React.lazy(() => import("@/registry/new-york/example/badge-secondary")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/badge-secondary")
+      ),
       files: ["registry/new-york/example/badge-secondary.tsx"],
     },
     "button-demo": {
       name: "button-demo",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/new-york/example/button-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/button-demo")
+      ),
       files: ["registry/new-york/example/button-demo.tsx"],
     },
     "button-secondary": {
       name: "button-secondary",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/new-york/example/button-secondary")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/button-secondary")
+      ),
       files: ["registry/new-york/example/button-secondary.tsx"],
     },
     "button-destructive": {
       name: "button-destructive",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/new-york/example/button-destructive")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/button-destructive")
+      ),
       files: ["registry/new-york/example/button-destructive.tsx"],
     },
     "button-outline": {
       name: "button-outline",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/new-york/example/button-outline")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/button-outline")
+      ),
       files: ["registry/new-york/example/button-outline.tsx"],
     },
     "button-ghost": {
       name: "button-ghost",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/new-york/example/button-ghost")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/button-ghost")
+      ),
       files: ["registry/new-york/example/button-ghost.tsx"],
     },
     "button-link": {
       name: "button-link",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/new-york/example/button-link")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/button-link")
+      ),
       files: ["registry/new-york/example/button-link.tsx"],
     },
     "button-with-icon": {
       name: "button-with-icon",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/new-york/example/button-with-icon")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/button-with-icon")
+      ),
       files: ["registry/new-york/example/button-with-icon.tsx"],
     },
     "button-loading": {
       name: "button-loading",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/new-york/example/button-loading")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/button-loading")
+      ),
       files: ["registry/new-york/example/button-loading.tsx"],
     },
     "button-icon": {
       name: "button-icon",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/new-york/example/button-icon")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/button-icon")
+      ),
       files: ["registry/new-york/example/button-icon.tsx"],
     },
     "button-as-child": {
       name: "button-as-child",
       type: "components:example",
       registryDependencies: ["button"],
-      component: React.lazy(() => import("@/registry/new-york/example/button-as-child")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/button-as-child")
+      ),
       files: ["registry/new-york/example/button-as-child.tsx"],
     },
     "calendar-demo": {
       name: "calendar-demo",
       type: "components:example",
       registryDependencies: ["calendar"],
-      component: React.lazy(() => import("@/registry/new-york/example/calendar-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/calendar-demo")
+      ),
       files: ["registry/new-york/example/calendar-demo.tsx"],
     },
     "calendar-form": {
       name: "calendar-form",
       type: "components:example",
-      registryDependencies: ["calendar","form","popover"],
-      component: React.lazy(() => import("@/registry/new-york/example/calendar-form")),
+      registryDependencies: ["calendar", "form", "popover"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/calendar-form")
+      ),
       files: ["registry/new-york/example/calendar-form.tsx"],
     },
     "card-demo": {
       name: "card-demo",
       type: "components:example",
-      registryDependencies: ["card","button","switch"],
-      component: React.lazy(() => import("@/registry/new-york/example/card-demo")),
+      registryDependencies: ["card", "button", "switch"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/card-demo")
+      ),
       files: ["registry/new-york/example/card-demo.tsx"],
     },
     "card-with-form": {
       name: "card-with-form",
       type: "components:example",
-      registryDependencies: ["button","card","input","label","select"],
-      component: React.lazy(() => import("@/registry/new-york/example/card-with-form")),
+      registryDependencies: ["button", "card", "input", "label", "select"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/card-with-form")
+      ),
       files: ["registry/new-york/example/card-with-form.tsx"],
     },
     "carousel-demo": {
       name: "carousel-demo",
       type: "components:example",
       registryDependencies: ["carousel"],
-      component: React.lazy(() => import("@/registry/new-york/example/carousel-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/carousel-demo")
+      ),
       files: ["registry/new-york/example/carousel-demo.tsx"],
     },
     "carousel-size": {
       name: "carousel-size",
       type: "components:example",
       registryDependencies: ["carousel"],
-      component: React.lazy(() => import("@/registry/new-york/example/carousel-size")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/carousel-size")
+      ),
       files: ["registry/new-york/example/carousel-size.tsx"],
     },
     "carousel-spacing": {
       name: "carousel-spacing",
       type: "components:example",
       registryDependencies: ["carousel"],
-      component: React.lazy(() => import("@/registry/new-york/example/carousel-spacing")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/carousel-spacing")
+      ),
       files: ["registry/new-york/example/carousel-spacing.tsx"],
     },
     "carousel-orientation": {
       name: "carousel-orientation",
       type: "components:example",
       registryDependencies: ["carousel"],
-      component: React.lazy(() => import("@/registry/new-york/example/carousel-orientation")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/carousel-orientation")
+      ),
       files: ["registry/new-york/example/carousel-orientation.tsx"],
     },
     "carousel-api": {
       name: "carousel-api",
       type: "components:example",
       registryDependencies: ["carousel"],
-      component: React.lazy(() => import("@/registry/new-york/example/carousel-api")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/carousel-api")
+      ),
       files: ["registry/new-york/example/carousel-api.tsx"],
     },
     "carousel-plugin": {
       name: "carousel-plugin",
       type: "components:example",
       registryDependencies: ["carousel"],
-      component: React.lazy(() => import("@/registry/new-york/example/carousel-plugin")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/carousel-plugin")
+      ),
       files: ["registry/new-york/example/carousel-plugin.tsx"],
     },
     "checkbox-demo": {
       name: "checkbox-demo",
       type: "components:example",
       registryDependencies: ["checkbox"],
-      component: React.lazy(() => import("@/registry/new-york/example/checkbox-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/checkbox-demo")
+      ),
       files: ["registry/new-york/example/checkbox-demo.tsx"],
     },
     "checkbox-disabled": {
       name: "checkbox-disabled",
       type: "components:example",
       registryDependencies: ["checkbox"],
-      component: React.lazy(() => import("@/registry/new-york/example/checkbox-disabled")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/checkbox-disabled")
+      ),
       files: ["registry/new-york/example/checkbox-disabled.tsx"],
     },
     "checkbox-form-multiple": {
       name: "checkbox-form-multiple",
       type: "components:example",
-      registryDependencies: ["checkbox","form"],
-      component: React.lazy(() => import("@/registry/new-york/example/checkbox-form-multiple")),
+      registryDependencies: ["checkbox", "form"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/checkbox-form-multiple")
+      ),
       files: ["registry/new-york/example/checkbox-form-multiple.tsx"],
     },
     "checkbox-form-single": {
       name: "checkbox-form-single",
       type: "components:example",
-      registryDependencies: ["checkbox","form"],
-      component: React.lazy(() => import("@/registry/new-york/example/checkbox-form-single")),
+      registryDependencies: ["checkbox", "form"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/checkbox-form-single")
+      ),
       files: ["registry/new-york/example/checkbox-form-single.tsx"],
     },
     "checkbox-with-text": {
       name: "checkbox-with-text",
       type: "components:example",
       registryDependencies: ["checkbox"],
-      component: React.lazy(() => import("@/registry/new-york/example/checkbox-with-text")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/checkbox-with-text")
+      ),
       files: ["registry/new-york/example/checkbox-with-text.tsx"],
     },
     "collapsible-demo": {
       name: "collapsible-demo",
       type: "components:example",
       registryDependencies: ["collapsible"],
-      component: React.lazy(() => import("@/registry/new-york/example/collapsible-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/collapsible-demo")
+      ),
       files: ["registry/new-york/example/collapsible-demo.tsx"],
     },
     "combobox-demo": {
       name: "combobox-demo",
       type: "components:example",
       registryDependencies: ["command"],
-      component: React.lazy(() => import("@/registry/new-york/example/combobox-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/combobox-demo")
+      ),
       files: ["registry/new-york/example/combobox-demo.tsx"],
     },
     "combobox-dropdown-menu": {
       name: "combobox-dropdown-menu",
       type: "components:example",
-      registryDependencies: ["command","dropdown-menu","button"],
-      component: React.lazy(() => import("@/registry/new-york/example/combobox-dropdown-menu")),
+      registryDependencies: ["command", "dropdown-menu", "button"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/combobox-dropdown-menu")
+      ),
       files: ["registry/new-york/example/combobox-dropdown-menu.tsx"],
     },
     "combobox-form": {
       name: "combobox-form",
       type: "components:example",
-      registryDependencies: ["command","form"],
-      component: React.lazy(() => import("@/registry/new-york/example/combobox-form")),
+      registryDependencies: ["command", "form"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/combobox-form")
+      ),
       files: ["registry/new-york/example/combobox-form.tsx"],
     },
     "combobox-popover": {
       name: "combobox-popover",
       type: "components:example",
-      registryDependencies: ["combobox","popover"],
-      component: React.lazy(() => import("@/registry/new-york/example/combobox-popover")),
+      registryDependencies: ["combobox", "popover"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/combobox-popover")
+      ),
       files: ["registry/new-york/example/combobox-popover.tsx"],
     },
     "combobox-responsive": {
       name: "combobox-responsive",
       type: "components:example",
-      registryDependencies: ["combobox","popover","drawer"],
-      component: React.lazy(() => import("@/registry/new-york/example/combobox-responsive")),
+      registryDependencies: ["combobox", "popover", "drawer"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/combobox-responsive")
+      ),
       files: ["registry/new-york/example/combobox-responsive.tsx"],
     },
     "command-demo": {
       name: "command-demo",
       type: "components:example",
       registryDependencies: ["command"],
-      component: React.lazy(() => import("@/registry/new-york/example/command-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/command-demo")
+      ),
       files: ["registry/new-york/example/command-demo.tsx"],
     },
     "command-dialog": {
       name: "command-dialog",
       type: "components:example",
-      registryDependencies: ["command","dialog"],
-      component: React.lazy(() => import("@/registry/new-york/example/command-dialog")),
+      registryDependencies: ["command", "dialog"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/command-dialog")
+      ),
       files: ["registry/new-york/example/command-dialog.tsx"],
     },
     "context-menu-demo": {
       name: "context-menu-demo",
       type: "components:example",
       registryDependencies: ["context-menu"],
-      component: React.lazy(() => import("@/registry/new-york/example/context-menu-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/context-menu-demo")
+      ),
       files: ["registry/new-york/example/context-menu-demo.tsx"],
     },
     "data-table-demo": {
       name: "data-table-demo",
       type: "components:example",
       registryDependencies: ["data-table"],
-      component: React.lazy(() => import("@/registry/new-york/example/data-table-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/data-table-demo")
+      ),
       files: ["registry/new-york/example/data-table-demo.tsx"],
     },
     "date-picker-demo": {
       name: "date-picker-demo",
       type: "components:example",
-      registryDependencies: ["button","calendar","popover"],
-      component: React.lazy(() => import("@/registry/new-york/example/date-picker-demo")),
+      registryDependencies: ["button", "calendar", "popover"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/date-picker-demo")
+      ),
       files: ["registry/new-york/example/date-picker-demo.tsx"],
     },
     "date-picker-form": {
       name: "date-picker-form",
       type: "components:example",
-      registryDependencies: ["button","calendar","form","popover"],
-      component: React.lazy(() => import("@/registry/new-york/example/date-picker-form")),
+      registryDependencies: ["button", "calendar", "form", "popover"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/date-picker-form")
+      ),
       files: ["registry/new-york/example/date-picker-form.tsx"],
     },
     "date-picker-with-presets": {
       name: "date-picker-with-presets",
       type: "components:example",
-      registryDependencies: ["button","calendar","popover","select"],
-      component: React.lazy(() => import("@/registry/new-york/example/date-picker-with-presets")),
+      registryDependencies: ["button", "calendar", "popover", "select"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/date-picker-with-presets")
+      ),
       files: ["registry/new-york/example/date-picker-with-presets.tsx"],
     },
     "date-picker-with-range": {
       name: "date-picker-with-range",
       type: "components:example",
-      registryDependencies: ["button","calendar","popover"],
-      component: React.lazy(() => import("@/registry/new-york/example/date-picker-with-range")),
+      registryDependencies: ["button", "calendar", "popover"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/date-picker-with-range")
+      ),
       files: ["registry/new-york/example/date-picker-with-range.tsx"],
     },
     "dialog-demo": {
       name: "dialog-demo",
       type: "components:example",
       registryDependencies: ["dialog"],
-      component: React.lazy(() => import("@/registry/new-york/example/dialog-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/dialog-demo")
+      ),
       files: ["registry/new-york/example/dialog-demo.tsx"],
     },
     "dialog-close-button": {
       name: "dialog-close-button",
       type: "components:example",
-      registryDependencies: ["dialog","button"],
-      component: React.lazy(() => import("@/registry/new-york/example/dialog-close-button")),
+      registryDependencies: ["dialog", "button"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/dialog-close-button")
+      ),
       files: ["registry/new-york/example/dialog-close-button.tsx"],
+    },
+    "dialog-static-backdrop": {
+      name: "dialog-static-backdrop",
+      type: "components:example",
+      registryDependencies: ["dialog", "button"],
+      component: React.lazy(
+        () => import("@/registry/default/example/dialog-static-backdrop")
+      ),
+      files: ["registry/default/example/dialog-static-backdrop.tsx"],
     },
     "drawer-demo": {
       name: "drawer-demo",
       type: "components:example",
       registryDependencies: ["drawer"],
-      component: React.lazy(() => import("@/registry/new-york/example/drawer-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/drawer-demo")
+      ),
       files: ["registry/new-york/example/drawer-demo.tsx"],
     },
     "drawer-dialog": {
       name: "drawer-dialog",
       type: "components:example",
-      registryDependencies: ["drawer","dialog"],
-      component: React.lazy(() => import("@/registry/new-york/example/drawer-dialog")),
+      registryDependencies: ["drawer", "dialog"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/drawer-dialog")
+      ),
       files: ["registry/new-york/example/drawer-dialog.tsx"],
     },
     "dropdown-menu-demo": {
       name: "dropdown-menu-demo",
       type: "components:example",
       registryDependencies: ["dropdown-menu"],
-      component: React.lazy(() => import("@/registry/new-york/example/dropdown-menu-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/dropdown-menu-demo")
+      ),
       files: ["registry/new-york/example/dropdown-menu-demo.tsx"],
     },
     "dropdown-menu-checkboxes": {
       name: "dropdown-menu-checkboxes",
       type: "components:example",
-      registryDependencies: ["dropdown-menu","checkbox"],
-      component: React.lazy(() => import("@/registry/new-york/example/dropdown-menu-checkboxes")),
+      registryDependencies: ["dropdown-menu", "checkbox"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/dropdown-menu-checkboxes")
+      ),
       files: ["registry/new-york/example/dropdown-menu-checkboxes.tsx"],
     },
     "dropdown-menu-radio-group": {
       name: "dropdown-menu-radio-group",
       type: "components:example",
-      registryDependencies: ["dropdown-menu","radio-group"],
-      component: React.lazy(() => import("@/registry/new-york/example/dropdown-menu-radio-group")),
+      registryDependencies: ["dropdown-menu", "radio-group"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/dropdown-menu-radio-group")
+      ),
       files: ["registry/new-york/example/dropdown-menu-radio-group.tsx"],
     },
     "hover-card-demo": {
       name: "hover-card-demo",
       type: "components:example",
       registryDependencies: ["hover-card"],
-      component: React.lazy(() => import("@/registry/new-york/example/hover-card-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/hover-card-demo")
+      ),
       files: ["registry/new-york/example/hover-card-demo.tsx"],
     },
     "input-demo": {
       name: "input-demo",
       type: "components:example",
       registryDependencies: ["input"],
-      component: React.lazy(() => import("@/registry/new-york/example/input-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/input-demo")
+      ),
       files: ["registry/new-york/example/input-demo.tsx"],
     },
     "input-disabled": {
       name: "input-disabled",
       type: "components:example",
       registryDependencies: ["input"],
-      component: React.lazy(() => import("@/registry/new-york/example/input-disabled")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/input-disabled")
+      ),
       files: ["registry/new-york/example/input-disabled.tsx"],
     },
     "input-file": {
       name: "input-file",
       type: "components:example",
       registryDependencies: ["input"],
-      component: React.lazy(() => import("@/registry/new-york/example/input-file")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/input-file")
+      ),
       files: ["registry/new-york/example/input-file.tsx"],
     },
     "input-form": {
       name: "input-form",
       type: "components:example",
-      registryDependencies: ["input","button","form"],
-      component: React.lazy(() => import("@/registry/new-york/example/input-form")),
+      registryDependencies: ["input", "button", "form"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/input-form")
+      ),
       files: ["registry/new-york/example/input-form.tsx"],
     },
     "input-with-button": {
       name: "input-with-button",
       type: "components:example",
-      registryDependencies: ["input","button"],
-      component: React.lazy(() => import("@/registry/new-york/example/input-with-button")),
+      registryDependencies: ["input", "button"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/input-with-button")
+      ),
       files: ["registry/new-york/example/input-with-button.tsx"],
     },
     "input-with-label": {
       name: "input-with-label",
       type: "components:example",
-      registryDependencies: ["input","button","label"],
-      component: React.lazy(() => import("@/registry/new-york/example/input-with-label")),
+      registryDependencies: ["input", "button", "label"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/input-with-label")
+      ),
       files: ["registry/new-york/example/input-with-label.tsx"],
     },
     "input-with-text": {
       name: "input-with-text",
       type: "components:example",
-      registryDependencies: ["input","button","label"],
-      component: React.lazy(() => import("@/registry/new-york/example/input-with-text")),
+      registryDependencies: ["input", "button", "label"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/input-with-text")
+      ),
       files: ["registry/new-york/example/input-with-text.tsx"],
     },
     "label-demo": {
       name: "label-demo",
       type: "components:example",
       registryDependencies: ["label"],
-      component: React.lazy(() => import("@/registry/new-york/example/label-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/label-demo")
+      ),
       files: ["registry/new-york/example/label-demo.tsx"],
     },
     "menubar-demo": {
       name: "menubar-demo",
       type: "components:example",
       registryDependencies: ["menubar"],
-      component: React.lazy(() => import("@/registry/new-york/example/menubar-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/menubar-demo")
+      ),
       files: ["registry/new-york/example/menubar-demo.tsx"],
     },
     "navigation-menu-demo": {
       name: "navigation-menu-demo",
       type: "components:example",
       registryDependencies: ["navigation-menu"],
-      component: React.lazy(() => import("@/registry/new-york/example/navigation-menu-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/navigation-menu-demo")
+      ),
       files: ["registry/new-york/example/navigation-menu-demo.tsx"],
     },
     "pagination-demo": {
       name: "pagination-demo",
       type: "components:example",
       registryDependencies: ["pagination"],
-      component: React.lazy(() => import("@/registry/new-york/example/pagination-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/pagination-demo")
+      ),
       files: ["registry/new-york/example/pagination-demo.tsx"],
     },
     "popover-demo": {
       name: "popover-demo",
       type: "components:example",
       registryDependencies: ["popover"],
-      component: React.lazy(() => import("@/registry/new-york/example/popover-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/popover-demo")
+      ),
       files: ["registry/new-york/example/popover-demo.tsx"],
     },
     "progress-demo": {
       name: "progress-demo",
       type: "components:example",
       registryDependencies: ["progress"],
-      component: React.lazy(() => import("@/registry/new-york/example/progress-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/progress-demo")
+      ),
       files: ["registry/new-york/example/progress-demo.tsx"],
     },
     "radio-group-demo": {
       name: "radio-group-demo",
       type: "components:example",
       registryDependencies: ["radio-group"],
-      component: React.lazy(() => import("@/registry/new-york/example/radio-group-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/radio-group-demo")
+      ),
       files: ["registry/new-york/example/radio-group-demo.tsx"],
     },
     "radio-group-form": {
       name: "radio-group-form",
       type: "components:example",
-      registryDependencies: ["radio-group","form"],
-      component: React.lazy(() => import("@/registry/new-york/example/radio-group-form")),
+      registryDependencies: ["radio-group", "form"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/radio-group-form")
+      ),
       files: ["registry/new-york/example/radio-group-form.tsx"],
     },
     "resizable-demo": {
       name: "resizable-demo",
       type: "components:example",
       registryDependencies: ["resizable"],
-      component: React.lazy(() => import("@/registry/new-york/example/resizable-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/resizable-demo")
+      ),
       files: ["registry/new-york/example/resizable-demo.tsx"],
     },
     "resizable-demo-with-handle": {
       name: "resizable-demo-with-handle",
       type: "components:example",
       registryDependencies: ["resizable"],
-      component: React.lazy(() => import("@/registry/new-york/example/resizable-demo-with-handle")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/resizable-demo-with-handle")
+      ),
       files: ["registry/new-york/example/resizable-demo-with-handle.tsx"],
     },
     "resizable-vertical": {
       name: "resizable-vertical",
       type: "components:example",
       registryDependencies: ["resizable"],
-      component: React.lazy(() => import("@/registry/new-york/example/resizable-vertical")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/resizable-vertical")
+      ),
       files: ["registry/new-york/example/resizable-vertical.tsx"],
     },
     "resizable-handle": {
       name: "resizable-handle",
       type: "components:example",
       registryDependencies: ["resizable"],
-      component: React.lazy(() => import("@/registry/new-york/example/resizable-handle")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/resizable-handle")
+      ),
       files: ["registry/new-york/example/resizable-handle.tsx"],
     },
     "scroll-area-demo": {
       name: "scroll-area-demo",
       type: "components:example",
       registryDependencies: ["scroll-area"],
-      component: React.lazy(() => import("@/registry/new-york/example/scroll-area-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/scroll-area-demo")
+      ),
       files: ["registry/new-york/example/scroll-area-demo.tsx"],
     },
     "scroll-area-horizontal-demo": {
       name: "scroll-area-horizontal-demo",
       type: "components:example",
       registryDependencies: ["scroll-area"],
-      component: React.lazy(() => import("@/registry/new-york/example/scroll-area-horizontal-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/scroll-area-horizontal-demo")
+      ),
       files: ["registry/new-york/example/scroll-area-horizontal-demo.tsx"],
     },
     "select-demo": {
       name: "select-demo",
       type: "components:example",
       registryDependencies: ["select"],
-      component: React.lazy(() => import("@/registry/new-york/example/select-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/select-demo")
+      ),
       files: ["registry/new-york/example/select-demo.tsx"],
     },
     "select-scrollable": {
       name: "select-scrollable",
       type: "components:example",
       registryDependencies: ["select"],
-      component: React.lazy(() => import("@/registry/new-york/example/select-scrollable")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/select-scrollable")
+      ),
       files: ["registry/new-york/example/select-scrollable.tsx"],
     },
     "select-form": {
       name: "select-form",
       type: "components:example",
       registryDependencies: ["select"],
-      component: React.lazy(() => import("@/registry/new-york/example/select-form")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/select-form")
+      ),
       files: ["registry/new-york/example/select-form.tsx"],
     },
     "separator-demo": {
       name: "separator-demo",
       type: "components:example",
       registryDependencies: ["separator"],
-      component: React.lazy(() => import("@/registry/new-york/example/separator-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/separator-demo")
+      ),
       files: ["registry/new-york/example/separator-demo.tsx"],
     },
     "sheet-demo": {
       name: "sheet-demo",
       type: "components:example",
       registryDependencies: ["sheet"],
-      component: React.lazy(() => import("@/registry/new-york/example/sheet-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/sheet-demo")
+      ),
       files: ["registry/new-york/example/sheet-demo.tsx"],
     },
     "sheet-side": {
       name: "sheet-side",
       type: "components:example",
       registryDependencies: ["sheet"],
-      component: React.lazy(() => import("@/registry/new-york/example/sheet-side")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/sheet-side")
+      ),
       files: ["registry/new-york/example/sheet-side.tsx"],
     },
     "skeleton-demo": {
       name: "skeleton-demo",
       type: "components:example",
       registryDependencies: ["skeleton"],
-      component: React.lazy(() => import("@/registry/new-york/example/skeleton-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/skeleton-demo")
+      ),
       files: ["registry/new-york/example/skeleton-demo.tsx"],
     },
     "slider-demo": {
       name: "slider-demo",
       type: "components:example",
       registryDependencies: ["slider"],
-      component: React.lazy(() => import("@/registry/new-york/example/slider-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/slider-demo")
+      ),
       files: ["registry/new-york/example/slider-demo.tsx"],
     },
     "sonner-demo": {
       name: "sonner-demo",
       type: "components:example",
       registryDependencies: ["sonner"],
-      component: React.lazy(() => import("@/registry/new-york/example/sonner-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/sonner-demo")
+      ),
       files: ["registry/new-york/example/sonner-demo.tsx"],
     },
     "switch-demo": {
       name: "switch-demo",
       type: "components:example",
       registryDependencies: ["switch"],
-      component: React.lazy(() => import("@/registry/new-york/example/switch-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/switch-demo")
+      ),
       files: ["registry/new-york/example/switch-demo.tsx"],
     },
     "switch-form": {
       name: "switch-form",
       type: "components:example",
-      registryDependencies: ["switch","form"],
-      component: React.lazy(() => import("@/registry/new-york/example/switch-form")),
+      registryDependencies: ["switch", "form"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/switch-form")
+      ),
       files: ["registry/new-york/example/switch-form.tsx"],
     },
     "table-demo": {
       name: "table-demo",
       type: "components:example",
       registryDependencies: ["table"],
-      component: React.lazy(() => import("@/registry/new-york/example/table-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/table-demo")
+      ),
       files: ["registry/new-york/example/table-demo.tsx"],
     },
     "tabs-demo": {
       name: "tabs-demo",
       type: "components:example",
       registryDependencies: ["tabs"],
-      component: React.lazy(() => import("@/registry/new-york/example/tabs-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/tabs-demo")
+      ),
       files: ["registry/new-york/example/tabs-demo.tsx"],
     },
     "textarea-demo": {
       name: "textarea-demo",
       type: "components:example",
       registryDependencies: ["textarea"],
-      component: React.lazy(() => import("@/registry/new-york/example/textarea-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/textarea-demo")
+      ),
       files: ["registry/new-york/example/textarea-demo.tsx"],
     },
     "textarea-disabled": {
       name: "textarea-disabled",
       type: "components:example",
       registryDependencies: ["textarea"],
-      component: React.lazy(() => import("@/registry/new-york/example/textarea-disabled")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/textarea-disabled")
+      ),
       files: ["registry/new-york/example/textarea-disabled.tsx"],
     },
     "textarea-form": {
       name: "textarea-form",
       type: "components:example",
-      registryDependencies: ["textarea","form"],
-      component: React.lazy(() => import("@/registry/new-york/example/textarea-form")),
+      registryDependencies: ["textarea", "form"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/textarea-form")
+      ),
       files: ["registry/new-york/example/textarea-form.tsx"],
     },
     "textarea-with-button": {
       name: "textarea-with-button",
       type: "components:example",
-      registryDependencies: ["textarea","button"],
-      component: React.lazy(() => import("@/registry/new-york/example/textarea-with-button")),
+      registryDependencies: ["textarea", "button"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/textarea-with-button")
+      ),
       files: ["registry/new-york/example/textarea-with-button.tsx"],
     },
     "textarea-with-label": {
       name: "textarea-with-label",
       type: "components:example",
-      registryDependencies: ["textarea","label"],
-      component: React.lazy(() => import("@/registry/new-york/example/textarea-with-label")),
+      registryDependencies: ["textarea", "label"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/textarea-with-label")
+      ),
       files: ["registry/new-york/example/textarea-with-label.tsx"],
     },
     "textarea-with-text": {
       name: "textarea-with-text",
       type: "components:example",
-      registryDependencies: ["textarea","label"],
-      component: React.lazy(() => import("@/registry/new-york/example/textarea-with-text")),
+      registryDependencies: ["textarea", "label"],
+      component: React.lazy(
+        () => import("@/registry/new-york/example/textarea-with-text")
+      ),
       files: ["registry/new-york/example/textarea-with-text.tsx"],
     },
     "toast-demo": {
       name: "toast-demo",
       type: "components:example",
       registryDependencies: ["toast"],
-      component: React.lazy(() => import("@/registry/new-york/example/toast-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toast-demo")
+      ),
       files: ["registry/new-york/example/toast-demo.tsx"],
     },
     "toast-destructive": {
       name: "toast-destructive",
       type: "components:example",
       registryDependencies: ["toast"],
-      component: React.lazy(() => import("@/registry/new-york/example/toast-destructive")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toast-destructive")
+      ),
       files: ["registry/new-york/example/toast-destructive.tsx"],
     },
     "toast-simple": {
       name: "toast-simple",
       type: "components:example",
       registryDependencies: ["toast"],
-      component: React.lazy(() => import("@/registry/new-york/example/toast-simple")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toast-simple")
+      ),
       files: ["registry/new-york/example/toast-simple.tsx"],
     },
     "toast-with-action": {
       name: "toast-with-action",
       type: "components:example",
       registryDependencies: ["toast"],
-      component: React.lazy(() => import("@/registry/new-york/example/toast-with-action")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toast-with-action")
+      ),
       files: ["registry/new-york/example/toast-with-action.tsx"],
     },
     "toast-with-title": {
       name: "toast-with-title",
       type: "components:example",
       registryDependencies: ["toast"],
-      component: React.lazy(() => import("@/registry/new-york/example/toast-with-title")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toast-with-title")
+      ),
       files: ["registry/new-york/example/toast-with-title.tsx"],
     },
     "toggle-group-demo": {
       name: "toggle-group-demo",
       type: "components:example",
       registryDependencies: ["toggle-group"],
-      component: React.lazy(() => import("@/registry/new-york/example/toggle-group-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toggle-group-demo")
+      ),
       files: ["registry/new-york/example/toggle-group-demo.tsx"],
     },
     "toggle-group-disabled": {
       name: "toggle-group-disabled",
       type: "components:example",
       registryDependencies: ["toggle-group"],
-      component: React.lazy(() => import("@/registry/new-york/example/toggle-group-disabled")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toggle-group-disabled")
+      ),
       files: ["registry/new-york/example/toggle-group-disabled.tsx"],
     },
     "toggle-group-lg": {
       name: "toggle-group-lg",
       type: "components:example",
       registryDependencies: ["toggle-group"],
-      component: React.lazy(() => import("@/registry/new-york/example/toggle-group-lg")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toggle-group-lg")
+      ),
       files: ["registry/new-york/example/toggle-group-lg.tsx"],
     },
     "toggle-group-outline": {
       name: "toggle-group-outline",
       type: "components:example",
       registryDependencies: ["toggle-group"],
-      component: React.lazy(() => import("@/registry/new-york/example/toggle-group-outline")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toggle-group-outline")
+      ),
       files: ["registry/new-york/example/toggle-group-outline.tsx"],
     },
     "toggle-group-sm": {
       name: "toggle-group-sm",
       type: "components:example",
       registryDependencies: ["toggle-group"],
-      component: React.lazy(() => import("@/registry/new-york/example/toggle-group-sm")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toggle-group-sm")
+      ),
       files: ["registry/new-york/example/toggle-group-sm.tsx"],
     },
     "toggle-group-single": {
       name: "toggle-group-single",
       type: "components:example",
       registryDependencies: ["toggle-group"],
-      component: React.lazy(() => import("@/registry/new-york/example/toggle-group-single")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toggle-group-single")
+      ),
       files: ["registry/new-york/example/toggle-group-single.tsx"],
     },
     "toggle-demo": {
       name: "toggle-demo",
       type: "components:example",
       registryDependencies: ["toggle"],
-      component: React.lazy(() => import("@/registry/new-york/example/toggle-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toggle-demo")
+      ),
       files: ["registry/new-york/example/toggle-demo.tsx"],
     },
     "toggle-disabled": {
       name: "toggle-disabled",
       type: "components:example",
       registryDependencies: ["toggle"],
-      component: React.lazy(() => import("@/registry/new-york/example/toggle-disabled")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toggle-disabled")
+      ),
       files: ["registry/new-york/example/toggle-disabled.tsx"],
     },
     "toggle-lg": {
       name: "toggle-lg",
       type: "components:example",
       registryDependencies: ["toggle"],
-      component: React.lazy(() => import("@/registry/new-york/example/toggle-lg")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toggle-lg")
+      ),
       files: ["registry/new-york/example/toggle-lg.tsx"],
     },
     "toggle-outline": {
       name: "toggle-outline",
       type: "components:example",
       registryDependencies: ["toggle"],
-      component: React.lazy(() => import("@/registry/new-york/example/toggle-outline")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toggle-outline")
+      ),
       files: ["registry/new-york/example/toggle-outline.tsx"],
     },
     "toggle-sm": {
       name: "toggle-sm",
       type: "components:example",
       registryDependencies: ["toggle"],
-      component: React.lazy(() => import("@/registry/new-york/example/toggle-sm")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toggle-sm")
+      ),
       files: ["registry/new-york/example/toggle-sm.tsx"],
     },
     "toggle-with-text": {
       name: "toggle-with-text",
       type: "components:example",
       registryDependencies: ["toggle"],
-      component: React.lazy(() => import("@/registry/new-york/example/toggle-with-text")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/toggle-with-text")
+      ),
       files: ["registry/new-york/example/toggle-with-text.tsx"],
     },
     "tooltip-demo": {
       name: "tooltip-demo",
       type: "components:example",
       registryDependencies: ["tooltip"],
-      component: React.lazy(() => import("@/registry/new-york/example/tooltip-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/tooltip-demo")
+      ),
       files: ["registry/new-york/example/tooltip-demo.tsx"],
     },
     "typography-blockquote": {
       name: "typography-blockquote",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/example/typography-blockquote")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/typography-blockquote")
+      ),
       files: ["registry/new-york/example/typography-blockquote.tsx"],
     },
     "typography-demo": {
       name: "typography-demo",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/example/typography-demo")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/typography-demo")
+      ),
       files: ["registry/new-york/example/typography-demo.tsx"],
     },
     "typography-h1": {
       name: "typography-h1",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/example/typography-h1")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/typography-h1")
+      ),
       files: ["registry/new-york/example/typography-h1.tsx"],
     },
     "typography-h2": {
       name: "typography-h2",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/example/typography-h2")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/typography-h2")
+      ),
       files: ["registry/new-york/example/typography-h2.tsx"],
     },
     "typography-h3": {
       name: "typography-h3",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/example/typography-h3")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/typography-h3")
+      ),
       files: ["registry/new-york/example/typography-h3.tsx"],
     },
     "typography-h4": {
       name: "typography-h4",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/example/typography-h4")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/typography-h4")
+      ),
       files: ["registry/new-york/example/typography-h4.tsx"],
     },
     "typography-inline-code": {
       name: "typography-inline-code",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/example/typography-inline-code")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/typography-inline-code")
+      ),
       files: ["registry/new-york/example/typography-inline-code.tsx"],
     },
     "typography-large": {
       name: "typography-large",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/example/typography-large")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/typography-large")
+      ),
       files: ["registry/new-york/example/typography-large.tsx"],
     },
     "typography-lead": {
       name: "typography-lead",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/example/typography-lead")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/typography-lead")
+      ),
       files: ["registry/new-york/example/typography-lead.tsx"],
     },
     "typography-list": {
       name: "typography-list",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/example/typography-list")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/typography-list")
+      ),
       files: ["registry/new-york/example/typography-list.tsx"],
     },
     "typography-muted": {
       name: "typography-muted",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/example/typography-muted")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/typography-muted")
+      ),
       files: ["registry/new-york/example/typography-muted.tsx"],
     },
     "typography-p": {
       name: "typography-p",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/example/typography-p")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/typography-p")
+      ),
       files: ["registry/new-york/example/typography-p.tsx"],
     },
     "typography-small": {
       name: "typography-small",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/example/typography-small")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/typography-small")
+      ),
       files: ["registry/new-york/example/typography-small.tsx"],
     },
     "typography-table": {
       name: "typography-table",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/example/typography-table")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/typography-table")
+      ),
       files: ["registry/new-york/example/typography-table.tsx"],
     },
     "mode-toggle": {
       name: "mode-toggle",
       type: "components:example",
       registryDependencies: undefined,
-      component: React.lazy(() => import("@/registry/new-york/example/mode-toggle")),
+      component: React.lazy(
+        () => import("@/registry/new-york/example/mode-toggle")
+      ),
       files: ["registry/new-york/example/mode-toggle.tsx"],
     },
-    "cards": {
+    cards: {
       name: "cards",
       type: "components:example",
       registryDependencies: undefined,

--- a/apps/www/components/main-nav.tsx
+++ b/apps/www/components/main-nav.tsx
@@ -63,14 +63,6 @@ export function MainNav() {
         >
           Examples
         </Link>
-        <Link
-          href={siteConfig.links.github}
-          className={cn(
-            "hidden text-foreground/60 transition-colors hover:text-foreground/80 lg:block"
-          )}
-        >
-          GitHub
-        </Link>
       </nav>
     </div>
   )

--- a/apps/www/content/docs/components/dialog.mdx
+++ b/apps/www/content/docs/components/dialog.mdx
@@ -115,3 +115,26 @@ To activate the `Dialog` component from within a `Context Menu` or `Dropdown Men
   </DialogContent>
 </Dialog>
 ```
+
+### Static backdrop
+
+<ComponentPreview name="dialog-static-backdrop" />
+
+## Notes
+
+To achieve the `static backdrop` dialog which does not close on clicking outside, add prop named `onInteractOutside` your`DialogContent` like given in example
+
+```tsx {14-25}
+<Dialog>
+  <DialogTrigger>Open</DialogTrigger>
+  <DialogContent onInteractOutside={(e) => e.preventDefault()}>
+    <DialogHeader>
+      <DialogTitle>Are you absolutely sure?</DialogTitle>
+      <DialogDescription>
+        This action cannot be undone. This will permanently delete your account
+        and remove your data from our servers.
+      </DialogDescription>
+    </DialogHeader>
+  </DialogContent>
+</Dialog>
+```

--- a/apps/www/registry/default/example/dialog-static-backdrop.tsx
+++ b/apps/www/registry/default/example/dialog-static-backdrop.tsx
@@ -1,0 +1,58 @@
+import { Button } from "@/registry/default/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/registry/default/ui/dialog"
+import { Input } from "@/registry/default/ui/input"
+import { Label } from "@/registry/default/ui/label"
+
+export default function DialogDemo() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline">Edit Profile</Button>
+      </DialogTrigger>
+      <DialogContent
+        className="sm:max-w-[425px]"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>Edit profile</DialogTitle>
+          <DialogDescription>
+            Make changes to your profile here. Click save when you're done.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="name" className="text-right">
+              Name
+            </Label>
+            <Input
+              id="name"
+              defaultValue="Pedro Duarte"
+              className="col-span-3"
+            />
+          </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="username" className="text-right">
+              Username
+            </Label>
+            <Input
+              id="username"
+              defaultValue="@peduarte"
+              className="col-span-3"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button type="submit">Save changes</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/www/registry/new-york/example/dialog-static-backdrop.tsx
+++ b/apps/www/registry/new-york/example/dialog-static-backdrop.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@/registry/new-york/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/registry/new-york/ui/dialog"
+import { Input } from "@/registry/new-york/ui/input"
+import { Label } from "@/registry/new-york/ui/label"
+
+export default function DialogDemo() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline">Edit Profile ny</Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Edit profile</DialogTitle>
+          <DialogDescription>
+            Make changes to your profile here. Click save when you're done.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="name" className="text-right">
+              Name
+            </Label>
+            <Input id="name" value="Pedro Duarte" className="col-span-3" />
+          </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="username" className="text-right">
+              Username
+            </Label>
+            <Input id="username" value="@peduarte" className="col-span-3" />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button type="submit">Save changes</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
Added a dialog component with static backdrop in docs.
Static backdrop does not close on clicking outside.

It is useful for those devs who are not interested in lots of reading docs but try to learn visually (personally, I am one of them and I scrolled to see how to achieve static backdrop and didn't read api reference)
