### PR TITLE
docs(introduction): remove outdated faq from the documentation

### DIFF
--- a/apps/www/content/docs/index.mdx
+++ b/apps/www/content/docs/index.mdx
@@ -32,15 +32,6 @@ One of the drawback of packaging the components in an npm package is that the st
 </AccordionItem>
 
 <AccordionItem value="faq-2">
-  <AccordionTrigger>
-    Do you plan to publish it as an npm package?
-  </AccordionTrigger>
-  <AccordionContent>
-    No. I have no plans to publish it as an npm package.
-  </AccordionContent>
-</AccordionItem>
-
-<AccordionItem value="faq-3">
 <AccordionTrigger>
 Which frameworks are supported?
 </AccordionTrigger>
@@ -51,7 +42,7 @@ You can use any framework that supports React. [Next.js](https://ui.shadcn.com/d
 </AccordionContent>
 </AccordionItem>
 
-<AccordionItem value="faq-4">
+<AccordionItem value="faq-3">
 	<AccordionTrigger>
 	Can I use this in my project?
 	</AccordionTrigger>


### PR DESCRIPTION
This pull request addresses an inconsistency found in the documentation regarding the publication of the shadcn-ui package on npm. Currently, the documentation states that there are no plans to publish the package on npm, while in reality, the package has already been published on npm.

To maintain accuracy and clarity in the documentation, this pull request removes the statement regarding the non-publication of the package on npm. Instead, it provides information or updates about the package's current status on npm.

[NPM Package](https://www.npmjs.com/package/shadcn-ui)