### PR TITLE
fix(Combobox): correct closing tag for Command component in Combobox

### DIFF
--- a/apps/www/content/docs/components/combobox.mdx
+++ b/apps/www/content/docs/components/combobox.mdx
@@ -104,7 +104,7 @@ export function ComboboxDemo() {
               ))}
             </CommandGroup>
           </CommandList>
-         <Command>
+         </Command>
       </PopoverContent>
     </Popover>
   )


### PR DESCRIPTION
#4472 
fix(Combobox): correct closing tag for Command component in Combobox usage codeblock.