### PR TITLE
fix: Fix the typo in error messages (`component.json` → `components.json`)

### DIFF
--- a/.changeset/rare-bugs-repair.md
+++ b/.changeset/rare-bugs-repair.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+fix typo in components.json

--- a/packages/shadcn/src/commands/add.ts
+++ b/packages/shadcn/src/commands/add.ts
@@ -82,13 +82,13 @@ export const add = new Command()
 
       let { errors, config } = await preFlightAdd(options)
 
-      // No component.json file. Prompt the user to run init.
+      // No components.json file. Prompt the user to run init.
       if (errors[ERRORS.MISSING_CONFIG]) {
         const { proceed } = await prompts({
           type: "confirm",
           name: "proceed",
           message: `You need to create a ${highlighter.info(
-            "component.json"
+            "components.json"
           )} file to add components. Proceed?`,
           initial: true,
         })

--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -125,7 +125,7 @@ export async function getRawConfig(cwd: string): Promise<RawConfig | null> {
 
     return rawConfigSchema.parse(configResult.config)
   } catch (error) {
-    const componentPath = `${cwd}/component.json`
+    const componentPath = `${cwd}/components.json`
     throw new Error(
       `Invalid configuration found in ${highlighter.info(componentPath)}.`
     )


### PR DESCRIPTION
This PR fixes the typo in the error message where the CLI tells the user to create a `component.json` file (singular), instead of a `components.json` file (plural).

Currently, the error message for not having a `components.json` file reads:
> ✔ You need to create a component.json file to add components. Proceed?

But, I believe it should be `components.json` (not `component.json`).

I also found another place in the get-cofing file where `components.json` is referenced as `component.json`, so included it in this PR.

Hope this helps 🤞