### PR TITLE
Fix: Update incorrect placeholder value in combobox form  new-york theme

### DIFF
--- a/apps/www/registry/new-york/example/combobox-form.tsx
+++ b/apps/www/registry/new-york/example/combobox-form.tsx
@@ -96,10 +96,10 @@ export default function ComboboxForm() {
                 <PopoverContent className="w-[200px] p-0">
                   <Command>
                     <CommandInput
-                      placeholder="Search framework..."
+                      placeholder="Search language..."
                       className="h-9"
                     />
-                    <CommandEmpty>No framework found.</CommandEmpty>
+                    <CommandEmpty>No language found.</CommandEmpty>
                     <CommandGroup>
                       {languages.map((language) => (
                         <CommandItem


### PR DESCRIPTION
This pull request fixes a mistake in the new-york theme of combobox form.

It updates the following text:
Changed "Search framework.." to "Search language.." Changed "No framework found." to "No language found."



<img width="1439" alt="Screenshot 2024-04-05 at 9 13 42 PM" src="https://github.com/shadcn-ui/ui/assets/96766940/2774f763-28c7-46db-9210-b8e3aa966c06">
