### PR TITLE
fix: link href for default style in sink 

### DIFF
--- a/apps/www/app/(app)/sink/layout.tsx
+++ b/apps/www/app/(app)/sink/layout.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link"
 
 import { ThemeWrapper } from "@/components/theme-wrapper"
-import { styles } from "@/registry/styles"
 
 interface SinkLayoutProps {
   children: React.ReactNode
@@ -12,11 +11,12 @@ export default function SinkLayout({ children }: SinkLayoutProps) {
     <div className="flex flex-col">
       <div className="container">
         <div className="flex space-x-2 px-2 py-4">
-          {styles.map((style) => (
-            <Link href={`/sink/${style.name}`} key={style.name}>
-              {style.label}
-            </Link>
-          ))}
+          <Link href={`/sink`} key={"default"}>
+            Default
+          </Link>
+          <Link href={`/sink/new-york`} key={"new-york"}>
+            New York
+          </Link>
         </div>
       </div>
       <div className="flex-1">


### PR DESCRIPTION
this link href is wrong here. [https://ui.shadcn.com/sink/new-york](https://ui.shadcn.com/sink/new-york) 
# 😁

![image](https://github.com/shadcn-ui/ui/assets/142723369/5adc5aab-d739-440c-a69a-f95c2ca2baa1)

it redirecte me to 404 page

![image](https://github.com/shadcn-ui/ui/assets/142723369/18c01554-fc50-4c2a-81c2-ddb46ee9e8a9)

# I fix it...

![ThumbsUpOkayGIF](https://github.com/shadcn-ui/ui/assets/142723369/16ffd081-85ba-4520-9eae-f7982ee9b654)
