### PR TITLE
fix: pin react-day-picker

### DIFF
--- a/apps/www/public/registry/index.json
+++ b/apps/www/public/registry/index.json
@@ -79,7 +79,7 @@
   {
     "name": "calendar",
     "dependencies": [
-      "react-day-picker",
+      "react-day-picker@8.10.1",
       "date-fns"
     ],
     "registryDependencies": [

--- a/apps/www/public/registry/styles/default/calendar.json
+++ b/apps/www/public/registry/styles/default/calendar.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar",
   "dependencies": [
-    "react-day-picker",
+    "react-day-picker@8.10.1",
     "date-fns"
   ],
   "registryDependencies": [

--- a/apps/www/public/registry/styles/new-york/calendar.json
+++ b/apps/www/public/registry/styles/new-york/calendar.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar",
   "dependencies": [
-    "react-day-picker",
+    "react-day-picker@8.10.1",
     "date-fns"
   ],
   "registryDependencies": [

--- a/apps/www/registry/ui.ts
+++ b/apps/www/registry/ui.ts
@@ -51,7 +51,7 @@ export const ui: Registry = [
   {
     name: "calendar",
     type: "components:ui",
-    dependencies: ["react-day-picker", "date-fns"],
+    dependencies: ["react-day-picker@8.10.1", "date-fns"],
     registryDependencies: ["button"],
     files: ["ui/calendar.tsx"],
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,7 @@
     "build": "tsup",
     "typecheck": "tsc --noEmit",
     "clean": "rimraf dist && rimraf components",
-    "start:dev": "cross-env COMPONENTS_REGISTRY_URL=http://localhost:3001 node dist/index.js",
+    "start:dev": "cross-env COMPONENTS_REGISTRY_URL=http://localhost:3003 node dist/index.js",
     "start": "node dist/index.js",
     "format:write": "prettier --write \"**/*.{ts,tsx,mdx}\" --cache",
     "format:check": "prettier --check \"**/*.{ts,tsx,mdx}\" --cache",


### PR DESCRIPTION
This pins react-day-picker to v8 while we work on upgrading to v9. See #4371.