### PR TITLE
docs(data table): only show hide btn in column header if enableHiding is set to true

### DIFF
--- a/apps/www/app/examples/tasks/components/data-table-column-header.tsx
+++ b/apps/www/app/examples/tasks/components/data-table-column-header.tsx
@@ -59,11 +59,15 @@ export function DataTableColumnHeader<TData, TValue>({
             <ArrowDownIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
             Desc
           </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => column.toggleVisibility(false)}>
-            <EyeNoneIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
-            Hide
-          </DropdownMenuItem>
+          {column.getCanHide() && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => column.toggleVisibility(false)}>
+                <EyeNoneIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
+                Hide
+              </DropdownMenuItem>
+            </>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>


### PR DESCRIPTION
In column header reusable component in the data table docs, the header dropdown hide button is currently visible even when the `enableHiding` property is set to `false` This pull request ensures that the button is displayed only when `enableHiding` is set to `true`.