### PR TITLE
fix: installation guide for form component

### DIFF
--- a/apps/www/content/docs/components/form.mdx
+++ b/apps/www/content/docs/components/form.mdx
@@ -91,6 +91,10 @@ const form = useForm()
 npx shadcn-ui@latest add form
 ```
 
+```bash
+npx shadcn-ui@latest add input
+```
+
 </Steps>
 
 </TabsContent>


### PR DESCRIPTION
Adds a new script below the adding of form component.

Closes #4647