### PR TITLE
fix: (bugfix #3481): New label gets underline during hover in sidebar…

### DIFF
--- a/apps/www/components/sidebar-nav.tsx
+++ b/apps/www/components/sidebar-nav.tsx
@@ -55,7 +55,7 @@ export function DocsSidebarNavItems({
             target={item.external ? "_blank" : ""}
             rel={item.external ? "noreferrer" : ""}
           >
-            <span className="hover:underline">{item.title}</span>
+            <span className="group-hover:underline">{item.title}</span>
             {item.label && (
               <span className="ml-2 rounded-md bg-[#adfa1d] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
                 {item.label}
@@ -70,7 +70,7 @@ export function DocsSidebarNavItems({
               item.disabled && "cursor-not-allowed opacity-60"
             )}
           >
-            <span className="hover:underline">{item.title}</span>
+            <span className="group-hover:underline">{item.title}</span>
             {item.label && (
               <span className="ml-2 rounded-md bg-muted px-1.5 py-0.5 text-xs leading-none text-muted-foreground no-underline group-hover:no-underline">
                 {item.label}

--- a/apps/www/components/sidebar-nav.tsx
+++ b/apps/www/components/sidebar-nav.tsx
@@ -46,7 +46,7 @@ export function DocsSidebarNavItems({
             key={index}
             href={item.href}
             className={cn(
-              "group flex w-full items-center rounded-md border border-transparent px-2 py-1 hover:underline",
+              "group flex w-full items-center rounded-md border border-transparent px-2 py-1",
               item.disabled && "cursor-not-allowed opacity-60",
               pathname === item.href
                 ? "font-medium text-foreground"
@@ -55,7 +55,7 @@ export function DocsSidebarNavItems({
             target={item.external ? "_blank" : ""}
             rel={item.external ? "noreferrer" : ""}
           >
-            {item.title}
+            <span className="hover:underline">{item.title}</span>
             {item.label && (
               <span className="ml-2 rounded-md bg-[#adfa1d] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
                 {item.label}
@@ -66,11 +66,11 @@ export function DocsSidebarNavItems({
           <span
             key={index}
             className={cn(
-              "flex w-full cursor-not-allowed items-center rounded-md p-2 text-muted-foreground hover:underline",
+              "flex w-full cursor-not-allowed items-center rounded-md p-2 text-muted-foreground",
               item.disabled && "cursor-not-allowed opacity-60"
             )}
           >
-            {item.title}
+            <span className="hover:underline">{item.title}</span>
             {item.label && (
               <span className="ml-2 rounded-md bg-muted px-1.5 py-0.5 text-xs leading-none text-muted-foreground no-underline group-hover:no-underline">
                 {item.label}


### PR DESCRIPTION
… fix added for #3481  "New" label gets underline during hover in sidebar
![image](https://github.com/shadcn-ui/ui/assets/48583769/03f58a8f-e319-4752-9ca8-3cb6f0a989b3)
