### PR TITLE
feat: add aria-disabled to button component

### DIFF
--- a/apps/www/registry/default/ui/button.tsx
+++ b/apps/www/registry/default/ui/button.tsx
@@ -40,11 +40,13 @@ export interface ButtonProps
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, asChild = false, disabled = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button"
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
+        disabled={disabled}
+        aria-disabled={disabled}
         ref={ref}
         {...props}
       />


### PR DESCRIPTION
This commit enhances the Button component by adding the `aria-disabled` attribute when the `disabled` prop is set to true. This addition improves accessibility for users relying on assistive technologies by conveying the disabled state information. The change ensures consistency between the visual state and accessibility properties.

### Affected component/components

Button

fixes: #2917