### PR TITLE
Feat(www): Add tooltip to 'Reset Theme' button for improved user guidance

### DIFF
--- a/apps/www/components/theme-customizer.tsx
+++ b/apps/www/components/theme-customizer.tsx
@@ -148,7 +148,7 @@ export function ThemeCustomizer() {
           </PopoverTrigger>
           <PopoverContent
             align="center"
-            className="z-40 w-[340px] rounded-[0.5rem] bg-white p-6 dark:bg-zinc-950"
+            className="z-40 w-[340px] rounded-[0.5rem] bg-white p-6 dark:bg-zinc-950" 
           >
             <Customizer />
           </PopoverContent>
@@ -170,33 +170,40 @@ function Customizer() {
 
   return (
     <ThemeWrapper
-      defaultTheme="zinc"
-      className="flex flex-col space-y-4 md:space-y-6"
+    defaultTheme="zinc"
+    className="flex flex-col space-y-4 md:space-y-6"
     >
-      <div className="flex items-start pt-4 md:pt-0">
-        <div className="space-y-1 pr-2">
-          <div className="font-semibold leading-none tracking-tight">
-            Customize
-          </div>
-          <div className="text-xs text-muted-foreground">
-            Pick a style and color for your components.
-          </div>
+    <div className="flex items-start pt-4 md:pt-0">
+      <div className="space-y-1 pr-2">
+        <div className="font-semibold leading-none tracking-tight">
+          Customize
         </div>
+        <div className="text-xs text-muted-foreground">
+          Pick a style and color for your components.
+        </div>
+      </div>
+      <Tooltip>
         <Button
-          variant="ghost"
-          size="icon"
-          className="ml-auto rounded-[0.5rem]"
-          onClick={() => {
-            setConfig({
-              ...config,
-              theme: "zinc",
-              radius: 0.5,
-            })
-          }}
-        >
-          <ResetIcon />
-          <span className="sr-only">Reset</span>
+        variant="ghost"
+        size="icon"
+        className="ml-auto rounded-[0.5rem]"
+        onClick={() => {
+          setConfig({
+            ...config,
+            theme: "zinc",
+            radius: 0.5,
+          })
+        }}
+      >
+      <TooltipTrigger> 
+        <ResetIcon />
+            <span className="sr-only">Reset</span>
+        </TooltipTrigger>
+        <TooltipContent align="center" className="rounded-[0.5rem] bg-zinc-900 text-zinc-50">
+          Reset to default
+        </TooltipContent>
         </Button>
+      </Tooltip>
       </div>
       <div className="flex flex-1 flex-col space-y-4 md:space-y-6">
         <div className="space-y-1.5">


### PR DESCRIPTION
Currently, resent button in themes isn't much descriptive to what its there for

![image](https://github.com/shadcn-ui/ui/assets/115284013/703c7dfc-55f6-40ba-b553-17095b1a6b88)

For this adding a tooltip regarding the same might be a good idea.


https://github.com/shadcn-ui/ui/assets/115284013/74fa8243-082b-4f59-9a6b-fb6e2529c327

