### PR TITLE
`refactor:` Typo in combobox language example : new-york style

### DIFF
--- a/apps/www/registry/new-york/example/combobox-form.tsx
+++ b/apps/www/registry/new-york/example/combobox-form.tsx
@@ -96,10 +96,10 @@ export default function ComboboxForm() {
                 <PopoverContent className="w-[200px] p-0">
                   <Command>
                     <CommandInput
-                      placeholder="Search framework..."
+                      placeholder="Search language..."
                       className="h-9"
                     />
-                    <CommandEmpty>No framework found.</CommandEmpty>
+                    <CommandEmpty>No language found.</CommandEmpty>
                     <CommandGroup>
                       {languages.map((language) => (
                         <CommandItem


### PR DESCRIPTION
## Typo Fix: Search Frameworks to Search Languages

### Description
I noticed a small typo in the example of the ComboBox component where it mentions "framework" It appears to be more appropriate to use "lnguage" in this context. I've made the necessary correction to enhance clarity and accuracy.

### Changes Made
- Updated the text in the ComboBox example of new-york style from "framework" to "language"

### Before
```jsx
<CommandInput placeholder="Search framework..." className="h-9" />
<CommandEmpty> No framework found.</CommandEmpty>
```

### After
```jsx
<CommandInput placeholder="Search language..." className="h-9" />
<CommandEmpty> No language found.</CommandEmpty>
```

**Checklist**

-  Checked the change locally to ensure accuracy.
-  Followed the contribution guidelines of the project.
