### PR TITLE
Add Custom tsconfig Path Option to add Command 

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -26,6 +26,7 @@ const addOptionsSchema = z.object({
   cwd: z.string(),
   all: z.boolean(),
   path: z.string().optional(),
+  tsconfig: z.string().optional(),
 })
 
 export const add = new Command()
@@ -41,6 +42,7 @@ export const add = new Command()
   )
   .option("-a, --all", "add all available components", false)
   .option("-p, --path <path>", "the path to add the component to.")
+  .option("-t, --tsconfig <tsconfig>", "the name of your tsconfig file")
   .action(async (components, opts) => {
     try {
       const options = addOptionsSchema.parse({
@@ -55,7 +57,7 @@ export const add = new Command()
         process.exit(1)
       }
 
-      const config = await getConfig(cwd)
+      const config = await getConfig(cwd, options.tsconfig)
       if (!config) {
         logger.warn(
           `Configuration is missing. Please run ${chalk.green(

--- a/packages/cli/test/fixtures/config-ts-nx/components.json
+++ b/packages/cli/test/fixtures/config-ts-nx/components.json
@@ -1,0 +1,15 @@
+{
+  "style": "new-york",
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "src/app/globals.css",
+    "baseColor": "zinc",
+    "cssVariables": true,
+    "prefix": "tw-"
+  },
+  "rsc": false,
+  "aliases": {
+    "utils": "~/lib/utils",
+    "components": "~/components"
+  }
+}

--- a/packages/cli/test/fixtures/config-ts-nx/package.json
+++ b/packages/cli/test/fixtures/config-ts-nx/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-cli-config-ts-nx",
+  "version": "1.0.0",
+  "main": "index.js",
+  "author": "shadcn",
+  "license": "MIT"
+}

--- a/packages/cli/test/fixtures/config-ts-nx/tsconfig.base.json
+++ b/packages/cli/test/fixtures/config-ts-nx/tsconfig.base.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "checkJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "noUncheckedIndexedAccess": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./src/*"]
+    }
+  },
+  "include": [
+    ".eslintrc.cjs",
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.cjs",
+    "**/*.mjs"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/packages/cli/test/utils/get-config.test.ts
+++ b/packages/cli/test/utils/get-config.test.ts
@@ -1,7 +1,7 @@
 import path from "path"
 import { expect, test } from "vitest"
 
-import { getConfig, getRawConfig } from "../../src/utils/get-config"
+import { getConfig, getRawConfig, loadProjectConfig } from "../../src/utils/get-config"
 
 test("get raw config", async () => {
   expect(
@@ -128,6 +128,98 @@ test("get config", async () => {
   })
 
   expect(
+    await getConfig(path.resolve(__dirname, "../fixtures/config-ts-nx/"), "tsconfig.base.json")
+  ).toEqual({
+    style: "new-york",
+    rsc: false,
+    tsx: true,
+    tailwind: {
+      config: "tailwind.config.ts",
+      baseColor: "zinc",
+      css: "src/app/globals.css",
+      cssVariables: true,
+      prefix: "tw-",
+    },
+    aliases: {
+      components: "~/components",
+      utils: "~/lib/utils",
+    },
+    resolvedPaths: {
+      tailwindConfig: path.resolve(
+        __dirname,
+        "../fixtures/config-ts-nx",
+        "tailwind.config.ts"
+      ),
+      tailwindCss: path.resolve(
+        __dirname,
+        "../fixtures/config-ts-nx",
+        "./src/app/globals.css"
+      ),
+      components: path.resolve(
+        __dirname,
+        "../fixtures/config-ts-nx",
+        "./src/components"
+      ),
+      ui: path.resolve(
+        __dirname,
+        "../fixtures/config-ts-nx",
+        "./src/components"
+      ),
+      utils: path.resolve(
+        __dirname,
+        "../fixtures/config-ts-nx",
+        "./src/lib/utils"
+      ),
+    },
+  })
+
+  expect(
+    await getConfig(path.resolve(__dirname, "../fixtures/config-full/"), undefined)
+  ).toEqual({
+    style: "new-york",
+    rsc: false,
+    tsx: true,
+    tailwind: {
+      config: "tailwind.config.ts",
+      baseColor: "zinc",
+      css: "src/app/globals.css",
+      cssVariables: true,
+      prefix: "tw-",
+    },
+    aliases: {
+      components: "~/components",
+      utils: "~/lib/utils",
+    },
+    resolvedPaths: {
+      tailwindConfig: path.resolve(
+        __dirname,
+        "../fixtures/config-full",
+        "tailwind.config.ts"
+      ),
+      tailwindCss: path.resolve(
+        __dirname,
+        "../fixtures/config-full",
+        "./src/app/globals.css"
+      ),
+      components: path.resolve(
+        __dirname,
+        "../fixtures/config-full",
+        "./src/components"
+      ),
+      ui: path.resolve(
+        __dirname,
+        "../fixtures/config-full",
+        "./src/components"
+      ),
+      utils: path.resolve(
+        __dirname,
+        "../fixtures/config-full",
+        "./src/lib/utils"
+      ),
+    },
+  })
+
+  expect(
     await getConfig(path.resolve(__dirname, "../fixtures/config-jsx"))
   ).toEqual({
     style: "default",
@@ -162,5 +254,45 @@ test("get config", async () => {
       ui: path.resolve(__dirname, "../fixtures/config-jsx", "./components"),
       utils: path.resolve(__dirname, "../fixtures/config-jsx", "./lib/utils"),
     },
+  })
+})
+
+test("get project config", async () => {
+  expect(
+    loadProjectConfig(path.resolve(__dirname, "../fixtures/config-ts-nx/"), true, "tsconfig.base.json")
+  ).toEqual({
+    absoluteBaseUrl: path.resolve(__dirname, "../fixtures/config-ts-nx/"),
+    configFileAbsolutePath: path.resolve(__dirname, "../fixtures/config-ts-nx/tsconfig.base.json"),
+    resultType: "success",
+    baseUrl: ".",
+    paths: {
+      "~/*": ["./src/*"]
+    },
+    addMatchAll: true,
+  })
+
+  expect(
+    loadProjectConfig(path.resolve(__dirname, "../fixtures/config-jsx"), false, "jsconfig.json")
+  ).toEqual({
+    absoluteBaseUrl: path.resolve(__dirname, "../fixtures/config-jsx/"),
+    configFileAbsolutePath: path.resolve(__dirname, "../fixtures/config-jsx/jsconfig.json"),
+    resultType: "success",
+    paths: {
+      "@/*": ["./*"]
+    },
+    addMatchAll: false,
+  })
+
+  expect(
+    loadProjectConfig(path.resolve(__dirname, "../fixtures/config-full"), false, "tsconfig.json")
+  ).toEqual({
+    absoluteBaseUrl: path.resolve(__dirname, "../fixtures/config-full/"),
+    configFileAbsolutePath: path.resolve(__dirname, "../fixtures/config-full/tsconfig.json"),
+    resultType: "success",
+    baseUrl: ".",
+    paths: {
+      "~/*": ["./src/*"]
+    },
+    addMatchAll: true,
   })
 })


### PR DESCRIPTION
# Description 

This pull request adds a new flag to the add command `--tsconfig`. It allows users to specify the name of their tsconfig file when adding components to the project. I understand this may be a niche use case but wanted to put it out there and see what the teams thoughts were. 

## Reason for adding

I am working on a large NX mono repo project that we want to use shadcn on. We are not using nextjs for the project so we can't utilize any of the community driven plugins that I see have been created, as they were made for nextjs specifically and don't allow granular control of where projects can place their shadcn components.  

## How I got to this solution

I followed the [manual](https://ui.shadcn.com/docs/installation/manual) installation instructions and the one problem I faced was that NX uses a tsconfig file called `tsconfig.base.json`. This config is extended in all libs and apps within the mono repo. It is also extended anytime we generate new apps or libs when executing the generator commands that NX offers. So altering the file name could be problematic. I also thought about just creating a new tsconfig.json file specifically for shadcn but the project already has a ton of config files and all our path aliases are in the base config, would be nice to keep everything consolidated. 

I tested thoroughly and added new tests. Let me know what you guys think and I appreciate your time and review :pray: 