### PR TITLE
feat(components): add new prop `overflow` to the carousel component

### DIFF
--- a/apps/www/__registry__/index.tsx
+++ b/apps/www/__registry__/index.tsx
@@ -1728,6 +1728,13 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/new-york/example/carousel-orientation")),
       files: ["registry/new-york/example/carousel-orientation.tsx"],
     },
+    "carousel-overflow": {
+      name: "carousel-overflow",
+      type: "components:example",
+      registryDependencies: ["carousel"],
+      component: React.lazy(() => import("@/registry/new-york/example/carousel-overflow")),
+      files: ["registry/new-york/example/carousel-overflow.tsx"],
+    },
     "carousel-api": {
       name: "carousel-api",
       type: "components:example",

--- a/apps/www/__registry__/index.tsx
+++ b/apps/www/__registry__/index.tsx
@@ -502,6 +502,13 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/default/example/carousel-orientation")),
       files: ["registry/default/example/carousel-orientation.tsx"],
     },
+    "carousel-overflow": {
+      name: "carousel-overflow",
+      type: "components:example",
+      registryDependencies: ["carousel"],
+      component: React.lazy(() => import("@/registry/default/example/carousel-overflow")),
+      files: ["registry/default/example/carousel-overflow.tsx"],
+    },
     "carousel-api": {
       name: "carousel-api",
       type: "components:example",

--- a/apps/www/components/component-preview.tsx
+++ b/apps/www/components/component-preview.tsx
@@ -90,7 +90,7 @@ export function ComponentPreview({
             </TabsTrigger>
           </TabsList>
         </div>
-        <TabsContent value="preview" className="relative rounded-md border">
+        <TabsContent value="preview" className="relative overflow-hidden rounded-md border">
           <div className="flex items-center justify-between p-4">
             <StyleSwitcher />
             {extractedClassNames ? (

--- a/apps/www/content/docs/components/carousel.mdx
+++ b/apps/www/content/docs/components/carousel.mdx
@@ -158,6 +158,22 @@ Use the `orientation` prop to set the orientation of the carousel.
 </Carousel>
 ```
 
+### Overflow
+
+Use the `overflow` prop to set the overflow of the carousel
+
+<ComponentPreview name="carousel-overflow" />
+
+```tsx showLineNumbers /hidden | visible/
+<Carousel overflow="hidden | visible">
+  <CarouselContent>
+    <CarouselItem>...</CarouselItem>
+    <CarouselItem>...</CarouselItem>
+    <CarouselItem>...</CarouselItem>
+  </CarouselContent>
+</Carousel>
+```
+
 ## Options
 
 You can pass options to the carousel using the `opts` prop. See the [Embla Carousel docs](https://www.embla-carousel.com/api/options/) for more information.

--- a/apps/www/registry/default/example/carousel-overflow.tsx
+++ b/apps/www/registry/default/example/carousel-overflow.tsx
@@ -1,0 +1,32 @@
+import * as React from "react"
+
+import { Card, CardContent } from "@/registry/default/ui/card"
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/registry/default/ui/carousel"
+
+export default function CarouselOverflow() {
+  return (
+    <Carousel className="w-full max-w-sm" overflow="visible">
+      <CarouselContent className="-ml-1">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <CarouselItem key={index} className="pl-1 md:basis-1/2 lg:basis-1/3">
+            <div className="p-1">
+              <Card>
+                <CardContent className="flex aspect-square items-center justify-center p-6">
+                  <span className="text-2xl font-semibold">{index + 1}</span>
+                </CardContent>
+              </Card>
+            </div>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  )
+}

--- a/apps/www/registry/default/ui/carousel.tsx
+++ b/apps/www/registry/default/ui/carousel.tsx
@@ -52,7 +52,7 @@ const Carousel = React.forwardRef<
       orientation = "horizontal",
       opts,
       setApi,
-      overflow = 'hidden',
+      overflow = "hidden",
       plugins,
       className,
       children,
@@ -128,6 +128,7 @@ const Carousel = React.forwardRef<
           carouselRef,
           api: api,
           opts,
+          overflow,
           orientation:
             orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
           scrollPrev,
@@ -159,12 +160,17 @@ const CarouselContent = React.forwardRef<
   const { overflow, carouselRef, orientation } = useCarousel()
 
   return (
-    <div ref={carouselRef} className="overflow-hidden">
+    <div
+      ref={carouselRef}
+      className={cn(
+        overflow === "hidden" ? "overflow-hidden" : "overflow-visible",
+        className
+      )}
+    >
       <div
         ref={ref}
         className={cn(
           "flex",
-          overflow === 'hidden' ? "overflow-hidden" : "overflow-visible",
           orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
           className
         )}

--- a/apps/www/registry/default/ui/carousel.tsx
+++ b/apps/www/registry/default/ui/carousel.tsx
@@ -18,6 +18,7 @@ type CarouselProps = {
   opts?: CarouselOptions
   plugins?: CarouselPlugin
   orientation?: "horizontal" | "vertical"
+  overflow?: "hidden" | "visible"
   setApi?: (api: CarouselApi) => void
 }
 
@@ -51,6 +52,7 @@ const Carousel = React.forwardRef<
       orientation = "horizontal",
       opts,
       setApi,
+      overflow = 'hidden',
       plugins,
       className,
       children,
@@ -154,7 +156,7 @@ const CarouselContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => {
-  const { carouselRef, orientation } = useCarousel()
+  const { overflow, carouselRef, orientation } = useCarousel()
 
   return (
     <div ref={carouselRef} className="overflow-hidden">
@@ -162,6 +164,7 @@ const CarouselContent = React.forwardRef<
         ref={ref}
         className={cn(
           "flex",
+          overflow === 'hidden' ? "overflow-hidden" : "overflow-visible",
           orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
           className
         )}

--- a/apps/www/registry/new-york/example/carousel-overflow.tsx
+++ b/apps/www/registry/new-york/example/carousel-overflow.tsx
@@ -1,0 +1,32 @@
+import * as React from "react"
+
+import { Card, CardContent } from "@/registry/new-york/ui/card"
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/registry/new-york/ui/carousel"
+
+export default function CarouselOverflow() {
+  return (
+    <Carousel className="w-full max-w-sm" overflow="visible">
+      <CarouselContent className="-ml-1">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <CarouselItem key={index} className="pl-1 md:basis-1/2 lg:basis-1/3">
+            <div className="p-1">
+              <Card>
+                <CardContent className="flex aspect-square items-center justify-center p-6">
+                  <span className="text-2xl font-semibold">{index + 1}</span>
+                </CardContent>
+              </Card>
+            </div>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  )
+}

--- a/apps/www/registry/new-york/ui/carousel.tsx
+++ b/apps/www/registry/new-york/ui/carousel.tsx
@@ -18,6 +18,7 @@ type CarouselProps = {
   opts?: CarouselOptions
   plugins?: CarouselPlugin
   orientation?: "horizontal" | "vertical"
+  overflow?: "hidden" | "visible"
   setApi?: (api: CarouselApi) => void
 }
 
@@ -154,7 +155,7 @@ const CarouselContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => {
-  const { carouselRef, orientation } = useCarousel()
+  const { carouselRef, orientation, overflow } = useCarousel()
 
   return (
     <div ref={carouselRef} className="overflow-hidden">
@@ -163,6 +164,7 @@ const CarouselContent = React.forwardRef<
         className={cn(
           "flex",
           orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          overflow === "hidden" ? "overflow-hidden" : "overflow-visible",
           className
         )}
         {...props}

--- a/apps/www/registry/new-york/ui/carousel.tsx
+++ b/apps/www/registry/new-york/ui/carousel.tsx
@@ -50,6 +50,7 @@ const Carousel = React.forwardRef<
   (
     {
       orientation = "horizontal",
+      overflow = 'hidden',
       opts,
       setApi,
       plugins,
@@ -127,6 +128,7 @@ const Carousel = React.forwardRef<
           carouselRef,
           api: api,
           opts,
+          overflow,
           orientation:
             orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
           scrollPrev,
@@ -158,13 +160,18 @@ const CarouselContent = React.forwardRef<
   const { carouselRef, orientation, overflow } = useCarousel()
 
   return (
-    <div ref={carouselRef} className="overflow-hidden">
+    <div
+      ref={carouselRef}
+      className={cn(
+        overflow === "hidden" ? "overflow-hidden" : "overflow-visible",
+        className
+      )}
+    >
       <div
         ref={ref}
         className={cn(
           "flex",
           orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
-          overflow === "hidden" ? "overflow-hidden" : "overflow-visible",
           className
         )}
         {...props}

--- a/apps/www/registry/registry.ts
+++ b/apps/www/registry/registry.ts
@@ -436,6 +436,12 @@ const example: Registry = [
     files: ["example/carousel-orientation.tsx"],
   },
   {
+    name: "carousel-overflow",
+    type: "components:example",
+    registryDependencies: ["carousel"],
+    files: ["example/carousel-overflow.tsx"],
+  },
+  {
     name: "carousel-api",
     type: "components:example",
     registryDependencies: ["carousel"],


### PR DESCRIPTION
Add a `overflow` property for carousel, to allow it to overflow naturally (useful for mobile carousels).

### Example:
```typescript
<Carousel overflow="visible">
      ...
</Carousel>
```

[### Preview Link](https://ui-7oibuhhby-alonzuman.vercel.app/docs/components/carousel)

### Desktop Demo
https://github.com/shadcn-ui/ui/assets/57261095/fd0d2c40-6278-42e4-9eb1-93fbc682c146

### Mobile Demo
*Notice how the cards scroll naturally outside of the screen as they are not bound the the containers width

https://github.com/shadcn-ui/ui/assets/57261095/d7a51b68-23e9-4f69-bcbb-ecac73da4ae5
