### PR TITLE
fix: asChild breaks DropdownMenuSubTrigger 

### DIFF
--- a/apps/www/registry/default/ui/dropdown-menu.tsx
+++ b/apps/www/registry/default/ui/dropdown-menu.tsx
@@ -33,8 +33,14 @@ const DropdownMenuSubTrigger = React.forwardRef<
     )}
     {...props}
   >
-    {children}
-    <ChevronRight className="ml-auto h-4 w-4" />
+    {props.asChild ? (
+      children
+    ) : (
+      <>
+        {children}
+        <ChevronRight className="ml-auto h-4 w-4" />
+      </>
+    )}
   </DropdownMenuPrimitive.SubTrigger>
 ))
 DropdownMenuSubTrigger.displayName =

--- a/apps/www/registry/new-york/ui/dropdown-menu.tsx
+++ b/apps/www/registry/new-york/ui/dropdown-menu.tsx
@@ -37,8 +37,14 @@ const DropdownMenuSubTrigger = React.forwardRef<
     )}
     {...props}
   >
-    {children}
-    <ChevronRightIcon className="ml-auto h-4 w-4" />
+    {props.asChild ? (
+      children
+    ) : (
+      <>
+        {children}
+        <ChevronRightIcon className="ml-auto h-4 w-4" />
+      </>
+    )}
   </DropdownMenuPrimitive.SubTrigger>
 ))
 DropdownMenuSubTrigger.displayName =


### PR DESCRIPTION
### Problem
Previously, if the `<DropdownMenuSubTrigger>` component was rendered with the `asChild`  enabled, the Radix primitive would throw an error since the component was receiving too many children.
### Solution
Now, the `<ChevronRight />` icon is conditionally rendered depending on whether `asChild` is enabled or not, avoiding this issue.
