### PR TITLE
FIX( documentation url): fix url in data-table documentation in mdx file

### DIFF
--- a/apps/www/content/docs/components/data-table.mdx
+++ b/apps/www/content/docs/components/data-table.mdx
@@ -3,7 +3,7 @@ title: Data Table
 description: Powerful table and datagrids built using TanStack Table.
 component: true
 links:
-  doc: https://tanstack.com/table/v8/docs/guide/introduction
+  doc: https://tanstack.com/table/v8/docs/introduction
 ---
 
 <ComponentPreview name="data-table-demo" />

--- a/apps/www/content/docs/components/data-table.mdx
+++ b/apps/www/content/docs/components/data-table.mdx
@@ -12,7 +12,7 @@ links:
 
 Every data table or datagrid I've created has been unique. They all behave differently, have specific sorting and filtering requirements, and work with different data sources.
 
-It doesn't make sense to combine all of these variations into a single component. If we do that, we'll lose the flexibility that [headless UI](https://tanstack.com/table/v8/docs/guide/introduction#what-is-headless-ui) provides.
+It doesn't make sense to combine all of these variations into a single component. If we do that, we'll lose the flexibility that [headless UI](https://tanstack.com/table/v8/docs/introduction#what-is-headless-ui) provides.
 
 So instead of a data-table component, I thought it would be more helpful to provide a guide on how to build your own.
 


### PR DESCRIPTION
### Changes
we just update the url of `data-table` documentation to the right one, because the current url is broken

ISSUE link: [click_here](https://github.com/shadcn-ui/ui/issues/3916)

example of problem:

https://github.com/shadcn-ui/ui/assets/90482598/8a7df07f-7003-4973-83e0-99146cb4eaa0




