### PR TITLE
Remove baseUrl from vite config

### DIFF
--- a/apps/www/content/docs/installation/vite.mdx
+++ b/apps/www/content/docs/installation/vite.mdx
@@ -31,7 +31,6 @@ Add the following code to the `tsconfig.json` file to resolve paths:
 {
   "compilerOptions": {
     // ...
-    "baseUrl": ".",
     "paths": {
       "@/*": [
         "./src/*"


### PR DESCRIPTION
The `baseUrl` config is not required. The paths config is relative to the location of the `tsconfig.json` file already, so setting baseUrl to `.` is a noop.

But the `baseUrl` config causes issues: If you have a folder named the same as your dependency (say "myproject/next/some/button.tsx"), import like

```
import { SomeButton } from "next/some/button"
```

will work with  TypeScript but won't work with Vite, so it will fail at runtime.

Note that following the Next.js installation instruction does **not** lead to having `baseUrl` set in the `tsconfig.json`.