### PR TITLE
fix: error handling in package info retrieval

### DIFF
--- a/packages/cli/src/utils/get-package-info.ts
+++ b/packages/cli/src/utils/get-package-info.ts
@@ -4,6 +4,13 @@ import { type PackageJson } from "type-fest"
 
 export function getPackageInfo() {
   const packageJsonPath = path.join("package.json")
+  const fileContent = fs.readJSONSync(packageJsonPath, {
+    throws: false,
+  }) as PackageJson | null
 
-  return fs.readJSONSync(packageJsonPath) as PackageJson
+  if (!fileContent) {
+    throw new Error("Failed to read or parse package.json. Make sure it exists or is not malformed.")
+  }
+
+  return fileContent
 }


### PR DESCRIPTION
This update improves the error handling mechanism in the package information retrieval function. Previously, the function would fail silently if it couldn't read or parse the 'package.json' file. Now, it explicitly throws an error with a helpful message, making it easier to diagnose issues related to a missing or malformed 'package.json' file. This change enhances the robustness of the CLI tool and improves the developer experience. 

#4822 