### PR TITLE
Update readme to reflect actual CLI docs (updated npx command)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -9,7 +9,7 @@ Use the `init` command to initialize dependencies for a new project.
 The `init` command installs dependencies, adds the `cn` util, configures `tailwind.config.js`, and CSS variables for the project.
 
 ```bash
-npx shadcn-ui init
+npx shadcn init
 ```
 
 ## add
@@ -19,19 +19,19 @@ Use the `add` command to add components to your project.
 The `add` command adds a component to your project and installs all required dependencies.
 
 ```bash
-npx shadcn-ui add [component]
+npx shadcn add [component]
 ```
 
 ### Example
 
 ```bash
-npx shadcn-ui add alert-dialog
+npx shadcn add alert-dialog
 ```
 
 You can also run the command without any arguments to view a list of all available components:
 
 ```bash
-npx shadcn-ui add
+npx shadcn add
 ```
 
 ## Documentation


### PR DESCRIPTION
I had some issues with pulling components. Apparently, the npx binary's name has changed and it was reflected in the docs, but not in the readme which is displayed [here](https://www.npmjs.com/package/shadcn-ui).