### PR TITLE
docs: misspelled "ChartTooltip"

### DIFF
--- a/apps/www/content/docs/components/chart.mdx
+++ b/apps/www/content/docs/components/chart.mdx
@@ -20,7 +20,7 @@ Charts are designed to look great out of the box. They work well with the other 
 
 We use [Recharts](https://recharts.org/) under the hood.
 
-We designed the `chart` component with composition in mind. **You build your charts using Recharts components and only bring in custom components, such as `ChartTootlip`, when and where you need it**.
+We designed the `chart` component with composition in mind. **You build your charts using Recharts components and only bring in custom components, such as `ChartTooltip`, when and where you need it**.
 
 ```tsx showLineNumbers /ChartContainer/ /ChartTooltipContent/
 import { Bar, BarChart } from "recharts"


### PR DESCRIPTION
docs: fix misspell of 'ChartTooltip'