### PR TITLE
fix: 🐛 incorrect import for sheet example

### DIFF
--- a/apps/www/registry/default/example/sheet-side.tsx
+++ b/apps/www/registry/default/example/sheet-side.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import { Button } from "@/registry/new-york/ui/button"
-import { Input } from "@/registry/new-york/ui/input"
-import { Label } from "@/registry/new-york/ui/label"
+import { Button } from "@/registry/default/ui/button"
+import { Input } from "@/registry/default/ui/input"
+import { Label } from "@/registry/default/ui/label"
 import {
   Sheet,
   SheetClose,
@@ -12,7 +12,7 @@ import {
   SheetHeader,
   SheetTitle,
   SheetTrigger,
-} from "@/registry/new-york/ui/sheet"
+} from "@/registry/default/ui/sheet"
 
 const SHEET_SIDES = ["top", "right", "bottom", "left"] as const
 


### PR DESCRIPTION
I noticed the import for a sheet example was coming from the wrong styling, so I did a quick fix here