### PR TITLE
fix: “border-boder” “border-primary” duplicates (e.g. “checkbox”, “radio-group”)

### DIFF
--- a/packages/cli/src/utils/transformers/transform-css-vars.ts
+++ b/packages/cli/src/utils/transformers/transform-css-vars.ts
@@ -140,7 +140,8 @@ export function applyColorMapping(
   mapping: z.infer<typeof registryBaseColorSchema>["inlineColors"]
 ) {
   // Handle border classes.
-  if (input.includes(" border ")) {
+  // Fix “border-border “border-primary” duplicates (e.g. “checkbox”, “radio-group”)
+  if (input.includes(" border ") && !input.includes("border-primary")) {
     input = input.replace(" border ", " border border-border ")
   }
 

--- a/packages/shadcn/src/utils/transformers/transform-css-vars.ts
+++ b/packages/shadcn/src/utils/transformers/transform-css-vars.ts
@@ -140,7 +140,8 @@ export function applyColorMapping(
   mapping: z.infer<typeof registryBaseColorSchema>["inlineColors"]
 ) {
   // Handle border classes.
-  if (input.includes(" border ")) {
+  // Fix “border-border “border-primary” duplicates (e.g. “checkbox”, “radio-group”)
+  if (input.includes(" border ") && !input.includes("border-primary")) {
     input = input.replace(" border ", " border border-border ")
   }
 


### PR DESCRIPTION
## What was the problem

- If you didn't include css variables in your initial setup, we converted them, and the special treatment for “border” resulted in duplicate styling for “border”.

## Where's the problem with the file?
- transform-css-vars.ts/applyColorMapping Fn

## How I fixed it

- We are deduplicating for “border” behind the scenes, but “border-primary” is not caught by this branch (more on why in the link below), so we added a conditional to convert it to “border-boder” when it is not a “border-primary”.

## Related issues 

- #4654 

## Check for PR 

- [ ] Passed local tests 
- [ ] Ensure that nothing other than the modification is affected 