### PR TITLE
docs: Improve UX by Extending Clickable Area for Switch Component

### DIFF
--- a/apps/www/registry/default/example/switch-demo.tsx
+++ b/apps/www/registry/default/example/switch-demo.tsx
@@ -3,9 +3,9 @@ import { Switch } from "@/registry/default/ui/switch"
 
 export default function SwitchDemo() {
   return (
-    <div className="flex items-center space-x-2">
+    <div className="flex items-center">
       <Switch id="airplane-mode" />
-      <Label htmlFor="airplane-mode">Airplane Mode</Label>
+      <Label htmlFor="airplane-mode" className="pl-2">Airplane Mode</Label>
     </div>
   )
 }

--- a/apps/www/registry/new-york/example/switch-demo.tsx
+++ b/apps/www/registry/new-york/example/switch-demo.tsx
@@ -3,9 +3,9 @@ import { Switch } from "@/registry/new-york/ui/switch"
 
 export default function SwitchDemo() {
   return (
-    <div className="flex items-center space-x-2">
+    <div className="flex items-center">
       <Switch id="airplane-mode" />
-      <Label htmlFor="airplane-mode">Airplane Mode</Label>
+      <Label htmlFor="airplane-mode" className="pl-2">Airplane Mode</Label>
     </div>
   )
 }


### PR DESCRIPTION
Close #2874 
### Issue Details
As demonstrated in the SwitchDemo example, a user cannot toggle the switch by clicking on the whitespace between the Switch and its Label. This specific behavior contrasts with user expectations set by similar components in other libraries, such as Radix UI, where the clickable area extends to the surrounding whitespace, allowing for a more forgiving click target.

### What I did
By removing space-x-2, which prevented toggling, and adding padding to the Label, usability is enhanced by aligning with common user expectations and improving the interaction experience.

### Before:
https://www.loom.com/share/4bcb04b031c54f50b15c306da3fe600e?sid=6e9c9cce-3bc3-461a-8479-d76faf3f8b09

### After:
https://www.loom.com/share/da928675828d42bf90a373bf34bbf66a?sid=08a12dab-a3fe-4302-b301-e495a36b9e41