### PR TITLE
refactor: remove unused import

### DIFF
--- a/apps/www/app/(app)/examples/mail/components/mail-list.tsx
+++ b/apps/www/app/(app)/examples/mail/components/mail-list.tsx
@@ -4,7 +4,6 @@ import formatDistanceToNow from "date-fns/formatDistanceToNow"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/registry/new-york/ui/badge"
 import { ScrollArea } from "@/registry/new-york/ui/scroll-area"
-import { Separator } from "@/registry/new-york/ui/separator"
 import { Mail } from "@/app/(app)/examples/mail/data"
 import { useMail } from "@/app/(app)/examples/mail/use-mail"
 

--- a/apps/www/components/main-nav.tsx
+++ b/apps/www/components/main-nav.tsx
@@ -1,13 +1,11 @@
 "use client"
 
-import * as React from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 
 import { siteConfig } from "@/config/site"
 import { cn } from "@/lib/utils"
 import { Icons } from "@/components/icons"
-import { Badge } from "@/registry/new-york/ui/badge"
 
 export function MainNav() {
   const pathname = usePathname()

--- a/apps/www/components/mobile-nav.tsx
+++ b/apps/www/components/mobile-nav.tsx
@@ -3,7 +3,6 @@
 import * as React from "react"
 import Link, { LinkProps } from "next/link"
 import { useRouter } from "next/navigation"
-import { ViewVerticalIcon } from "@radix-ui/react-icons"
 
 import { docsConfig } from "@/config/docs"
 import { siteConfig } from "@/config/site"

--- a/apps/www/components/providers.tsx
+++ b/apps/www/components/providers.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import * as React from "react"
 import { Provider as JotaiProvider } from "jotai"
 import { ThemeProvider as NextThemesProvider } from "next-themes"
 import { ThemeProviderProps } from "next-themes/dist/types"

--- a/apps/www/components/style-switcher.tsx
+++ b/apps/www/components/style-switcher.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import * as React from "react"
 import { type SelectTriggerProps } from "@radix-ui/react-select"
 
 import { cn } from "@/lib/utils"

--- a/apps/www/components/theme-switcher.tsx
+++ b/apps/www/components/theme-switcher.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import * as React from "react"
+import { useEffect } from "react"
 import { useSelectedLayoutSegment } from "next/navigation"
 
 import { useConfig } from "@/hooks/use-config"
@@ -9,7 +9,7 @@ export function ThemeSwitcher() {
   const [config] = useConfig()
   const segment = useSelectedLayoutSegment()
 
-  React.useEffect(() => {
+  useEffect(() => {
     document.body.classList.forEach((className) => {
       if (className.match(/^theme.*/)) {
         document.body.classList.remove(className)


### PR DESCRIPTION
Remove unused import, replace `React.useEffect` with `useEffect` from `import { useEffect }` to reduce import cost.