### PR TITLE
fix(docs): resolve imports for IDE

### DIFF
--- a/apps/www/content/docs/installation/vite.mdx
+++ b/apps/www/content/docs/installation/vite.mdx
@@ -27,6 +27,30 @@ npx tailwindcss init -p
 
 Add the following code to the `tsconfig.json` file to resolve paths:
 
+```ts {11-16} showLineNumbers
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}
+```
+
+### Edit tsconfig.app.json file
+
+Add the following code to the `tsconfig.app.json` file to resolve paths, for your IDE:
+
 ```ts {4-9} showLineNumbers
 {
   "compilerOptions": {


### PR DESCRIPTION
IDE uses the config mentioned in the `tsconfig.app.json` file whereas shadcn uses the config mentioned in the `tsconfig.json` file for path resolution 

Before adding the path to `tsconfig.app.json`

![image](https://github.com/user-attachments/assets/749c99f9-8d96-44f4-922b-c0a08623d104)


After adding the path to `tsconfig.app.json`

![image](https://github.com/user-attachments/assets/f5bef190-94e6-4c3e-8a7b-82f3ae3f9396)

This commit mentions the same in the installation with `vite` docs
