### PR TITLE
fix: 'undefined' Error message in FormMessage Component

### DIFF
--- a/apps/www/registry/default/ui/form.tsx
+++ b/apps/www/registry/default/ui/form.tsx
@@ -147,7 +147,7 @@ const FormMessage = React.forwardRef<
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, children, ...props }, ref) => {
   const { error, formMessageId } = useFormField()
-  const body = error ? String(error?.message) : children
+  const body = error ? String(error?.message ?? error?.root?.message) : children
 
   if (!body) {
     return null


### PR DESCRIPTION
I have used the root message, if there is no error message in the error Object.

✅ Closes: #4131 