### PR TITLE
docs: add missing closing tag in combobox docs

### DIFF
--- a/apps/www/content/docs/components/combobox.mdx
+++ b/apps/www/content/docs/components/combobox.mdx
@@ -103,7 +103,8 @@ export function ComboboxDemo() {
                 </CommandItem>
               ))}
             </CommandGroup>
-        </CommandList>
+          </CommandList>
+        </Command>
       </PopoverContent>
     </Popover>
   )


### PR DESCRIPTION
Noticed there was a missing </Command> in the docs while copy pasting it over. 