### PR TITLE
use "?url" suffix in "tailwind.css" import (Remix)

### DIFF
--- a/apps/www/content/docs/installation/remix.mdx
+++ b/apps/www/content/docs/installation/remix.mdx
@@ -78,7 +78,7 @@ export default {
 In your `app/root.tsx` file, import the `tailwind.css` file:
 
 ```js {1, 4}
-import styles from "./tailwind.css"
+import styles from "./tailwind.css?url"
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: styles },


### PR DESCRIPTION
Importing `tailwind.css` is incorrect as it will treat that file as a CSS Module, throwing that it has no `default` export. 

Instead, the tutorial relies on the import returning a _URL_ to the stylesheet. Adding `?url` to the import specifier is the way to go. 