### PR TITLE
feat: added CarouselDot to Carousel Component

### DIFF
--- a/apps/www/registry/default/ui/carousel.tsx
+++ b/apps/www/registry/default/ui/carousel.tsx
@@ -1,3 +1,4 @@
+'use client'
 import * as React from 'react'
 
 import { Button } from '@/components/ui/button'


### PR DESCRIPTION
### Description
Add `CarouselDot` component to render individual dots for navigation in the carousel.

### Changes Made
- Added `CarouselDot` component
- Used `CarouselDot` component in `Carousel` to render dots for navigation
- Added `dotClassName` prop to `Carousel` to customize dot button styling

### Screenshots 
![Screenshot_20240220_233112](https://github.com/shadcn-ui/ui/assets/103078485/80e2ee98-292b-4496-a6cb-79dcfaf460da)


### Additional Notes
- The `CarouselDot` component provides a flexible way to customize the appearance of navigation dots in the carousel.