### PR TITLE
chore(www): add link button to example code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build
 # misc
 .DS_Store
 *.pem
+.idea
 
 # debug
 npm-debug.log*

--- a/apps/www/components/examples-nav.tsx
+++ b/apps/www/components/examples-nav.tsx
@@ -1,11 +1,14 @@
 "use client"
 
 import Link from "next/link"
-import { usePathname } from "next/navigation"
-import { ArrowRightIcon } from "@radix-ui/react-icons"
+import {usePathname} from "next/navigation"
+import {ArrowRightIcon} from "@radix-ui/react-icons"
 
-import { cn } from "@/lib/utils"
-import { ScrollArea, ScrollBar } from "@/registry/new-york/ui/scroll-area"
+import {cn} from "@/lib/utils"
+import {ScrollArea, ScrollBar} from "@/registry/new-york/ui/scroll-area"
+import {siteConfig} from "@/config/site";
+import {buttonVariants} from "@/registry/new-york/ui/button";
+import {Icons} from "@/components/icons";
 
 const examples = [
   {
@@ -50,15 +53,16 @@ const examples = [
   },
 ]
 
-interface ExamplesNavProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface ExamplesNavProps extends React.HTMLAttributes<HTMLDivElement> {
+}
 
-export function ExamplesNav({ className, ...props }: ExamplesNavProps) {
+export function ExamplesNav({className, ...props}: ExamplesNavProps) {
   const pathname = usePathname()
 
   return (
-    <div className="relative">
+    <div className="relative flex flex-col md:flex-row justify-between md:items-center mb-4">
       <ScrollArea className="max-w-[600px] lg:max-w-none">
-        <div className={cn("mb-4 flex items-center", className)} {...props}>
+        <div className={cn("mb-4 flex items-center md:mb-0", className)} {...props}>
           {examples.map((example, index) => (
             <Link
               href={example.href}
@@ -66,7 +70,7 @@ export function ExamplesNav({ className, ...props }: ExamplesNavProps) {
               className={cn(
                 "flex h-7 items-center justify-center rounded-full px-4 text-center text-sm transition-colors hover:text-primary",
                 pathname?.startsWith(example.href) ||
-                  (index === 0 && pathname === "/")
+                (index === 0 && pathname === "/")
                   ? "bg-muted font-medium text-primary"
                   : "text-muted-foreground"
               )}
@@ -75,8 +79,18 @@ export function ExamplesNav({ className, ...props }: ExamplesNavProps) {
             </Link>
           ))}
         </div>
-        <ScrollBar orientation="horizontal" className="invisible" />
+        <ScrollBar orientation="horizontal" className="invisible"/>
       </ScrollArea>
+
+      <Link
+        target="_blank"
+        rel="noreferrer"
+        href={siteConfig.links.githubExampleCode}
+        className={cn(buttonVariants({variant: "outline"}), 'lg:mb-0')}
+      >
+        <Icons.gitHub className="mr-2 h-4 w-4"/>
+        Example code
+      </Link>
     </div>
   )
 }
@@ -85,7 +99,7 @@ interface ExampleCodeLinkProps {
   pathname: string | null
 }
 
-export function ExampleCodeLink({ pathname }: ExampleCodeLinkProps) {
+export function ExampleCodeLink({pathname}: ExampleCodeLinkProps) {
   const example = examples.find((example) => pathname?.startsWith(example.href))
 
   if (!example?.code) {
@@ -100,7 +114,7 @@ export function ExampleCodeLink({ pathname }: ExampleCodeLinkProps) {
       className="absolute right-0 top-0 hidden items-center rounded-[0.5rem] text-sm font-medium md:flex"
     >
       View code
-      <ArrowRightIcon className="ml-1 h-4 w-4" />
+      <ArrowRightIcon className="ml-1 h-4 w-4"/>
     </Link>
   )
 }

--- a/apps/www/config/site.ts
+++ b/apps/www/config/site.ts
@@ -7,6 +7,7 @@ export const siteConfig = {
   links: {
     twitter: "https://twitter.com/shadcn",
     github: "https://github.com/shadcn-ui/ui",
+    githubExampleCode: "https://github.com/shadcn-ui/ui/tree/main/apps/www/app/examples"
   },
 }
 


### PR DESCRIPTION
# Description
When I want to view the code of the examples, I notice that there is no link to redirect me to the source code. So this PR adds a small link button to make easier the accessibility to the example code.

# Screenshots
### Tablet
<img width="783" alt="image" src="https://github.com/shadcn-ui/ui/assets/67383906/df4e1533-b7a7-4d21-8334-4abe6aa9ff48">

### Mobile
<img width="480" alt="image" src="https://github.com/shadcn-ui/ui/assets/67383906/1bd48a2c-7823-4155-950a-c639cc25a0ce">

### Desktop
<img width="1697" alt="image" src="https://github.com/shadcn-ui/ui/assets/67383906/6fbce10b-6e99-4ae2-907b-3c1517d897c1">

