### PR TITLE
fix(cli): fix tailwind merge not working on custom tailwind prefix

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -372,7 +372,9 @@ export async function runInit(cwd: string, config: Config) {
   // Write cn file.
   await fs.writeFile(
     `${config.resolvedPaths.utils}.${extension}`,
-    extension === "ts" ? templates.UTILS : templates.UTILS_JS,
+    template(extension === "ts" ? templates.UTILS : templates.UTILS_JS)({
+      prefix: config.tailwind.prefix,
+    }),
     "utf8"
   )
 

--- a/packages/cli/src/utils/templates.ts
+++ b/packages/cli/src/utils/templates.ts
@@ -1,5 +1,6 @@
 export const UTILS = `import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { extendTailwindMerge } from "tailwind-merge"
+const twMerge = extendTailwindMerge({ prefix: "<%- prefix %>" })
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -7,7 +8,8 @@ export function cn(...inputs: ClassValue[]) {
 `
 
 export const UTILS_JS = `import { clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { extendTailwindMerge } from "tailwind-merge"
+const twMerge = extendTailwindMerge({ prefix: "<%- prefix %>" })
 
 export function cn(...inputs) {
   return twMerge(clsx(inputs))


### PR DESCRIPTION
The custom tailwind prefix support is introduced in pull #770, which works mostly as intended. However, the default template for tailwind-merge util doesn't respect the prefix setting (mentioned [here](https://github.com/shadcn-ui/ui/pull/770#issuecomment-1736465848)), which breaks the merging in prefixed tailwind classes. This PR fixes this problem during initial setup.