### PR TITLE
docs(Sheet): Fix sheet size update code

### DIFF
--- a/apps/www/content/docs/components/sheet.mdx
+++ b/apps/www/content/docs/components/sheet.mdx
@@ -90,7 +90,7 @@ You can adjust the size of the sheet using CSS classes:
 ```tsx {3}
 <Sheet>
   <SheetTrigger>Open</SheetTrigger>
-  <SheetContent className="w-[400px] sm:w-[540px]">
+  <SheetContent className="sm:max-w-[540px]">
     <SheetHeader>
       <SheetTitle>Are you absolutely sure?</SheetTitle>
       <SheetDescription>


### PR DESCRIPTION
**What?**
Changing the width of the Sheet component following the docs doesn't work.

**Why?**
Because the Sheet component uses `sm:max-w` class, overriding the default width with `sm:w-[540px]` or `w-[540px]` doesn't work.

**How?**
Because the Sheet component uses `sm:max-w` class, we should use the same class (`sm:max-w-[540px]`) when overriding the default width.
