### PR TITLE
Add asChild for DrawerClose

### DIFF
--- a/apps/www/content/docs/components/drawer.mdx
+++ b/apps/www/content/docs/components/drawer.mdx
@@ -75,7 +75,7 @@ import {
     </DrawerHeader>
     <DrawerFooter>
       <Button>Submit</Button>
-      <DrawerClose>
+      <DrawerClose asChild>
         <Button variant="outline">Cancel</Button>
       </DrawerClose>
     </DrawerFooter>


### PR DESCRIPTION
```
In HTML, <button> cannot be a descendant of <button>.
This will cause a hydration error.
```

I added asChild for DrawerClose for example of using Drawer component in docs


[Related issue](https://github.com/shadcn-ui/ui/issues/4662)