### PR TITLE
fix: update ButtonAsChild component to use "#as-child" as the href value

### DIFF
--- a/apps/www/registry/default/example/button-as-child.tsx
+++ b/apps/www/registry/default/example/button-as-child.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/registry/default/ui/button"
 export default function ButtonAsChild() {
   return (
     <Button asChild>
-      <Link href="/login">Login</Link>
+      <Link href="#as-child">Login</Link>
     </Button>
   )
 }


### PR DESCRIPTION
Avoid 404 error when clicking as child button component example