### PR TITLE
fix(toaster): import required React

### DIFF
--- a/apps/www/registry/default/ui/toaster.tsx
+++ b/apps/www/registry/default/ui/toaster.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import * as React from "react"
 import {
   Toast,
   ToastClose,


### PR DESCRIPTION
I got an exception when importing Toaster that is missing React in the head.