### PR TITLE
refactor: remove unused icon imports on collapsible example

### DIFF
--- a/apps/www/__registry__/default/example/collapsible-demo.tsx
+++ b/apps/www/__registry__/default/example/collapsible-demo.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { ChevronsUpDown, Plus, X } from "lucide-react"
+import { ChevronsUpDown } from "lucide-react"
 
 import { Button } from "@/registry/default/ui/button"
 import {

--- a/apps/www/registry/default/example/collapsible-demo.tsx
+++ b/apps/www/registry/default/example/collapsible-demo.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { ChevronsUpDown, Plus, X } from "lucide-react"
+import { ChevronsUpDown } from "lucide-react"
 
 import { Button } from "@/registry/default/ui/button"
 import {


### PR DESCRIPTION
### Changes

```diff
- import { ChevronsUpDown, Plus, X } from "lucide-react"
+ import { ChevronsUpDown } from "lucide-react"
```