### PR TITLE
docs: Update TanStack Table link in Data table

### DIFF
--- a/apps/www/content/docs/components/data-table.mdx
+++ b/apps/www/content/docs/components/data-table.mdx
@@ -3,7 +3,7 @@ title: Data Table
 description: Powerful table and datagrids built using TanStack Table.
 component: true
 links:
-  doc: https://tanstack.com/table/v8/docs/guide/introduction
+  doc: https://tanstack.com/table/v8/docs/introduction
 ---
 
 <ComponentPreview name="data-table-demo" />


### PR DESCRIPTION
Fix docs link.

From : https://tanstack.com/table/v8/docs/guide/introduction

To: https://tanstack.com/table/v8/docs/introduction