### PR TITLE
docs: update closing tag of Command tag in combobox

### DIFF
--- a/apps/www/content/docs/components/combobox.mdx
+++ b/apps/www/content/docs/components/combobox.mdx
@@ -104,7 +104,7 @@ export function ComboboxDemo() {
               ))}
             </CommandGroup>
           </CommandList>
-         <Command>
+        </Command>
       </PopoverContent>
     </Popover>
   )


### PR DESCRIPTION
Update Closing tag in `<Command>` tag in Combobox component doc

Before:
![image](https://github.com/user-attachments/assets/398cc314-0e36-4145-9f77-a974c0733905)

After:
![image](https://github.com/user-attachments/assets/f88a90fe-4555-4894-8f8e-bc82f5b6b4da)

