### PR TITLE
Fix Demo ComboBox Component Scroll on KeyDown Press

### DIFF
--- a/apps/www/registry/default/example/combobox-demo.tsx
+++ b/apps/www/registry/default/example/combobox-demo.tsx
@@ -45,6 +45,19 @@ const frameworks = [
 export default function ComboboxDemo() {
   const [open, setOpen] = React.useState(false)
   const [value, setValue] = React.useState("")
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+  const handleKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setOpen(true);
+
+      if (buttonRef.current) {
+        buttonRef.current.focus(); 
+      }
+    }
+  }, [buttonRef]); 
+
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -54,6 +67,8 @@ export default function ComboboxDemo() {
           role="combobox"
           aria-expanded={open}
           className="w-[200px] justify-between"
+          onKeyDown={handleKeyDown}
+
         >
           {value
             ? frameworks.find((framework) => framework.value === value)?.label

--- a/apps/www/registry/new-york/example/combobox-demo.tsx
+++ b/apps/www/registry/new-york/example/combobox-demo.tsx
@@ -45,6 +45,19 @@ const frameworks = [
 export default function ComboboxDemo() {
   const [open, setOpen] = React.useState(false)
   const [value, setValue] = React.useState("")
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+
+  const handleKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setOpen(true);
+
+      if (buttonRef.current) {
+        buttonRef.current.focus(); 
+      }
+    }
+  }, [buttonRef]); 
+
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -54,6 +67,7 @@ export default function ComboboxDemo() {
           role="combobox"
           aria-expanded={open}
           className="w-[200px] justify-between"
+          onKeyDown={handleKeyDown}
         >
           {value
             ? frameworks.find((framework) => framework.value === value)?.label


### PR DESCRIPTION
In, https://ui.shadcn.com/docs/components/combobox
While focusing on the Combo Box and pressing key down button, instead of opening the popover menu its making the whole page scroll. I fixed this issue now when we focus on the combo box and press key down, it opens the pop over instead of scrolling the whole page.

https://github.com/shadcn-ui/ui/assets/146798454/386713af-881a-4547-8a63-e001fcc36746

