### PR TITLE
fix: Fixing charts type error

### DIFF
--- a/apps/www/registry/new-york/ui/chart.tsx
+++ b/apps/www/registry/new-york/ui/chart.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as RechartsPrimitive from "recharts"
-import {
+import type {
   NameType,
   Payload,
   ValueType,


### PR DESCRIPTION
chart.tsx (new-york) using React currently gives module not found error for the types imported from recharts/types/component/DefaultTooltipContent