### PR TITLE
fix: astro/vite error 'react-hook-form' does not provide an export named 'FieldValues'

### DIFF
--- a/apps/www/registry/default/ui/form.tsx
+++ b/apps/www/registry/default/ui/form.tsx
@@ -5,11 +5,13 @@ import * as LabelPrimitive from "@radix-ui/react-label"
 import { Slot } from "@radix-ui/react-slot"
 import {
   Controller,
+  FormProvider,
+  useFormContext,
+} from "react-hook-form"
+import type {
   ControllerProps,
   FieldPath,
   FieldValues,
-  FormProvider,
-  useFormContext,
 } from "react-hook-form"
 
 import { cn } from "@/lib/utils"

--- a/apps/www/registry/new-york/ui/form.tsx
+++ b/apps/www/registry/new-york/ui/form.tsx
@@ -5,11 +5,13 @@ import * as LabelPrimitive from "@radix-ui/react-label"
 import { Slot } from "@radix-ui/react-slot"
 import {
   Controller,
+  FormProvider,
+  useFormContext,
+} from "react-hook-form"
+import type {
   ControllerProps,
   FieldPath,
   FieldValues,
-  FormProvider,
-  useFormContext,
 } from "react-hook-form"
 
 import { cn } from "@/lib/utils"


### PR DESCRIPTION
It's just marking the types as types.  

I recommend use https://biomejs.dev/, it catch this error early.


![Screenshot 2024-09-26 at 12 32 55 PM](https://github.com/user-attachments/assets/230a446f-71fc-4cb3-ab4e-29f2c6d50663)
