### PR TITLE
fix: 'actionTypes' is assigned a value but only used as a type. @typescript-eslint/no-unused-vars

### DIFF
--- a/apps/www/registry/default/hooks/use-toast.ts
+++ b/apps/www/registry/default/hooks/use-toast.ts
@@ -18,6 +18,7 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const actionTypes = {
   ADD_TOAST: "ADD_TOAST",
   UPDATE_TOAST: "UPDATE_TOAST",

--- a/apps/www/registry/new-york/hooks/use-toast.ts
+++ b/apps/www/registry/new-york/hooks/use-toast.ts
@@ -18,6 +18,7 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const actionTypes = {
   ADD_TOAST: "ADD_TOAST",
   UPDATE_TOAST: "UPDATE_TOAST",


### PR DESCRIPTION
having an issue with the toast component 
![image](https://github.com/user-attachments/assets/c8713b19-398e-4922-9cc2-f8e952ef22b1)
