### PR TITLE
fix(use-toast): a switch clause should only have a single statement for `remove_toast`

### DIFF
--- a/apps/www/registry/default/ui/use-toast.ts
+++ b/apps/www/registry/default/ui/use-toast.ts
@@ -116,15 +116,11 @@ export const reducer = (state: State, action: Action): State => {
       }
     }
     case "REMOVE_TOAST":
-      if (action.toastId === undefined) {
-        return {
-          ...state,
-          toasts: [],
-        }
-      }
       return {
         ...state,
-        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+        toasts: action.toastId
+          ? state.toasts.filter((t) => t.id !== action.toastId)
+          : [],
       }
   }
 }

--- a/apps/www/registry/new-york/ui/use-toast.ts
+++ b/apps/www/registry/new-york/ui/use-toast.ts
@@ -116,15 +116,11 @@ export const reducer = (state: State, action: Action): State => {
       }
     }
     case "REMOVE_TOAST":
-      if (action.toastId === undefined) {
-        return {
-          ...state,
-          toasts: [],
-        }
-      }
       return {
         ...state,
-        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+        toasts: action.toastId
+          ? state.toasts.filter((t) => t.id !== action.toastId)
+          : [],
       }
   }
 }


### PR DESCRIPTION
Hello, I'm proposing a PR which advocates that each switch clause should be limited to a single statement for cleaner and more optimized code. 
