### PR TITLE
fix: missing close tag for command

### DIFF
--- a/apps/www/content/docs/components/combobox.mdx
+++ b/apps/www/content/docs/components/combobox.mdx
@@ -104,7 +104,7 @@ export function ComboboxDemo() {
               ))}
             </CommandGroup>
           </CommandList>
-         <Command>
+         </Command>
       </PopoverContent>
     </Popover>
   )

--- a/apps/www/content/docs/components/combobox.mdx
+++ b/apps/www/content/docs/components/combobox.mdx
@@ -104,7 +104,7 @@ export function ComboboxDemo() {
               ))}
             </CommandGroup>
           </CommandList>
-         </Command>
+        </Command>
       </PopoverContent>
     </Popover>
   )


### PR DESCRIPTION
There is a misssing / for `Command`.