### PR TITLE
docs(carousel): clarify plugin usage with 'use client'

### DIFF
--- a/apps/www/content/docs/components/carousel.mdx
+++ b/apps/www/content/docs/components/carousel.mdx
@@ -254,7 +254,9 @@ See the [Embla Carousel docs](https://www.embla-carousel.com/api/events/) for mo
 
 You can use the `plugins` prop to add plugins to the carousel.
 
-```ts showLineNumbers {1,6-10}
+```ts showLineNumbers {1-3,8-12}
+"use client"
+
 import Autoplay from "embla-carousel-autoplay"
 
 export function Example() {

--- a/apps/www/registry/default/example/carousel-plugin.tsx
+++ b/apps/www/registry/default/example/carousel-plugin.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 import Autoplay from "embla-carousel-autoplay"
 

--- a/apps/www/registry/new-york/example/carousel-plugin.tsx
+++ b/apps/www/registry/new-york/example/carousel-plugin.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 import Autoplay from "embla-carousel-autoplay"
 


### PR DESCRIPTION
Updated docs and examples to specify that plugins should operate within the 'use client' directive.

### Summary
This PR updates the documentation for the Carousel component to include the use client directive in the plugin example. The adjustment ensures compatibility with Next.js 14 server components and clarifies the correct usage of client-side interactivity within the documentation.

### Context
With Next.js 14 emphasizing the distinction between server and client components, it's important for documentation to clearly illustrate where and how interactive elements should be used. The current example in the Carousel documentation doesn't specify that the Autoplay plugin requires client-side execution context. This omission could lead to Unhandled Runtime Error when the Autoplay plugin is used in server components. #3393

Changes
Added use client directive to the documentation example.