### PR TITLE
feat: Support remote registry urls in cli

### DIFF
--- a/packages/shadcn/src/commands/add.ts
+++ b/packages/shadcn/src/commands/add.ts
@@ -20,6 +20,7 @@ export const addOptionsSchema = z.object({
   cwd: z.string(),
   all: z.boolean(),
   path: z.string().optional(),
+  registry: z.string().optional(),
   silent: z.boolean(),
   srcDir: z.boolean().optional(),
 })
@@ -40,6 +41,7 @@ export const add = new Command()
   )
   .option("-a, --all", "add all available components", false)
   .option("-p, --path <path>", "the path to add the component to.")
+  .option("-r, --registry <registry>", "the registry to use.")
   .option("-s, --silent", "mute output.", false)
   .option(
     "--src-dir",
@@ -77,6 +79,10 @@ export const add = new Command()
       }
 
       if (!options.components?.length) {
+        options.components = await promptForRegistryComponents(options)
+      }
+
+      if (options.registry) {
         options.components = await promptForRegistryComponents(options)
       }
 
@@ -161,7 +167,7 @@ export const add = new Command()
 async function promptForRegistryComponents(
   options: z.infer<typeof addOptionsSchema>
 ) {
-  const registryIndex = await getRegistryIndex()
+  const registryIndex = await getRegistryIndex(options.registry)
   if (!registryIndex) {
     logger.break()
     handleError(new Error("Failed to fetch registry index."))

--- a/packages/shadcn/src/utils/add-components.ts
+++ b/packages/shadcn/src/utils/add-components.ts
@@ -12,6 +12,7 @@ export async function addComponents(
   components: string[],
   config: Config,
   options: {
+    registry?: string
     overwrite?: boolean
     silent?: boolean
     isNewProject?: boolean
@@ -27,7 +28,11 @@ export async function addComponents(
   const registrySpinner = spinner(`Checking registry.`, {
     silent: options.silent,
   })?.start()
-  const tree = await registryResolveItemsTree(components, config)
+  const tree = await registryResolveItemsTree(
+    options.registry,
+    components,
+    config
+  )
   if (!tree) {
     registrySpinner?.fail()
     return handleError(new Error("Failed to fetch components from registry."))

--- a/packages/shadcn/src/utils/updaters/update-files.ts
+++ b/packages/shadcn/src/utils/updaters/update-files.ts
@@ -34,6 +34,7 @@ export async function updateFiles(
   files: RegistryItem["files"],
   config: Config,
   options: {
+    registry?: string
     overwrite?: boolean
     force?: boolean
     silent?: boolean
@@ -54,7 +55,7 @@ export async function updateFiles(
 
   const [projectInfo, baseColor] = await Promise.all([
     getProjectInfo(config.resolvedPaths.cwd),
-    getRegistryBaseColor(config.tailwind.baseColor),
+    getRegistryBaseColor(options.registry, config.tailwind.baseColor),
   ])
 
   const filesCreated = []


### PR DESCRIPTION
Created a proof of concept to enable the following command

```
npx shadcn add -r "https://magicui.design/r"
```

Would allow users to browse remote registries using the cli and select multiple components at a time

This removes the hardcoded dependency on `REGISTRY_URL`: