### PR TITLE
Fix issue with tailwind dark mode not working in version 3.4.1+

### DIFF
--- a/packages/cli/src/utils/templates.ts
+++ b/packages/cli/src/utils/templates.ts
@@ -16,7 +16,7 @@ export function cn(...inputs) {
 
 export const TAILWIND_CONFIG = `/** @type {import('tailwindcss').Config} */
 module.exports = {
-  darkMode: ["class"],
+  darkMode: ["selector"],
   content: [
     './pages/**/*.{<%- extension %>,<%- extension %>x}',
     './components/**/*.{<%- extension %>,<%- extension %>x}',


### PR DESCRIPTION
Tailwind 3.4.1 made a change to how dark mode is applied. Instead of using `class="dark"` it now uses `class="selector"`.