### PR TITLE
docs: add missing command

### DIFF
--- a/apps/www/content/docs/components/combobox.mdx
+++ b/apps/www/content/docs/components/combobox.mdx
@@ -103,7 +103,8 @@ export function ComboboxDemo() {
                 </CommandItem>
               ))}
             </CommandGroup>
-        </CommandList>
+          </CommandList>
+         <Command>
       </PopoverContent>
     </Popover>
   )


### PR DESCRIPTION
Just adding a missing `<Command>` that was missing from one of the docs examples.