### PR TITLE
fix(www): fix chart-area-axes having same stackId

### DIFF
--- a/apps/www/registry/default/block/chart-area-axes.tsx
+++ b/apps/www/registry/default/block/chart-area-axes.tsx
@@ -88,7 +88,7 @@ export default function Component() {
               fill="var(--color-desktop)"
               fillOpacity={0.4}
               stroke="var(--color-desktop)"
-              stackId="a"
+              stackId="b"
             />
           </AreaChart>
         </ChartContainer>

--- a/apps/www/registry/new-york/block/chart-area-axes.tsx
+++ b/apps/www/registry/new-york/block/chart-area-axes.tsx
@@ -88,7 +88,7 @@ export default function Component() {
               fill="var(--color-desktop)"
               fillOpacity={0.4}
               stroke="var(--color-desktop)"
-              stackId="a"
+              stackId="b"
             />
           </AreaChart>
         </ChartContainer>


### PR DESCRIPTION
Close https://github.com/shadcn-ui/ui/issues/4533

Having the same `stackId` causes the y-axis to show the sum of the two area charts.
