### PR TITLE
remove comment in bash block

### DIFF
--- a/apps/www/content/docs/installation/vite.mdx
+++ b/apps/www/content/docs/installation/vite.mdx
@@ -73,7 +73,6 @@ Add the following code to the `tsconfig.app.json` file to resolve paths, for you
 Add the following code to the vite.config.ts so your app can resolve paths without error
 
 ```bash
-# (so you can import "path" without error)
 npm i -D @types/node
 ```
 


### PR DESCRIPTION
Currently, a comment in the vite install docs (`# (so you can import "path" without error)`) is included in a bash block, causing errors in the terminal when copied. 

This PR removes the comment, which is already described in plaintext above, improving developer installation experience.