### PR TITLE
fix: dashboard-02 block (shadcn-ui#3098)

### DIFF
--- a/apps/www/registry/default/block/dashboard-02.tsx
+++ b/apps/www/registry/default/block/dashboard-02.tsx
@@ -57,7 +57,7 @@ export default function Dashboard() {
           <div className="flex-1">
             <nav className="grid items-start px-2 text-sm font-medium lg:px-4">
               <Link
-                href="/"
+                href="#"
                 className="flex items-center gap-3 rounded-lg px-3 py-2 text-muted-foreground transition-all hover:text-primary"
               >
                 <Home className="h-4 w-4" />

--- a/apps/www/registry/new-york/block/dashboard-02.tsx
+++ b/apps/www/registry/new-york/block/dashboard-02.tsx
@@ -57,7 +57,7 @@ export default function Dashboard() {
           <div className="flex-1">
             <nav className="grid items-start px-2 text-sm font-medium lg:px-4">
               <Link
-                href="/"
+                href="#"
                 className="flex items-center gap-3 rounded-lg px-3 py-2 text-muted-foreground transition-all hover:text-primary"
               >
                 <Home className="h-4 w-4" />


### PR DESCRIPTION
Change link in the block `dashboard-02` from `"/"` to `"#"`.

As described in issue #3098 