### PR TITLE
fix(mdx): rehype pretty code title not showing in light mode

### DIFF
--- a/apps/www/styles/mdx.css
+++ b/apps/www/styles/mdx.css
@@ -15,7 +15,7 @@
 }
 
 [data-rehype-pretty-code-fragment] {
-  @apply relative text-white;
+  @apply relative;
 }
 
 [data-rehype-pretty-code-fragment] code {
@@ -59,7 +59,7 @@
 }
 
 [data-rehype-pretty-code-title] {
-  @apply mt-2 pt-6 px-4 text-sm font-medium;
+  @apply mt-2 pt-6 px-4 text-sm font-medium text-black dark:text-white;
 }
 
 [data-rehype-pretty-code-title] + pre {


### PR DESCRIPTION
This commit addresses visibility issues in light mode where the code block title was blending with the white background due to the "text-white" Tailwind class. To improve readability, I changed the title color to black for light themes and white for dark themes, ensuring better contrast and legibility across different modes.

**Before applying the fix:**
![before-fix](https://github.com/shadcn-ui/ui/assets/89612748/7697064f-962b-4361-8aaf-59518e3952ae)

**After applying the fix:**
![after-fix](https://github.com/shadcn-ui/ui/assets/89612748/eecbda1e-aa8b-4905-a576-31e4546713f0)
