### PR TITLE
add aria label(jsx-a11y/label-has-associated-control)

### DIFF
--- a/apps/www/registry/default/example/checkbox-demo.tsx
+++ b/apps/www/registry/default/example/checkbox-demo.tsx
@@ -5,7 +5,7 @@ import { Checkbox } from "@/registry/default/ui/checkbox"
 export default function CheckboxDemo() {
   return (
     <div className="flex items-center space-x-2">
-      <Checkbox id="terms" />
+      <Checkbox aria-label='terms' id="terms" />
       <label
         htmlFor="terms"
         className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"


### PR DESCRIPTION
Fixed jsx-a11y/label-has-associated-control was not supported.

Occurs when using shadcn/ui as Filed in tanstack form