### PR TITLE
Update next.mdx - import typo fixed

### DIFF
--- a/apps/www/content/docs/installation/next.mdx
+++ b/apps/www/content/docs/installation/next.mdx
@@ -50,7 +50,7 @@ Here's how I configure Inter for Next.js:
 import "@/styles/globals.css"
 import { Inter as FontSans } from "next/font/google"
 
-import { cn } from "../@/lib/utils"
+import { cn } from "@/lib/utils"
 
 const fontSans = FontSans({
   subsets: ["latin"],


### PR DESCRIPTION
Before - 
```ts
import { cn } from "../@/lib/utils"
```

After - 
```ts
import { cn } from "@/lib/utils"
```