### PR TITLE
refactor: mdx file for importing DataTableColumnHeader (reusable components for data table)

### DIFF
--- a/apps/www/content/docs/components/data-table.mdx
+++ b/apps/www/content/docs/components/data-table.mdx
@@ -838,12 +838,14 @@ Make any column header sortable and hideable.
 
 <ComponentSource src="/app/(app)/examples/tasks/components/data-table-column-header.tsx" />
 
-```tsx {5}
+```tsx {6}
 export const columns = [
   {
     accessorKey: "email",
     header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Email" />
+      return{
+        <DataTableColumnHeader column={column} title="Email" />
+      }
     ),
   },
 ]


### PR DESCRIPTION
I'm using Shadcn UI and began creating data table. When I started building reusable components for the data table, I encountered an issue with the import for DataTableColumnHeader. Adding the return statement resolved the problem.I fixed it to prevent others from encountering the same problem.