### PR TITLE
fix eslint prefer nullish coalescing operator

### DIFF
--- a/apps/www/registry/default/ui/progress.tsx
+++ b/apps/www/registry/default/ui/progress.tsx
@@ -19,7 +19,7 @@ const Progress = React.forwardRef<
   >
     <ProgressPrimitive.Indicator
       className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      style={{ transform: `translateX(-${100 - (value ?? 0)}%)` }}
     />
   </ProgressPrimitive.Root>
 ))

--- a/apps/www/registry/new-york/ui/progress.tsx
+++ b/apps/www/registry/new-york/ui/progress.tsx
@@ -19,7 +19,7 @@ const Progress = React.forwardRef<
   >
     <ProgressPrimitive.Indicator
       className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      style={{ transform: `translateX(-${100 - (value ?? 0)}%)` }}
     />
   </ProgressPrimitive.Root>
 ))


### PR DESCRIPTION
Fix the following error:


Error: Prefer using nullish coalescing operator (`??`) instead of a logical or (`||`), as it is a safer operator. @typescript-eslint/prefer-nullish-coalescing
