### PR TITLE
fix: add missing eslint ignore for chart color config

### DIFF
--- a/apps/www/registry/new-york/ui/chart.tsx
+++ b/apps/www/registry/new-york/ui/chart.tsx
@@ -74,7 +74,7 @@ ChartContainer.displayName = "Chart"
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
   const colorConfig = Object.entries(config).filter(
-    ([_, config]) => config.theme || config.color
+    ([_, config]) => config.theme || config.color // eslint-disable-line @typescript-eslint/no-unused-vars
   )
 
   if (!colorConfig.length) {


### PR DESCRIPTION
A small fix for the chart component to pass eslint by ignoring the unused variable in the filter. I have only just starting using shadcn and currently have priorities that stop me spending more than the 2 minutes to refactor this properly.
