### PR TITLE
docs(combobox): fixed command closing tag

### DIFF
--- a/apps/www/content/docs/components/combobox.mdx
+++ b/apps/www/content/docs/components/combobox.mdx
@@ -104,7 +104,7 @@ export function ComboboxDemo() {
               ))}
             </CommandGroup>
           </CommandList>
-         <Command>
+         </Command>
       </PopoverContent>
     </Popover>
   )


### PR DESCRIPTION
When copying the combobox instalation code, there is a error on the command closing tag