### PR TITLE
fix: Correct styling for code block title

### DIFF
--- a/apps/www/styles/mdx.css
+++ b/apps/www/styles/mdx.css
@@ -15,7 +15,7 @@
 }
 
 [data-rehype-pretty-code-fragment] {
-  @apply relative text-white;
+  @apply relative dark:text-white;
 }
 
 [data-rehype-pretty-code-fragment] code {


### PR DESCRIPTION
Code block titles are only visible in dark mode, scoping text color to dark mode to fix this