### PR TITLE
fix(dashboard-3): align aside and header borders in default style

### DIFF
--- a/apps/www/registry/default/block/dashboard-03.tsx
+++ b/apps/www/registry/default/block/dashboard-03.tsx
@@ -52,7 +52,7 @@ export const containerClassName = "w-full h-full"
 
 export default function Dashboard() {
   return (
-    <div className="grid h-screen w-full pl-[53px]">
+    <div className="grid h-screen w-full pl-[56px]">
       <aside className="inset-y fixed  left-0 z-20 flex h-full flex-col border-r">
         <div className="border-b p-2">
           <Button variant="outline" size="icon" aria-label="Home">
@@ -170,7 +170,7 @@ export default function Dashboard() {
         </nav>
       </aside>
       <div className="flex flex-col">
-        <header className="sticky top-0 z-10 flex h-[53px] items-center gap-1 border-b bg-background px-4">
+        <header className="sticky top-0 z-10 flex h-[57px] items-center gap-1 border-b bg-background px-4">
           <h1 className="text-xl font-semibold">Playground</h1>
           <Drawer>
             <DrawerTrigger asChild>


### PR DESCRIPTION
## Overview

This Pull Request fixes the misalignment between the aside and header borders in the default style for the dashboard-03 component of the blocks. It achieves alignment by adjusting the header height to match the aside border.

## Screenshots

Before:
<img width="1440" alt="Before fix" src="https://github.com/shadcn-ui/ui/assets/52102693/de6bbf55-a61f-4418-a7d2-9fe4eaca351d">


After:
<img width="1440" alt="After fix" src="https://github.com/shadcn-ui/ui/assets/52102693/5c60e223-e98f-4e56-8dfc-393de09571a3">

