### PR TITLE
Fix radio group input

### DIFF
--- a/apps/www/registry/default/ui/radio-group.tsx
+++ b/apps/www/registry/default/ui/radio-group.tsx
@@ -24,6 +24,13 @@ const RadioGroupItem = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
 >(({ className, ...props }, ref) => {
+  React.useEffect(() => {
+    document.querySelectorAll<HTMLInputElement>('input[type="radio"]').forEach(input => {
+      if (input.value) {
+        input.id = `radio-${input.value.replace(/\s+/g, '-').toLowerCase()}`
+      }
+    })
+  }, [])
   return (
     <RadioGroupPrimitive.Item
       ref={ref}

--- a/apps/www/registry/new-york/ui/radio-group.tsx
+++ b/apps/www/registry/new-york/ui/radio-group.tsx
@@ -24,6 +24,13 @@ const RadioGroupItem = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
 >(({ className, ...props }, ref) => {
+  React.useEffect(() => {
+    document.querySelectorAll<HTMLInputElement>('input[type="radio"]').forEach(input => {
+      if (input.value) {
+        input.id = `radio-${input.value.replace(/\s+/g, '-').toLowerCase()}`
+      }
+    })
+  }, [])
   return (
     <RadioGroupPrimitive.Item
       ref={ref}


### PR DESCRIPTION
This PR adds a `useEffect` hook to set the `id` attribute for the `input` element inside `RadioGroupPrimitive.Item`. This change addresses a Chrome issue: _"A form field element should have an id or name attribute."_

Although the `autoComplete` prop is not really used in the context of a radio group, adding the `id` prevents the warning and improves accessibility without affecting the functionality.