### PR TITLE
fix(www): normalize CRLF to LF when building registry

### DIFF
--- a/apps/www/scripts/build-registry.mts
+++ b/apps/www/scripts/build-registry.mts
@@ -290,9 +290,13 @@ async function buildStyles(registry: Registry) {
           "utf8"
         )
 
+        const CRLF = "\r\n"
+        const LF = "\n"
+        const normalizedContent = content.replace(new RegExp(CRLF, "g"), LF)
+
         return {
           name: basename(file),
-          content,
+          content: normalizedContent,
         }
       })
 


### PR DESCRIPTION
Currently when running the build registry script on windows, we get a huge diff because all the registry files are regenerated using CRLF line endings instead of LF. We are then required to manually pick the appropriate registry files to stage, and manually replace the CRLF line endings with LF.

This change makes development (and contributing) for Windows users much easier.