### PR TITLE
feat: persist package manager selection

### DIFF
--- a/apps/www/components/copy-button.tsx
+++ b/apps/www/components/copy-button.tsx
@@ -219,22 +219,22 @@ export function CopyNpmCommandButton({
           <DropdownMenuItem
             onClick={() => copyCommand(commands.__npmCommand__, "npm")}
           >
-            npm
+            npm {selectedPackageManager === "npm" && "✓"}
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => copyCommand(commands.__yarnCommand__, "yarn")}
           >
-            yarn
+            yarn {selectedPackageManager === "yarn" && "✓"}
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => copyCommand(commands.__pnpmCommand__, "pnpm")}
           >
-            pnpm
+            pnpm {selectedPackageManager === "pnpm" && "✓"}
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => copyCommand(commands.__bunCommand__, "bun")}
           >
-            bun
+            bun {selectedPackageManager === "bun" && "✓"}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/www/components/copy-button.tsx
+++ b/apps/www/components/copy-button.tsx
@@ -140,6 +140,8 @@ export function CopyNpmCommandButton({
   ...props
 }: CopyNpmCommandButtonProps) {
   const [hasCopied, setHasCopied] = React.useState(false)
+  const [selectedPackageManager, setSelectedPackageManager] =
+    React.useState<string>("npm")
 
   React.useEffect(() => {
     setTimeout(() => {
@@ -157,9 +159,20 @@ export function CopyNpmCommandButton({
         },
       })
       setHasCopied(true)
+      localStorage.setItem("selectedPackageManager", pm)
+      setSelectedPackageManager(pm)
     },
     []
   )
+
+  React.useEffect(() => {
+    const savedPackageManager = localStorage.getItem("selectedPackageManager")
+    if (savedPackageManager) {
+      setSelectedPackageManager(savedPackageManager)
+    }
+  }, [])
+
+  console.log("Selected package manager:", selectedPackageManager)
 
   return (
     <DropdownMenu>

--- a/apps/www/components/copy-button.tsx
+++ b/apps/www/components/copy-button.tsx
@@ -167,7 +167,12 @@ export function CopyNpmCommandButton({
 
   React.useEffect(() => {
     const savedPackageManager = localStorage.getItem("selectedPackageManager")
-    if (savedPackageManager) {
+    if (
+      savedPackageManager === "npm" ||
+      savedPackageManager === "pnpm" ||
+      savedPackageManager === "yarn" ||
+      savedPackageManager === "bun"
+    ) {
       setSelectedPackageManager(savedPackageManager)
     }
   }, [])
@@ -177,7 +182,6 @@ export function CopyNpmCommandButton({
       <Button
         size="icon"
         variant="ghost"
-        // added mr-4 here to move the dropdown to the right
         className={cn(
           "relative z-10 h-6 w-6 text-zinc-50 hover:bg-zinc-700 hover:text-zinc-50 mr-4",
           className

--- a/apps/www/components/copy-button.tsx
+++ b/apps/www/components/copy-button.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { DropdownMenuTriggerProps } from "@radix-ui/react-dropdown-menu"
-import { CheckIcon, ClipboardIcon } from "lucide-react"
+import { CheckIcon, ChevronDownIcon, ClipboardIcon } from "lucide-react"
 import { NpmCommands } from "types/unist"
 
 import { Event, trackEvent } from "@/lib/events"
@@ -172,49 +172,72 @@ export function CopyNpmCommandButton({
     }
   }, [])
 
-  console.log("Selected package manager:", selectedPackageManager)
-
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          size="icon"
-          variant="ghost"
-          className={cn(
-            "relative z-10 h-6 w-6 text-zinc-50 hover:bg-zinc-700 hover:text-zinc-50",
-            className
-          )}
-        >
-          {hasCopied ? (
-            <CheckIcon className="h-3 w-3" />
-          ) : (
-            <ClipboardIcon className="h-3 w-3" />
-          )}
-          <span className="sr-only">Copy</span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem
-          onClick={() => copyCommand(commands.__npmCommand__, "npm")}
-        >
-          npm
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => copyCommand(commands.__yarnCommand__, "yarn")}
-        >
-          yarn
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => copyCommand(commands.__pnpmCommand__, "pnpm")}
-        >
-          pnpm
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => copyCommand(commands.__bunCommand__, "bun")}
-        >
-          bun
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <div className="flex items-center">
+      <Button
+        size="icon"
+        variant="ghost"
+        // added mr-4 here to move the dropdown to the right
+        className={cn(
+          "relative z-10 h-6 w-6 text-zinc-50 hover:bg-zinc-700 hover:text-zinc-50 mr-4",
+          className
+        )}
+        onClick={() => {
+          if (selectedPackageManager === "npm") {
+            copyCommand(commands.__npmCommand__, "npm")
+          } else if (selectedPackageManager === "yarn") {
+            copyCommand(commands.__yarnCommand__, "yarn")
+          } else if (selectedPackageManager === "pnpm") {
+            copyCommand(commands.__pnpmCommand__, "pnpm")
+          } else if (selectedPackageManager === "bun") {
+            copyCommand(commands.__bunCommand__, "bun")
+          }
+        }}
+      >
+        {hasCopied ? (
+          <CheckIcon className="h-3 w-3" />
+        ) : (
+          <ClipboardIcon className="h-3 w-3" />
+        )}
+        <span className="sr-only">Copy</span>
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            size="icon"
+            variant="ghost"
+            className={cn(
+              "relative z-10 h-6 w-6 text-zinc-50 hover:bg-zinc-700 hover:text-zinc-50",
+              className
+            )}
+          >
+            <ChevronDownIcon className="h-3 w-3" />
+            <span className="sr-only">Select package manager</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onClick={() => copyCommand(commands.__npmCommand__, "npm")}
+          >
+            npm
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => copyCommand(commands.__yarnCommand__, "yarn")}
+          >
+            yarn
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => copyCommand(commands.__pnpmCommand__, "pnpm")}
+          >
+            pnpm
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => copyCommand(commands.__bunCommand__, "bun")}
+          >
+            bun
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   )
 }


### PR DESCRIPTION
saw this tweet about the issue and here's my implementation for it

https://x.com/BodaNabeel/status/1830613162787533136

### Overview: stored selected package manager in the localstorage and added a dropdown beside clipboard to select package manager. Clipboard icon now only copies the command for the selected package manager

added the logic to persist the selected package manager using localstorage.

- the selected package manager will be stored in the local storage
- the clipboard icon now only copies the command for the selected package manager instead of oepning a dropdown
- added a dropdown beside the clipboard icon to select the package manger
- selecting the package manager from dropdown will also copy the command 
- default package manager is npm

![image](https://github.com/user-attachments/assets/1c50f3fb-b962-4d27-bef8-fd2c13d88418)
![image](https://github.com/user-attachments/assets/6501a357-7177-42a4-b659-399618859bb3)

Here's the video

use this [link](https://youtu.be/8_dDD5UsmXg) if video below is not working

https://github.com/user-attachments/assets/e656fa80-6aed-473f-ab1b-b227c4f8d9ec

Need some help in updating the entire cli tho to show the command of the selected package manager
