### PR TITLE
docs: correct validation message for Bio in FormSchema for TextAreaForm

### DIFF
--- a/apps/www/registry/default/example/textarea-form.tsx
+++ b/apps/www/registry/default/example/textarea-form.tsx
@@ -24,7 +24,7 @@ const FormSchema = z.object({
       message: "Bio must be at least 10 characters.",
     })
     .max(160, {
-      message: "Bio must not be longer than 30 characters.",
+      message: "Bio must not be longer than 160 characters.",
     }),
 })
 

--- a/apps/www/registry/new-york/example/textarea-form.tsx
+++ b/apps/www/registry/new-york/example/textarea-form.tsx
@@ -24,7 +24,7 @@ const FormSchema = z.object({
       message: "Bio must be at least 10 characters.",
     })
     .max(160, {
-      message: "Bio must not be longer than 30 characters.",
+      message: "Bio must not be longer than 160 characters.",
     }),
 })
 


### PR DESCRIPTION
The validation message for the zod FormSchema was not matching with the actual max length.

(PS This is my first ever open source contribution.)