### PR TITLE
fix(rehype): fixs text colors inside code block when in light theme

### DIFF
--- a/apps/www/styles/mdx.css
+++ b/apps/www/styles/mdx.css
@@ -73,3 +73,7 @@
 .steps > h3 {
   @apply mt-8 mb-4 text-base font-semibold;
 }
+
+[data-language="txt"] .line {
+  @apply text-zinc-50/60
+}


### PR DESCRIPTION
This pr fix #3115 issue and also all others places where the rehype txt data language is used (aka data-table, astro, gatsby.... pages)

![image](https://github.com/shadcn-ui/ui/assets/33487047/515ac959-0c37-40ea-81c9-5b7d7d0463f4)

![image](https://github.com/shadcn-ui/ui/assets/33487047/345e13f6-ed7d-41d4-8230-6837b1edd5f2)

