### PR TITLE
refactor: separate deps and dev deps during "init"

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -31,10 +31,13 @@ import { z } from "zod"
 import { applyPrefixesCss } from "../utils/transformers/transform-tw-prefix"
 
 const PROJECT_DEPENDENCIES = [
-  "tailwindcss-animate",
   "class-variance-authority",
   "clsx",
   "tailwind-merge",
+]
+
+const PROJECT_DEV_DEPENDENCIES = [
+  "tailwindcss-animate",
 ]
 
 const initOptionsSchema = z.object({
@@ -395,5 +398,18 @@ export async function runInit(cwd: string, config: Config) {
       cwd,
     }
   )
+
+  const devDeps = [
+    ...PROJECT_DEV_DEPENDENCIES,
+  ]
+
+  await execa(
+    packageManager,
+    [packageManager === "npm" ? "install -D" : "add -D", ...devDeps],
+    {
+      cwd,
+    }
+  )
+
   dependenciesSpinner?.succeed()
 }


### PR DESCRIPTION
- tailwindcss/animate is a dev dependency and is preferably installed as such
- change is minor as only -D flag is introduced which is present in all package managers including npm, bun, pnpm or yarn