### PR TITLE
Added back themes to the block page

### DIFF
--- a/apps/www/app/(blocks)/blocks/[style]/[name]/page.tsx
+++ b/apps/www/app/(blocks)/blocks/[style]/[name]/page.tsx
@@ -88,7 +88,7 @@ export default async function BlockPage({
 
   return (
     <>
-      {/* <ThemesStyle /> */}
+      <ThemesStyle />
       <div
         className={cn(
           "themes-wrapper bg-background",


### PR DESCRIPTION
Fixing the theme picker for blocks

Based on this Issue [https://github.com/shadcn-ui/ui/issues/5211](https://github.com/shadcn-ui/ui/issues/5211)

Before:
https://github.com/user-attachments/assets/179e358f-0ce1-4056-bd61-64a9f2e07e29

After:
https://github.com/user-attachments/assets/62c0e783-b4fb-48ef-9ab1-7607bb815e89

