### PR TITLE
fix: #4895

### DIFF
--- a/apps/www/registry/default/ui/navigation-menu.tsx
+++ b/apps/www/registry/default/ui/navigation-menu.tsx
@@ -53,11 +53,17 @@ const NavigationMenuTrigger = React.forwardRef<
     className={cn(navigationMenuTriggerStyle(), "group", className)}
     {...props}
   >
-    {children}{" "}
-    <ChevronDown
-      className="relative top-[1px] ml-1 h-3 w-3 transition duration-200 group-data-[state=open]:rotate-180"
-      aria-hidden="true"
-    />
+    {!props.asChild ? (
+      <>
+        {children}{" "}
+        <ChevronDown
+          className="relative top-[1px] ml-1 h-3 w-3 transition duration-200 group-data-[state=open]:rotate-180"
+          aria-hidden="true"
+        />
+      </>
+    ) : (
+      children
+    )}
   </NavigationMenuPrimitive.Trigger>
 ))
 NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName

--- a/apps/www/registry/new-york/ui/navigation-menu.tsx
+++ b/apps/www/registry/new-york/ui/navigation-menu.tsx
@@ -53,11 +53,17 @@ const NavigationMenuTrigger = React.forwardRef<
     className={cn(navigationMenuTriggerStyle(), "group", className)}
     {...props}
   >
-    {children}{" "}
-    <ChevronDownIcon
-      className="relative top-[1px] ml-1 h-3 w-3 transition duration-300 group-data-[state=open]:rotate-180"
-      aria-hidden="true"
-    />
+    {!props.asChild ? (
+      <>
+        {children}{" "}
+        <ChevronDownIcon
+          className="relative top-[1px] ml-1 h-3 w-3 transition duration-300 group-data-[state=open]:rotate-180"
+          aria-hidden="true"
+        />
+      </>
+    ) : (
+      children
+    )}
   </NavigationMenuPrimitive.Trigger>
 ))
 NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName


### PR DESCRIPTION
Update NavigationMenuTrigger to ensure that it only adds the chevron component when the asChild prop is falsy to prevent the React.only error from occurring

Addresses the follow bug report I filed: https://github.com/shadcn-ui/ui/issues/4985