### PR TITLE
Fix Link import in breadcrumb.mdx

### DIFF
--- a/apps/www/content/docs/components/breadcrumb.mdx
+++ b/apps/www/content/docs/components/breadcrumb.mdx
@@ -181,7 +181,7 @@ To use a custom link component from your routing library, you can use the `asChi
 />
 
 ```tsx showLineNumbers {1,8-10}
-import { Link } from "next/link"
+import Link from "next/link"
 
 ...
 


### PR DESCRIPTION
Fix `Link` import (https://nextjs.org/docs/app/api-reference/components/link).