### PR TITLE
fix: :bug: title color for code block in light mode

### DIFF
--- a/apps/www/styles/mdx.css
+++ b/apps/www/styles/mdx.css
@@ -59,7 +59,7 @@
 }
 
 [data-rehype-pretty-code-title] {
-  @apply mt-2 pt-6 px-4 text-sm font-medium;
+  @apply mt-2 pt-6 px-4 text-sm font-medium text-foreground;
 }
 
 [data-rehype-pretty-code-title] + pre {


### PR DESCRIPTION
## Dark mode

in dark mode the title above the code block worked fine.

<img width="745" alt="image" src="https://github.com/shadcn-ui/ui/assets/61006057/5d9ba564-5237-48f4-8d25-96ad3fa33dfa">

## Light mode

In light mode, the title wouldn't appear, because the background was also white.

<img width="740" alt="image" src="https://github.com/shadcn-ui/ui/assets/61006057/ab07ff8e-9345-42f7-a518-d615b10965cb">

### Selected Text

Here you can see that the text is still rendered in light mode.

<img width="736" alt="image" src="https://github.com/shadcn-ui/ui/assets/61006057/641e9682-b91d-49fb-b174-a3778f5c0e8b">

