### PR TITLE
docs: use example.com instead of email.com in example

### DIFF
--- a/apps/www/app/examples/dashboard/components/recent-sales.tsx
+++ b/apps/www/app/examples/dashboard/components/recent-sales.tsx
@@ -15,7 +15,7 @@ export function RecentSales() {
         <div className="ml-4 space-y-1">
           <p className="text-sm font-medium leading-none">Olivia Martin</p>
           <p className="text-sm text-muted-foreground">
-            olivia.martin@email.com
+            olivia.martin@example.com
           </p>
         </div>
         <div className="ml-auto font-medium">+$1,999.00</div>
@@ -27,7 +27,7 @@ export function RecentSales() {
         </Avatar>
         <div className="ml-4 space-y-1">
           <p className="text-sm font-medium leading-none">Jackson Lee</p>
-          <p className="text-sm text-muted-foreground">jackson.lee@email.com</p>
+          <p className="text-sm text-muted-foreground">jackson.lee@example.com</p>
         </div>
         <div className="ml-auto font-medium">+$39.00</div>
       </div>
@@ -39,7 +39,7 @@ export function RecentSales() {
         <div className="ml-4 space-y-1">
           <p className="text-sm font-medium leading-none">Isabella Nguyen</p>
           <p className="text-sm text-muted-foreground">
-            isabella.nguyen@email.com
+            isabella.nguyen@example.com
           </p>
         </div>
         <div className="ml-auto font-medium">+$299.00</div>
@@ -51,7 +51,7 @@ export function RecentSales() {
         </Avatar>
         <div className="ml-4 space-y-1">
           <p className="text-sm font-medium leading-none">William Kim</p>
-          <p className="text-sm text-muted-foreground">will@email.com</p>
+          <p className="text-sm text-muted-foreground">will@example.com</p>
         </div>
         <div className="ml-auto font-medium">+$99.00</div>
       </div>
@@ -62,7 +62,7 @@ export function RecentSales() {
         </Avatar>
         <div className="ml-4 space-y-1">
           <p className="text-sm font-medium leading-none">Sofia Davis</p>
-          <p className="text-sm text-muted-foreground">sofia.davis@email.com</p>
+          <p className="text-sm text-muted-foreground">sofia.davis@example.com</p>
         </div>
         <div className="ml-auto font-medium">+$39.00</div>
       </div>


### PR DESCRIPTION
email.com is a real (though a bit scammy) domain operated by mail.com.

It's better to use @example.com as a documentational email (unless you own all the mail adresses in the example).