### PR TITLE
fix(docs): incorrect link to tailwindcss colors documentation

### DIFF
--- a/apps/www/app/(app)/colors/layout.tsx
+++ b/apps/www/app/(app)/colors/layout.tsx
@@ -33,7 +33,7 @@ export default function ChartsLayout({
             <a href="#colors">Browse Colors</a>
           </Button>
           <Button asChild variant="ghost" size="sm">
-            <Link href="/docs/components/chart">Documentation</Link>
+            <Link target="_blank" href="https://tailwindcss.com/docs/customizing-colors">Documentation</Link>
           </Button>
         </PageActions>
       </PageHeader>

--- a/apps/www/app/(app)/colors/layout.tsx
+++ b/apps/www/app/(app)/colors/layout.tsx
@@ -33,7 +33,7 @@ export default function ChartsLayout({
             <a href="#colors">Browse Colors</a>
           </Button>
           <Button asChild variant="ghost" size="sm">
-            <Link target="_blank" href="https://tailwindcss.com/docs/customizing-colors">Documentation</Link>
+            <Link href="/docs/theming">Documentation</Link>
           </Button>
         </PageActions>
       </PageHeader>


### PR DESCRIPTION
The Tailwind CSS colors documentation link should be https://tailwindcss.com/docs/customizing-colors, rather than `/docs/components/chart`.