### PR TITLE
docs: 5th option updated and missing option added in vite installation

### DIFF
--- a/apps/www/content/docs/installation/vite.mdx
+++ b/apps/www/content/docs/installation/vite.mdx
@@ -83,7 +83,8 @@ Would you like to use TypeScript (recommended)? no / yes
 Which style would you like to use? › Default
 Which color would you like to use as base color? › Slate
 Where is your global CSS file? › › src/index.css
-Do you want to use CSS variables for colors? › no / yes
+Would you like to use CSS variables for colors? › no / yes
+Are you using a custom tailwind prefix eg.tw-? (Leave blank if not)
 Where is your tailwind.config.js located? › tailwind.config.js
 Configure the import alias for components: › @/components
 Configure the import alias for utils: › @/lib/utils


### PR DESCRIPTION
1. In vite installation option 5th its asking "Would you like to use CSS variables for colors?" but in docs its "Do you want to use CSS variables for colors? " and this pr updates it in the docs to what actually asking in installation

2.  in Vite installation theres a missing option which is asked after "would you like to use CSS variable for colors", the asked question is  "Are you using a custom tailwind prefix eg. tw-?  (Leave blank if not) " this option is missing in docs but it is asking while installation so i added it to the docs