### PR TITLE
(fix) - input(inputProps) @typescript-eslint/no-empty-interface

### DIFF
--- a/apps/www/registry/default/ui/input.tsx
+++ b/apps/www/registry/default/ui/input.tsx
@@ -1,9 +1,8 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "~/lib/utils"
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/apps/www/registry/default/ui/input.tsx
+++ b/apps/www/registry/default/ui/input.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "~/lib/utils"
+import { cn } from "@/lib/utils"
 
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
 


### PR DESCRIPTION
Fixes [#4083 ](https://github.com/shadcn-ui/ui/issues/4083)

An interface declaring no members is equivalent to its supertype.eslint@typescript-eslint/no-empty-interface.

The issue in the code is due to the `InputProps` interface extending `React.InputHTMLAttributes<HTMLInputElement> `without adding any new members. This is flagged by the ESLint rule @typescript-eslint/no-empty-interface, which indicates that an interface declaring no members is equivalent to its supertype. 

By changing the InputProps interface to a type alias:
`export type InputProps = React.InputHTMLAttribute <HTMLInputElement>`

By using a type alias instead of an interface, the code directly assigns InputProps to `React.InputHTMLAttributes<HTMLInputElement>` and avoids the ESLint warning about empty interfaces, as the type alias does not have the same issue.