### PR TITLE
feat(cli): ignoreCase of components option list on add command

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -20,7 +20,13 @@ import prompts from "prompts"
 import { z } from "zod"
 
 const addOptionsSchema = z.object({
-  components: z.array(z.string()).optional(),
+  components: z
+    .array(z.string())
+    .optional()
+    .transform(
+      (components) =>
+        components?.map((component) => component.toLowerCase()) || components
+    ),
   yes: z.boolean(),
   overwrite: z.boolean(),
   cwd: z.string(),


### PR DESCRIPTION
## Description

If for some reason when trying to use **add command** has an uppercase letter, this not will work because the components name now are case-sensitive

Then this pr uses Zod to transform all components arguments to lowercase.

### Before 
<img width="493" alt="Screenshot 2024-02-20 at 11 52 19" src="https://github.com/shadcn-ui/ui/assets/13812512/cfeaba82-7ad5-4c62-ae2f-8ad5a82f7916">

### After
<img width="637" alt="Screenshot 2024-02-20 at 11 54 37" src="https://github.com/shadcn-ui/ui/assets/13812512/59629c7c-2890-457b-a73c-a2483e95ef4b">
