### PR TITLE
feat(cli): add new flag to the cli, to skip installation of the dependencies

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -26,6 +26,7 @@ const addOptionsSchema = z.object({
   cwd: z.string(),
   all: z.boolean(),
   path: z.string().optional(),
+  noInstall: z.boolean().default(false),
 })
 
 export const add = new Command()
@@ -41,6 +42,7 @@ export const add = new Command()
   )
   .option("-a, --all", "add all available components", false)
   .option("-p, --path <path>", "the path to add the component to.")
+  .option("-n, --no-install", "Skip Installing Dependencies.", false)
   .action(async (components, opts) => {
     try {
       const options = addOptionsSchema.parse({
@@ -106,7 +108,7 @@ export const add = new Command()
         const { proceed } = await prompts({
           type: "confirm",
           name: "proceed",
-          message: `Ready to install components and dependencies. Proceed?`,
+          message: `Ready to install components ${options.noInstall ? 'without' : 'and'} dependencies. Proceed?`,
           initial: true,
         })
 
@@ -179,6 +181,9 @@ export const add = new Command()
 
           await fs.writeFile(filePath, content)
         }
+
+        if (options.noInstall)
+          continue
 
         const packageManager = await getPackageManager(cwd)
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -41,6 +41,7 @@ const initOptionsSchema = z.object({
   cwd: z.string(),
   yes: z.boolean(),
   defaults: z.boolean(),
+  noInstall: z.boolean().default(false),
 })
 
 export const init = new Command()
@@ -48,6 +49,7 @@ export const init = new Command()
   .description("initialize your project and install dependencies")
   .option("-y, --yes", "skip confirmation prompt.", false)
   .option("-d, --defaults,", "use default configuration.", false)
+  .option("-n, --no-install,", "Skip Installing Dependencies.", false)
   .option(
     "-c, --cwd <cwd>",
     "the working directory. defaults to the current directory.",
@@ -73,12 +75,12 @@ export const init = new Command()
           projectConfig,
           opts.defaults
         )
-        await runInit(cwd, config)
+        await runInit(cwd, config, options.noInstall)
       } else {
         // Read config.
         const existingConfig = await getConfig(cwd)
         const config = await promptForConfig(cwd, existingConfig, options.yes)
-        await runInit(cwd, config)
+        await runInit(cwd, config, options.noInstall)
       }
 
       logger.info("")
@@ -304,7 +306,7 @@ export async function promptForMinimalConfig(
   return await resolveConfigPaths(cwd, config)
 }
 
-export async function runInit(cwd: string, config: Config) {
+export async function runInit(cwd: string, config: Config, noInstall = false) {
   const spinner = ora(`Initializing project...`)?.start()
 
   // Ensure all resolved paths directories exist.
@@ -377,6 +379,9 @@ export async function runInit(cwd: string, config: Config) {
   )
 
   spinner?.succeed()
+
+  if(noInstall) 
+    return
 
   // Install dependencies.
   const dependenciesSpinner = ora(`Installing dependencies...`)?.start()


### PR DESCRIPTION
flag: --no-install

Purpose: the root nextjs canary version doesn't support, several dependencies due to which it's hard to add new component to the project as `npx shadcn@latest add button`



https://github.com/user-attachments/assets/f243cd45-dde1-4e73-9341-5fbe18d6edd5

