### PR TITLE
fix: remove redundant check on add cli command

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -80,9 +80,7 @@ export const add = new Command()
           choices: registryIndex.map((entry) => ({
             title: entry.name,
             value: entry.name,
-            selected: options.all
-              ? true
-              : options.components?.includes(entry.name),
+            selected: options.components?.includes(entry.name),
           })),
         })
         selectedComponents = components


### PR DESCRIPTION
# Remove redundant check on add cli command

Remove redundant check of options.all

before:

```ts
      if (!options.components?.length && !options.all) {
        const { components } = await prompts({
          type: "multiselect",
          name: "components",
          message: "Which components would you like to add?",
          hint: "Space to select. A to toggle all. Enter to submit.",
          instructions: false,
          choices: registryIndex.map((entry) => ({
            title: entry.name,
            value: entry.name,
            selected: options.all // redundant
              ? true
              : options.components?.includes(entry.name),
          })),
        })
        selectedComponents = components
      }
```

after:

```ts
      if (!options.components?.length && !options.all) {
        const { components } = await prompts({
          type: "multiselect",
          name: "components",
          message: "Which components would you like to add?",
          hint: "Space to select. A to toggle all. Enter to submit.",
          instructions: false,
          choices: registryIndex.map((entry) => ({
            title: entry.name,
            value: entry.name,
            selected: options.components?.includes(entry.name),
          })),
        })
        selectedComponents = components
       }
```