### PR TITLE
Remove the space above the icon in `New York` theme

### DIFF
--- a/apps/www/registry/new-york/ui/alert.tsx
+++ b/apps/www/registry/new-york/ui/alert.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
   {
     variants: {
       variant: {


### PR DESCRIPTION
As you can see, there is a space above the icon next to the title

![Screenshot 2024-10-08 at 09 15 25](https://github.com/user-attachments/assets/5fa91083-248e-458e-8c4b-68abe20488ec)

Compare to default theme, it's normal

![Screenshot 2024-10-08 at 09 16 05](https://github.com/user-attachments/assets/84062fef-d5aa-40e9-98ce-54f0fd617317)

