### PR TITLE
fix(shadcn):  default next styles are not completely cleared

### DIFF
--- a/.changeset/hip-ads-destroy.md
+++ b/.changeset/hip-ads-destroy.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+remove next.js default vars

--- a/packages/shadcn/test/utils/schema/__snapshots__/registry-resolve-items-tree.test.ts.snap
+++ b/packages/shadcn/test/utils/schema/__snapshots__/registry-resolve-items-tree.test.ts.snap
@@ -251,7 +251,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}


### PR DESCRIPTION
after initializing nextjs project, the global css is 

![CleanShot 2024-09-21 at 08 16 21@2x](https://github.com/user-attachments/assets/4fb1eefc-9129-47b5-b41d-2428eff20fe8)

after initializing shadcn , the global css is

![CleanShot 2024-09-21 at 08 20 12@2x](https://github.com/user-attachments/assets/504b28bf-24f3-4dbd-a5d4-26ee178cf2cb)

`--foreground`, `--background` of nextjs conflict with shadcn. nextjs will override shadcn.

![CleanShot 2024-09-21 at 08 27 39@2x](https://github.com/user-attachments/assets/f6d5a16c-e990-4ba9-be91-58421407e85f)


Fix #4923 
