### PR TITLE
fix: resizable mail component example, min width

### DIFF
--- a/apps/www/app/(app)/examples/mail/components/mail.tsx
+++ b/apps/www/app/(app)/examples/mail/components/mail.tsx
@@ -218,7 +218,7 @@ export function Mail({
           </Tabs>
         </ResizablePanel>
         <ResizableHandle withHandle />
-        <ResizablePanel defaultSize={defaultLayout[2]}>
+        <ResizablePanel defaultSize={defaultLayout[2]} minSize={30}>
           <MailDisplay
             mail={mails.find((item) => item.id === mail.selected) || null}
           />


### PR DESCRIPTION
- [x] added a min width to mail example component 

### bug:
![image](https://github.com/user-attachments/assets/43c8d8f0-308f-41bb-bb7b-e7dfab77861d)
content was overflowing horizontally on increasing the size of the 2rd column resizable component 
**We have a scroll bar at the bottom**

### fix:
![image](https://github.com/user-attachments/assets/592572fd-96e9-4439-adac-9f45673d351e)
![image](https://github.com/user-attachments/assets/67133bc3-b475-4dc6-984f-265f43102f8b)
min width added to the 3rd column (mail preview)