### PR TITLE
fix(cli): trim whitespaces for config and css file locations

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -190,8 +190,8 @@ export async function promptForConfig(
     $schema: "https://ui.shadcn.com/schema.json",
     style: options.style,
     tailwind: {
-      config: options.tailwindConfig,
-      css: options.tailwindCss,
+      config: options.tailwindConfig?.trim(),
+      css: options.tailwindCss?.trim(),
       baseColor: options.tailwindBaseColor,
       cssVariables: options.tailwindCssVariables,
       prefix: options.tailwindPrefix,


### PR DESCRIPTION
Trim whitespaces for the config file and css file location input string when the user enters it from cli using the built-in trim method of String object in javascript

Link for Issue: https://github.com/shadcn-ui/ui/issues/4355