### PR TITLE
fix(www): useSyncExternal store in dark mode example instead of useState+useEffect

### DIFF
--- a/apps/www/hooks/use-media-query.tsx
+++ b/apps/www/hooks/use-media-query.tsx
@@ -1,19 +1,12 @@
 import * as React from "react"
 
 export function useMediaQuery(query: string) {
-  const [value, setValue] = React.useState(false)
+  const subscribe = React.useCallback((callback: (e: MediaQueryListEvent) => void) => {
+    matchMedia(query).addEventListener("change", callback);
+    return () => matchMedia(query).removeEventListener("change", callback);
+  }, [query, callback]);
 
-  React.useEffect(() => {
-    function onChange(event: MediaQueryListEvent) {
-      setValue(event.matches)
-    }
+  const getSnapshot = React.useCallback(() => matchMedia(query).matches, [query]);
 
-    const result = matchMedia(query)
-    result.addEventListener("change", onChange)
-    setValue(result.matches)
-
-    return () => result.removeEventListener("change", onChange)
-  }, [query])
-
-  return value
+  return React.useSyncExternalStore(subscribe, getSnapshot);
 }

--- a/apps/www/hooks/use-media-query.tsx
+++ b/apps/www/hooks/use-media-query.tsx
@@ -4,7 +4,7 @@ export function useMediaQuery(query: string) {
   const subscribe = React.useCallback((callback: (e: MediaQueryListEvent) => void) => {
     matchMedia(query).addEventListener("change", callback);
     return () => matchMedia(query).removeEventListener("change", callback);
-  }, [query, callback]);
+  }, [query]);
 
   const getSnapshot = React.useCallback(() => matchMedia(query).matches, [query]);
 


### PR DESCRIPTION
useSyncExternalStore is preffered over useEffect+useState. 

More can be read here: https://react.dev/learn/you-might-not-need-an-effect#subscribing-to-an-external-store

also: Is it just me, or hooks actually ain't even shown on https://ui.shadcn.com ?