### PR TITLE
feat: add skeleton wrapper component

### DIFF
--- a/apps/www/content/docs/components/skeleton.mdx
+++ b/apps/www/content/docs/components/skeleton.mdx
@@ -56,3 +56,12 @@ import { Skeleton } from "@/components/ui/skeleton"
   name="skeleton-card"
   description="A card with skeleton showing a loading state."
 />
+
+### With children
+
+Use the loading prop to control whether the skeleton or its children are displayed. Skeleton preserves the dimensions of children when they are hidden and disables interactive elements.
+
+<ComponentPreview
+  name="skeleton-wrapper"
+  description="A skeleton wrapper component with loading prop."
+/>

--- a/apps/www/public/registry/styles/default/skeleton.json
+++ b/apps/www/public/registry/styles/default/skeleton.json
@@ -3,7 +3,7 @@
   "files": [
     {
       "name": "skeleton.tsx",
-      "content": "import { cn } from \"@/lib/utils\"\n\nfunction Skeleton({\n  className,\n  ...props\n}: React.HTMLAttributes<HTMLDivElement>) {\n  return (\n    <div\n      className={cn(\"animate-pulse rounded-md bg-muted\", className)}\n      {...props}\n    />\n  )\n}\n\nexport { Skeleton }\n"
+      "content": "import React from 'react';\nimport { cn } from \"@/lib/utils\";\n\ninterface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {\n  loading?: boolean;\n}\n\nfunction Skeleton({\n  className,\n  children,\n  loading = true,\n  ...props\n}: SkeletonProps) {\n  if (!loading) return children;\n\n  return (\n    <div className=\"relative inline-block\">\n      <div\n        className={cn(\n          'absolute inset-0 animate-pulse rounded-md bg-secondary',\n          className,\n        )}\n        {...props}\n      />\n      <div className=\"invisible\">{children}</div>\n    </div>\n  );\n}\n\nexport { Skeleton };\n"
     }
   ],
   "type": "components:ui"

--- a/apps/www/public/registry/styles/new-york/skeleton.json
+++ b/apps/www/public/registry/styles/new-york/skeleton.json
@@ -3,7 +3,7 @@
   "files": [
     {
       "name": "skeleton.tsx",
-      "content": "import { cn } from \"@/lib/utils\"\n\nfunction Skeleton({\n  className,\n  ...props\n}: React.HTMLAttributes<HTMLDivElement>) {\n  return (\n    <div\n      className={cn(\"animate-pulse rounded-md bg-primary/10\", className)}\n      {...props}\n    />\n  )\n}\n\nexport { Skeleton }\n"
+      "content": "import React from 'react';\nimport { cn } from \"@/lib/utils\";\n\ninterface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {\n  loading?: boolean;\n}\n\nfunction Skeleton({\n  className,\n  children,\n  loading = true,\n  ...props\n}: SkeletonProps) {\n  if (!loading) return children;\n\n  return (\n    <div className=\"relative inline-block\">\n      <div\n        className={cn(\n          'absolute inset-0 animate-pulse rounded-md bg-secondary',\n          className,\n        )}\n        {...props}\n      />\n      <div className=\"invisible\">{children}</div>\n    </div>\n  );\n}\n\nexport { Skeleton };\n"
     }
   ],
   "type": "components:ui"

--- a/apps/www/registry/default/example/skeleton-wrapper.tsx
+++ b/apps/www/registry/default/example/skeleton-wrapper.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from "@/registry/default/ui/skeleton"
+
+export default function SkeletonWrapper() {
+  return (
+    <div className="flex flex-col text-start space-x-2 space-y-3">
+      <Skeleton>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
+        felis tellus, efficitur id convallis a, viverra eget libero. Nam magna
+        erat, fringilla sed commodo sed, aliquet nec magna.
+      </Skeleton>
+      <Skeleton loading={false}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
+        felis tellus, efficitur id convallis a, viverra
+      </Skeleton>
+    </div>
+  )
+}

--- a/apps/www/registry/default/ui/skeleton.tsx
+++ b/apps/www/registry/default/ui/skeleton.tsx
@@ -1,14 +1,30 @@
+import React from "react"
+
 import { cn } from "@/lib/utils"
+
+interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  loading?: boolean
+}
 
 function Skeleton({
   className,
+  children,
+  loading = true,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) {
+}: SkeletonProps) {
+  if (!loading) return children
+
   return (
-    <div
-      className={cn("animate-pulse rounded-md bg-muted", className)}
-      {...props}
-    />
+    <div className="relative inline-block">
+      <div
+        className={cn(
+          "absolute inset-0 animate-pulse rounded-md bg-secondary",
+          className
+        )}
+        {...props}
+      />
+      <div className="invisible">{children}</div>
+    </div>
   )
 }
 

--- a/apps/www/registry/new-york/example/skeleton-wrapper.tsx
+++ b/apps/www/registry/new-york/example/skeleton-wrapper.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from "@/registry/new-york/ui/skeleton"
+
+export default function SkeletonWrapper() {
+  return (
+    <div className="flex flex-col text-start space-x-2 space-y-3">
+      <Skeleton>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
+        felis tellus, efficitur id convallis a, viverra eget libero. Nam magna
+        erat, fringilla sed commodo sed, aliquet nec magna.
+      </Skeleton>
+      <Skeleton loading={false}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque
+        felis tellus, efficitur id convallis a, viverra
+      </Skeleton>
+    </div>
+  )
+}

--- a/apps/www/registry/new-york/ui/skeleton.tsx
+++ b/apps/www/registry/new-york/ui/skeleton.tsx
@@ -1,14 +1,30 @@
+import React from "react"
+
 import { cn } from "@/lib/utils"
+
+interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  loading?: boolean
+}
 
 function Skeleton({
   className,
+  children,
+  loading = true,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) {
+}: SkeletonProps) {
+  if (!loading) return children
+
   return (
-    <div
-      className={cn("animate-pulse rounded-md bg-primary/10", className)}
-      {...props}
-    />
+    <div className="relative inline-block">
+      <div
+        className={cn(
+          "absolute inset-0 animate-pulse rounded-md bg-secondary",
+          className
+        )}
+        {...props}
+      />
+      <div className="invisible">{children}</div>
+    </div>
   )
 }
 


### PR DESCRIPTION
**Summary:**
This PR adds the `skeleton-wrapper` component for skeleton loading states.

### **With children:**
- Control visibility with `isLoading` and preserves children’s dimensions 

**Usage Example:**
```jsx
<Skeleton loading={false}>
  {Number(500_000).toLocaleString()}
</Skeleton>
```

Fixes: This PR fixes issue #4608