### PR TITLE
changed checkbox centering

### DIFF
--- a/apps/www/registry/new-york/ui/checkbox.tsx
+++ b/apps/www/registry/new-york/ui/checkbox.tsx
@@ -18,10 +18,8 @@ const Checkbox = React.forwardRef<
     )}
     {...props}
   >
-    <CheckboxPrimitive.Indicator
-      className={cn("flex items-center justify-center text-current")}
-    >
-      <CheckIcon className="h-4 w-4" />
+    <CheckboxPrimitive.Indicator className={cn("relative text-current")}>
+      <CheckIcon className="absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ))


### PR DESCRIPTION
Currently the check icon is not fully centered when using flexbox. 

Before:

<img width="317" alt="Screenshot 2024-03-30 at 20 03 54" src="https://github.com/shadcn-ui/ui/assets/59118406/c62cbbd7-2173-45a1-9a7b-53670f6818f7">

When changed to relative + centering with position absolute and transformation:

<img width="283" alt="Screenshot 2024-03-30 at 20 04 54" src="https://github.com/shadcn-ui/ui/assets/59118406/b379fe40-dae3-4e15-9f6b-853affdf71c0">