### PR TITLE
feat(rehype-npm-command): add support for yarn, pnpm, and bun commands

### DIFF
--- a/apps/www/lib/rehype-npm-command.ts
+++ b/apps/www/lib/rehype-npm-command.ts
@@ -8,6 +8,27 @@ export function rehypeNpmCommand() {
         return
       }
 
+      //npm create
+      if (node.properties?.["__rawString__"]?.startsWith("npm create")) {
+        const npmCommand = node.properties?.["__rawString__"]
+        node.properties["__npmCommand__"] = npmCommand
+
+        if (npmCommand.includes("@latest")) {
+          node.properties["__yarnCommand__"] = npmCommand
+            .replace("npm create", "yarn create")
+            .replace("@latest", "")
+        }
+
+        node.properties["__pnpmCommand__"] = npmCommand.replace(
+          "npm create",
+          "pnpm create"
+        )
+        node.properties["__bunCommand__"] = npmCommand.replace(
+          "npm create",
+          "bun create"
+        )
+      }
+
       // npm install.
       if (node.properties?.["__rawString__"]?.startsWith("npm install")) {
         const npmCommand = node.properties?.["__rawString__"]


### PR DESCRIPTION
- Added logic to handle `npm create` commands and convert them to `yarn create`, `pnpm create`, and `bun create`.
- Specifically handles `npm create vite@latest` and `npm create astro@latest` by removing `@latest` for yarn commands.

(default command copied to clipboard) : 
![image](https://github.com/user-attachments/assets/2fe2f88c-76de-4041-b5ab-213d6e158846)

commit (more options for installation):
![image](https://github.com/user-attachments/assets/563a05da-381f-4875-87c8-fb6af0d28d81)

 
