### PR TITLE
fix: addet darkmode for GripVertical icon SVG in resizable.tsx

### DIFF
--- a/apps/www/registry/default/ui/resizable.tsx
+++ b/apps/www/registry/default/ui/resizable.tsx
@@ -36,7 +36,7 @@ const ResizableHandle = ({
   >
     {withHandle && (
       <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border bg-border">
-        <GripVertical className="h-2.5 w-2.5" />
+        <GripVertical className="h-2.5 w-2.5 stroke-neutral-800 dark:stroke-neutral-200" />
       </div>
     )}
   </ResizablePrimitive.PanelResizeHandle>


### PR DESCRIPTION
I noticed that the griphandle icon SVG does not display the correct color when dark mode is activated. This fix ensures that the griphandle icon displays the correct color.


Without the fix:
<img width="421" alt="Screenshot 2024-07-29 at 15 35 22" src="https://github.com/user-attachments/assets/9980f7d9-3d0e-4764-a6d2-665f79516145">

With the Fix:
<img width="233" alt="Screenshot 2024-07-29 at 15 36 01" src="https://github.com/user-attachments/assets/91a3a96e-e809-4a13-b352-50f7b462199a">
