### PR TITLE
fix: Playground example model selector working

### DIFF
--- a/apps/www/app/(app)/examples/playground/components/model-selector.tsx
+++ b/apps/www/app/(app)/examples/playground/components/model-selector.tsx
@@ -135,14 +135,17 @@ function ModelItem({ model, isSelected, onSelect, onPeek }: ModelItemProps) {
   const ref = React.useRef<HTMLDivElement>(null)
 
   useMutationObserver(ref, (mutations) => {
-    for (const mutation of mutations) {
-      if (mutation.type === "attributes") {
-        if (mutation.attributeName === "aria-selected") {
-          onPeek(model)
-        }
+    mutations.forEach((mutation) => {
+      if (
+        mutation.type === "attributes" &&
+        mutation.attributeName === "aria-selected" &&
+        ref.current?.getAttribute("aria-selected") === "true"
+      ) {
+        onPeek(model);
       }
-    }
-  })
+    });
+  });
+  
 
   return (
     <CommandItem


### PR DESCRIPTION
Issue: 
The ModelItem component's onPeek handler was sometimes logging incorrect data, causing the model selector to appear inconsistent.

Changes Made:
Verified that the aria-selected attribute is true before calling onPeek(model), ensuring the function is only called when the element is actually selected.

Fixed Model Selector Inconsistency in Playground Example

fixes #4506 