### PR TITLE
fix(examples/button): prevent button asChild from redirecting to 404

### DIFF
--- a/apps/www/registry/default/example/button-as-child.tsx
+++ b/apps/www/registry/default/example/button-as-child.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/registry/default/ui/button"
 export default function ButtonAsChild() {
   return (
     <Button asChild>
-      <Link href="/login">Login</Link>
+      <Link href="#">Login</Link>
     </Button>
   )
 }

--- a/apps/www/registry/new-york/example/button-as-child.tsx
+++ b/apps/www/registry/new-york/example/button-as-child.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/registry/new-york/ui/button"
 export default function ButtonAsChild() {
   return (
     <Button asChild>
-      <Link href="/login">Login</Link>
+      <Link href="#">Login</Link>
     </Button>
   )
 }


### PR DESCRIPTION
The asChild Button example in the documentation redirects to `/login` causing a 404 [here](https://ui.shadcn.com/docs/components/button#as-child).

This PR fixes #480 by changing the href to `#`

Referencing `#as-child` example itself replaces the URL state. I was not sure if this was a desired behaviour so I kept it as `#` as I saw it in multiple examples across the docs.


> First time trying to contribute, sorry in advance if something is wrong.