### PR TITLE
feat: add container proprs for AlertDialogContent

### DIFF
--- a/apps/www/__registry__/default/ui/alert-dialog.tsx
+++ b/apps/www/__registry__/default/ui/alert-dialog.tsx
@@ -27,11 +27,15 @@ const AlertDialogOverlay = React.forwardRef<
 ))
 AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
 
+interface AlertDialogContentProps
+  extends React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content> {
+  container?: HTMLElement | null | undefined
+}
 const AlertDialogContent = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <AlertDialogPortal>
+  AlertDialogContentProps
+>(({ className, container, ...props }, ref) => (
+  <AlertDialogPortal container={container}>
     <AlertDialogOverlay />
     <AlertDialogPrimitive.Content
       ref={ref}


### PR DESCRIPTION
It is very necessary to add the 'container' props. 
The lack of the container has led to unexpected CSS and cannot be resolved.