### PR TITLE
(Docs): Add `name` prop to `Select` component when using within `Form`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,9 @@ pnpm --filter=www dev
 
 Documentation is written using [MDX](https://mdxjs.com). You can find the documentation files in the `apps/www/content/docs` directory.
 
+If the documentation running locally doesn't reflect the file changes, you can delete the `contentlayer` folder and run
+the `pnpm --filter=www dev` command again.
+
 ## Components
 
 We use a registry system for developing components. You can find the source code for the components under `apps/www/registry`. The components are organized by styles.

--- a/apps/www/__registry__/default/example/select-form.tsx
+++ b/apps/www/__registry__/default/example/select-form.tsx
@@ -57,7 +57,7 @@ export default function SelectForm() {
           render={({ field }) => (
             <FormItem>
               <FormLabel>Email</FormLabel>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
+              <Select name={field.name} onValueChange={field.onChange} defaultValue={field.value}>
                 <FormControl>
                   <SelectTrigger>
                     <SelectValue placeholder="Select a verified email to display" />

--- a/apps/www/app/(app)/examples/forms/profile-form.tsx
+++ b/apps/www/app/(app)/examples/forms/profile-form.tsx
@@ -111,7 +111,7 @@ export function ProfileForm() {
           render={({ field }) => (
             <FormItem>
               <FormLabel>Email</FormLabel>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
+              <Select name={field.name} onValueChange={field.onChange} defaultValue={field.value}>
                 <FormControl>
                   <SelectTrigger>
                     <SelectValue placeholder="Select a verified email to display" />

--- a/apps/www/registry/default/example/select-form.tsx
+++ b/apps/www/registry/default/example/select-form.tsx
@@ -57,7 +57,7 @@ export default function SelectForm() {
           render={({ field }) => (
             <FormItem>
               <FormLabel>Email</FormLabel>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
+              <Select name={field.name} onValueChange={field.onChange} defaultValue={field.value}>
                 <FormControl>
                   <SelectTrigger>
                     <SelectValue placeholder="Select a verified email to display" />

--- a/apps/www/registry/new-york/example/select-form.tsx
+++ b/apps/www/registry/new-york/example/select-form.tsx
@@ -57,7 +57,7 @@ export default function SelectForm() {
           render={({ field }) => (
             <FormItem>
               <FormLabel>Email</FormLabel>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
+              <Select name={field.name} onValueChange={field.onChange} defaultValue={field.value}>
                 <FormControl>
                   <SelectTrigger>
                     <SelectValue placeholder="Select a verified email to display" />


### PR DESCRIPTION
This is a simple update regarding the usage of the `Select` component as child of a `Form`.

I was integrating my form with server actions, and when not having the `field.name` passed as `name` to `Select` component, like this:

```jsx
<Form>
  ...
   <Select name={field.name} onValueChange={field.onChange} defaultValue={field.value}>
     ...
   </Select>
  ...
</Form>
```

The `formData` would not have the field with the chosen value from the select dropdown. It would either have a falsy value (e.g.: `''`) or always have the default value (if set).

I'm not sure in which case this issue surfaces, but I think the addition there will prevent any other similar error, be it in another context or not.

**PS:**: I'm also adding a small note on `CONTRIBUTING.md` about the changes on docs not reflecting after saving the files.