### PR TITLE
Remove `export` statement from `fontSans` variable, it causes type error

### DIFF
--- a/apps/www/content/docs/installation/next.mdx
+++ b/apps/www/content/docs/installation/next.mdx
@@ -52,7 +52,7 @@ import { Inter as FontSans } from "next/font/google"
 
 import { cn } from "../@/lib/utils"
 
-export const fontSans = FontSans({
+const fontSans = FontSans({
   subsets: ["latin"],
   variable: "--font-sans",
 })


### PR DESCRIPTION
![Screenshot 2024-02-14 at 12 56 41 AM](https://github.com/shadcn-ui/ui/assets/38455472/9408e38c-698c-4b6d-9d3e-a89377426234)

```
info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules
00:54:08.501 | Failed to compile.
00:54:08.502 |  
00:54:08.503 | app/layout.tsx
00:54:08.503 | Type error: Layout "app/layout.tsx" does not match the required types of a Next.js Layout.
00:54:08.503 | "fontSans" is not a valid Layout export field.
00:54:08.503 |  
00:54:08.533 | ELIFECYCLE  Command failed with exit code 1.
00:54:08.557 | Error: Command "pnpm run build" exited with 1
00:54:08.876

<br class="Apple-interchange-newline">
```

It's weird that no one talks about this, should we update the documentation to avoid this error.