### PR TITLE
add useMediaQuery code to Responsive drawer Component Doc

### DIFF
--- a/apps/www/content/docs/components/drawer.mdx
+++ b/apps/www/content/docs/components/drawer.mdx
@@ -90,3 +90,27 @@ import {
 You can combine the `Dialog` and `Drawer` components to create a responsive dialog. This renders a `Dialog` component on desktop and a `Drawer` on mobile.
 
 <ComponentPreview name="drawer-dialog" />
+
+#### useMediaQuery
+Create this file in your @/hooks/use-media-query.tsx
+```tsx showLineNumbers
+import * as React from "react"
+
+export function useMediaQuery(query: string) {
+  const [value, setValue] = React.useState(false)
+
+  React.useEffect(() => {
+    function onChange(event: MediaQueryListEvent) {
+      setValue(event.matches)
+    }
+
+    const result = matchMedia(query)
+    result.addEventListener("change", onChange)
+    setValue(result.matches)
+
+    return () => result.removeEventListener("change", onChange)
+  }, [query])
+
+  return value
+}
+```


### PR DESCRIPTION
this pull request shows the code for useMediaQuery, it is quite important that it should be right next to where it is used so people do not have to look for it or just have errors while trying to Responsive drawers