### PR TITLE
fix: set icon height and width to parent dimensions #3077

### DIFF
--- a/apps/www/registry/default/ui/checkbox.tsx
+++ b/apps/www/registry/default/ui/checkbox.tsx
@@ -21,7 +21,7 @@ const Checkbox = React.forwardRef<
     <CheckboxPrimitive.Indicator
       className={cn("flex items-center justify-center text-current")}
     >
-      <Check className="h-4 w-4" />
+      <Check className="h-full w-full" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ))

--- a/apps/www/registry/new-york/ui/checkbox.tsx
+++ b/apps/www/registry/new-york/ui/checkbox.tsx
@@ -21,7 +21,7 @@ const Checkbox = React.forwardRef<
     <CheckboxPrimitive.Indicator
       className={cn("flex items-center justify-center text-current")}
     >
-      <CheckIcon className="h-4 w-4" />
+      <CheckIcon className="h-full w-full" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ))


### PR DESCRIPTION
Fixed the movement of checkbox on being checked in data table. You could also see the movement when you use Checkbox as  a standalone component.

Made the icon taken parent's dimensions.

![image](https://github.com/shadcn-ui/ui/assets/8769408/81d81872-420d-4678-b185-95fc18057296)


Previously there was also a additional issue of the icon's dimension

![image](https://github.com/shadcn-ui/ui/assets/8769408/b1fff1c0-ef04-47c1-b5c7-16a460722254)
