### PR TITLE
feature: Add a new <Text> component. (Do not merge yet)

### DIFF
--- a/apps/www/registry/default/example/text-demo.tsx
+++ b/apps/www/registry/default/example/text-demo.tsx
@@ -1,0 +1,124 @@
+import React from "react"
+
+import { Text } from "../ui/Text"
+
+const codeExample = `
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+`.trim()
+
+const TextDemo = () => {
+  return (
+    <div className="p-10 space-y-10">
+      <div>
+        [Heading]
+        <Text variant="h1">This is H1</Text>
+        <Text variant="h2">This is H2</Text>
+        <Text variant="h3">This is H3</Text>
+        <Text variant="h4">This is H4</Text>
+        <Text variant="h5">This is H5</Text>
+        <Text variant="h6">This is H6</Text>
+      </div>
+
+      <div>
+        [Base]
+        <Text variant="lead">This is lead</Text>
+        <Text variant="large">This is large</Text>
+        <Text variant="p">This is p (Default)</Text>
+        <Text variant="small">This is small</Text>
+        <Text variant="muted">This is muted</Text>
+      </div>
+
+      <div>
+        [Styled]
+        <Text variant="blockquote">This is a blockquote.</Text>
+        <Text variant="p">
+          You can <strong>Emphasize Text</strong> like this.
+        </Text>
+        <Text variant="p" className="italic">
+          You can use italic Text like this.
+        </Text>
+        <Text variant="p" className="line-through">
+          You can use deleted Text like this.
+        </Text>
+        <Text variant="highlighted">This Text is highlighted.</Text>
+        <Text variant="p" className="text-indigo-500">
+          You can easily customize Text with className, or you can add new
+          variants to make it reusable.
+        </Text>
+      </div>
+
+      <div>
+        [Code]
+        <Text variant="codeBlock" className="max-w-sm">
+          {codeExample}
+        </Text>
+      </div>
+
+      <div>
+        [List]
+        <Text variant="list">
+          <li>First list</li>
+          <li>Second list</li>
+          <li>Third list</li>
+        </Text>
+        <Text variant="orderedList">
+          <li>First orderedList</li>
+          <li>Second orderedList</li>
+          <li>Third orderedList</li>
+        </Text>
+      </div>
+
+      <div>
+        [Table]
+        <div>
+          <Text variant="small">
+            This is a simple table. I recommend using the{" "}
+            <a
+              href="https://ui.shadcn.com/docs/components/table"
+              className="text-slate-500 underline"
+            >
+              Table Component
+            </a>{" "}
+            instead of this. Additionally, you can use the Button component to
+            easily handle link buttons.
+          </Text>
+        </div>
+        <div className="max-w-md">
+          <Text variant="table">
+            <Text variant="thead">
+              <Text variant="tr">
+                <Text variant="th">Category</Text>
+                <Text variant="th">Tech stack</Text>
+              </Text>
+            </Text>
+            <Text variant="tbody">
+              <Text variant="tr">
+                <Text variant="td">Framework</Text>
+                <Text variant="td">Next.js (React)</Text>
+              </Text>
+              <Text variant="tr">
+                <Text variant="td">Language</Text>
+                <Text variant="td">Typescript</Text>
+              </Text>
+              <Text variant="tr">
+                <Text variant="td">Styling</Text>
+                <Text variant="td">TailwindCSS</Text>
+              </Text>
+              <Text variant="tr">
+                <Text variant="td">UI Component</Text>
+                <Text variant="td">shadcn-ui</Text>
+              </Text>
+            </Text>
+          </Text>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default TextDemo

--- a/apps/www/registry/default/ui/text.tsx
+++ b/apps/www/registry/default/ui/text.tsx
@@ -1,0 +1,144 @@
+import React from "react"
+import clsx from "clsx"
+
+type TextProps = {
+  variant:
+    | "h1"
+    | "h2"
+    | "h3"
+    | "h4"
+    | "h5"
+    | "h6"
+    //
+    | "lead"
+    | "p"
+    | "large"
+    | "small"
+    | "muted"
+    //
+    | "codeBlock"
+    //
+    | "blockquote"
+    | "highlighted"
+    //
+    | "list"
+    | "orderedList"
+    //
+    | "table"
+    | "thead"
+    | "tbody"
+    | "tr"
+    | "th"
+    | "td"
+  children: React.ReactNode
+  className?: string
+}
+
+const Text = ({ variant, children, className }: TextProps) => {
+  const baseStyles = {
+    /* Heading */
+    h1: "scroll-m-20 text-6xl font-semibold tracking-tight lg:text-7xl",
+    h2: "scroll-m-20 text-5xl font-semibold tracking-tight lg:text-6xl",
+    h3: "scroll-m-20 text-4xl font-semibold tracking-tight lg:text-5xl",
+    h4: "scroll-m-20 text-3xl font-semibold tracking-tight",
+    h5: "scroll-m-20 text-2xl font-semibold",
+    h6: "scroll-m-20 text-xl font-semibold",
+
+    /* Base */
+    lead: "text-xl font-medium",
+    large: "text-lg font-medium",
+    p: "leading-normal text-base",
+    small: "text-sm font-base leading-tight",
+    muted: "text-sm font-medium text-muted-foreground",
+
+    /* Code */
+    codeBlock:
+      "relative rounded-lg bg-muted text-foreground px-8 py-10 font-mono text-sm font-medium overflow-x-auto whitespace-pre",
+
+    /* Styled */
+    blockquote: "mt-4 border-l-2 pl-4 italic",
+    highlighted: "bg-yellow-200",
+
+    /* List */
+    list: "my-4 ml-6 list-disc [&>li]:mt-2",
+    orderedList: "my-4 ml-6 list-decimal [&>li]:mt-2",
+
+    /* Table */
+    table: "w-full border-collapse",
+    thead: "border-b bg-muted",
+    tbody: "",
+    tr: "",
+    th: "border px-4 py-2 text-left font-bold",
+    td: "border px-4 py-2 text-left",
+  }
+
+  const classes = clsx(baseStyles[variant], className)
+
+  switch (variant) {
+    /* Heading */
+
+    case "h1":
+      return <h1 className={classes}>{children}</h1>
+    case "h2":
+      return <h2 className={classes}>{children}</h2>
+    case "h3":
+      return <h3 className={classes}>{children}</h3>
+    case "h4":
+      return <h4 className={classes}>{children}</h4>
+    case "h5":
+      return <h5 className={classes}>{children}</h5>
+    case "h6":
+      return <h6 className={classes}>{children}</h6>
+
+    /* Base */
+    case "lead":
+      return <p className={classes}>{children}</p>
+    case "large":
+      return <div className={classes}>{children}</div>
+    case "p":
+      return <p className={classes}>{children}</p>
+    case "small":
+      return <small className={classes}>{children}</small>
+    case "muted":
+      return <p className={classes}>{children}</p>
+
+    /* Styled */
+    case "blockquote":
+      return <blockquote className={classes}>{children}</blockquote>
+    case "highlighted":
+      return <mark className={classes}>{children}</mark>
+
+    /* List */
+    case "list":
+      return <ul className={classes}>{children}</ul>
+    case "orderedList":
+      return <ol className={classes}>{children}</ol>
+
+    /* Code */
+    case "codeBlock":
+      return (
+        <pre className={classes}>
+          <code>{children}</code>
+        </pre>
+      )
+
+    /* Table */
+    case "table":
+      return <table className={classes}>{children}</table>
+    case "thead":
+      return <thead className={classes}>{children}</thead>
+    case "tbody":
+      return <tbody className={classes}>{children}</tbody>
+    case "tr":
+      return <tr className={classes}>{children}</tr>
+    case "th":
+      return <th className={classes}>{children}</th>
+    case "td":
+      return <td className={classes}>{children}</td>
+
+    default:
+      return <p className={classes}>{children}</p>
+  }
+}
+
+export { Text }

--- a/apps/www/registry/new-york/example/text-demo.tsx
+++ b/apps/www/registry/new-york/example/text-demo.tsx
@@ -1,0 +1,124 @@
+import React from "react"
+
+import { Text } from "../ui/Text"
+
+const codeExample = `
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+`.trim()
+
+const TextDemo = () => {
+  return (
+    <div className="p-10 space-y-10">
+      <div>
+        [Heading]
+        <Text variant="h1">This is H1</Text>
+        <Text variant="h2">This is H2</Text>
+        <Text variant="h3">This is H3</Text>
+        <Text variant="h4">This is H4</Text>
+        <Text variant="h5">This is H5</Text>
+        <Text variant="h6">This is H6</Text>
+      </div>
+
+      <div>
+        [Base]
+        <Text variant="lead">This is lead</Text>
+        <Text variant="large">This is large</Text>
+        <Text variant="p">This is p (Default)</Text>
+        <Text variant="small">This is small</Text>
+        <Text variant="muted">This is muted</Text>
+      </div>
+
+      <div>
+        [Styled]
+        <Text variant="blockquote">This is a blockquote.</Text>
+        <Text variant="p">
+          You can <strong>Emphasize Text</strong> like this.
+        </Text>
+        <Text variant="p" className="italic">
+          You can use italic Text like this.
+        </Text>
+        <Text variant="p" className="line-through">
+          You can use deleted Text like this.
+        </Text>
+        <Text variant="highlighted">This Text is highlighted.</Text>
+        <Text variant="p" className="text-indigo-500">
+          You can easily customize Text with className, or you can add new
+          variants to make it reusable.
+        </Text>
+      </div>
+
+      <div>
+        [Code]
+        <Text variant="codeBlock" className="max-w-sm">
+          {codeExample}
+        </Text>
+      </div>
+
+      <div>
+        [List]
+        <Text variant="list">
+          <li>First list</li>
+          <li>Second list</li>
+          <li>Third list</li>
+        </Text>
+        <Text variant="orderedList">
+          <li>First orderedList</li>
+          <li>Second orderedList</li>
+          <li>Third orderedList</li>
+        </Text>
+      </div>
+
+      <div>
+        [Table]
+        <div>
+          <Text variant="small">
+            This is a simple table. I recommend using the{" "}
+            <a
+              href="https://ui.shadcn.com/docs/components/table"
+              className="text-slate-500 underline"
+            >
+              Table Component
+            </a>{" "}
+            instead of this. Additionally, you can use the Button component to
+            easily handle link buttons.
+          </Text>
+        </div>
+        <div className="max-w-md">
+          <Text variant="table">
+            <Text variant="thead">
+              <Text variant="tr">
+                <Text variant="th">Category</Text>
+                <Text variant="th">Tech stack</Text>
+              </Text>
+            </Text>
+            <Text variant="tbody">
+              <Text variant="tr">
+                <Text variant="td">Framework</Text>
+                <Text variant="td">Next.js (React)</Text>
+              </Text>
+              <Text variant="tr">
+                <Text variant="td">Language</Text>
+                <Text variant="td">Typescript</Text>
+              </Text>
+              <Text variant="tr">
+                <Text variant="td">Styling</Text>
+                <Text variant="td">TailwindCSS</Text>
+              </Text>
+              <Text variant="tr">
+                <Text variant="td">UI Component</Text>
+                <Text variant="td">shadcn-ui</Text>
+              </Text>
+            </Text>
+          </Text>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default TextDemo

--- a/apps/www/registry/new-york/ui/text.tsx
+++ b/apps/www/registry/new-york/ui/text.tsx
@@ -1,0 +1,144 @@
+import React from "react"
+import clsx from "clsx"
+
+type TextProps = {
+  variant:
+    | "h1"
+    | "h2"
+    | "h3"
+    | "h4"
+    | "h5"
+    | "h6"
+    //
+    | "lead"
+    | "p"
+    | "large"
+    | "small"
+    | "muted"
+    //
+    | "codeBlock"
+    //
+    | "blockquote"
+    | "highlighted"
+    //
+    | "list"
+    | "orderedList"
+    //
+    | "table"
+    | "thead"
+    | "tbody"
+    | "tr"
+    | "th"
+    | "td"
+  children: React.ReactNode
+  className?: string
+}
+
+const Text = ({ variant, children, className }: TextProps) => {
+  const baseStyles = {
+    /* Heading */
+    h1: "scroll-m-20 text-6xl font-semibold tracking-tight lg:text-7xl",
+    h2: "scroll-m-20 text-5xl font-semibold tracking-tight lg:text-6xl",
+    h3: "scroll-m-20 text-4xl font-semibold tracking-tight lg:text-5xl",
+    h4: "scroll-m-20 text-3xl font-semibold tracking-tight",
+    h5: "scroll-m-20 text-2xl font-semibold",
+    h6: "scroll-m-20 text-xl font-semibold",
+
+    /* Base */
+    lead: "text-xl font-medium",
+    large: "text-lg font-medium",
+    p: "leading-normal text-base",
+    small: "text-sm font-base leading-tight",
+    muted: "text-sm font-medium text-muted-foreground",
+
+    /* Code */
+    codeBlock:
+      "relative rounded-lg bg-muted text-foreground px-8 py-10 font-mono text-sm font-medium overflow-x-auto whitespace-pre",
+
+    /* Styled */
+    blockquote: "mt-4 border-l-2 pl-4 italic",
+    highlighted: "bg-yellow-200",
+
+    /* List */
+    list: "my-4 ml-6 list-disc [&>li]:mt-2",
+    orderedList: "my-4 ml-6 list-decimal [&>li]:mt-2",
+
+    /* Table */
+    table: "w-full border-collapse",
+    thead: "border-b bg-muted",
+    tbody: "",
+    tr: "",
+    th: "border px-4 py-2 text-left font-bold",
+    td: "border px-4 py-2 text-left",
+  }
+
+  const classes = clsx(baseStyles[variant], className)
+
+  switch (variant) {
+    /* Heading */
+
+    case "h1":
+      return <h1 className={classes}>{children}</h1>
+    case "h2":
+      return <h2 className={classes}>{children}</h2>
+    case "h3":
+      return <h3 className={classes}>{children}</h3>
+    case "h4":
+      return <h4 className={classes}>{children}</h4>
+    case "h5":
+      return <h5 className={classes}>{children}</h5>
+    case "h6":
+      return <h6 className={classes}>{children}</h6>
+
+    /* Base */
+    case "lead":
+      return <p className={classes}>{children}</p>
+    case "large":
+      return <div className={classes}>{children}</div>
+    case "p":
+      return <p className={classes}>{children}</p>
+    case "small":
+      return <small className={classes}>{children}</small>
+    case "muted":
+      return <p className={classes}>{children}</p>
+
+    /* Styled */
+    case "blockquote":
+      return <blockquote className={classes}>{children}</blockquote>
+    case "highlighted":
+      return <mark className={classes}>{children}</mark>
+
+    /* List */
+    case "list":
+      return <ul className={classes}>{children}</ul>
+    case "orderedList":
+      return <ol className={classes}>{children}</ol>
+
+    /* Code */
+    case "codeBlock":
+      return (
+        <pre className={classes}>
+          <code>{children}</code>
+        </pre>
+      )
+
+    /* Table */
+    case "table":
+      return <table className={classes}>{children}</table>
+    case "thead":
+      return <thead className={classes}>{children}</thead>
+    case "tbody":
+      return <tbody className={classes}>{children}</tbody>
+    case "tr":
+      return <tr className={classes}>{children}</tr>
+    case "th":
+      return <th className={classes}>{children}</th>
+    case "td":
+      return <td className={classes}>{children}</td>
+
+    default:
+      return <p className={classes}>{children}</p>
+  }
+}
+
+export { Text }


### PR DESCRIPTION
<aside>

<img width="400" alt="image_1" src="https://github.com/user-attachments/assets/8a3d721a-5cad-4467-ad28-b071fcfa48b1">

<img width="400" alt="image_2" src="https://github.com/user-attachments/assets/92a2b5c5-fe1d-4e7b-8be6-1ee8816f6625">


</aside>

# **What is this.**

<img width="284" alt="image_1111" src="https://github.com/user-attachments/assets/afa4324a-81fd-4329-9137-162dc93f7279">


This component simplifies writing text using shadcn-ui and TailwindCSS.

Although there is an existing Typography example, it makes the code look messy due to its length when used. 
So, I created a Text component to manage text throughout the project.


# **For more information.**

I’ve uploaded the component to a public repository. Feel free to check it out!
### [-> Repository](https://github.com/bytaesu/shadcn-ui-text)

# **In conclusion.**

Additional work is still needed, such as a user guide, installation, etc. Once merged, I will work on it further to fit shadcn-ui and submit an additional pull request so that it can be used right away.