### PR TITLE
docs: refactor / future-proof Laravel installation instructions

### DIFF
--- a/apps/www/content/docs/installation/laravel.mdx
+++ b/apps/www/content/docs/installation/laravel.mdx
@@ -39,15 +39,14 @@ Are you using React Server Components? › no / yes
 
 ### Update tailwind.config.js
 
-The `shadcn-ui` CLI will automatically overwrite your `tailwind.config.js`. Update it to look like this:
+The `shadcn-ui` CLI will automatically overwrite your `tailwind.config.js`. Ensure that you restore the Laravel-specific properties:
 
 ```js
-import forms from "@tailwindcss/forms"
-import defaultTheme from "tailwindcss/defaultTheme"
+import defaultTheme from "tailwindcss/defaultTheme";
+import forms from "@tailwindcss/forms";
 
 /** @type {import('tailwindcss').Config} */
-export default {
-  darkMode: "class",
+module.exports = {
   content: [
     "./vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php",
     "./storage/framework/views/*.php",
@@ -55,74 +54,23 @@ export default {
     "./resources/js/**/*.tsx",
   ],
 
+  ...
+
   theme: {
-    container: {
-      center: true,
-      padding: "2rem",
-      screens: {
-        "2xl": "1400px",
-      },
-    },
+
+    ...
+
     extend: {
-      colors: {
-        border: "hsl(var(--border))",
-        input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
-        primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
-        },
-        secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
-        },
-        destructive: {
-          DEFAULT: "hsl(var(--destructive))",
-          foreground: "hsl(var(--destructive-foreground))",
-        },
-        muted: {
-          DEFAULT: "hsl(var(--muted))",
-          foreground: "hsl(var(--muted-foreground))",
-        },
-        accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
-        },
-        popover: {
-          DEFAULT: "hsl(var(--popover))",
-          foreground: "hsl(var(--popover-foreground))",
-        },
-        card: {
-          DEFAULT: "hsl(var(--card))",
-          foreground: "hsl(var(--card-foreground))",
-        },
-      },
-      borderRadius: {
-        lg: `var(--radius)`,
-        md: `calc(var(--radius) - 2px)`,
-        sm: "calc(var(--radius) - 4px)",
-      },
+
+      ...
+
       fontFamily: {
         sans: ["Figtree", ...defaultTheme.fontFamily.sans],
       },
-      keyframes: {
-        "accordion-down": {
-          from: { height: 0 },
-          to: { height: "var(--radix-accordion-content-height)" },
-        },
-        "accordion-up": {
-          from: { height: "var(--radix-accordion-content-height)" },
-          to: { height: 0 },
-        },
-      },
-      animation: {
-        "accordion-down": "accordion-down 0.2s ease-out",
-        "accordion-up": "accordion-up 0.2s ease-out",
-      },
-    },
-  },
+    }
+  }
+
+  ...
 
   plugins: [forms, require("tailwindcss-animate")],
 }


### PR DESCRIPTION
I was running through the Laravel installation docs and stumbled on the step to copy / paste the updated Tailwind config file. I noticed that this overwrites specific properties which are added with the shadcn installation (for example, `prefix`.) Most importantly, the config to copy / paste no longer adheres to Tailwind config types, specifically:

```
keyframes: {
        "accordion-down": {
          from: { height: 0 },
          to: { height: "var(--radix-accordion-content-height)" },
        },
```

`height` should now be considered a string.

I figured for future proofing it'd just be easiest to instruct on adding back the Laravel-specific properties to the config file.