### PR TITLE
fix(cli): list files to be overwritten

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -102,6 +102,7 @@ export async function promptForConfig(
 
   const styles = await getRegistryStyles()
   const baseColors = await getRegistryBaseColors()
+  const extension = defaultConfig?.tsx ? "ts" : "js"
 
   const options = await prompts([
     {
@@ -184,6 +185,14 @@ export async function promptForConfig(
       active: "yes",
       inactive: "no",
     },
+    {
+      type: "confirm",
+      name: "proceed",
+      message: `Running the command will overwrite following files.\n${highlight(
+        `\t/component.json\n\t/tailwind.config.${extension}\n\t/app/global.css\n\t/lib/utils.${extension}\n`
+      )}Make sure you have committed your changes before proceeding. Proceed?`,
+      initial: true,
+    },
   ])
 
   const config = rawConfigSchema.parse({
@@ -238,6 +247,7 @@ export async function promptForMinimalConfig(
   let style = defaultConfig.style
   let baseColor = defaultConfig.tailwind.baseColor
   let cssVariables = defaultConfig.tailwind.cssVariables
+  const extension = defaultConfig.tsx ? "ts" : "js"
 
   if (!defaults) {
     const styles = await getRegistryStyles()
@@ -273,6 +283,14 @@ export async function promptForMinimalConfig(
         initial: defaultConfig?.tailwind.cssVariables,
         active: "yes",
         inactive: "no",
+      },
+      {
+        type: "confirm",
+        name: "proceed",
+        message: `Running the command will overwrite following files.\n${highlight(
+          `\t/component.json\n\t/tailwind.config.${extension}\n\t/app/global.css\n\t/lib/utils.${extension}\n`
+        )}Make sure you have committed your changes before proceeding. Proceed?`,
+        initial: true,
       },
     ])
 


### PR DESCRIPTION
Based on the issue (Closes #183), I added a prompt that lists the files that will be overwritten when using the `init` CLI command.

![image](https://github.com/shadcn-ui/ui/assets/25415799/4fe6c2b2-817c-40e3-81da-51a4e6b55e58)

Would love any feedback.
