### PR TITLE
docs(dropdown-menu): Add `modal` prop usage example

### DIFF
--- a/apps/www/content/docs/components/dropdown-menu.mdx
+++ b/apps/www/content/docs/components/dropdown-menu.mdx
@@ -75,6 +75,14 @@ import {
 </DropdownMenu>
 ```
 
+To optionally prevent the dropdown menu from hiding page-level scrollbars, you can use `modal={false}`.
+
+```tsx
+<DropdownMenu modal={false}>
+  ...
+</DropdownMenu>
+```
+
 ## Examples
 
 ### Checkboxes

--- a/apps/www/content/docs/components/dropdown-menu.mdx
+++ b/apps/www/content/docs/components/dropdown-menu.mdx
@@ -75,7 +75,7 @@ import {
 </DropdownMenu>
 ```
 
-To optionally prevent the dropdown menu from hiding page-level scrollbars, you can use `modal={false}`.
+Optionally prevent scrollbar hiding with `modal={false}`
 
 ```tsx
 <DropdownMenu modal={false}>


### PR DESCRIPTION
Added modal prop example to DropdownMenu docs for page-level scrollbar visibility control.

reference https://github.com/radix-ui/primitives/issues/1272#issuecomment-1136899602