### PR TITLE
fix(www): typo close Command tag in ComboboxDemo

### DIFF
--- a/apps/www/content/docs/components/combobox.mdx
+++ b/apps/www/content/docs/components/combobox.mdx
@@ -104,7 +104,7 @@ export function ComboboxDemo() {
               ))}
             </CommandGroup>
           </CommandList>
-         <Command>
+        </Command>
       </PopoverContent>
     </Popover>
   )


### PR DESCRIPTION
In the example of use (https://ui.shadcn.com/docs/components/combobox#usage) there is a typo, close tag Command is missing.