### PR TITLE
Added getCanHide() for column header in Tasks Example for data tables

### DIFF
--- a/apps/www/app/(app)/examples/tasks/components/data-table-column-header.tsx
+++ b/apps/www/app/(app)/examples/tasks/components/data-table-column-header.tsx
@@ -59,11 +59,15 @@ export function DataTableColumnHeader<TData, TValue>({
             <ArrowDownIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
             Desc
           </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => column.toggleVisibility(false)}>
-            <EyeNoneIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
-            Hide
-          </DropdownMenuItem>
+          {column.getCanHide() && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => column.toggleVisibility(false)}>
+                <EyeNoneIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
+                Hide
+              </DropdownMenuItem>
+            </>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>


### PR DESCRIPTION
In the Tasks example (which shows the functioning of the table component), the column header dropdown had the hide option even if the column was set to unhide able.

I added the getCanHide() check to fix that.