### PR TITLE
fix: add an createCookieSessionStorage import

### DIFF
--- a/apps/www/content/docs/dark-mode/remix.mdx
+++ b/apps/www/content/docs/dark-mode/remix.mdx
@@ -30,6 +30,7 @@ npm install remix-themes
 
 ```tsx title="app/sessions.server.tsx"
 import { createThemeSessionResolver } from "remix-themes"
+import { createCookieSessionStorage } from '@remix-run/node';
 
 // You can default to 'development' if process.env.NODE_ENV is not set
 const isProduction = process.env.NODE_ENV === "production"


### PR DESCRIPTION
#### Including the import for createCookieSessionStorage

Importing createCookieSessionStorage from @remix-run/node as there is a need to import manually, as the import is not included.