### PR TITLE
fix(cli): --version have to follow packages/cli version

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,19 +4,17 @@ import { diff } from "@/src/commands/diff"
 import { init } from "@/src/commands/init"
 import { Command } from "commander"
 
-import { getPackageInfo } from "./utils/get-package-info"
+import packageJson from "../package.json"
 
 process.on("SIGINT", () => process.exit(0))
 process.on("SIGTERM", () => process.exit(0))
 
 async function main() {
-  const packageInfo = await getPackageInfo()
-
   const program = new Command()
     .name("shadcn-ui")
     .description("add components and dependencies to your project")
     .version(
-      packageInfo.version || "1.0.0",
+      packageJson.version,
       "-v, --version",
       "display the version number"
     )

--- a/packages/cli/src/utils/get-package-info.ts
+++ b/packages/cli/src/utils/get-package-info.ts
@@ -1,9 +1,0 @@
-import path from "path"
-import fs from "fs-extra"
-import { type PackageJson } from "type-fest"
-
-export function getPackageInfo() {
-  const packageJsonPath = path.join("package.json")
-
-  return fs.readJSONSync(packageJsonPath) as PackageJson
-}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,6 +3,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "isolatedModules": false,
+    "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]


### PR DESCRIPTION
# Description
`npx shadcn-ui@latest -v` does not follow ther version

If you run this command `npx shadcn-ui@latest -v`
1.  in an environment without package.json, the following error occurs
<img width="764" alt="image" src="https://github.com/shadcn-ui/ui/assets/70435257/cded4bbe-a7be-4faf-af79-c5e18a8df303">
<br />


2. in an environment with package.json, output the version of package.json where the command was executed 
<img width="533" alt="image" src="https://github.com/shadcn-ui/ui/assets/70435257/a080b584-b1be-431c-9e7c-c935d62deb5c">

# Fix
So I fixed it to follow the package/cli/package.json version