### PR TITLE
Fix incorrect badge variant in dashboard-06 of blocks

### DIFF
--- a/apps/www/__registry__/default/block/dashboard-06.tsx
+++ b/apps/www/__registry__/default/block/dashboard-06.tsx
@@ -362,7 +362,7 @@ export default function Dashboard() {
                           Laser Lemonade Machine
                         </TableCell>
                         <TableCell>
-                          <Badge variant="outline">Draft</Badge>
+                          <Badge variant="secondary">Draft</Badge>
                         </TableCell>
                         <TableCell className="hidden md:table-cell">
                           $499.99

--- a/apps/www/__registry__/new-york/block/dashboard-06.tsx
+++ b/apps/www/__registry__/new-york/block/dashboard-06.tsx
@@ -360,7 +360,7 @@ export default function Dashboard() {
                           Laser Lemonade Machine
                         </TableCell>
                         <TableCell>
-                          <Badge variant="outline">Draft</Badge>
+                          <Badge variant="secondary">Draft</Badge>
                         </TableCell>
                         <TableCell>$499.99</TableCell>
                         <TableCell className="hidden md:table-cell">

--- a/apps/www/registry/default/block/dashboard-06-chunk-0.tsx
+++ b/apps/www/registry/default/block/dashboard-06-chunk-0.tsx
@@ -70,7 +70,7 @@ export default function Component() {
                 Laser Lemonade Machine
               </TableCell>
               <TableCell>
-                <Badge variant="outline">Draft</Badge>
+                <Badge variant="secondary">Draft</Badge>
               </TableCell>
               <TableCell className="hidden md:table-cell">$499.99</TableCell>
               <TableCell className="hidden md:table-cell">25</TableCell>

--- a/apps/www/registry/default/block/dashboard-06.tsx
+++ b/apps/www/registry/default/block/dashboard-06.tsx
@@ -362,7 +362,7 @@ export default function Dashboard() {
                           Laser Lemonade Machine
                         </TableCell>
                         <TableCell>
-                          <Badge variant="outline">Draft</Badge>
+                          <Badge variant="secondary">Draft</Badge>
                         </TableCell>
                         <TableCell className="hidden md:table-cell">
                           $499.99

--- a/apps/www/registry/new-york/block/dashboard-06-chunk-1.tsx
+++ b/apps/www/registry/new-york/block/dashboard-06-chunk-1.tsx
@@ -70,7 +70,7 @@ export default function Component() {
                 Laser Lemonade Machine
               </TableCell>
               <TableCell>
-                <Badge variant="outline">Draft</Badge>
+                <Badge variant="secondary">Draft</Badge>
               </TableCell>
               <TableCell>$499.99</TableCell>
               <TableCell className="hidden md:table-cell">25</TableCell>

--- a/apps/www/registry/new-york/block/dashboard-06.tsx
+++ b/apps/www/registry/new-york/block/dashboard-06.tsx
@@ -360,7 +360,7 @@ export default function Dashboard() {
                           Laser Lemonade Machine
                         </TableCell>
                         <TableCell>
-                          <Badge variant="outline">Draft</Badge>
+                          <Badge variant="secondary">Draft</Badge>
                         </TableCell>
                         <TableCell>$499.99</TableCell>
                         <TableCell className="hidden md:table-cell">


### PR DESCRIPTION
The status style of the first item in the product list is incorrect.

![image](https://github.com/shadcn-ui/ui/assets/47883837/61a14052-1a78-42c3-b417-d26baecfa8f5)

URL: https://ui.shadcn.com/blocks#dashboard-06