### PR TITLE
Update vite.mdx

### DIFF
--- a/apps/www/content/docs/installation/vite.mdx
+++ b/apps/www/content/docs/installation/vite.mdx
@@ -23,6 +23,14 @@ npm install -D tailwindcss postcss autoprefixer
 npx tailwindcss init -p
 ```
 
+Update the `index.css` file with the tailwind headers:
+
+```index.css tailwind headers
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
 ### Edit tsconfig.json file
 
 The current version of Vite splits TypeScript configuration into three files, two of which need to be edited.


### PR DESCRIPTION
added step to update index.css so that the new Shadcn CLI tool with correctly parse the tailwind configuration. This will prevent an error from being thrown.