### PR TITLE
fix(radio-group): center indicator icon

### DIFF
--- a/apps/www/registry/default/ui/radio-group.tsx
+++ b/apps/www/registry/default/ui/radio-group.tsx
@@ -33,8 +33,8 @@ const RadioGroupItem = React.forwardRef<
       )}
       {...props}
     >
-      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
-        <Circle className="h-2.5 w-2.5 fill-current text-current" />
+      <RadioGroupPrimitive.Indicator className="relative block">
+        <Circle className="h-2.5 w-2.5 fill-current text-current absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   )

--- a/apps/www/registry/new-york/ui/radio-group.tsx
+++ b/apps/www/registry/new-york/ui/radio-group.tsx
@@ -33,8 +33,8 @@ const RadioGroupItem = React.forwardRef<
       )}
       {...props}
     >
-      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
-        <CheckIcon className="h-3.5 w-3.5 fill-primary" />
+      <RadioGroupPrimitive.Indicator className="relative block">
+        <CheckIcon className="h-3.5 w-3.5 fill-primary absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   )


### PR DESCRIPTION
Center  `radio-group`  component indicator icon mark
Fix #2044 

| Before                            | After                           |
| ----------------------------------- | ----------------------------------- |
|![Screenshot 2024-02-15 223917](https://github.com/shadcn-ui/ui/assets/87615573/96d815ce-241e-460b-8c98-21b2996717b4)| ![Screenshot 2024-02-15 223845](https://github.com/shadcn-ui/ui/assets/87615573/f973e28d-1f5d-48a1-8423-609ad640ef21) |
| ![Screenshot 2024-02-15 222304](https://github.com/shadcn-ui/ui/assets/87615573/263de1e2-8748-44d1-8af6-d39189dbc427)| ![Screenshot 2024-02-15 222317](https://github.com/shadcn-ui/ui/assets/87615573/f019e1ff-d15b-4826-9ecc-2cf9e79af285)  |

