### PR TITLE
docs(components): add combobox-add-option example

### DIFF
--- a/apps/www/__registry__/index.tsx
+++ b/apps/www/__registry__/index.tsx
@@ -962,6 +962,17 @@ export const Index: Record<string, any> = {
       subcategory: "undefined",
       chunks: []
     },
+    "combobox-add-option": {
+      name: "combobox-add-option",
+      type: "components:example",
+      registryDependencies: ["command"],
+      component: React.lazy(() => import("@/registry/default/example/combobox-add-option")),
+      source: "",
+      files: ["registry/default/example/combobox-add-option.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
     "combobox-demo": {
       name: "combobox-demo",
       type: "components:example",
@@ -3352,6 +3363,17 @@ export const Index: Record<string, any> = {
       subcategory: "undefined",
       chunks: []
     },
+    "combobox-add-option": {
+      name: "combobox-add-option",
+      type: "components:example",
+      registryDependencies: ["command"],
+      component: React.lazy(() => import("@/registry/new-york/example/combobox-add-option")),
+      source: "",
+      files: ["registry/new-york/example/combobox-add-option.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
     "combobox-demo": {
       name: "combobox-demo",
       type: "components:example",
@@ -4525,17 +4547,9 @@ export const Index: Record<string, any> = {
       subcategory: "Dashboard",
       chunks: [{
         name: "dashboard-06-chunk-0",
-        description: "A breadcrumb with two links and a page indicator.",
+        description: "A list of products in a table with actions. Each row has an image, name, status, price, total sales, created at and actions.",
         component: React.lazy(() => import("@/registry/new-york/block/dashboard-06-chunk-0")),
         file: "registry/new-york/block/dashboard-06-chunk-0.tsx",
-        container: {
-          className: "undefined"
-        }
-      },{
-        name: "dashboard-06-chunk-1",
-        description: "A list of products in a table with actions. Each row has an image, name, status, price, total sales, created at and actions.",
-        component: React.lazy(() => import("@/registry/new-york/block/dashboard-06-chunk-1")),
-        file: "registry/new-york/block/dashboard-06-chunk-1.tsx",
         container: {
           className: "undefined"
         }

--- a/apps/www/content/docs/components/combobox.mdx
+++ b/apps/www/content/docs/components/combobox.mdx
@@ -131,3 +131,7 @@ You can create a responsive combobox by using the `<Popover />` on desktop and t
 ### Form
 
 <ComponentPreview name="combobox-form" />
+
+### Add option
+
+<ComponentPreview name="combobox-add-option" />

--- a/apps/www/registry/default/example/combobox-add-option.tsx
+++ b/apps/www/registry/default/example/combobox-add-option.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import * as React from "react"
+import { Check, ChevronsUpDown } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/registry/default/ui/button"
+import {
+  Command,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+} from "@/registry/default/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/registry/default/ui/popover"
+
+const filterData = [
+  {
+    value: "limit",
+    label: "Limit",
+  },
+  {
+    value: "offset",
+    label: "Offset",
+  },
+  {
+    value: "order",
+    label: "Order",
+  },
+  {
+    value: "sort",
+    label: "Sort",
+  },
+]
+
+export default function ComboboxNewOption() {
+  const [open, setOpen] = React.useState(false)
+  const [value, setValue] = React.useState("")
+  const [search, setSearch] = React.useState("")
+  const [filters, setFilters] = React.useState(filterData)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-[200px] justify-between"
+        >
+          {value
+            ? filters.find((filter) => filter.value === value)?.label
+            : "Select filter..."}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[200px] p-0">
+        <Command>
+          <CommandInput
+            placeholder="Search filter..."
+            value={search}
+            onValueChange={setSearch}
+          />
+          <CommandGroup>
+            {filters.map((filter) => (
+              <CommandItem
+                key={filter.value}
+                value={filter.value}
+                onSelect={(currentValue) => {
+                  setValue(currentValue === value ? "" : currentValue)
+                  setOpen(false)
+                }}
+              >
+                <Check
+                  className={cn(
+                    "mr-2 h-4 w-4",
+                    value === filter.value ? "opacity-100" : "opacity-0"
+                  )}
+                />
+                {filter.label}
+              </CommandItem>
+            ))}
+            {search &&
+              !filters.some(
+                (filter) => filter.value.toLowerCase() === search.toLowerCase()
+              ) && (
+                <CommandItem
+                  value={search}
+                  onSelect={(currentValue) => {
+                    setValue(currentValue)
+                    setFilters([
+                      ...filters,
+                      { value: currentValue, label: search },
+                    ])
+                    setOpen(false)
+                  }}
+                >
+                  <Check className="mr-2 h-4 w-4 opacity-0" />
+                  <span className="truncate">Add "{search}"</span>
+                </CommandItem>
+              )}
+          </CommandGroup>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/www/registry/examples.ts
+++ b/apps/www/registry/examples.ts
@@ -254,6 +254,12 @@ export const examples: Registry = [
     files: ["example/collapsible-demo.tsx"],
   },
   {
+    name: "combobox-add-option",
+    type: "components:example",
+    registryDependencies: ["command"],
+    files: ["example/combobox-add-option.tsx"],
+  },
+  {
     name: "combobox-demo",
     type: "components:example",
     registryDependencies: ["command"],

--- a/apps/www/registry/new-york/example/combobox-add-option.tsx
+++ b/apps/www/registry/new-york/example/combobox-add-option.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import * as React from "react"
+import { CaretSortIcon, CheckIcon } from "@radix-ui/react-icons"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/registry/new-york/ui/button"
+import {
+  Command,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+} from "@/registry/new-york/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/registry/new-york/ui/popover"
+
+const filterData = [
+  {
+    value: "limit",
+    label: "Limit",
+  },
+  {
+    value: "offset",
+    label: "Offset",
+  },
+  {
+    value: "order",
+    label: "Order",
+  },
+  {
+    value: "sort",
+    label: "Sort",
+  },
+]
+
+export default function ComboboxNewOption() {
+  const [open, setOpen] = React.useState(false)
+  const [value, setValue] = React.useState("")
+  const [search, setSearch] = React.useState("")
+  const [filters, setFilters] = React.useState(filterData)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-[200px] justify-between"
+        >
+          {value
+            ? filters.find((filter) => filter.value === value)?.label
+            : "Select filter..."}
+          <CaretSortIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[200px] p-0">
+        <Command>
+          <CommandInput
+            placeholder="Search filter..."
+            className="h-9"
+            value={search}
+            onValueChange={setSearch}
+          />
+          <CommandGroup>
+            {filters.map((filter) => (
+              <CommandItem
+                key={filter.value}
+                value={filter.value}
+                onSelect={(currentValue) => {
+                  setValue(currentValue === value ? "" : currentValue)
+                  setOpen(false)
+                }}
+              >
+                {filter.label}
+                <CheckIcon
+                  className={cn(
+                    "ml-auto h-4 w-4",
+                    value === filter.value ? "opacity-100" : "opacity-0"
+                  )}
+                />
+              </CommandItem>
+            ))}
+            {search &&
+              !filters.some(
+                (filter) => filter.value.toLowerCase() === search.toLowerCase()
+              ) && (
+                <CommandItem
+                  value={search}
+                  onSelect={(currentValue) => {
+                    setValue(currentValue)
+                    setFilters([
+                      ...filters,
+                      { value: currentValue, label: search },
+                    ])
+                    setOpen(false)
+                  }}
+                >
+                  <span className="truncate">Add "{search}"</span>
+                  <CheckIcon className="ml-auto h-4 w-4 opacity-0" />
+                </CommandItem>
+              )}
+          </CommandGroup>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}


### PR DESCRIPTION
## Motivation

I recently needed to implement a select component in a project I am working on. This select component needed the functionality to allow users to search within the select options and add an option that is not in the default list of options.

## Description of Change

This PR adds a new combobox example.

The `combobox-add-option` example allows users to add a value that is not present in the default options of the select component.

### Example

https://github.com/shadcn-ui/ui/assets/71855521/bffcf8ef-8fb8-4d28-b174-699bda25a1dd