### PR TITLE
fix(blocks): replace code with @/components/ui imports while copying from lift-mode

### DIFF
--- a/apps/www/lib/blocks.ts
+++ b/apps/www/lib/blocks.ts
@@ -55,7 +55,9 @@ export async function getBlock(
 
       return {
         ...chunk,
-        code: sourceFile.getText(),
+        code: sourceFile
+          .getText()
+          .replaceAll(`@/registry/${style}/`, "@/components/"),
       }
     })
   )


### PR DESCRIPTION
FIXES : https://x.com/jimmeyer/status/1776487418150981661?s=46

The copy button in lift mode was copying code having imports as "@/registry/.../*.tsx" 

This PR replaces all the imports by "@/components/ui/*.tsx"