### PR TITLE
docs(input-otp): add example for inputMode prop

### DIFF
--- a/apps/www/__registry__/default/block/dashboard-01.tsx
+++ b/apps/www/__registry__/default/block/dashboard-01.tsx
@@ -229,7 +229,9 @@ export default function Dashboard() {
           </Card>
         </div>
         <div className="grid gap-4 md:gap-8 lg:grid-cols-2 xl:grid-cols-3">
-          <Card className="xl:col-span-2" x-chunk="dashboard-01-chunk-4">
+          <Card
+            className="xl:col-span-2" x-chunk="dashboard-01-chunk-4"
+          >
             <CardHeader className="flex flex-row items-center">
               <div className="grid gap-2">
                 <CardTitle>Transactions</CardTitle>

--- a/apps/www/__registry__/default/block/dashboard-02.tsx
+++ b/apps/www/__registry__/default/block/dashboard-02.tsx
@@ -227,8 +227,7 @@ export default function Dashboard() {
             <h1 className="text-lg font-semibold md:text-2xl">Inventory</h1>
           </div>
           <div
-            className="flex flex-1 items-center justify-center rounded-lg border border-dashed shadow-sm"
-            x-chunk="dashboard-02-chunk-1"
+            className="flex flex-1 items-center justify-center rounded-lg border border-dashed shadow-sm" x-chunk="dashboard-02-chunk-1"
           >
             <div className="flex flex-col items-center gap-1 text-center">
               <h3 className="text-2xl font-bold tracking-tight">

--- a/apps/www/__registry__/default/block/dashboard-03.tsx
+++ b/apps/www/__registry__/default/block/dashboard-03.tsx
@@ -302,8 +302,7 @@ export default function Dashboard() {
         </header>
         <main className="grid flex-1 gap-4 overflow-auto p-4 md:grid-cols-2 lg:grid-cols-3">
           <div
-            className="relative hidden flex-col items-start gap-8 md:flex"
-            x-chunk="dashboard-03-chunk-0"
+            className="relative hidden flex-col items-start gap-8 md:flex" x-chunk="dashboard-03-chunk-0"
           >
             <form className="grid w-full items-start gap-6">
               <fieldset className="grid gap-6 rounded-lg border p-4">
@@ -420,8 +419,7 @@ export default function Dashboard() {
             </Badge>
             <div className="flex-1" />
             <form
-              className="relative overflow-hidden rounded-lg border bg-background focus-within:ring-1 focus-within:ring-ring"
-              x-chunk="dashboard-03-chunk-1"
+              className="relative overflow-hidden rounded-lg border bg-background focus-within:ring-1 focus-within:ring-ring" x-chunk="dashboard-03-chunk-1"
             >
               <Label htmlFor="message" className="sr-only">
                 Message

--- a/apps/www/__registry__/default/block/dashboard-04.tsx
+++ b/apps/www/__registry__/default/block/dashboard-04.tsx
@@ -157,8 +157,7 @@ export default function Dashboard() {
         </div>
         <div className="mx-auto grid w-full max-w-6xl items-start gap-6 md:grid-cols-[180px_1fr] lg:grid-cols-[250px_1fr]">
           <nav
-            className="grid gap-4 text-sm text-muted-foreground"
-            x-chunk="dashboard-04-chunk-0"
+            className="grid gap-4 text-sm text-muted-foreground" x-chunk="dashboard-04-chunk-0"
           >
             <Link href="#" className="font-semibold text-primary">
               General

--- a/apps/www/__registry__/default/block/dashboard-05.tsx
+++ b/apps/www/__registry__/default/block/dashboard-05.tsx
@@ -283,7 +283,9 @@ export default function Dashboard() {
         <main className="grid flex-1 items-start gap-4 p-4 sm:px-6 sm:py-0 md:gap-8 lg:grid-cols-3 xl:grid-cols-3">
           <div className="grid auto-rows-max items-start gap-4 md:gap-8 lg:col-span-2">
             <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-2 xl:grid-cols-4">
-              <Card className="sm:col-span-2" x-chunk="dashboard-05-chunk-0">
+              <Card
+                className="sm:col-span-2" x-chunk="dashboard-05-chunk-0"
+              >
                 <CardHeader className="pb-3">
                   <CardTitle>Your Orders</CardTitle>
                   <CardDescription className="max-w-lg text-balance leading-relaxed">
@@ -561,7 +563,9 @@ export default function Dashboard() {
             </Tabs>
           </div>
           <div>
-            <Card className="overflow-hidden" x-chunk="dashboard-05-chunk-4">
+            <Card
+              className="overflow-hidden" x-chunk="dashboard-05-chunk-4"
+            >
               <CardHeader className="flex flex-row items-start bg-muted/50">
                 <div className="grid gap-0.5">
                   <CardTitle className="group flex items-center gap-2 text-lg">

--- a/apps/www/__registry__/default/block/dashboard-07.tsx
+++ b/apps/www/__registry__/default/block/dashboard-07.tsx
@@ -535,8 +535,7 @@ export default function Dashboard() {
                   </CardContent>
                 </Card>
                 <Card
-                  className="overflow-hidden"
-                  x-chunk="dashboard-07-chunk-4"
+                  className="overflow-hidden" x-chunk="dashboard-07-chunk-4"
                 >
                   <CardHeader>
                     <CardTitle>Product Images</CardTitle>

--- a/apps/www/__registry__/index.tsx
+++ b/apps/www/__registry__/index.tsx
@@ -1292,6 +1292,17 @@ export const Index: Record<string, any> = {
       subcategory: "undefined",
       chunks: []
     },
+    "input-otp-input-mode": {
+      name: "input-otp-input-mode",
+      type: "components:example",
+      registryDependencies: ["input-otp"],
+      component: React.lazy(() => import("@/registry/default/example/input-otp-input-mode")),
+      source: "",
+      files: ["registry/default/example/input-otp-input-mode.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
     "input-otp-separator": {
       name: "input-otp-separator",
       type: "components:example",
@@ -3682,6 +3693,17 @@ export const Index: Record<string, any> = {
       subcategory: "undefined",
       chunks: []
     },
+    "input-otp-input-mode": {
+      name: "input-otp-input-mode",
+      type: "components:example",
+      registryDependencies: ["input-otp"],
+      component: React.lazy(() => import("@/registry/new-york/example/input-otp-input-mode")),
+      source: "",
+      files: ["registry/new-york/example/input-otp-input-mode.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
     "input-otp-separator": {
       name: "input-otp-separator",
       type: "components:example",
@@ -4525,17 +4547,9 @@ export const Index: Record<string, any> = {
       subcategory: "Dashboard",
       chunks: [{
         name: "dashboard-06-chunk-0",
-        description: "A breadcrumb with two links and a page indicator.",
+        description: "A list of products in a table with actions. Each row has an image, name, status, price, total sales, created at and actions.",
         component: React.lazy(() => import("@/registry/new-york/block/dashboard-06-chunk-0")),
         file: "registry/new-york/block/dashboard-06-chunk-0.tsx",
-        container: {
-          className: "undefined"
-        }
-      },{
-        name: "dashboard-06-chunk-1",
-        description: "A list of products in a table with actions. Each row has an image, name, status, price, total sales, created at and actions.",
-        component: React.lazy(() => import("@/registry/new-york/block/dashboard-06-chunk-1")),
-        file: "registry/new-york/block/dashboard-06-chunk-1.tsx",
         container: {
           className: "undefined"
         }

--- a/apps/www/__registry__/new-york/block/dashboard-01.tsx
+++ b/apps/www/__registry__/new-york/block/dashboard-01.tsx
@@ -229,7 +229,9 @@ export default function Dashboard() {
           </Card>
         </div>
         <div className="grid gap-4 md:gap-8 lg:grid-cols-2 xl:grid-cols-3">
-          <Card className="xl:col-span-2" x-chunk="dashboard-01-chunk-4">
+          <Card
+            className="xl:col-span-2" x-chunk="dashboard-01-chunk-4"
+          >
             <CardHeader className="flex flex-row items-center">
               <div className="grid gap-2">
                 <CardTitle>Transactions</CardTitle>

--- a/apps/www/__registry__/new-york/block/dashboard-02.tsx
+++ b/apps/www/__registry__/new-york/block/dashboard-02.tsx
@@ -227,8 +227,7 @@ export default function Dashboard() {
             <h1 className="text-lg font-semibold md:text-2xl">Inventory</h1>
           </div>
           <div
-            className="flex flex-1 items-center justify-center rounded-lg border border-dashed shadow-sm"
-            x-chunk="dashboard-02-chunk-1"
+            className="flex flex-1 items-center justify-center rounded-lg border border-dashed shadow-sm" x-chunk="dashboard-02-chunk-1"
           >
             <div className="flex flex-col items-center gap-1 text-center">
               <h3 className="text-2xl font-bold tracking-tight">

--- a/apps/www/__registry__/new-york/block/dashboard-03.tsx
+++ b/apps/www/__registry__/new-york/block/dashboard-03.tsx
@@ -302,8 +302,7 @@ export default function Dashboard() {
         </header>
         <main className="grid flex-1 gap-4 overflow-auto p-4 md:grid-cols-2 lg:grid-cols-3">
           <div
-            className="relative hidden flex-col items-start gap-8 md:flex"
-            x-chunk="dashboard-03-chunk-0"
+            className="relative hidden flex-col items-start gap-8 md:flex" x-chunk="dashboard-03-chunk-0"
           >
             <form className="grid w-full items-start gap-6">
               <fieldset className="grid gap-6 rounded-lg border p-4">
@@ -420,8 +419,7 @@ export default function Dashboard() {
             </Badge>
             <div className="flex-1" />
             <form
-              className="relative overflow-hidden rounded-lg border bg-background focus-within:ring-1 focus-within:ring-ring"
-              x-chunk="dashboard-03-chunk-1"
+              className="relative overflow-hidden rounded-lg border bg-background focus-within:ring-1 focus-within:ring-ring" x-chunk="dashboard-03-chunk-1"
             >
               <Label htmlFor="message" className="sr-only">
                 Message

--- a/apps/www/__registry__/new-york/block/dashboard-04.tsx
+++ b/apps/www/__registry__/new-york/block/dashboard-04.tsx
@@ -157,8 +157,7 @@ export default function Dashboard() {
         </div>
         <div className="mx-auto grid w-full max-w-6xl items-start gap-6 md:grid-cols-[180px_1fr] lg:grid-cols-[250px_1fr]">
           <nav
-            className="grid gap-4 text-sm text-muted-foreground"
-            x-chunk="dashboard-04-chunk-0"
+            className="grid gap-4 text-sm text-muted-foreground" x-chunk="dashboard-04-chunk-0"
           >
             <Link href="#" className="font-semibold text-primary">
               General

--- a/apps/www/__registry__/new-york/block/dashboard-05.tsx
+++ b/apps/www/__registry__/new-york/block/dashboard-05.tsx
@@ -284,7 +284,9 @@ export default function Dashboard() {
         <main className="grid flex-1 items-start gap-4 p-4 sm:px-6 sm:py-0 md:gap-8 lg:grid-cols-3 xl:grid-cols-3">
           <div className="grid auto-rows-max items-start gap-4 md:gap-8 lg:col-span-2">
             <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-2 xl:grid-cols-4">
-              <Card className="sm:col-span-2" x-chunk="dashboard-05-chunk-0">
+              <Card
+                className="sm:col-span-2" x-chunk="dashboard-05-chunk-0"
+              >
                 <CardHeader className="pb-3">
                   <CardTitle>Your Orders</CardTitle>
                   <CardDescription className="max-w-lg text-balance leading-relaxed">
@@ -562,7 +564,9 @@ export default function Dashboard() {
             </Tabs>
           </div>
           <div>
-            <Card className="overflow-hidden" x-chunk="dashboard-05-chunk-4">
+            <Card
+              className="overflow-hidden" x-chunk="dashboard-05-chunk-4"
+            >
               <CardHeader className="flex flex-row items-start bg-muted/50">
                 <div className="grid gap-0.5">
                   <CardTitle className="group flex items-center gap-2 text-lg">

--- a/apps/www/__registry__/new-york/block/dashboard-06.tsx
+++ b/apps/www/__registry__/new-york/block/dashboard-06.tsx
@@ -216,7 +216,7 @@ export default function Dashboard() {
               </nav>
             </SheetContent>
           </Sheet>
-          <Breadcrumb className="hidden md:flex" x-chunk="dashboard-06-chunk-0">
+          <Breadcrumb className="hidden md:flex">
             <BreadcrumbList>
               <BreadcrumbItem>
                 <BreadcrumbLink asChild>
@@ -317,7 +317,7 @@ export default function Dashboard() {
               </div>
             </div>
             <TabsContent value="all">
-              <Card x-chunk="dashboard-06-chunk-1">
+              <Card x-chunk="dashboard-06-chunk-0">
                 <CardHeader>
                   <CardTitle>Products</CardTitle>
                   <CardDescription>

--- a/apps/www/__registry__/new-york/block/dashboard-07.tsx
+++ b/apps/www/__registry__/new-york/block/dashboard-07.tsx
@@ -535,8 +535,7 @@ export default function Dashboard() {
                   </CardContent>
                 </Card>
                 <Card
-                  className="overflow-hidden"
-                  x-chunk="dashboard-07-chunk-4"
+                  className="overflow-hidden" x-chunk="dashboard-07-chunk-4"
                 >
                   <CardHeader>
                     <CardTitle>Product Images</CardTitle>

--- a/apps/www/content/docs/components/input-otp.mdx
+++ b/apps/www/content/docs/components/input-otp.mdx
@@ -156,6 +156,32 @@ import { REGEXP_ONLY_DIGITS_AND_CHARS } from "input-otp"
 </InputOTP>
 ```
 
+### Input Mode
+
+Use the `inputMode` prop to change virtual keyboard layout on mobile devices. The default value is `numeric`. Possible values are `numeric`, `tel`, `text`, `email`, `url`, `search`, `password`.
+
+<ComponentPreview
+  name="input-otp-input-mode"
+  description="An input OTP with input mode as text."
+/>
+
+```tsx showLineNumbers {8}
+import { REGEXP_ONLY_DIGITS_AND_CHARS } from "input-otp"
+
+...
+
+<InputOTP
+  maxLength={6}
+  pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+  inputMode="text"
+>
+  <InputOTPGroup>
+    <InputOTPSlot index={0} />
+    {/* ... */}
+  </InputOTPGroup>
+</InputOTP>
+```
+
 ### Separator
 
 You can use the `<InputOTPSeparator />` component to add a separator between the input groups.

--- a/apps/www/registry/default/example/input-otp-input-mode.tsx
+++ b/apps/www/registry/default/example/input-otp-input-mode.tsx
@@ -1,0 +1,26 @@
+import { REGEXP_ONLY_DIGITS_AND_CHARS } from "input-otp"
+
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+} from "@/registry/default/ui/input-otp"
+
+export default function InputOTPInputMode() {
+  return (
+    <InputOTP
+      maxLength={6}
+      pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+      inputMode="text"
+    >
+      <InputOTPGroup>
+        <InputOTPSlot index={0} />
+        <InputOTPSlot index={1} />
+        <InputOTPSlot index={2} />
+        <InputOTPSlot index={3} />
+        <InputOTPSlot index={4} />
+        <InputOTPSlot index={5} />
+      </InputOTPGroup>
+    </InputOTP>
+  )
+}

--- a/apps/www/registry/examples.ts
+++ b/apps/www/registry/examples.ts
@@ -438,6 +438,12 @@ export const examples: Registry = [
     files: ["example/input-otp-pattern.tsx"],
   },
   {
+    name: "input-otp-input-mode",
+    type: "components:example",
+    registryDependencies: ["input-otp"],
+    files: ["example/input-otp-input-mode.tsx"],
+  },
+  {
     name: "input-otp-separator",
     type: "components:example",
     registryDependencies: ["input-otp"],

--- a/apps/www/registry/new-york/block/dashboard-06-chunk-0.tsx
+++ b/apps/www/registry/new-york/block/dashboard-06-chunk-0.tsx
@@ -1,34 +1,287 @@
-import Link from "next/link"
+import Image from "next/image"
+import { MoreHorizontal } from "lucide-react"
 
+import { Badge } from "@/registry/new-york/ui/badge"
+import { Button } from "@/registry/new-york/ui/button"
 import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/registry/new-york/ui/breadcrumb"
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/registry/new-york/ui/card"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/registry/new-york/ui/dropdown-menu"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/registry/new-york/ui/table"
 
 export default function Component() {
   return (
-    <Breadcrumb className="hidden md:flex" x-chunk="dashboard-06-chunk-0">
-      <BreadcrumbList>
-        <BreadcrumbItem>
-          <BreadcrumbLink asChild>
-            <Link href="#">Dashboard</Link>
-          </BreadcrumbLink>
-        </BreadcrumbItem>
-        <BreadcrumbSeparator />
-        <BreadcrumbItem>
-          <BreadcrumbLink asChild>
-            <Link href="#">Products</Link>
-          </BreadcrumbLink>
-        </BreadcrumbItem>
-        <BreadcrumbSeparator />
-        <BreadcrumbItem>
-          <BreadcrumbPage>All Products</BreadcrumbPage>
-        </BreadcrumbItem>
-      </BreadcrumbList>
-    </Breadcrumb>
+    <Card x-chunk="dashboard-06-chunk-0">
+      <CardHeader>
+        <CardTitle>Products</CardTitle>
+        <CardDescription>
+          Manage your products and view their sales performance.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="hidden w-[100px] sm:table-cell">
+                <span className="sr-only">Image</span>
+              </TableHead>
+              <TableHead>Name</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Price</TableHead>
+              <TableHead className="hidden md:table-cell">
+                Total Sales
+              </TableHead>
+              <TableHead className="hidden md:table-cell">Created at</TableHead>
+              <TableHead>
+                <span className="sr-only">Actions</span>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow>
+              <TableCell className="hidden sm:table-cell">
+                <Image
+                  alt="Product image"
+                  className="aspect-square rounded-md object-cover"
+                  height="64"
+                  src="/placeholder.svg"
+                  width="64"
+                />
+              </TableCell>
+              <TableCell className="font-medium">
+                Laser Lemonade Machine
+              </TableCell>
+              <TableCell>
+                <Badge variant="outline">Draft</Badge>
+              </TableCell>
+              <TableCell>$499.99</TableCell>
+              <TableCell className="hidden md:table-cell">25</TableCell>
+              <TableCell className="hidden md:table-cell">
+                2023-07-12 10:42 AM
+              </TableCell>
+              <TableCell>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button aria-haspopup="true" size="icon" variant="ghost">
+                      <MoreHorizontal className="h-4 w-4" />
+                      <span className="sr-only">Toggle menu</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                    <DropdownMenuItem>Edit</DropdownMenuItem>
+                    <DropdownMenuItem>Delete</DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="hidden sm:table-cell">
+                <Image
+                  alt="Product image"
+                  className="aspect-square rounded-md object-cover"
+                  height="64"
+                  src="/placeholder.svg"
+                  width="64"
+                />
+              </TableCell>
+              <TableCell className="font-medium">
+                Hypernova Headphones
+              </TableCell>
+              <TableCell>
+                <Badge variant="outline">Active</Badge>
+              </TableCell>
+              <TableCell>$129.99</TableCell>
+              <TableCell className="hidden md:table-cell">100</TableCell>
+              <TableCell className="hidden md:table-cell">
+                2023-10-18 03:21 PM
+              </TableCell>
+              <TableCell>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button aria-haspopup="true" size="icon" variant="ghost">
+                      <MoreHorizontal className="h-4 w-4" />
+                      <span className="sr-only">Toggle menu</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                    <DropdownMenuItem>Edit</DropdownMenuItem>
+                    <DropdownMenuItem>Delete</DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="hidden sm:table-cell">
+                <Image
+                  alt="Product image"
+                  className="aspect-square rounded-md object-cover"
+                  height="64"
+                  src="/placeholder.svg"
+                  width="64"
+                />
+              </TableCell>
+              <TableCell className="font-medium">AeroGlow Desk Lamp</TableCell>
+              <TableCell>
+                <Badge variant="outline">Active</Badge>
+              </TableCell>
+              <TableCell>$39.99</TableCell>
+              <TableCell className="hidden md:table-cell">50</TableCell>
+              <TableCell className="hidden md:table-cell">
+                2023-11-29 08:15 AM
+              </TableCell>
+              <TableCell>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button aria-haspopup="true" size="icon" variant="ghost">
+                      <MoreHorizontal className="h-4 w-4" />
+                      <span className="sr-only">Toggle menu</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                    <DropdownMenuItem>Edit</DropdownMenuItem>
+                    <DropdownMenuItem>Delete</DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="hidden sm:table-cell">
+                <Image
+                  alt="Product image"
+                  className="aspect-square rounded-md object-cover"
+                  height="64"
+                  src="/placeholder.svg"
+                  width="64"
+                />
+              </TableCell>
+              <TableCell className="font-medium">
+                TechTonic Energy Drink
+              </TableCell>
+              <TableCell>
+                <Badge variant="secondary">Draft</Badge>
+              </TableCell>
+              <TableCell>$2.99</TableCell>
+              <TableCell className="hidden md:table-cell">0</TableCell>
+              <TableCell className="hidden md:table-cell">
+                2023-12-25 11:59 PM
+              </TableCell>
+              <TableCell>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button aria-haspopup="true" size="icon" variant="ghost">
+                      <MoreHorizontal className="h-4 w-4" />
+                      <span className="sr-only">Toggle menu</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                    <DropdownMenuItem>Edit</DropdownMenuItem>
+                    <DropdownMenuItem>Delete</DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="hidden sm:table-cell">
+                <Image
+                  alt="Product image"
+                  className="aspect-square rounded-md object-cover"
+                  height="64"
+                  src="/placeholder.svg"
+                  width="64"
+                />
+              </TableCell>
+              <TableCell className="font-medium">
+                Gamer Gear Pro Controller
+              </TableCell>
+              <TableCell>
+                <Badge variant="outline">Active</Badge>
+              </TableCell>
+              <TableCell>$59.99</TableCell>
+              <TableCell className="hidden md:table-cell">75</TableCell>
+              <TableCell className="hidden md:table-cell">
+                2024-01-01 12:00 AM
+              </TableCell>
+              <TableCell>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button aria-haspopup="true" size="icon" variant="ghost">
+                      <MoreHorizontal className="h-4 w-4" />
+                      <span className="sr-only">Toggle menu</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                    <DropdownMenuItem>Edit</DropdownMenuItem>
+                    <DropdownMenuItem>Delete</DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="hidden sm:table-cell">
+                <Image
+                  alt="Product image"
+                  className="aspect-square rounded-md object-cover"
+                  height="64"
+                  src="/placeholder.svg"
+                  width="64"
+                />
+              </TableCell>
+              <TableCell className="font-medium">Luminous VR Headset</TableCell>
+              <TableCell>
+                <Badge variant="outline">Active</Badge>
+              </TableCell>
+              <TableCell>$199.99</TableCell>
+              <TableCell className="hidden md:table-cell">30</TableCell>
+              <TableCell className="hidden md:table-cell">
+                2024-02-14 02:14 PM
+              </TableCell>
+              <TableCell>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button aria-haspopup="true" size="icon" variant="ghost">
+                      <MoreHorizontal className="h-4 w-4" />
+                      <span className="sr-only">Toggle menu</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                    <DropdownMenuItem>Edit</DropdownMenuItem>
+                    <DropdownMenuItem>Delete</DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </CardContent>
+      <CardFooter>
+        <div className="text-xs text-muted-foreground">
+          Showing <strong>1-10</strong> of <strong>32</strong> products
+        </div>
+      </CardFooter>
+    </Card>
   )
 }

--- a/apps/www/registry/new-york/example/input-otp-input-mode.tsx
+++ b/apps/www/registry/new-york/example/input-otp-input-mode.tsx
@@ -1,0 +1,26 @@
+import { REGEXP_ONLY_DIGITS_AND_CHARS } from "input-otp"
+
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+} from "@/registry/new-york/ui/input-otp"
+
+export default function InputOTPInputMode() {
+  return (
+    <InputOTP
+      maxLength={6}
+      pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+      inputMode="text"
+    >
+      <InputOTPGroup>
+        <InputOTPSlot index={0} />
+        <InputOTPSlot index={1} />
+        <InputOTPSlot index={2} />
+        <InputOTPSlot index={3} />
+        <InputOTPSlot index={4} />
+        <InputOTPSlot index={5} />
+      </InputOTPGroup>
+    </InputOTP>
+  )
+}


### PR DESCRIPTION
Resolves #3941.

adds documentation for `inputMode` prop to the `InputOTP` component. The wording is taken over from API reference of https://github.com/guilhermerodz/input-otp dependency.

Changes to dashboard blocks were autogenerated by the build-registry script.

@shadcn Please review if you have time. This is my first ever open source contribution, and I intend to make more of them in this project. Kindly excuse if there's any issues. 

Cheers,
Shreyans :)