### PR TITLE
feat(www): save preferred package manager

### DIFF
--- a/apps/www/components/copy-button.tsx
+++ b/apps/www/components/copy-button.tsx
@@ -189,12 +189,7 @@ export function CopyNpmCommandButton({
       } else {
         const pmData = JSON.parse(pmStorage) as PackageManagerData
         pmData[pm] += 1
-        if (
-          (pmData.preferred === undefined && pmData[pm] >= 3) ||
-          (pmData.preferred !== pm &&
-            pmData.preferred !== undefined &&
-            pmData[pm] > pmData[pmData.preferred] + 3)
-        ) {
+        if (pmData.preferred === undefined && pmData[pm] >= 3) {
           pmData.preferred = pm
         }
         localStorage.setItem("ppm", JSON.stringify(pmData))

--- a/apps/www/components/copy-button.tsx
+++ b/apps/www/components/copy-button.tsx
@@ -2,8 +2,8 @@
 
 import * as React from "react"
 import { DropdownMenuTriggerProps } from "@radix-ui/react-dropdown-menu"
-import { CheckIcon, CopyIcon } from "@radix-ui/react-icons"
-import { NpmCommands } from "types/unist"
+import { CheckIcon, CopyIcon, GearIcon } from "@radix-ui/react-icons"
+import { NpmCommands, PackageManagerData } from "types/unist"
 
 import { Event, trackEvent } from "@/lib/events"
 import { cn } from "@/lib/utils"
@@ -143,12 +143,25 @@ export function CopyNpmCommandButton({
   ...props
 }: CopyNpmCommandButtonProps) {
   const [hasCopied, setHasCopied] = React.useState(false)
+  const [preferredPackageManager, setPreferredPackageManager] = React.useState<
+    "npm" | "pnpm" | "yarn" | "bun" | undefined
+  >(undefined)
 
   React.useEffect(() => {
     setTimeout(() => {
       setHasCopied(false)
     }, 2000)
   }, [hasCopied])
+
+  React.useEffect(() => {
+    const pmStorage = localStorage.getItem("ppm") // ppm = preferred package manager
+    if (pmStorage != null) {
+      const pmData = JSON.parse(pmStorage) as PackageManagerData
+      if (pmData?.preferred !== undefined) {
+        setPreferredPackageManager(pmData.preferred)
+      }
+    }
+  }, [])
 
   const copyCommand = React.useCallback(
     (value: string, pm: "npm" | "pnpm" | "yarn" | "bun") => {
@@ -160,20 +173,137 @@ export function CopyNpmCommandButton({
         },
       })
       setHasCopied(true)
+
+      const pmStorage = localStorage.getItem("ppm") // ppm = preferred package manager
+      if (pmStorage == null) {
+        localStorage.setItem(
+          "ppm",
+          JSON.stringify({
+            bun: pm === "bun" ? 1 : 0,
+            npm: pm === "npm" ? 1 : 0,
+            pnpm: pm === "pnpm" ? 1 : 0,
+            yarn: pm === "yarn" ? 1 : 0,
+            preferred: undefined,
+          } satisfies PackageManagerData)
+        )
+      } else {
+        const pmData = JSON.parse(pmStorage) as PackageManagerData
+        pmData[pm] += 1
+        if (
+          (pmData.preferred === undefined && pmData[pm] >= 3) ||
+          (pmData.preferred !== pm &&
+            pmData.preferred !== undefined &&
+            pmData[pm] > pmData[pmData.preferred] + 3)
+        ) {
+          pmData.preferred = pm
+        }
+        localStorage.setItem("ppm", JSON.stringify(pmData))
+      }
     },
     []
   )
+  const setPackageManager = React.useCallback(
+    (pm: "npm" | "pnpm" | "yarn" | "bun") => {
+      localStorage.setItem(
+        "ppm",
+        JSON.stringify({
+          bun: pm === "bun" ? 1 : 0,
+          npm: pm === "npm" ? 1 : 0,
+          pnpm: pm === "pnpm" ? 1 : 0,
+          yarn: pm === "yarn" ? 1 : 0,
+          preferred: pm,
+        } satisfies PackageManagerData)
+      )
+      setPreferredPackageManager(pm)
+    },
+    []
+  )
+  const settingsClicked = React.useCallback(
+    (value: string, pm: "npm" | "pnpm" | "yarn" | "bun") => {
+      if (preferredPackageManager !== undefined) {
+        setPackageManager(pm)
+      } else {
+        copyCommand(value, pm)
+      }
+    },
+    [copyCommand, preferredPackageManager, setPackageManager]
+  )
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
+    <div className={cn("relative z-10 flex gap-1", className)}>
+      {/* Settings or Wildcard Package Manager Dropdown */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-6 w-6 text-zinc-50 hover:bg-zinc-700 hover:text-zinc-50"
+          >
+            {preferredPackageManager === undefined ? (
+              <>
+                {hasCopied ? (
+                  <CheckIcon className="h-3 w-3" />
+                ) : (
+                  <CopyIcon className="h-3 w-3" />
+                )}
+                <span className="sr-only">Copy</span>
+              </>
+            ) : (
+              <GearIcon className="h-3 w-3" />
+            )}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onClick={() => settingsClicked(commands.__npmCommand__, "npm")}
+            className="flex items-center"
+          >
+            {preferredPackageManager === "npm" && (
+              <CheckIcon className="mr-2 h-4 w-4" />
+            )}
+            <span className="flex-1">npm</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => settingsClicked(commands.__yarnCommand__, "yarn")}
+          >
+            {preferredPackageManager === "yarn" && (
+              <CheckIcon className="mr-2 h-4 w-4" />
+            )}
+            <span className="flex-1">yarn</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => settingsClicked(commands.__pnpmCommand__, "pnpm")}
+          >
+            {preferredPackageManager === "pnpm" && (
+              <CheckIcon className="mr-2 h-4 w-4" />
+            )}
+            <span className="flex-1">pnpm</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => settingsClicked(commands.__bunCommand__, "bun")}
+          >
+            {preferredPackageManager === "bun" && (
+              <CheckIcon className="mr-2 h-4 w-4" />
+            )}
+            <span className="flex-1">bun</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* Preferred Package Manager Quick Copy */}
+      {preferredPackageManager !== undefined && (
         <Button
           size="icon"
           variant="ghost"
-          className={cn(
-            "relative z-10 h-6 w-6 text-zinc-50 hover:bg-zinc-700 hover:text-zinc-50",
-            className
-          )}
+          className="h-6 w-6 text-zinc-50 hover:bg-zinc-700 hover:text-zinc-50"
+          onClick={() => {
+            if (preferredPackageManager !== undefined) {
+              copyCommand(
+                commands[`__${preferredPackageManager}Command__` as const],
+                preferredPackageManager
+              )
+            }
+          }}
         >
           {hasCopied ? (
             <CheckIcon className="h-3 w-3" />
@@ -182,29 +312,7 @@ export function CopyNpmCommandButton({
           )}
           <span className="sr-only">Copy</span>
         </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem
-          onClick={() => copyCommand(commands.__npmCommand__, "npm")}
-        >
-          npm
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => copyCommand(commands.__yarnCommand__, "yarn")}
-        >
-          yarn
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => copyCommand(commands.__pnpmCommand__, "pnpm")}
-        >
-          pnpm
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => copyCommand(commands.__bunCommand__, "bun")}
-        >
-          bun
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+      )}
+    </div>
   )
 }

--- a/apps/www/types/unist.ts
+++ b/apps/www/types/unist.ts
@@ -29,3 +29,11 @@ export interface NpmCommands {
   __pnpmCommand__?: string
   __bunCommand__?: string
 }
+
+export interface PackageManagerData {
+  npm: number;
+  yarn: number;
+  pnpm: number;
+  bun: number;
+  preferred?: 'npm'|'yarn'|'pnpm'|'bun';
+}


### PR DESCRIPTION
This pull request adds the feature requested in #2446. When a user first uses the documentation the experience remains the same. After they use the same package manager 5 times, however, it becomes their "preferred" package manager which is stored in `localStorage`. They can change this at any time after the preferred manager has been determined using a "settings" button which appears next to the copy button. The copy button behavior then changes from a dropdown menu to a standard button which simply copies the command for the user's preferred package manager.

![image](https://github.com/shadcn-ui/ui/assets/34199284/0f25e887-ab8b-4e3c-9531-98f5408ca408)
