### PR TITLE
Improve error handling in registry fetch

### DIFF
--- a/packages/shadcn/src/utils/registry/index.ts
+++ b/packages/shadcn/src/utils/registry/index.ts
@@ -174,13 +174,21 @@ async function fetchRegistry(paths: string[]) {
             404: "Not found",
             500: "Internal server error",
           }
-          const result = await response.json()
-          const message =
-            result && typeof result === "object" && "error" in result
-              ? result.error
-              : response.statusText || errorMessages[response.status]
+
+          let errorMessage =
+            response.statusText ||
+            errorMessages[response.status] ||
+            "Unknown error"
+
+          try {
+            const result = await response.json()
+            if (result && typeof result === "object" && "error" in result) {
+              errorMessage = `${result.error}`
+            }
+          } catch (error) {}
+
           throw new Error(
-            `Failed to fetch from ${highlighter.info(url)}.\n${message}`
+            `Failed to fetch from ${highlighter.info(url)}.\n${errorMessage}`
           )
         }
 


### PR DESCRIPTION
This PR enhances the error handling when fetching from the registry fails. The main improvements are:

1. Attempt to parse the response as JSON to extract custom error messages.
2. Fallback to the original fetch error if JSON parsing fails.

This should provide more informative error messages, especially for responses like 404s. The current behaviour will always fail on the `response.json()` step if the response cant be parsed to json. 

This error is not caught at the moment making the error read: 
```
Something went wrong. Please check the error below for more details.
If the problem persists, please open an issue on GitHub.

Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

New behaviour this would become:
```
Something went wrong. Please check the error below for more details.
If the problem persists, please open an issue on GitHub.

Failed to fetch from https://ui.shadcn.com/r/colors/sdsd.json.
Not Found
```

P.S: Not a massive fan of the empty catch block but not sure how else to handle this as a json parse error would be relevant to the failure. Could possible append it to the error message, but again, is it really relevant?