### PR TITLE
Feat: add FormRootError component

### DIFF
--- a/apps/www/registry/default/ui/form.tsx
+++ b/apps/www/registry/default/ui/form.tsx
@@ -8,6 +8,7 @@ import {
   FieldValues,
   FormProvider,
   useFormContext,
+  useFormState,
 } from "react-hook-form"
 
 import { cn } from "@/lib/utils"
@@ -164,6 +165,27 @@ const FormMessage = React.forwardRef<
 })
 FormMessage.displayName = "FormMessage"
 
+const FormRootError = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { errors } = useFormState()
+  const rootError = errors.root
+  if (!rootError) {
+    return null
+  }
+  return (
+    <p
+      ref={ref}
+      className={cn("text-sm font-medium text-destructive", className)}
+      {...props}
+    >
+      {rootError.message}
+    </p>
+  )
+})
+FormRootError.displayName = "FormRootError"
+
 export {
   useFormField,
   Form,
@@ -172,5 +194,6 @@ export {
   FormControl,
   FormDescription,
   FormMessage,
+  FormRootError,
   FormField,
 }

--- a/apps/www/registry/new-york/ui/form.tsx
+++ b/apps/www/registry/new-york/ui/form.tsx
@@ -8,6 +8,7 @@ import {
   FieldValues,
   FormProvider,
   useFormContext,
+  useFormState,
 } from "react-hook-form"
 
 import { cn } from "@/lib/utils"
@@ -164,6 +165,27 @@ const FormMessage = React.forwardRef<
 })
 FormMessage.displayName = "FormMessage"
 
+const FormRootError = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { errors } = useFormState()
+  const rootError = errors.root
+  if (!rootError) {
+    return null
+  }
+  return (
+    <p
+      ref={ref}
+      className={cn("text-[0.8rem] font-medium text-destructive", className)}
+      {...props}
+    >
+      {rootError.message}
+    </p>
+  )
+})
+FormRootError.displayName = "FormRootError"
+
 export {
   useFormField,
   Form,
@@ -172,5 +194,6 @@ export {
   FormControl,
   FormDescription,
   FormMessage,
+  FormRootError,
   FormField,
 }


### PR DESCRIPTION
## Why?

- display the root error in a form
- error is cleared once form is submitted again
- form error is rendered in a consistent way with the input errors

![image](https://github.com/shadcn-ui/ui/assets/38565644/cb2a5edf-d090-402c-a71d-f944ea5d8ea9)

## How?

1. Add `<FormRootError />`

2. Handle form root errors. For example:

```typescript
const form = useForm<UserLoginSchema>({
    resolver: zodResolver(userLoginSchema),
    defaultValues: {
      email: "",
      password: "",
    },
  })

 const onSubmit = async (values: UserLoginSchema) => {
    const error = await handleLogin(values)
    if (error) {
      form.setError("root", {
        message: error.message,
      })
    }
  }
``` 

Note: perhaps `FormRootError` is not the best name. I'm very open to suggestions.