### PR TITLE
fix(www): removed blank line because the highlighted line was misaligned

### DIFF
--- a/apps/www/content/docs/dark-mode/remix.mdx
+++ b/apps/www/content/docs/dark-mode/remix.mdx
@@ -58,7 +58,6 @@ Add the `ThemeProvider` to your root layout.
 ```tsx {1-3,6-11,15-22,25-26,28,33} title="app/root.tsx"
 import clsx from "clsx"
 import { PreventFlashOnWrongTheme, ThemeProvider, useTheme } from "remix-themes"
-
 import { themeSessionResolver } from "./sessions.server"
 
 // Return the theme from the session storage using the loader


### PR DESCRIPTION
Hi,  
I addressed the issue of the misaligned line highlighting by deleting the blank lines.

<img width="746" alt="スクリーンショット 2024-07-19 15 44 35" src="https://github.com/user-attachments/assets/b2b10d61-5be6-4d1d-93c1-e841ddd5bb6c">
