### PR TITLE
fix: update codeblockwrapper component styles

### DIFF
--- a/apps/www/components/code-block-wrapper.tsx
+++ b/apps/www/components/code-block-wrapper.tsx
@@ -40,8 +40,8 @@ export function CodeBlockWrapper({
         </CollapsibleContent>
         <div
           className={cn(
-            "absolute flex items-center justify-center bg-gradient-to-b from-zinc-700/30 to-zinc-950/90 p-2",
-            isOpened ? "inset-x-0 bottom-0 h-12" : "inset-0"
+            "absolute flex items-center justify-center",
+            isOpened ? "inset-x-0 bottom-6" : "inset-0"
           )}
         >
           <CollapsibleTrigger asChild>


### PR DESCRIPTION
Before:
It didn't allow me to use the horizontal scroll
![Captura de pantalla 2024-03-30 091708](https://github.com/shadcn-ui/ui/assets/128724547/c4b56733-fd7d-4c04-8f21-2bc899f594da)

now: 
yes you can use the horizontal scroll
![Captura de pantalla 2024-03-30 110214](https://github.com/shadcn-ui/ui/assets/128724547/3d13c4ab-5c2d-41a0-b4fe-1b85ac4e629a)
