### PR TITLE
[FIX] overflow of carousel itens, adding an space to the page in some cases

### DIFF
--- a/apps/www/__registry__/default/ui/carousel.tsx
+++ b/apps/www/__registry__/default/ui/carousel.tsx
@@ -137,7 +137,7 @@ const Carousel = React.forwardRef<
         <div
           ref={ref}
           onKeyDownCapture={handleKeyDown}
-          className={cn("relative", className)}
+          className={cn("relative overflow-hidden", className)}
           role="region"
           aria-roledescription="carousel"
           {...props}

--- a/apps/www/registry/default/ui/carousel.tsx
+++ b/apps/www/registry/default/ui/carousel.tsx
@@ -137,7 +137,7 @@ const Carousel = React.forwardRef<
         <div
           ref={ref}
           onKeyDownCapture={handleKeyDown}
-          className={cn("relative", className)}
+          className={cn("relative overflow-hidden", className)}
           role="region"
           aria-roledescription="carousel"
           {...props}

--- a/apps/www/registry/new-york/ui/carousel.tsx
+++ b/apps/www/registry/new-york/ui/carousel.tsx
@@ -137,7 +137,7 @@ const Carousel = React.forwardRef<
         <div
           ref={ref}
           onKeyDownCapture={handleKeyDown}
-          className={cn("relative", className)}
+          className={cn("relative overflow-hidden", className)}
           role="region"
           aria-roledescription="carousel"
           {...props}


### PR DESCRIPTION
in some cases, like mine, the carousel was adding an space at the right side of the page in mobile views, i 've fixed by adding overflow-hidden to the parent component, in my case it was very helpfull so i expect it will be helpfull to someone else too