### PR TITLE
fix(www): ensure radio group label click area is fully clickable

### DIFF
--- a/apps/www/__registry__/default/example/radio-group-demo.tsx
+++ b/apps/www/__registry__/default/example/radio-group-demo.tsx
@@ -4,17 +4,17 @@ import { RadioGroup, RadioGroupItem } from "@/registry/default/ui/radio-group"
 export default function RadioGroupDemo() {
   return (
     <RadioGroup defaultValue="comfortable">
-      <div className="flex items-center space-x-2">
+      <div className="flex items-center">
         <RadioGroupItem value="default" id="r1" />
-        <Label htmlFor="r1">Default</Label>
+        <Label htmlFor="r1" className="pl-2">Default</Label>
       </div>
-      <div className="flex items-center space-x-2">
+      <div className="flex items-center">
         <RadioGroupItem value="comfortable" id="r2" />
-        <Label htmlFor="r2">Comfortable</Label>
+        <Label htmlFor="r2" className="pl-2">Comfortable</Label>
       </div>
-      <div className="flex items-center space-x-2">
+      <div className="flex items-center">
         <RadioGroupItem value="compact" id="r3" />
-        <Label htmlFor="r3">Compact</Label>
+        <Label htmlFor="r3" className="pl-2">Compact</Label>
       </div>
     </RadioGroup>
   )

--- a/apps/www/__registry__/default/example/radio-group-form.tsx
+++ b/apps/www/__registry__/default/example/radio-group-form.tsx
@@ -53,27 +53,27 @@ export default function RadioGroupForm() {
                   defaultValue={field.value}
                   className="flex flex-col space-y-1"
                 >
-                  <FormItem className="flex items-center space-x-3 space-y-0">
+                  <FormItem className="flex items-center space-y-0">
                     <FormControl>
                       <RadioGroupItem value="all" />
                     </FormControl>
-                    <FormLabel className="font-normal">
+                    <FormLabel className="font-normal pl-3">
                       All new messages
                     </FormLabel>
                   </FormItem>
-                  <FormItem className="flex items-center space-x-3 space-y-0">
+                  <FormItem className="flex items-center space-y-0">
                     <FormControl>
                       <RadioGroupItem value="mentions" />
                     </FormControl>
-                    <FormLabel className="font-normal">
+                    <FormLabel className="font-normal pl-3">
                       Direct messages and mentions
                     </FormLabel>
                   </FormItem>
-                  <FormItem className="flex items-center space-x-3 space-y-0">
+                  <FormItem className="flex items-center space-y-0">
                     <FormControl>
                       <RadioGroupItem value="none" />
                     </FormControl>
-                    <FormLabel className="font-normal">Nothing</FormLabel>
+                    <FormLabel className="font-normal pl-3">Nothing</FormLabel>
                   </FormItem>
                 </RadioGroup>
               </FormControl>

--- a/apps/www/app/(app)/examples/forms/notifications/notifications-form.tsx
+++ b/apps/www/app/(app)/examples/forms/notifications/notifications-form.tsx
@@ -73,27 +73,27 @@ export function NotificationsForm() {
                   defaultValue={field.value}
                   className="flex flex-col space-y-1"
                 >
-                  <FormItem className="flex items-center space-x-3 space-y-0">
+                  <FormItem className="flex items-center space-y-0">
                     <FormControl>
                       <RadioGroupItem value="all" />
                     </FormControl>
-                    <FormLabel className="font-normal">
+                    <FormLabel className="font-normal pl-3">
                       All new messages
                     </FormLabel>
                   </FormItem>
-                  <FormItem className="flex items-center space-x-3 space-y-0">
+                  <FormItem className="flex items-center space-y-0">
                     <FormControl>
                       <RadioGroupItem value="mentions" />
                     </FormControl>
-                    <FormLabel className="font-normal">
+                    <FormLabel className="font-normal pl-3">
                       Direct messages and mentions
                     </FormLabel>
                   </FormItem>
-                  <FormItem className="flex items-center space-x-3 space-y-0">
+                  <FormItem className="flex items-center space-y-0">
                     <FormControl>
                       <RadioGroupItem value="none" />
                     </FormControl>
-                    <FormLabel className="font-normal">Nothing</FormLabel>
+                    <FormLabel className="font-normal pl-3">Nothing</FormLabel>
                   </FormItem>
                 </RadioGroup>
               </FormControl>

--- a/apps/www/content/docs/components/radio-group.mdx
+++ b/apps/www/content/docs/components/radio-group.mdx
@@ -59,13 +59,13 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 
 ```tsx
 <RadioGroup defaultValue="option-one">
-  <div className="flex items-center space-x-2">
+  <div className="flex items-center">
     <RadioGroupItem value="option-one" id="option-one" />
-    <Label htmlFor="option-one">Option One</Label>
+    <Label htmlFor="option-one" className="pl-2">Option One</Label>
   </div>
-  <div className="flex items-center space-x-2">
+  <div className="flex items-center">
     <RadioGroupItem value="option-two" id="option-two" />
-    <Label htmlFor="option-two">Option Two</Label>
+    <Label htmlFor="option-two" className="pl-2">Option Two</Label>
   </div>
 </RadioGroup>
 ```

--- a/apps/www/registry/default/example/radio-group-demo.tsx
+++ b/apps/www/registry/default/example/radio-group-demo.tsx
@@ -4,17 +4,17 @@ import { RadioGroup, RadioGroupItem } from "@/registry/default/ui/radio-group"
 export default function RadioGroupDemo() {
   return (
     <RadioGroup defaultValue="comfortable">
-      <div className="flex items-center space-x-2">
+      <div className="flex items-center">
         <RadioGroupItem value="default" id="r1" />
-        <Label htmlFor="r1">Default</Label>
+        <Label htmlFor="r1" className="pl-2">Default</Label>
       </div>
-      <div className="flex items-center space-x-2">
+      <div className="flex items-center">
         <RadioGroupItem value="comfortable" id="r2" />
-        <Label htmlFor="r2">Comfortable</Label>
+        <Label htmlFor="r2" className="pl-2">Comfortable</Label>
       </div>
-      <div className="flex items-center space-x-2">
+      <div className="flex items-center">
         <RadioGroupItem value="compact" id="r3" />
-        <Label htmlFor="r3">Compact</Label>
+        <Label htmlFor="r3" className="pl-2">Compact</Label>
       </div>
     </RadioGroup>
   )

--- a/apps/www/registry/default/example/radio-group-form.tsx
+++ b/apps/www/registry/default/example/radio-group-form.tsx
@@ -53,27 +53,27 @@ export default function RadioGroupForm() {
                   defaultValue={field.value}
                   className="flex flex-col space-y-1"
                 >
-                  <FormItem className="flex items-center space-x-3 space-y-0">
+                  <FormItem className="flex items-center space-y-0">
                     <FormControl>
                       <RadioGroupItem value="all" />
                     </FormControl>
-                    <FormLabel className="font-normal">
+                    <FormLabel className="font-normal pl-3">
                       All new messages
                     </FormLabel>
                   </FormItem>
-                  <FormItem className="flex items-center space-x-3 space-y-0">
+                  <FormItem className="flex items-center space-y-0">
                     <FormControl>
                       <RadioGroupItem value="mentions" />
                     </FormControl>
-                    <FormLabel className="font-normal">
+                    <FormLabel className="font-normal pl-3">
                       Direct messages and mentions
                     </FormLabel>
                   </FormItem>
-                  <FormItem className="flex items-center space-x-3 space-y-0">
+                  <FormItem className="flex items-center space-y-0">
                     <FormControl>
                       <RadioGroupItem value="none" />
                     </FormControl>
-                    <FormLabel className="font-normal">Nothing</FormLabel>
+                    <FormLabel className="font-normal pl-3">Nothing</FormLabel>
                   </FormItem>
                 </RadioGroup>
               </FormControl>

--- a/apps/www/registry/new-york/example/radio-group-demo.tsx
+++ b/apps/www/registry/new-york/example/radio-group-demo.tsx
@@ -4,17 +4,17 @@ import { RadioGroup, RadioGroupItem } from "@/registry/new-york/ui/radio-group"
 export default function RadioGroupDemo() {
   return (
     <RadioGroup defaultValue="comfortable">
-      <div className="flex items-center space-x-2">
+      <div className="flex items-center">
         <RadioGroupItem value="default" id="r1" />
-        <Label htmlFor="r1">Default</Label>
+        <Label htmlFor="r1" className="pl-2">Default</Label>
       </div>
-      <div className="flex items-center space-x-2">
+      <div className="flex items-center">
         <RadioGroupItem value="comfortable" id="r2" />
-        <Label htmlFor="r2">Comfortable</Label>
+        <Label htmlFor="r2" className="pl-2">Comfortable</Label>
       </div>
-      <div className="flex items-center space-x-2">
+      <div className="flex items-center">
         <RadioGroupItem value="compact" id="r3" />
-        <Label htmlFor="r3">Compact</Label>
+        <Label htmlFor="r3" className="pl-2">Compact</Label>
       </div>
     </RadioGroup>
   )

--- a/apps/www/registry/new-york/example/radio-group-form.tsx
+++ b/apps/www/registry/new-york/example/radio-group-form.tsx
@@ -53,27 +53,27 @@ export default function RadioGroupForm() {
                   defaultValue={field.value}
                   className="flex flex-col space-y-1"
                 >
-                  <FormItem className="flex items-center space-x-3 space-y-0">
+                  <FormItem className="flex items-center space-y-0">
                     <FormControl>
                       <RadioGroupItem value="all" />
                     </FormControl>
-                    <FormLabel className="font-normal">
+                    <FormLabel className="font-normal pl-3">
                       All new messages
                     </FormLabel>
                   </FormItem>
-                  <FormItem className="flex items-center space-x-3 space-y-0">
+                  <FormItem className="flex items-center space-y-0">
                     <FormControl>
                       <RadioGroupItem value="mentions" />
                     </FormControl>
-                    <FormLabel className="font-normal">
+                    <FormLabel className="font-normal pl-3">
                       Direct messages and mentions
                     </FormLabel>
                   </FormItem>
-                  <FormItem className="flex items-center space-x-3 space-y-0">
+                  <FormItem className="flex items-center space-y-0">
                     <FormControl>
                       <RadioGroupItem value="none" />
                     </FormControl>
-                    <FormLabel className="font-normal">Nothing</FormLabel>
+                    <FormLabel className="font-normal pl-3">Nothing</FormLabel>
                   </FormItem>
                 </RadioGroup>
               </FormControl>


### PR DESCRIPTION
## Description
This PR addresses an issue with the radio group example where the space between the radio button and its label was not clickable. The existing implementation used `space-x-3` for spacing, which resulted in a gap that did not register clicks.

### Before
- The space between the radio button and the label did not register clicks.
- Users had to click directly on the radio button or the label.

### After
- The label is now correctly spaced using `pl-3`, ensuring the clickable area includes the space between the radio button and the label.
- Clicking anywhere in the space between the radio button and the label will now register a click.

## Changes
- Replaced `space-x-3` with `pl-3` in the `FormLabel` for the radio group example.

## Video
### Before
https://github.com/shadcn-ui/ui/assets/694736/0443f715-6481-4b2a-8ac9-e60107195a03

### After
https://github.com/shadcn-ui/ui/assets/694736/3651037f-f718-4da8-be32-8fdfacd911ce

