### PR TITLE
Update Remix installation guide to use URL import for Tailwind CSS

### DIFF
--- a/apps/www/content/docs/installation/remix.mdx
+++ b/apps/www/content/docs/installation/remix.mdx
@@ -78,7 +78,7 @@ export default {
 In your `app/root.tsx` file, import the `tailwind.css` file:
 
 ```js {1, 4}
-import styles from "./tailwind.css"
+import styles from "./tailwind.css?url"
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: styles },


### PR DESCRIPTION
This PR updates our Remix integration documentation to align with Tailwind CSS's recommended URL import method. According to the official Tailwind CSS documentation for Remix (https://tailwindcss.com/docs/guides/remix), using URL imports is now the preferred approach. This change ensures our guide reflects current best practices for integrating Tailwind CSS with Remix projects.