### PR TITLE
docs(combobox): Close command tag in combobox documentation

### DIFF
--- a/apps/www/content/docs/components/combobox.mdx
+++ b/apps/www/content/docs/components/combobox.mdx
@@ -104,7 +104,7 @@ export function ComboboxDemo() {
               ))}
             </CommandGroup>
           </CommandList>
-         <Command>
+         </Command>
       </PopoverContent>
     </Popover>
   )


### PR DESCRIPTION
Close command tag in combobox documentation.

