### PR TITLE
fix(components): form error message for multiple values

### DIFF
--- a/apps/www/registry/default/ui/form.tsx
+++ b/apps/www/registry/default/ui/form.tsx
@@ -147,7 +147,7 @@ const FormMessage = React.forwardRef<
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, children, ...props }, ref) => {
   const { error, formMessageId } = useFormField()
-  const body = error ? String(error?.message) : children
+  const body = error ? Array.isArray(error) ? String(error[0]?.message) : String(error?.message) : children
 
   if (!body) {
     return null

--- a/apps/www/registry/new-york/ui/form.tsx
+++ b/apps/www/registry/new-york/ui/form.tsx
@@ -147,7 +147,7 @@ const FormMessage = React.forwardRef<
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, children, ...props }, ref) => {
   const { error, formMessageId } = useFormField()
-  const body = error ? String(error?.message) : children
+  const body = error ? Array.isArray(error) ? String(error[0]?.message) : String(error?.message) : children
 
   if (!body) {
     return null


### PR DESCRIPTION
When we have a form schema which looks like this:

```ts
z.object({
    emails: z.array(z.string().email("Please provide valid emails")),
});
```

error message with show `undefined` because error is an array of errors