### PR TITLE
docs(astro): fix naming of global.css

### DIFF
--- a/apps/www/content/docs/installation/astro.mdx
+++ b/apps/www/content/docs/installation/astro.mdx
@@ -95,7 +95,7 @@ You will be asked a few questions to configure `components.json`:
 Would you like to use TypeScript (recommended)? no / yes
 Which style would you like to use? › Default
 Which color would you like to use as base color? › Slate
-Where is your global CSS file? › › ./src/styles/globals.css
+Where is your global CSS file? › › ./src/styles/global.css
 Do you want to use CSS variables for colors? › no / yes
 Where is your tailwind.config.js located? › tailwind.config.mjs
 Configure the import alias for components: › @/components
@@ -103,19 +103,19 @@ Configure the import alias for utils: › @/lib/utils
 Are you using React Server Components? › no
 ```
 
-### Import the globals.css file
+### Import the global.css file
 
-Import the `globals.css` file in the `src/pages/index.astro` file:
+Import the `global.css` file in the `src/pages/index.astro` file:
 
 ```ts {2} showLineNumbers
 ---
-import '@/styles/globals.css'
+import '@/styles/global.css'
 ---
 ```
 
 ### Update astro tailwind config
 
-To prevent serving the Tailwind base styles twice, we need to tell Astro not to apply the base styles, since we already include them in our own `globals.css` file. To do this, set the `applyBaseStyles` config option for the tailwind plugin in `astro.config.mjs` to `false`.
+To prevent serving the Tailwind base styles twice, we need to tell Astro not to apply the base styles, since we already include them in our own `global.css` file. To do this, set the `applyBaseStyles` config option for the tailwind plugin in `astro.config.mjs` to `false`.
 
 ```ts {3-5} showLineNumbers
 export default defineConfig({


### PR DESCRIPTION
I realized there is a naming mistake in the Astro installation guide. The guide refers to the file as `globals.css`, but in all official Astro starters, the file is named `global.css`, which could be misleading.