### PR TITLE
fix(www): Fixed landing page crash (ui.shadcn.com) due to Select/Dropdown/Combobox examples

### DIFF
--- a/apps/www/__registry__/default/example/combobox-form.tsx
+++ b/apps/www/__registry__/default/example/combobox-form.tsx
@@ -13,6 +13,7 @@ import {
   CommandGroup,
   CommandInput,
   CommandItem,
+  CommandList
 } from "@/registry/default/ui/command"
 import {
   Form,
@@ -86,8 +87,8 @@ export default function ComboboxForm() {
                     >
                       {field.value
                         ? languages.find(
-                            (language) => language.value === field.value
-                          )?.label
+                          (language) => language.value === field.value
+                        )?.label
                         : "Select language"}
                       <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                     </Button>
@@ -97,27 +98,29 @@ export default function ComboboxForm() {
                   <Command>
                     <CommandInput placeholder="Search language..." />
                     <CommandEmpty>No language found.</CommandEmpty>
-                    <CommandGroup>
-                      {languages.map((language) => (
-                        <CommandItem
-                          value={language.label}
-                          key={language.value}
-                          onSelect={() => {
-                            form.setValue("language", language.value)
-                          }}
-                        >
-                          <Check
-                            className={cn(
-                              "mr-2 h-4 w-4",
-                              language.value === field.value
-                                ? "opacity-100"
-                                : "opacity-0"
-                            )}
-                          />
-                          {language.label}
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
+                    <CommandList>
+                      <CommandGroup>
+                        {languages.map((language) => (
+                          <CommandItem
+                            value={language.label}
+                            key={language.value}
+                            onSelect={() => {
+                              form.setValue("language", language.value)
+                            }}
+                          >
+                            <Check
+                              className={cn(
+                                "mr-2 h-4 w-4",
+                                language.value === field.value
+                                  ? "opacity-100"
+                                  : "opacity-0"
+                              )}
+                            />
+                            {language.label}
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
                   </Command>
                 </PopoverContent>
               </Popover>

--- a/apps/www/__registry__/default/example/combobox-form.tsx
+++ b/apps/www/__registry__/default/example/combobox-form.tsx
@@ -97,8 +97,8 @@ export default function ComboboxForm() {
                 <PopoverContent className="w-[200px] p-0">
                   <Command>
                     <CommandInput placeholder="Search language..." />
-                    <CommandEmpty>No language found.</CommandEmpty>
                     <CommandList>
+                      <CommandEmpty>No language found.</CommandEmpty>
                       <CommandGroup>
                         {languages.map((language) => (
                           <CommandItem

--- a/apps/www/app/(app)/examples/forms/account/account-form.tsx
+++ b/apps/www/app/(app)/examples/forms/account/account-form.tsx
@@ -181,8 +181,8 @@ export function AccountForm() {
                 <PopoverContent className="w-[200px] p-0">
                   <Command>
                     <CommandInput placeholder="Search language..." />
-                    <CommandEmpty>No language found.</CommandEmpty>
                     <CommandList>
+                      <CommandEmpty>No language found.</CommandEmpty>
                       <CommandGroup>
                         {languages.map((language) => (
                           <CommandItem

--- a/apps/www/app/(app)/examples/forms/account/account-form.tsx
+++ b/apps/www/app/(app)/examples/forms/account/account-form.tsx
@@ -15,6 +15,7 @@ import {
   CommandGroup,
   CommandInput,
   CommandItem,
+  CommandList
 } from "@/registry/new-york/ui/command"
 import {
   Form,
@@ -170,8 +171,8 @@ export function AccountForm() {
                     >
                       {field.value
                         ? languages.find(
-                            (language) => language.value === field.value
-                          )?.label
+                          (language) => language.value === field.value
+                        )?.label
                         : "Select language"}
                       <CaretSortIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                     </Button>
@@ -181,27 +182,29 @@ export function AccountForm() {
                   <Command>
                     <CommandInput placeholder="Search language..." />
                     <CommandEmpty>No language found.</CommandEmpty>
-                    <CommandGroup>
-                      {languages.map((language) => (
-                        <CommandItem
-                          value={language.label}
-                          key={language.value}
-                          onSelect={() => {
-                            form.setValue("language", language.value)
-                          }}
-                        >
-                          <CheckIcon
-                            className={cn(
-                              "mr-2 h-4 w-4",
-                              language.value === field.value
-                                ? "opacity-100"
-                                : "opacity-0"
-                            )}
-                          />
-                          {language.label}
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
+                    <CommandList>
+                      <CommandGroup>
+                        {languages.map((language) => (
+                          <CommandItem
+                            value={language.label}
+                            key={language.value}
+                            onSelect={() => {
+                              form.setValue("language", language.value)
+                            }}
+                          >
+                            <CheckIcon
+                              className={cn(
+                                "mr-2 h-4 w-4",
+                                language.value === field.value
+                                  ? "opacity-100"
+                                  : "opacity-0"
+                              )}
+                            />
+                            {language.label}
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
                   </Command>
                 </PopoverContent>
               </Popover>

--- a/apps/www/app/(app)/examples/playground/components/preset-selector.tsx
+++ b/apps/www/app/(app)/examples/playground/components/preset-selector.tsx
@@ -49,8 +49,8 @@ export function PresetSelector({ presets, ...props }: PresetSelectorProps) {
       <PopoverContent className="w-[300px] p-0">
         <Command>
           <CommandInput placeholder="Search presets..." />
-          <CommandEmpty>No presets found.</CommandEmpty>
           <CommandList>
+            <CommandEmpty>No presets found.</CommandEmpty>
             <CommandGroup heading="Examples">
               {presets.map((preset) => (
                 <CommandItem

--- a/apps/www/app/(app)/examples/playground/components/preset-selector.tsx
+++ b/apps/www/app/(app)/examples/playground/components/preset-selector.tsx
@@ -13,6 +13,7 @@ import {
   CommandGroup,
   CommandInput,
   CommandItem,
+  CommandList
 } from "@/registry/new-york/ui/command"
 import {
   Popover,
@@ -49,27 +50,29 @@ export function PresetSelector({ presets, ...props }: PresetSelectorProps) {
         <Command>
           <CommandInput placeholder="Search presets..." />
           <CommandEmpty>No presets found.</CommandEmpty>
-          <CommandGroup heading="Examples">
-            {presets.map((preset) => (
-              <CommandItem
-                key={preset.id}
-                onSelect={() => {
-                  setSelectedPreset(preset)
-                  setOpen(false)
-                }}
-              >
-                {preset.name}
-                <CheckIcon
-                  className={cn(
-                    "ml-auto h-4 w-4",
-                    selectedPreset?.id === preset.id
-                      ? "opacity-100"
-                      : "opacity-0"
-                  )}
-                />
-              </CommandItem>
-            ))}
-          </CommandGroup>
+          <CommandList>
+            <CommandGroup heading="Examples">
+              {presets.map((preset) => (
+                <CommandItem
+                  key={preset.id}
+                  onSelect={() => {
+                    setSelectedPreset(preset)
+                    setOpen(false)
+                  }}
+                >
+                  {preset.name}
+                  <CheckIcon
+                    className={cn(
+                      "ml-auto h-4 w-4",
+                      selectedPreset?.id === preset.id
+                        ? "opacity-100"
+                        : "opacity-0"
+                    )}
+                  />
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
           <CommandGroup className="pt-0">
             <CommandItem onSelect={() => router.push("/examples")}>
               More examples

--- a/apps/www/registry/default/example/combobox-form.tsx
+++ b/apps/www/registry/default/example/combobox-form.tsx
@@ -13,6 +13,7 @@ import {
   CommandGroup,
   CommandInput,
   CommandItem,
+  CommandList
 } from "@/registry/default/ui/command"
 import {
   Form,
@@ -86,8 +87,8 @@ export default function ComboboxForm() {
                     >
                       {field.value
                         ? languages.find(
-                            (language) => language.value === field.value
-                          )?.label
+                          (language) => language.value === field.value
+                        )?.label
                         : "Select language"}
                       <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                     </Button>
@@ -97,27 +98,29 @@ export default function ComboboxForm() {
                   <Command>
                     <CommandInput placeholder="Search language..." />
                     <CommandEmpty>No language found.</CommandEmpty>
-                    <CommandGroup>
-                      {languages.map((language) => (
-                        <CommandItem
-                          value={language.label}
-                          key={language.value}
-                          onSelect={() => {
-                            form.setValue("language", language.value)
-                          }}
-                        >
-                          <Check
-                            className={cn(
-                              "mr-2 h-4 w-4",
-                              language.value === field.value
-                                ? "opacity-100"
-                                : "opacity-0"
-                            )}
-                          />
-                          {language.label}
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
+                    <CommandList>
+                      <CommandGroup>
+                        {languages.map((language) => (
+                          <CommandItem
+                            value={language.label}
+                            key={language.value}
+                            onSelect={() => {
+                              form.setValue("language", language.value)
+                            }}
+                          >
+                            <Check
+                              className={cn(
+                                "mr-2 h-4 w-4",
+                                language.value === field.value
+                                  ? "opacity-100"
+                                  : "opacity-0"
+                              )}
+                            />
+                            {language.label}
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
                   </Command>
                 </PopoverContent>
               </Popover>

--- a/apps/www/registry/default/example/combobox-form.tsx
+++ b/apps/www/registry/default/example/combobox-form.tsx
@@ -97,8 +97,8 @@ export default function ComboboxForm() {
                 <PopoverContent className="w-[200px] p-0">
                   <Command>
                     <CommandInput placeholder="Search language..." />
-                    <CommandEmpty>No language found.</CommandEmpty>
                     <CommandList>
+                      <CommandEmpty>No language found.</CommandEmpty>
                       <CommandGroup>
                         {languages.map((language) => (
                           <CommandItem

--- a/apps/www/registry/new-york/example/combobox-form.tsx
+++ b/apps/www/registry/new-york/example/combobox-form.tsx
@@ -100,8 +100,8 @@ export default function ComboboxForm() {
                       placeholder="Search framework..."
                       className="h-9"
                     />
-                    <CommandEmpty>No framework found.</CommandEmpty>
                     <CommandList>
+                      <CommandEmpty>No framework found.</CommandEmpty>
                       <CommandGroup>
                         {languages.map((language) => (
                           <CommandItem

--- a/apps/www/registry/new-york/example/combobox-form.tsx
+++ b/apps/www/registry/new-york/example/combobox-form.tsx
@@ -13,6 +13,7 @@ import {
   CommandGroup,
   CommandInput,
   CommandItem,
+  CommandList
 } from "@/registry/new-york/ui/command"
 import {
   Form,
@@ -86,8 +87,8 @@ export default function ComboboxForm() {
                     >
                       {field.value
                         ? languages.find(
-                            (language) => language.value === field.value
-                          )?.label
+                          (language) => language.value === field.value
+                        )?.label
                         : "Select language"}
                       <CaretSortIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                     </Button>
@@ -100,27 +101,29 @@ export default function ComboboxForm() {
                       className="h-9"
                     />
                     <CommandEmpty>No framework found.</CommandEmpty>
-                    <CommandGroup>
-                      {languages.map((language) => (
-                        <CommandItem
-                          value={language.label}
-                          key={language.value}
-                          onSelect={() => {
-                            form.setValue("language", language.value)
-                          }}
-                        >
-                          {language.label}
-                          <CheckIcon
-                            className={cn(
-                              "ml-auto h-4 w-4",
-                              language.value === field.value
-                                ? "opacity-100"
-                                : "opacity-0"
-                            )}
-                          />
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
+                    <CommandList>
+                      <CommandGroup>
+                        {languages.map((language) => (
+                          <CommandItem
+                            value={language.label}
+                            key={language.value}
+                            onSelect={() => {
+                              form.setValue("language", language.value)
+                            }}
+                          >
+                            {language.label}
+                            <CheckIcon
+                              className={cn(
+                                "ml-auto h-4 w-4",
+                                language.value === field.value
+                                  ? "opacity-100"
+                                  : "opacity-0"
+                              )}
+                            />
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
                   </Command>
                 </PopoverContent>
               </Popover>


### PR DESCRIPTION
### Changes:

This PR resolves issues: 
1. https://github.com/shadcn-ui/ui/issues/4096
2. https://github.com/shadcn-ui/ui/issues/4102 for both default and new york
3. https://github.com/shadcn-ui/ui/issues/4106 for both default and new york

All Test cases passed.

### Screenshot:

In account:

<img width="1512" alt="image" src="https://github.com/shadcn-ui/ui/assets/94426452/6a31b743-1e8c-4c73-afa3-cf956367273c">

In components (default and new york):

<img width="1512" alt="image" src="https://github.com/shadcn-ui/ui/assets/94426452/645b259c-f15e-40dd-a783-06a9c8c24209">

In Playground, Preset selector has been updated as well #4102 

<img width="1512" alt="image" src="https://github.com/shadcn-ui/ui/assets/94426452/c4c460c9-791a-45c8-8756-2a301e2c245b">

Test cases:

<img width="1181" alt="343621341-a53eed18-b9f3-49ab-9a2d-87f9b928fb73" src="https://github.com/shadcn-ui/ui/assets/94426452/3b3992cb-afe1-4dd6-b1d8-dadc67eb7f1b">





