### PR TITLE
docs: fix Remix setup doc

### DIFF
--- a/apps/www/content/docs/installation/remix.mdx
+++ b/apps/www/content/docs/installation/remix.mdx
@@ -15,45 +15,58 @@ npx create-remix@latest my-app
 
 ### Install Tailwind CSS
 
+Install tailwindcss
+
 ```bash
-npm add -D tailwindcss@latest autoprefixer@latest
-npx tailwindcss init
+npm install -D tailwindcss postcss autoprefixer
+```
+If you would like to use TypeScript (recommended), you can init Tailwind CSS like this:
+
+```bash
+npx tailwindcss init --ts -p
 ```
 
-Then we create a `postcss.config.js` file:
+Otherwise, you can init Tailwind CSS without TypeScript like this:
+
+```bash
+npx tailwindcss init -p
+```
+
+Then add the paths to all of your template files in your tailwind.config.ts file.
 
 ```js
+import type { Config } from 'tailwindcss'
+
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
+  content: ['./app/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
   },
-}
+  plugins: [],
+} satisfies Config
 ```
 
-And finally we add the following to our `remix.config.js` file:
+Finally create a ./app/tailwind.css file and add the @tailwind directives for each of Tailwind’s layers.
 
-```js {4-5}
-/** @type {import('@remix-run/dev').AppConfig} */
-export default {
-  ...
-  tailwind: true,
-  postcss: true,
-  ...
-};
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 ```
+
+
 
 ### Add `tailwind.css` to your app
 
 In your `app/root.tsx` file, import the `tailwind.css` file:
 
 ```js {1, 4}
-import styles from "./tailwind.css"
+import type { LinksFunction } from "@remix-run/node";
+import stylesheet from "~/tailwind.css?url";
 
 export const links: LinksFunction = () => [
-  { rel: "stylesheet", href: styles },
-  ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),
-]
+  { rel: "stylesheet", href: stylesheet },
+];
 ```
 
 ### Run the CLI

--- a/apps/www/content/docs/installation/remix.mdx
+++ b/apps/www/content/docs/installation/remix.mdx
@@ -13,47 +13,11 @@ Start by creating a new Remix project using `create-remix`:
 npx create-remix@latest my-app
 ```
 
-### Run the CLI
-
-Run the `shadcn-ui` init command to setup your project:
-
-```bash
-npx shadcn-ui@latest init
-```
-
-### Configure components.json
-
-You will be asked a few questions to configure `components.json`:
-
-```txt showLineNumbers
-Would you like to use TypeScript (recommended)? no / yes
-Which style would you like to use? › Default
-Which color would you like to use as base color? › Slate
-Where is your global CSS file? › app/tailwind.css
-Do you want to use CSS variables for colors? › no / yes
-Where is your tailwind.config.js located? › tailwind.config.js
-Configure the import alias for components: › ~/components
-Configure the import alias for utils: › ~/lib/utils
-Are you using React Server Components? › no
-```
-
-### App structure
-
-<Callout>
-
-**Note**: This app structure is only a suggestion. You can place the files wherever you want.
-
-</Callout>
-
-- Place the UI components in the `app/components/ui` folder.
-- Your own components can be placed in the `app/components` folder.
-- The `app/lib` folder contains all the utility functions. We have a `utils.ts` where we define the `cn` helper.
-- The `app/tailwind.css` file contains the global CSS.
-
 ### Install Tailwind CSS
 
 ```bash
 npm add -D tailwindcss@latest autoprefixer@latest
+npx tailwindcss init
 ```
 
 Then we create a `postcss.config.js` file:
@@ -91,6 +55,43 @@ export const links: LinksFunction = () => [
   ...(cssBundleHref ? [{ rel: "stylesheet", href: cssBundleHref }] : []),
 ]
 ```
+
+### Run the CLI
+
+Run the `shadcn-ui` init command to setup your project:
+
+```bash
+npx shadcn-ui@latest init
+```
+
+### Configure components.json
+
+You will be asked a few questions to configure `components.json`:
+
+```txt showLineNumbers
+Would you like to use TypeScript (recommended)? no / yes
+Which style would you like to use? › Default
+Which color would you like to use as base color? › Slate
+Where is your global CSS file? › app/tailwind.css
+Do you want to use CSS variables for colors? › no / yes
+Where is your tailwind.config.js located? › tailwind.config.js
+Configure the import alias for components: › ~/components
+Configure the import alias for utils: › ~/lib/utils
+Are you using React Server Components? › no
+```
+
+### App structure
+
+<Callout>
+
+**Note**: This app structure is only a suggestion. You can place the files wherever you want.
+
+</Callout>
+
+- Place the UI components in the `app/components/ui` folder.
+- Your own components can be placed in the `app/components` folder.
+- The `app/lib` folder contains all the utility functions. We have a `utils.ts` where we define the `cn` helper.
+- The `app/tailwind.css` file contains the global CSS.
 
 ### That's it
 


### PR DESCRIPTION

## Motivation
While following the Remix setup documentation, I encountered an error when executing the CLI on the second step. The error message is depicted in the image below:
<img width="1511" alt="image" src="https://github.com/shadcn-ui/ui/assets/52117621/8e35657c-2e0c-438b-9b90-0de0a911c758">

It became apparent that the Tailwind CSS framework needs to be installed prior to executing the shadcn-ui initialization command.
## Changes
To resolve this issue, I have reorganized the documentation to ensure that the Tailwind CSS installation section precedes the CLI execution section. 