### PR TITLE
fix #3520: Input component can't handle type tel and pattern

### DIFF
--- a/apps/www/registry/default/ui/input.tsx
+++ b/apps/www/registry/default/ui/input.tsx
@@ -7,6 +7,20 @@ export interface InputProps
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {
+    const validateInput = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      const isKeycodeInRange =
+        event.keyCode >= 65 &&
+        event.keyCode <= 90 &&
+        !event.metaKey &&
+        !event.shiftKey &&
+        !event.altKey &&
+        !event.ctrlKey
+      const regex = /[a-zA-Z]/i
+      isKeycodeInRange &&
+        type === "tel" &&
+        regex.test(event.key) &&
+        event.preventDefault()
+    }
     return (
       <input
         type={type}
@@ -16,6 +30,10 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         )}
         ref={ref}
         {...props}
+        onKeyDown={(e) => {
+          validateInput(e)
+          props.onKeyDown?.(e)
+        }}
       />
     )
   }

--- a/apps/www/registry/new-york/ui/input.tsx
+++ b/apps/www/registry/new-york/ui/input.tsx
@@ -7,6 +7,20 @@ export interface InputProps
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {
+    const validateInput = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      const isKeycodeInRange =
+        event.keyCode >= 65 &&
+        event.keyCode <= 90 &&
+        !event.metaKey &&
+        !event.shiftKey &&
+        !event.altKey &&
+        !event.ctrlKey
+      const regex = /[a-zA-Z]/i
+      isKeycodeInRange &&
+        type === "tel" &&
+        regex.test(event.key) &&
+        event.preventDefault()
+    }
     return (
       <input
         type={type}
@@ -16,6 +30,10 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         )}
         ref={ref}
         {...props}
+        onKeyDown={(e) => {
+          validateInput(e)
+          props.onKeyDown?.(e)
+        }}
       />
     )
   }


### PR DESCRIPTION

As shown in below demo,
Input type tel now blocks user from entering alphabets. All keys except letter keys are allowed.

https://github.com/shadcn-ui/ui/assets/71744384/73399542-658f-4b82-895e-4d1669d2ac09

