### PR TITLE
Fix ts error on missing exported member in pagination.tsx

### DIFF
--- a/apps/www/registry/default/ui/pagination.tsx
+++ b/apps/www/registry/default/ui/pagination.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { ButtonProps, buttonVariants } from "@/registry/default/ui/button"
+import { type ButtonProps, buttonVariants } from "@/registry/default/ui/button"
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav


### PR DESCRIPTION
When integrating the library with astro I was getting the error:

````
Error hydrating /src/components/dashboard/DashMain.tsx SyntaxError: The requested module '/src/components/ui/button.tsx?t=1717073729765' does not provide an export named 'ButtonProps' (at pagination.tsx:5:10)
````

Fixed with type import