### PR TITLE
chore: imporve the error message when the Tailwind config does not exist

### DIFF
--- a/packages/cli/src/utils/get-project-info.ts
+++ b/packages/cli/src/utils/get-project-info.ts
@@ -186,7 +186,7 @@ export async function preFlight(cwd: string) {
 
   if (!tailwindConfig.length) {
     throw new Error(
-      "Tailwind CSS is not installed. Visit https://tailwindcss.com/docs/installation to get started."
+      "Tailwind CSS configuration does not exist. Visit https://tailwindcss.com/docs/installation to get started."
     )
   }
 


### PR DESCRIPTION
Hi! I was confused by the `Tailwind CSS is not install` error message, so I tried to improve it. I thought I better return the error exactly as I found it.