### PR TITLE
DrawerClose needs asChild prop to avoid nested button elements

### DIFF
--- a/apps/www/content/docs/components/drawer.mdx
+++ b/apps/www/content/docs/components/drawer.mdx
@@ -75,7 +75,7 @@ import {
     </DrawerHeader>
     <DrawerFooter>
       <Button>Submit</Button>
-      <DrawerClose>
+      <DrawerClose asChild>
         <Button variant="outline">Cancel</Button>
       </DrawerClose>
     </DrawerFooter>


### PR DESCRIPTION
Noticed when I used this snippet I got a `<button> cannot appear as a descendant of <button>`. Did a quick check and it looks like this is already fixed everywhere else in the codebase!