### PR TITLE
refactor(charts): slow single page to fast multiple tabs (solve: #4308)

### DIFF
--- a/apps/www/app/(app)/charts/page.tsx
+++ b/apps/www/app/(app)/charts/page.tsx
@@ -3,21 +3,20 @@ import { ChartDisplay } from "@/components/chart-display"
 import { ChartsNav } from "@/components/charts-nav"
 import { ThemesSwitcher } from "@/components/themes-selector"
 import { ThemesStyle } from "@/components/themes-styles"
-import { Separator } from "@/registry/new-york/ui/separator"
+import { Tabs, TabsContent } from "@/registry/new-york/ui/tabs"
 import * as Charts from "@/app/(app)/charts/charts"
 
 export default function ChartsPage() {
   return (
-    <div className="grid gap-4">
-      <ChartsNav className="[&>a:first-child]:bg-muted [&>a:first-child]:font-medium [&>a:first-child]:text-primary" />
-      <ThemesStyle />
-      <div className="gap-6 md:flex md:flex-row-reverse md:items-start">
+    <Tabs defaultValue="examples">
+      <ChartsNav />
+      <div className="mt-2 w-full gap-6 md:flex md:flex-row-reverse md:items-start">
+        <ThemesStyle />
         <ThemesSwitcher
           themes={THEMES}
           className="fixed inset-x-0 bottom-0 z-40 flex bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 lg:sticky lg:bottom-auto lg:top-20"
         />
-        <div className="grid flex-1 gap-12">
-          <h2 className="sr-only">Examples</h2>
+        <TabsContent value="examples" className="w-full">
           <div
             id="examples"
             className="grid flex-1 scroll-mt-20 items-start gap-10 md:grid-cols-2 md:gap-6 lg:grid-cols-3 xl:gap-10"
@@ -35,7 +34,8 @@ export default function ChartsPage() {
               <Charts.ChartPieDonutText />
             </ChartDisplay>
           </div>
-          <Separator />
+        </TabsContent>
+        <TabsContent value="area-chart" className="w-full">
           <div
             id="area-chart"
             className="grid flex-1 scroll-mt-20 items-start gap-10 md:grid-cols-2 md:gap-6 lg:grid-cols-3 xl:gap-10"
@@ -73,7 +73,8 @@ export default function ChartsPage() {
               </ChartDisplay>
             </div>
           </div>
-          <Separator />
+        </TabsContent>
+        <TabsContent value="bar-chart" className="w-full">
           <div
             id="bar-chart"
             className="grid flex-1 scroll-mt-20 items-start gap-10 md:grid-cols-2 md:gap-6 lg:grid-cols-3 xl:gap-10"
@@ -111,7 +112,8 @@ export default function ChartsPage() {
               </ChartDisplay>
             </div>
           </div>
-          <Separator />
+        </TabsContent>
+        <TabsContent value="line-chart" className="w-full">
           <div
             id="line-chart"
             className="grid flex-1 scroll-mt-20 items-start gap-10 md:grid-cols-2 md:gap-6 lg:grid-cols-3 xl:gap-10"
@@ -149,7 +151,8 @@ export default function ChartsPage() {
               </ChartDisplay>
             </div>
           </div>
-          <Separator />
+        </TabsContent>
+        <TabsContent value="pie-chart" className="w-full">
           <div
             id="pie-chart"
             className="grid flex-1 scroll-mt-20 items-start gap-10 md:grid-cols-2 md:gap-6 lg:grid-cols-3 xl:gap-10"
@@ -188,7 +191,8 @@ export default function ChartsPage() {
               <Charts.ChartPieInteractive />
             </ChartDisplay>
           </div>
-          <Separator />
+        </TabsContent>
+        <TabsContent value="radar-chart" className="w-full">
           <div
             id="radar-chart"
             className="grid flex-1 scroll-mt-20 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:gap-10"
@@ -236,7 +240,8 @@ export default function ChartsPage() {
               <Charts.ChartRadarIcons />
             </ChartDisplay>
           </div>
-          <Separator />
+        </TabsContent>
+        <TabsContent value="radial-chart" className="w-full">
           <div
             id="radial-chart"
             className="grid flex-1 scroll-mt-20 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:gap-10"
@@ -260,7 +265,8 @@ export default function ChartsPage() {
               <Charts.ChartRadialStacked />
             </ChartDisplay>
           </div>
-          <Separator />
+        </TabsContent>
+        <TabsContent value="tooltip" className="w-full">
           <div
             id="tooltip"
             className="chart-wrapper grid flex-1 scroll-mt-20 items-start gap-10 md:grid-cols-2 md:gap-6 lg:grid-cols-3 xl:gap-10"
@@ -293,8 +299,8 @@ export default function ChartsPage() {
               <Charts.ChartTooltipAdvanced />
             </ChartDisplay>
           </div>
-        </div>
+        </TabsContent>
       </div>
-    </div>
+    </Tabs>
   )
 }

--- a/apps/www/components/charts-nav.tsx
+++ b/apps/www/components/charts-nav.tsx
@@ -1,68 +1,50 @@
 "use client"
 
-import Link from "next/link"
-import { usePathname } from "next/navigation"
-
-import { cn } from "@/lib/utils"
-import { ScrollArea, ScrollBar } from "@/registry/new-york/ui/scroll-area"
+import { TabsList, TabsTrigger } from "@/registry/new-york/ui/tabs"
 
 const links = [
   {
+    name: "Examples",
+    tab: "examples",
+  },
+  {
     name: "Area Chart",
-    href: "/charts#area-chart",
+    tab: "area-chart",
   },
   {
     name: "Bar Chart",
-    href: "/charts#bar-chart",
+    tab: "bar-chart",
   },
   {
     name: "Line Chart",
-    href: "/charts#line-chart",
+    tab: "line-chart",
   },
   {
     name: "Pie Chart",
-    href: "/charts#pie-chart",
+    tab: "pie-chart",
   },
   {
     name: "Radar Chart",
-    href: "/charts#radar-chart",
+    tab: "radar-chart",
   },
   {
     name: "Radial Chart",
-    href: "/charts#radial-chart",
+    tab: "radial-chart",
   },
   {
     name: "Tooltip",
-    href: "/charts#tooltip",
+    tab: "tooltip",
   },
 ]
 
-export function ChartsNav({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
-  const pathname = usePathname()
-
+export function ChartsNav() {
   return (
-    <ScrollArea className="max-w-[600px] lg:max-w-none">
-      <div className={cn("flex items-center", className)} {...props}>
-        {links.map((example, index) => (
-          <Link
-            href={example.href}
-            key={example.href}
-            className={cn(
-              "flex h-7 shrink-0 items-center justify-center rounded-full px-4 text-center text-sm transition-colors hover:text-primary",
-              pathname?.startsWith(example.href) ||
-                (index === 0 && pathname === "/")
-                ? "bg-muted font-medium text-primary"
-                : "text-muted-foreground"
-            )}
-          >
-            {example.name}
-          </Link>
-        ))}
-      </div>
-      <ScrollBar orientation="horizontal" className="invisible" />
-    </ScrollArea>
+    <TabsList>
+      {links.map((link) => (
+        <TabsTrigger key={link.tab} value={link.tab}>
+          {link.name}
+        </TabsTrigger>
+      ))}
+    </TabsList>
   )
 }


### PR DESCRIPTION
### Description
- #4308 
- I refactored slow single page using `<Tabs />` component supported by shadcn/ui.
- The result is pretty remarkable. See the following benchmark results.
- **Total Blocking Time** : `2720ms -> 1020ms` **(62.5% Improved)**
- **Speed Index** : `2.7s -> 1.3s` **(51.8% Improved)**

### System
- Google Chrome | 126.0.6478.185 (arm64)
- OS | macOS Version 14.5(Build 23F79)
- JavaScript | V8 12.6.228.28
- User Agent | Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36

### Additional
- The only difference is you can't share the link with selected tab. 
	- related issue: #414
- I'm willing to contribute! Let me know if it's worth doing so.

### As-Is
<img width="2032" alt="스크린샷 2024-07-29 오후 10 04 34" src="https://github.com/user-attachments/assets/699585a6-5706-49ee-acc5-621e21ef6695">

### To-Be
<img width="2032" alt="스크린샷 2024-07-29 오후 10 01 10" src="https://github.com/user-attachments/assets/65ff1fb5-8de4-46b6-bd97-24182fa151d7">
- The reason accessibility dropped from 100 to 96 is that the default color set of the <TabsTrigger /> is not very accessibility-friendly.
<img width="627" alt="image" src="https://github.com/user-attachments/assets/68f9d118-b6f2-431e-82f5-3f5359484be6">

