### PR TITLE
Add link to official Tailwind Vite installation guide

### DIFF
--- a/apps/www/content/docs/installation/vite.mdx
+++ b/apps/www/content/docs/installation/vite.mdx
@@ -23,6 +23,10 @@ npm install -D tailwindcss postcss autoprefixer
 npx tailwindcss init -p
 ```
 
+Follow the remaining instructions in the Tailwind documentation to add Tailwind to your project:
+
+[Official Tailwind Vite installation guide](https://tailwindcss.com/docs/guides/vite)
+
 ### Edit tsconfig.json file
 
 The current version of Vite splits TypeScript configuration into three files, two of which need to be edited.


### PR DESCRIPTION
This PR adds a link to the official Tailwind Vite installation guide in the Vite installation documentation. This will provide users with additional resources and instructions for adding Tailwind to their projects.

closes #4747