### PR TITLE
feat(shadcn): allow removal of variables from external registries

### DIFF
--- a/.changeset/four-rings-sniff.md
+++ b/.changeset/four-rings-sniff.md
@@ -1,0 +1,5 @@
+---
+"shadcn": minor
+---
+
+Allow removal of CSS variables and tailwind properties from external registry files

--- a/packages/shadcn/src/utils/registry/schema.ts
+++ b/packages/shadcn/src/utils/registry/schema.ts
@@ -31,8 +31,8 @@ export const registryItemTailwindSchema = z.object({
 })
 
 export const registryItemCssVarsSchema = z.object({
-  light: z.record(z.string(), z.string()).optional(),
-  dark: z.record(z.string(), z.string()).optional(),
+  light: z.record(z.string(), z.string().nullable()).optional(),
+  dark: z.record(z.string(), z.string().nullable()).optional(),
 })
 
 export const registryItemSchema = z.object({

--- a/packages/shadcn/src/utils/updaters/update-css-vars.ts
+++ b/packages/shadcn/src/utils/updaters/update-css-vars.ts
@@ -264,7 +264,7 @@ function cleanupDefaultNextStylesPlugin() {
 function addOrUpdateVars(
   baseLayer: AtRule,
   selector: string,
-  vars: Record<string, string>
+  vars: Record<string, string | null>
 ) {
   let ruleNode = baseLayer.nodes?.find(
     (node): node is Rule => node.type === "rule" && node.selector === selector
@@ -282,17 +282,24 @@ function addOrUpdateVars(
 
   Object.entries(vars).forEach(([key, value]) => {
     const prop = `--${key.replace(/^--/, "")}`
-    const newDecl = postcss.decl({
-      prop,
-      value,
-      raws: { semicolon: true },
-    })
 
+    // Gets the var declaration based on the key
     const existingDecl = ruleNode?.nodes.find(
       (node): node is postcss.Declaration =>
         node.type === "decl" && node.prop === prop
     )
-
-    existingDecl ? existingDecl.replaceWith(newDecl) : ruleNode?.append(newDecl)
+    if (value === null) {
+      // Key is set to null, remove it
+      existingDecl?.remove()
+    } else {
+      const newDecl = postcss.decl({
+        prop,
+        value,
+        raws: { semicolon: true },
+      })
+      existingDecl
+        ? existingDecl.replaceWith(newDecl)
+        : ruleNode?.append(newDecl)
+    }
   })
 }

--- a/packages/shadcn/src/utils/updaters/update-tailwind-config.ts
+++ b/packages/shadcn/src/utils/updaters/update-tailwind-config.ts
@@ -171,6 +171,22 @@ function addTailwindConfigProperty(
   return configObject
 }
 
+function removeNull(obj: Record<string, any>) {
+  return Object.entries(obj).reduce<Record<string, any>>(
+    (acc, [key, value]) => {
+      if (value) {
+        if (typeof value === "object" && !Array.isArray(value)) {
+          acc[key] = removeNull(value)
+        } else {
+          acc[key] = value
+        }
+      }
+      return acc
+    },
+    {}
+  )
+}
+
 async function addTailwindConfigTheme(
   configObject: ObjectLiteralExpression,
   theme: UpdaterTailwindConfig["theme"]
@@ -195,7 +211,8 @@ async function addTailwindConfigTheme(
     const themeObjectString = themeInitializer.getText()
     const themeObject = await parseObjectLiteral(themeObjectString)
     const result = deepmerge(themeObject, theme)
-    const resultString = objectToString(result)
+
+    const resultString = objectToString(removeNull(result ?? {}))
       .replace(/\'\"/g, "'") // Replace `\" with "
       .replace(/\"\'/g, "'") // Replace `\" with "
       .replace(/\'\[/g, "[") // Replace `[ with [

--- a/packages/shadcn/test/utils/updaters/__snapshots__/update-tailwind-config.test.ts.snap
+++ b/packages/shadcn/test/utils/updaters/__snapshots__/update-tailwind-config.test.ts.snap
@@ -466,3 +466,33 @@ const config: Config = {
 export default config
   "
 `;
+
+exports[`transformTailwindConfig -> theme > should remove properties set explicitly to null 1`] = `
+"import type { Config } from 'tailwindcss'
+
+const config: Config = {
+    darkMode: ["class"],
+    content: [
+    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+  	extend: {
+  		colors: {
+  			foreground: 'hsl(var(--foreground))',
+  			primary: {
+  				DEFAULT: 'hsl(var(--primary))',
+  				foreground: 'hsl(var(--primary-foreground))'
+  			},
+  			card: {
+  				DEFAULT: 'hsl(var(--card))',
+  				foreground: 'hsl(var(--card-foreground))'
+  			}
+  		}
+  	}
+  },
+}
+export default config
+  "
+`;

--- a/packages/shadcn/test/utils/updaters/update-css-vars.test.ts
+++ b/packages/shadcn/test/utils/updaters/update-css-vars.test.ts
@@ -172,4 +172,69 @@ describe("transformCssVars", () => {
         "
     `)
   })
+
+  test("should remove existing light and dark variables when providing null", async () => {
+    expect(
+      await transformCssVars(
+        `@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base{
+  :root{
+    --background: 210 40% 98%;
+    --foreground: black;
+  }
+
+  .dark{
+    --background: 222.2 84% 4.9%;
+    --foreground: white;
+  }
+}
+  `,
+        {
+          light: {
+            background: "215 20.2% 65.1%",
+            foreground: null,
+            custom: '255 0% 0%'
+          },
+          dark: {
+            custom: "0 0% 0%",
+            foreground: null,
+          },
+        },
+        {
+          tailwind: {
+            cssVariables: true,
+          },
+        }
+      )
+    ).toMatchInlineSnapshot(`
+"@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base{
+  :root{
+    --background: 215 20.2% 65.1%;
+    --custom: 255 0% 0%;
+  }
+
+  .dark{
+    --background: 222.2 84% 4.9%;
+    --custom: 0 0% 0%;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}
+  "
+`)
+  })
 })

--- a/packages/shadcn/test/utils/updaters/update-tailwind-config.test.ts
+++ b/packages/shadcn/test/utils/updaters/update-tailwind-config.test.ts
@@ -809,6 +809,52 @@ export default config
       )
     ).toMatchSnapshot()
   })
+
+  test("should remove properties set explicitly to null", async () => {
+    expect(
+      await transformTailwindConfig(
+        `import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+      },
+    },
+  },
+}
+export default config
+  `,
+        {
+          theme: {
+            extend: {
+              colors: {
+                primary: {
+                  DEFAULT: "hsl(var(--primary))",
+                  foreground: "hsl(var(--primary-foreground))",
+                },
+                card: {
+                  DEFAULT: "hsl(var(--card))",
+                  foreground: "hsl(var(--card-foreground))",
+                },
+                background: null,
+              },
+            },
+          },
+        },
+        {
+          config: SHARED_CONFIG,
+        }
+      )
+    ).toMatchSnapshot()
+  })
 })
 
 describe("nestSpreadProperties", () => {


### PR DESCRIPTION
Allows external registries to remove CSS / tailwind variables that are not being used by their systems

# Use case
We are building out our component registry for internal use but have chosen to use our own named tokens for theming

Currently, if we wanted to remove the defaults, that requires a manual step for our consumers to delete those CSS variables/tailwind colours manually after running `shadcn init`.

We've worked around this temporarily by having our own cli that calls `shadcn init` and removes those variables

# Proposal
Update schemas/utils to allow `null` when defining `cssVariables` or in the `tailwind` properties to remove them when running `shadcn add ...`. This should allow us to remove our own cli to fully leverage the `shadcn` tooling 🎉 

```json
// http://localhost:3000/registry/theme-foo.json
{
  "theme": "theme-foo",
  "type": "registry:theme",
  "cssVars": {
    "light": {
      "card": null,
      "card-foreground": null,
      "info": "210.8 100% 56.9%"
    },
    "dark": {
      "card": null,
      "card-foreground": null
    }
  },
  "tailwind": {
    "config": {
      "theme": {
        "extend": {
          "colors": {
            "card": null,
            "info": "hsl(var(--info))"
          }
        }
      }
    }
  }
}
```

After running `pnpx shadcn@latest add http://localhost:3000/registry/theme-foo.json` this should:
1. Remove `--card`, and `--card-foreground` from the `globals.css` file
2. Add `--info` to the `globals.css` file
3. Remove `theme.extend.colors.card` from `tailwind.config.ts`
4. Add `theme.extend.colors.info` to `tailwind.config.ts`
