### PR TITLE
docs(Sheet component): bugfix for "adjust size" code example.

### DIFF
--- a/apps/www/content/docs/components/sheet.mdx
+++ b/apps/www/content/docs/components/sheet.mdx
@@ -90,7 +90,7 @@ You can adjust the size of the sheet using CSS classes:
 ```tsx {3}
 <Sheet>
   <SheetTrigger>Open</SheetTrigger>
-  <SheetContent className="w-[400px] sm:w-[540px]">
+  <SheetContent className="w-[400px] sm:max-w-[540px]">
     <SheetHeader>
       <SheetTitle>Are you absolutely sure?</SheetTitle>
       <SheetDescription>


### PR DESCRIPTION
Examples > Size > SheetContent component >classname:

The given example using `sm:w-[540]` does not work, because it is overridden by the internal `sm:max-w-sm` by the default `right` variant.

Changed it to `sm:max-w-[540]`.