### PR TITLE
Update next.mdx: remove extra step

### DIFF
--- a/apps/www/content/docs/dark-mode/next.mdx
+++ b/apps/www/content/docs/dark-mode/next.mdx
@@ -15,26 +15,12 @@ Start by installing `next-themes`:
 npm install next-themes
 ```
 
-### Create a theme provider
-
-```tsx title="components/theme-provider.tsx"
-"use client"
-
-import * as React from "react"
-import { ThemeProvider as NextThemesProvider } from "next-themes"
-import { type ThemeProviderProps } from "next-themes/dist/types"
-
-export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
-}
-```
-
 ### Wrap your root layout
 
 Add the `ThemeProvider` to your root layout.
 
 ```tsx {1,9-11} title="app/layout.tsx"
-import { ThemeProvider } from "@/components/theme-provider"
+import { ThemeProvider } from "next-themes"
 
 export default function RootLayout({ children }: RootLayoutProps) {
   return (


### PR DESCRIPTION
Re-exporting `ThemeProvider` from `next-themes` inside `@/components/theme-provider` is unnecessary