### PR TITLE
fix: handle nested error messages in FormMessage

### DIFF
--- a/apps/www/registry/default/ui/form.tsx
+++ b/apps/www/registry/default/ui/form.tsx
@@ -145,7 +145,7 @@ const FormMessage = React.forwardRef<
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, children, ...props }, ref) => {
   const { error, formMessageId } = useFormField()
-  const body = error ? String(error?.message) : children
+  const body = error ? String(error.root?.message || error.message) : children
 
   if (!body) {
     return null


### PR DESCRIPTION
I've identified an issue when using the FormMessage component in conjunction with react-hook-form's useFieldArray. Specifically, when submitting a form that triggers validation errors for fields within a field array, the error messages are structured within a root object. This structure, particularly upon submission, causes the FormMessage component to incorrectly display undefined instead of the actual error message.

Problem:
The FormMessage component does not account for error messages nested within a root object, which is a common pattern when using useFieldArray from react-hook-form.

Proposed Solution:
I propose updating the FormMessage component to correctly handle error messages that are nested within a root object. This involves checking for the presence of a root object within the error data and, if present, accessing the message property within it.

Implementation:
A conditional check can be added to determine if the error data contains a root object and then render the message from this root object if it exists.

I'm not sure if I've done everything correctly since this is my first contribution, but I'm grateful for the opportunity.