### PR TITLE
chore(components): remove unnecessary imports

### DIFF
--- a/apps/www/components/main-nav.tsx
+++ b/apps/www/components/main-nav.tsx
@@ -7,7 +7,6 @@ import { usePathname } from "next/navigation"
 import { siteConfig } from "@/config/site"
 import { cn } from "@/lib/utils"
 import { Icons } from "@/components/icons"
-import { Badge } from "@/registry/new-york/ui/badge"
 
 export function MainNav() {
   const pathname = usePathname()

--- a/apps/www/components/mobile-nav.tsx
+++ b/apps/www/components/mobile-nav.tsx
@@ -3,7 +3,6 @@
 import * as React from "react"
 import Link, { LinkProps } from "next/link"
 import { useRouter } from "next/navigation"
-import { ViewVerticalIcon } from "@radix-ui/react-icons"
 
 import { docsConfig } from "@/config/docs"
 import { siteConfig } from "@/config/site"


### PR DESCRIPTION
Removing unnecessary imports from **mobile-nav** and **main-nav** component

`ViewVerticalIcon`, `Badge` imports are unused as seen in screenshot below

<img width="1470" alt="Screenshot 2024-01-27 at 1 20 14 PM" src="https://github.com/shadcn-ui/ui/assets/90947491/32f37856-41bd-44ba-beee-a99310cad32f">
