### PR TITLE
Initialize FormFieldContext with null for improved type safety

### DIFF
--- a/apps/www/registry/default/ui/form.tsx
+++ b/apps/www/registry/default/ui/form.tsx
@@ -24,9 +24,7 @@ type FormFieldContextValue<
   name: TName
 }
 
-const FormFieldContext = React.createContext<FormFieldContextValue>(
-  {} as FormFieldContextValue
-)
+const FormFieldContext = React.createContext<FormFieldContextValue | null>(null)
 
 const FormField = <
   TFieldValues extends FieldValues = FieldValues,
@@ -46,11 +44,11 @@ const useFormField = () => {
   const itemContext = React.useContext(FormItemContext)
   const { getFieldState, formState } = useFormContext()
 
-  const fieldState = getFieldState(fieldContext.name, formState)
-
   if (!fieldContext) {
     throw new Error("useFormField should be used within <FormField>")
   }
+
+  const fieldState = getFieldState(fieldContext.name, formState)
 
   const { id } = itemContext
 


### PR DESCRIPTION
## Purpose
This PR refactors the `FormFieldContext` to use `null` as its initial value, enhancing type safety and making the component's behavior more predictable.

## Origin of the Change
The need for this refactor was discovered when TypeScript and ESLint raised a warning about a potentially unnecessary null check in the `useFormField` hook:

```typescript
// This check was flagged as potentially unnecessary
if (!fieldContext) {
  throw new Error('useFormField should be used within <FormField>')
}
```

## Changes
- Modified `FormFieldContext` initialization to use `null` instead of an empty object cast to `FormFieldContextValue`.
- Updated `useFormField` hook to handle the potentially null context value.
- Adjusted TypeScript types to reflect the new context structure.

## Potential Impacts
- This change shouldn't affect existing functionality if the `FormField` component is used as intended.
- Improves developer experience by catching potential misuse of the `useFormField` hook earlier.