### PR TITLE
docs(next-installation): Fixed type error in Next.js installation by removing export from fontSans

### DIFF
--- a/apps/www/content/docs/installation/next.mdx
+++ b/apps/www/content/docs/installation/next.mdx
@@ -52,7 +52,7 @@ import { Inter as FontSans } from "next/font/google"
 
 import { cn } from "../@/lib/utils"
 
-export const fontSans = FontSans({
+const fontSans = FontSans({
   subsets: ["latin"],
   variable: "--font-sans",
 })


### PR DESCRIPTION
This PR fixes the issue [#2337](https://github.com/shadcn-ui/ui/issues/2377).

I removed `export` of `fontSans` from `app/layout.tsx`, which was causing a type error. 
I have ensured that this modification does not impact other functionalities. Your feedback on this pull request would be greatly appreciated.

Thank you for your consideration.