### PR TITLE
fix(dashboard-1): add z-10 to fix nav overlay

### DIFF
--- a/apps/www/registry/default/block/dashboard-01.tsx
+++ b/apps/www/registry/default/block/dashboard-01.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link"
 import {
   Activity,
   ArrowUpRight,
@@ -9,7 +10,6 @@ import {
   Search,
   Users,
 } from "lucide-react"
-import Link from "next/link"
 
 import {
   Avatar,

--- a/apps/www/registry/default/block/dashboard-01.tsx
+++ b/apps/www/registry/default/block/dashboard-01.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link"
 import {
   Activity,
   ArrowUpRight,
@@ -10,6 +9,7 @@ import {
   Search,
   Users,
 } from "lucide-react"
+import Link from "next/link"
 
 import {
   Avatar,
@@ -54,7 +54,7 @@ export const containerClassName = "w-full h-full"
 export default function Dashboard() {
   return (
     <div className="flex min-h-screen w-full flex-col">
-      <header className="sticky top-0 flex h-16 items-center gap-4 border-b bg-background px-4 md:px-6">
+      <header className="sticky top-0 z-10 flex h-16 items-center gap-4 border-b bg-background px-4 md:px-6">
         <nav className="hidden flex-col gap-6 text-lg font-medium md:flex md:flex-row md:items-center md:gap-5 md:text-sm lg:gap-6">
           <Link
             href="#"

--- a/apps/www/registry/new-york/block/dashboard-01.tsx
+++ b/apps/www/registry/new-york/block/dashboard-01.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link"
 import {
   Activity,
   ArrowUpRight,
@@ -9,7 +10,6 @@ import {
   Search,
   Users,
 } from "lucide-react"
-import Link from "next/link"
 
 import {
   Avatar,

--- a/apps/www/registry/new-york/block/dashboard-01.tsx
+++ b/apps/www/registry/new-york/block/dashboard-01.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link"
 import {
   Activity,
   ArrowUpRight,
@@ -10,6 +9,7 @@ import {
   Search,
   Users,
 } from "lucide-react"
+import Link from "next/link"
 
 import {
   Avatar,
@@ -54,7 +54,7 @@ export const containerClassName = "w-full h-full"
 export default function Dashboard() {
   return (
     <div className="flex min-h-screen w-full flex-col">
-      <header className="sticky top-0 flex h-16 items-center gap-4 border-b bg-background px-4 md:px-6">
+      <header className="sticky top-0 z-10 flex h-16 items-center gap-4 border-b bg-background px-4 md:px-6">
         <nav className="hidden flex-col gap-6 text-lg font-medium md:flex md:flex-row md:items-center md:gap-5 md:text-sm lg:gap-6">
           <Link
             href="#"


### PR DESCRIPTION
When in smaller screens the `Transactions` and `Recent Sales` of dashboard-1 overlay the sticky header/nav. This pr fix #3132

![image](https://github.com/shadcn-ui/ui/assets/33487047/3ab16f42-c42e-4576-8d93-6531c63608bd)
