### PR TITLE
refactor: :recycle: add check for style set up in local storage

### DIFF
--- a/apps/www/components/component-preview.tsx
+++ b/apps/www/components/component-preview.tsx
@@ -40,6 +40,10 @@ export function ComponentPreview({
   const Code = Codes[index]
 
   const Preview = React.useMemo(() => {
+    if (!styles.map((style) => style.name).includes(config.style)) {
+      throw new Error(`Style \`${config.style}\` not found in registry. Please clear your local storage and try again.`)
+    }
+
     const Component = Index[config.style][name]?.component
 
     if (!Component) {


### PR DESCRIPTION
This fixes #3402

Since I was developing and using different styles from the current `default` and `new-york` ones in a fork, I was getting the other in the issue. This check at least lets the user know, what went wrong instead of simply saying that the component doesn't exist