### PR TITLE
Fix: Text mismatch in code and preview

### DIFF
--- a/apps/www/content/docs/components/alert-dialog.mdx
+++ b/apps/www/content/docs/components/alert-dialog.mdx
@@ -66,7 +66,7 @@ import {
 
 ```tsx
 <AlertDialog>
-  <AlertDialogTrigger>Open</AlertDialogTrigger>
+  <AlertDialogTrigger>Show Dialog</AlertDialogTrigger>
   <AlertDialogContent>
     <AlertDialogHeader>
       <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>


### PR DESCRIPTION
In Preview button Content is "Show Dialog" but in Usage code it is "Open"