### PR TITLE
fix(components): add disabled prop support to Label component

### DIFF
--- a/apps/www/registry/default/example/label-disabled-demo.tsx
+++ b/apps/www/registry/default/example/label-disabled-demo.tsx
@@ -1,0 +1,11 @@
+import { Label } from "@/registry/default/ui/label"
+
+export default function LabelDemo() {
+  return (
+    <div>
+      <div className="flex items-center space-x-2">
+        <Label disabled htmlFor="terms">Accept terms and conditions</Label>
+      </div>
+    </div>
+  )
+}

--- a/apps/www/registry/default/ui/form.tsx
+++ b/apps/www/registry/default/ui/form.tsx
@@ -88,8 +88,10 @@ FormItem.displayName = "FormItem"
 
 const FormLabel = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
->(({ className, ...props }, ref) => {
+  React.ComponentPropsWithoutRef<
+    typeof LabelPrimitive.Root & { disabled?: boolean }
+  > & { disabled?: boolean }
+>(({ className, disabled, ...props }, ref) => {
   const { error, formItemId } = useFormField()
 
   return (
@@ -97,6 +99,7 @@ const FormLabel = React.forwardRef<
       ref={ref}
       className={cn(error && "text-destructive", className)}
       htmlFor={formItemId}
+      disabled={disabled}
       {...props}
     />
   )

--- a/apps/www/registry/default/ui/label.tsx
+++ b/apps/www/registry/default/ui/label.tsx
@@ -7,17 +7,24 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+  {
+    variants: {
+      disabled: {
+        true: "cursor-not-allowed opacity-50",
+      },
+    },
+  }
 )
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
     VariantProps<typeof labelVariants>
->(({ className, ...props }, ref) => (
+>(({ className,disabled, ...props }, ref) => (
   <LabelPrimitive.Root
     ref={ref}
-    className={cn(labelVariants(), className)}
+    className={cn(labelVariants({ disabled }), className)}
     {...props}
   />
 ))

--- a/apps/www/registry/new-york/example/label-disabled-demo.tsx
+++ b/apps/www/registry/new-york/example/label-disabled-demo.tsx
@@ -1,0 +1,11 @@
+import { Label } from "@/registry/new-york/ui/label"
+
+export default function LabelDemo() {
+  return (
+    <div>
+      <div className="flex items-center space-x-2">
+        <Label disabled htmlFor="terms">Accept terms and conditions</Label>
+      </div>
+    </div>
+  )
+}

--- a/apps/www/registry/new-york/ui/form.tsx
+++ b/apps/www/registry/new-york/ui/form.tsx
@@ -88,8 +88,10 @@ FormItem.displayName = "FormItem"
 
 const FormLabel = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
->(({ className, ...props }, ref) => {
+  React.ComponentPropsWithoutRef<
+    typeof LabelPrimitive.Root & { disabled?: boolean }
+  > & { disabled?: boolean }
+>(({ className, disabled, ...props }, ref) => {
   const { error, formItemId } = useFormField()
 
   return (
@@ -97,6 +99,7 @@ const FormLabel = React.forwardRef<
       ref={ref}
       className={cn(error && "text-destructive", className)}
       htmlFor={formItemId}
+      disabled={disabled}
       {...props}
     />
   )

--- a/apps/www/registry/new-york/ui/label.tsx
+++ b/apps/www/registry/new-york/ui/label.tsx
@@ -7,17 +7,24 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+  {
+    variants: {
+      disabled: {
+        true: "cursor-not-allowed opacity-50",
+      },
+    },
+  }
 )
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
     VariantProps<typeof labelVariants>
->(({ className, ...props }, ref) => (
+>(({ className,disabled, ...props }, ref) => (
   <LabelPrimitive.Root
     ref={ref}
-    className={cn(labelVariants(), className)}
+    className={cn(labelVariants({ disabled }), className)}
     {...props}
   />
 ))


### PR DESCRIPTION
The Label component doesn't directly support the disabled prop. The Label component is based on the Radix UI Label primitive, which doesn't have a built-in disabled property.

what I did was change the Label and Form Component to accept a disabled prop

Example of using disabled in a form label:

```
        <FormField
          control={form.control}
          name="message"
          render={({ field }) => (
            <FormItem>
              <FormLabel disabled={loading}>Message</FormLabel>
              <FormControl>
                <Textarea placeholder="Your message" {...field} disabled={loading} />
              </FormControl>
              <FormMessage />
            </FormItem>
          )}
        />
```

output:

![image](https://github.com/user-attachments/assets/25012a2b-9c6f-4044-9a35-76854e365515)

before making the changes to the label and form components I was getting this error:

```
Type '{ children: string; disabled: boolean; }' is not assignable to type 'IntrinsicAttributes & Omit<LabelProps & RefAttributes<HTMLLabelElement>, "ref"> & RefAttributes<HTMLLabelElement>'. Property 'disabled' does not exist on type 'IntrinsicAttributes & Omit<LabelProps & RefAttributes<HTMLLabelElement>, "ref"> & RefAttributes<HTMLLabelElement>'.ts(2322)
(property) disabled: boolean
```

so I fixed it and hope this will help I'm not sure if there is another component that uses label same as the form but if there is it has to be updated also I'm not expert and this is my first real pull request 
