### PR TITLE
fix(www): rehype yarn dlx command

### DIFF
--- a/apps/www/lib/rehype-npm-command.ts
+++ b/apps/www/lib/rehype-npm-command.ts
@@ -51,7 +51,10 @@ export function rehypeNpmCommand() {
       ) {
         const npmCommand = node.properties?.["__rawString__"]
         node.properties["__npmCommand__"] = npmCommand
-        node.properties["__yarnCommand__"] = npmCommand
+        node.properties["__yarnCommand__"] = npmCommand.replace(
+          "npx",
+          "yarn dlx"
+        )
         node.properties["__pnpmCommand__"] = npmCommand.replace(
           "npx",
           "pnpm dlx"


### PR DESCRIPTION
The "copy code" function did not work correctly for the Yarn package manager.
It was copying `npx` when it should be copying `yarn dlx`.