### PR TITLE
fix: missing key in `<ScrollArea />` example

### DIFF
--- a/apps/www/registry/default/example/scroll-area-demo.tsx
+++ b/apps/www/registry/default/example/scroll-area-demo.tsx
@@ -13,12 +13,10 @@ export default function ScrollAreaDemo() {
       <div className="p-4">
         <h4 className="mb-4 text-sm font-medium leading-none">Tags</h4>
         {tags.map((tag) => (
-          <>
-            <div key={tag} className="text-sm">
-              {tag}
-            </div>
+          <React.Fragment key={tag}>
+            <div className="text-sm">{tag}</div>
             <Separator className="my-2" />
-          </>
+          </React.Fragment>
         ))}
       </div>
     </ScrollArea>

--- a/apps/www/registry/new-york/example/scroll-area-demo.tsx
+++ b/apps/www/registry/new-york/example/scroll-area-demo.tsx
@@ -13,12 +13,10 @@ export default function ScrollAreaDemo() {
       <div className="p-4">
         <h4 className="mb-4 text-sm font-medium leading-none">Tags</h4>
         {tags.map((tag) => (
-          <>
-            <div key={tag} className="text-sm">
-              {tag}
-            </div>
+          <React.Fragment key={tag}>
+            <div className="text-sm">{tag}</div>
             <Separator className="my-2" />
-          </>
+          </React.Fragment>
         ))}
       </div>
     </ScrollArea>


### PR DESCRIPTION
This was addressed in https://github.com/shadcn-ui/ui/pull/1295. 

The change in the previous PR fixed the issue in the IDE. However when running the app, the `Warning: Each child in a list should have a unique "key" prop.` will still appear.

The key should be applied to the `Fragment` itself. [Example in react docs](https://react.dev/reference/react/Fragment#rendering-a-list-of-fragments).


Just a change for examples, I don't need to update registry or anything right?