### PR TITLE
docs(drawer): add asChild prop on DrawerClose example

### DIFF
--- a/apps/www/content/docs/components/drawer.mdx
+++ b/apps/www/content/docs/components/drawer.mdx
@@ -75,7 +75,7 @@ import {
     </DrawerHeader>
     <DrawerFooter>
       <Button>Submit</Button>
-      <DrawerClose>
+      <DrawerClose asChild>
         <Button variant="outline">Cancel</Button>
       </DrawerClose>
     </DrawerFooter>


### PR DESCRIPTION
`asChild` prop was missing since there is a `<Button />` inside.  It was causing a `validateDOMNesting` error, and shrinking the _cancel_ button