### PR TITLE
docs: add ref prop to checkbox form examples

### DIFF
--- a/apps/www/registry/default/example/checkbox-form-multiple.tsx
+++ b/apps/www/registry/default/example/checkbox-form-multiple.tsx
@@ -96,6 +96,7 @@ export default function CheckboxReactHookFormMultiple() {
                       >
                         <FormControl>
                           <Checkbox
+                            ref={field.ref}
                             checked={field.value?.includes(item.id)}
                             onCheckedChange={(checked) => {
                               return checked

--- a/apps/www/registry/default/example/checkbox-form-single.tsx
+++ b/apps/www/registry/default/example/checkbox-form-single.tsx
@@ -50,6 +50,7 @@ export default function CheckboxReactHookFormSingle() {
             <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4">
               <FormControl>
                 <Checkbox
+                  ref={field.ref}
                   checked={field.value}
                   onCheckedChange={field.onChange}
                 />

--- a/apps/www/registry/new-york/example/checkbox-form-multiple.tsx
+++ b/apps/www/registry/new-york/example/checkbox-form-multiple.tsx
@@ -96,6 +96,7 @@ export default function CheckboxReactHookFormMultiple() {
                       >
                         <FormControl>
                           <Checkbox
+                            ref={field.ref}
                             checked={field.value?.includes(item.id)}
                             onCheckedChange={(checked) => {
                               return checked

--- a/apps/www/registry/new-york/example/checkbox-form-single.tsx
+++ b/apps/www/registry/new-york/example/checkbox-form-single.tsx
@@ -50,6 +50,7 @@ export default function CheckboxReactHookFormSingle() {
             <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4 shadow">
               <FormControl>
                 <Checkbox
+                  ref={field.ref}
                   checked={field.value}
                   onCheckedChange={field.onChange}
                 />


### PR DESCRIPTION
I find it almost necessary to pass a `ref` to the React Hook Forms `Controller` because [it allows the RHF to focus the error input](https://react-hook-form.com/docs/usecontroller/controller) (so also to automatically scroll into it in most browsers).

Therefore, I suggest that the form examples for the `Checkbox` component should include passing the `ref` prop.