### PR TITLE
fix(docs): Broken Link in Data Table

### DIFF
--- a/apps/www/content/docs/components/data-table.mdx
+++ b/apps/www/content/docs/components/data-table.mdx
@@ -3,7 +3,7 @@ title: Data Table
 description: Powerful table and datagrids built using TanStack Table.
 component: true
 links:
-  doc: https://tanstack.com/table/v8/docs/guide/introduction
+  doc: https://tanstack.com/table/v8/docs/introduction
 ---
 
 <ComponentPreview name="data-table-demo" />


### PR DESCRIPTION
Old link leads to a `404`