### PR TITLE
bug fixed :- TypeError: undefined is not iterable

### DIFF
--- a/apps/www/content/docs/components/combobox.mdx
+++ b/apps/www/content/docs/components/combobox.mdx
@@ -28,6 +28,7 @@ import {
   CommandGroup,
   CommandInput,
   CommandItem,
+  CommandList,
 } from "@/components/ui/command"
 import {
   Popover,
@@ -81,6 +82,7 @@ export function ComboboxDemo() {
         <Command>
           <CommandInput placeholder="Search framework..." />
           <CommandEmpty>No framework found.</CommandEmpty>
+          <CommandList>
           <CommandGroup>
             {frameworks.map((framework) => (
               <CommandItem
@@ -101,6 +103,7 @@ export function ComboboxDemo() {
               </CommandItem>
             ))}
           </CommandGroup>
+          </CommandList>
         </Command>
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
The problem here with example code, It's throw `TypeError: undefined is not iterable` error when we trigger the popover.
 
We have to wrap `CommandGroup` with `CommandList` to solve this issue and i added it.