### PR TITLE
fix(www): fixed checkbox UI when resized

### DIFF
--- a/apps/www/registry/default/ui/checkbox.tsx
+++ b/apps/www/registry/default/ui/checkbox.tsx
@@ -19,7 +19,7 @@ const Checkbox = React.forwardRef<
     {...props}
   >
     <CheckboxPrimitive.Indicator
-      className={cn("flex items-center justify-center text-current")}
+      className={cn("flex items-center justify-center text-current h-full")}
     >
       <Check className="h-4 w-4" />
     </CheckboxPrimitive.Indicator>

--- a/apps/www/registry/new-york/ui/checkbox.tsx
+++ b/apps/www/registry/new-york/ui/checkbox.tsx
@@ -19,7 +19,7 @@ const Checkbox = React.forwardRef<
     {...props}
   >
     <CheckboxPrimitive.Indicator
-      className={cn("flex items-center justify-center text-current")}
+      className={cn("flex items-center justify-center text-current h-full")}
     >
       <CheckIcon className="h-4 w-4" />
     </CheckboxPrimitive.Indicator>


### PR DESCRIPTION
The checkbox inner UI (where the checkmark is) isn't centered under some conditions when the checkbox is resized. Giving the container full height ensures the inner UI is always centered and does not try to exceed its bounds. 