### PR TITLE
Add Overflow to Component Previews

### DIFF
--- a/apps/www/components/component-preview.tsx
+++ b/apps/www/components/component-preview.tsx
@@ -121,7 +121,7 @@ export function ComponentPreview({
           <ThemeWrapper defaultTheme="zinc">
             <div
               className={cn(
-                "preview flex min-h-[350px] w-full justify-center p-10",
+                "preview flex min-h-[350px] w-full justify-center p-10 overflow-x-auto",
                 {
                   "items-center": align === "center",
                   "items-start": align === "start",


### PR DESCRIPTION
### Context
**Docs Site**

For components that are inline that don't wrap, I noticed on mobile that they overflow their component preview container.

This change just ensures that if they aren't meant to wrap we provide some way for them to stay confined to the container.


#### Before
<img width="389" alt="Screenshot 2024-08-31 at 9 31 41 AM" src="https://github.com/user-attachments/assets/4e4dbf7a-7c78-4430-b480-c29c8b834821">



#### After
<img width="437" alt="Screenshot 2024-08-31 at 9 36 17 AM" src="https://github.com/user-attachments/assets/64953a9d-1301-41fd-a500-1a4a8d1fc52b">

