### PR TITLE
fix(#3130): doc site code block light theme color missing

### DIFF
--- a/apps/www/content/docs/components/data-table.mdx
+++ b/apps/www/content/docs/components/data-table.mdx
@@ -84,7 +84,7 @@ export const payments: Payment[] = [
 
 Start by creating the following file structure:
 
-```txt
+```tsx
 app
 └── payments
     ├── columns.tsx


### PR DESCRIPTION
Fix #3130 

![image](https://github.com/shadcn-ui/ui/assets/132245096/d5d53b0c-ad26-4032-acf9-86d59fea4e81)
