### PR TITLE
feat(blocks): add copy dependencies

### DIFF
--- a/apps/www/components/block-copy-dependencies-button.tsx
+++ b/apps/www/components/block-copy-dependencies-button.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon } from "@radix-ui/react-icons"
+import { CopyIcon } from "lucide-react"
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/registry/new-york/ui/tooltip"
+
+import { CopyNpmCommandButton } from "./copy-button"
+
+const BUTTON_STYLE =
+  "inline-flex h-7 w-7 items-center justify-center whitespace-nowrap rounded-md border border-input bg-background text-sm font-medium text-accent-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-3.5"
+
+const generateCommands = (registryDependencies: string[]) => {
+  /*
+   * Remove any extra spaces and trim the dependencies
+   * to ensure the command is formatted correctly.
+   */
+  const cleanedDependencies = registryDependencies.map((dep) =>
+    dep.trim().replace(/\s+/g, " ")
+  )
+
+  return {
+    __npmCommand__: `npx shadcn-ui@latest add ${cleanedDependencies.join(" ")}`,
+    // TODO: No any examples for add shadcn-ui component with yarn so I not add the command for yarn yet.
+    __yarnCommand__: `npx shadcn-ui@latest add ${cleanedDependencies.join(
+      " "
+    )}`,
+    __pnpmCommand__: `pnpm dlx shadcn-ui@latest add ${cleanedDependencies.join(
+      " "
+    )}`,
+    __bunCommand__: `bunx --bun shadcn-ui@latest add ${cleanedDependencies.join(
+      " "
+    )}`,
+  }
+}
+
+export const BlockCopyDependenciesButton = ({
+  registryDependencies,
+}: {
+  registryDependencies: string[]
+}) => {
+  const [hasCopied, setHasCopied] = React.useState(false)
+  const commands = generateCommands(registryDependencies)
+
+  const resetCopy = React.useCallback(() => {
+    setHasCopied(false)
+  }, [])
+
+  React.useEffect(() => {
+    const timer = setTimeout(resetCopy, 2000)
+    return () => clearTimeout(timer)
+  }, [hasCopied, resetCopy])
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div>
+          <CopyNpmCommandButton
+            commands={commands}
+            className={BUTTON_STYLE}
+            isBlockAction={true}
+          >
+            <span className="sr-only">Copy</span>
+            {hasCopied ? <CheckIcon /> : <CopyIcon />}
+          </CopyNpmCommandButton>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>Copy dependencies</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/www/components/block-preview.tsx
+++ b/apps/www/components/block-preview.tsx
@@ -40,6 +40,8 @@ import {
 } from "@/registry/new-york/ui/toggle-group"
 import { Block } from "@/registry/schema"
 
+import { BlockCopyDependenciesButton } from "./block-copy-dependencies-button"
+
 export function BlockPreview({ block }: { block: Block }) {
   const [config] = useConfig()
   const [isLoading, setIsLoading] = React.useState(true)
@@ -145,6 +147,11 @@ export function BlockPreview({ block }: { block: Block }) {
               </PopoverContent>
             </Popover>
             <Separator orientation="vertical" className="mx-2 h-4" />
+            {block.registryDependencies && (
+              <BlockCopyDependenciesButton
+                registryDependencies={block.registryDependencies}
+              />
+            )}
             <BlockCopyCodeButton name={block.name} code={block.code} />
             <V0Button
               name={block.name}

--- a/apps/www/components/copy-button.tsx
+++ b/apps/www/components/copy-button.tsx
@@ -135,11 +135,13 @@ export function CopyWithClassNames({
 
 interface CopyNpmCommandButtonProps extends DropdownMenuTriggerProps {
   commands: Required<NpmCommands>
+  isBlockAction?: boolean
 }
 
 export function CopyNpmCommandButton({
   commands,
   className,
+  isBlockAction = false,
   ...props
 }: CopyNpmCommandButtonProps) {
   const [hasCopied, setHasCopied] = React.useState(false)
@@ -153,15 +155,17 @@ export function CopyNpmCommandButton({
   const copyCommand = React.useCallback(
     (value: string, pm: "npm" | "pnpm" | "yarn" | "bun") => {
       copyToClipboardWithMeta(value, {
-        name: "copy_npm_command",
+        name: isBlockAction ? "copy_block_dependencies" : "copy_npm_command",
         properties: {
           command: value,
-          pm,
+          packageManager: pm,
+          isBlockAction,
         },
       })
       setHasCopied(true)
     },
-    []
+
+    [isBlockAction]
   )
 
   return (

--- a/apps/www/lib/events.ts
+++ b/apps/www/lib/events.ts
@@ -9,6 +9,7 @@ const eventSchema = z.object({
     "copy_primitive_code",
     "copy_theme_code",
     "copy_block_code",
+    "copy_block_dependencies",
   ]),
   // declare type AllowedPropertyValues = string | number | boolean | null
   properties: z


### PR DESCRIPTION
This PR introduces enhancements to the copy of the dependencies of blocks. The changes include:

- Created a new event type for analytics
- Created a new copy button using `CopyNpmCommandButton`.
- New copy button added to blocks preview file.

### NOTE
- I couldn't find any example using `yarn` so I added `npx` command to it for now.
- I had a hard time using `CopyNpmCommandButton` with Tooltip on the other file because I couldn't access the ref value when using it in the other file. So for now I wrapped it with a `<div>` as the safest solution. I can quickly edit this if a better suggestion is offered.

### ScreenShots

![image](https://github.com/shadcn-ui/ui/assets/60575283/316078df-4540-43d7-bfc9-d182ca8a4632)
![image](https://github.com/shadcn-ui/ui/assets/60575283/68370d85-1196-48e8-9a3b-a0ba7c0169ae)
![image](https://github.com/shadcn-ui/ui/assets/60575283/0c722b8e-de8c-407f-baac-6d22f379bbe4)

> example output when select pnpm in from dropdown: `pnpm dlx shadcn-ui@latest add badge breadcrumb button card dropdown-menu input pagination progress separator sheet table tabs tooltip`