### PR TITLE
feature: Pass button variant to AlertDialogAction to handle Destructive Confirm Dialog

### DIFF
--- a/apps/www/registry/default/ui/alert-dialog.tsx
+++ b/apps/www/registry/default/ui/alert-dialog.tsx
@@ -100,14 +100,16 @@ AlertDialogDescription.displayName =
 
 const AlertDialogAction = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Action>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action> & {
+    variant?: "default" | "destructive";
+  }
+>(({ className, variant = "default", ...props }, ref) => (
   <AlertDialogPrimitive.Action
     ref={ref}
-    className={cn(buttonVariants(), className)}
+    className={cn(buttonVariants({ variant }), className)}
     {...props}
   />
-))
+));
 AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
 
 const AlertDialogCancel = React.forwardRef<


### PR DESCRIPTION
In case delete or destructive, the confirm button should be highlighted with destructive style. Update AlertDialogAction to handle it