### PR TITLE
fix: handle potential undefined item in chart.tsx

### DIFF
--- a/apps/www/registry/default/ui/chart.tsx
+++ b/apps/www/registry/default/ui/chart.tsx
@@ -137,7 +137,7 @@ const ChartTooltipContent = React.forwardRef<
       }
 
       const [item] = payload
-      const key = `${labelKey || item.dataKey || item.name || "value"}`
+      const key = `${labelKey || item?.dataKey || item?.name || "value"}`
       const itemConfig = getPayloadConfigFromPayload(config, item, key)
       const value =
         !labelKey && typeof label === "string"

--- a/apps/www/registry/new-york/ui/chart.tsx
+++ b/apps/www/registry/new-york/ui/chart.tsx
@@ -137,7 +137,7 @@ const ChartTooltipContent = React.forwardRef<
       }
 
       const [item] = payload
-      const key = `${labelKey || item.dataKey || item.name || "value"}`
+      const key = `${labelKey || item?.dataKey || item?.name || "value"}`
       const itemConfig = getPayloadConfigFromPayload(config, item, key)
       const value =
         !labelKey && typeof label === "string"


### PR DESCRIPTION
Add optional chaining to avoid TypeScript error when `item` is undefined in the key generation in `Chart` component.

Closes #4218 