### PR TITLE
docs(www): :memo: correct inline script placement in astro darkmode index astro example

### DIFF
--- a/apps/www/content/docs/dark-mode/astro.mdx
+++ b/apps/www/content/docs/dark-mode/astro.mdx
@@ -38,7 +38,6 @@ import '../styles/globals.css'
       <h1>Astro</h1>
 	</body>
 </html>
-</script>
 ```
 
 ### Add a mode toggle


### PR DESCRIPTION
Fixes incorrect script tag placement in Astro dark mode documentation example, ensuring proper HTML structure.