### PR TITLE
Adding support for ~ in target specification

### DIFF
--- a/.changeset/clever-swans-tan.md
+++ b/.changeset/clever-swans-tan.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+add support for ~ dir in target path

--- a/packages/shadcn/src/utils/updaters/update-files.ts
+++ b/packages/shadcn/src/utils/updaters/update-files.ts
@@ -17,6 +17,19 @@ import { transformRsc } from "@/src/utils/transformers/transform-rsc"
 import { transformTwPrefixes } from "@/src/utils/transformers/transform-tw-prefix"
 import prompts from "prompts"
 
+export function resolveTargetDir(
+  projectInfo: Awaited<ReturnType<typeof getProjectInfo>>,
+  config: Config,
+  target: string
+) {
+  if (target.startsWith("~/")) {
+    return path.join(config.resolvedPaths.cwd, target.replace("~/", ""))
+  }
+  return projectInfo?.isSrcDir
+    ? path.join(config.resolvedPaths.cwd, "src", target)
+    : path.join(config.resolvedPaths.cwd, target)
+}
+
 export async function updateFiles(
   files: RegistryItem["files"],
   config: Config,
@@ -58,9 +71,7 @@ export async function updateFiles(
     let filePath = path.join(targetDir, fileName)
 
     if (file.target) {
-      filePath = projectInfo?.isSrcDir
-        ? path.join(config.resolvedPaths.cwd, "src", file.target)
-        : path.join(config.resolvedPaths.cwd, file.target)
+      filePath = resolveTargetDir(projectInfo, config, file.target)
       targetDir = path.dirname(filePath)
     }
 

--- a/packages/shadcn/test/utils/updaters/update-files.test.ts
+++ b/packages/shadcn/test/utils/updaters/update-files.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest"
+
+import { resolveTargetDir } from "../../../src/utils/updaters/update-files"
+
+describe("resolveTargetDir", () => {
+  test("should handle a home target without a src directory", () => {
+    const targetDir = resolveTargetDir(
+      {
+        isSrcDir: false,
+      },
+      {
+        resolvedPaths: {
+          cwd: "/foo/bar",
+        },
+      },
+      "~/.env"
+    )
+    expect(targetDir).toBe("/foo/bar/.env")
+  })
+
+  test("should handle a home target even with a src directory", () => {
+    const targetDir = resolveTargetDir(
+      {
+        isSrcDir: true,
+      },
+      {
+        resolvedPaths: {
+          cwd: "/foo/bar",
+        },
+      },
+      "~/.env"
+    )
+    expect(targetDir).toBe("/foo/bar/.env")
+  })
+
+  test("should handle a simple target", () => {
+    const targetDir = resolveTargetDir(
+      {
+        isSrcDir: true,
+      },
+      {
+        resolvedPaths: {
+          cwd: "/foo/bar",
+        },
+      },
+      "./components/ui/button.tsx"
+    )
+    expect(targetDir).toBe("/foo/bar/src/components/ui/button.tsx")
+  })
+})

--- a/packages/shadcn/test/utils/updaters/update-files.test.ts
+++ b/packages/shadcn/test/utils/updaters/update-files.test.ts
@@ -36,6 +36,21 @@ describe("resolveTargetDir", () => {
   test("should handle a simple target", () => {
     const targetDir = resolveTargetDir(
       {
+        isSrcDir: false,
+      },
+      {
+        resolvedPaths: {
+          cwd: "/foo/bar",
+        },
+      },
+      "./components/ui/button.tsx"
+    )
+    expect(targetDir).toBe("/foo/bar/components/ui/button.tsx")
+  })
+
+  test("should handle a simple target with src directory", () => {
+    const targetDir = resolveTargetDir(
+      {
         isSrcDir: true,
       },
       {


### PR DESCRIPTION
Adding support for a `~/` prefix in the `target` specification of a block file so that you can specify files relative to the root of the project regardless of whether the project is `src` based or not.