### PR TITLE
fix: implement `itemSorter` prop in `ChartTooltip` component

### DIFF
--- a/apps/www/registry/new-york/ui/chart.tsx
+++ b/apps/www/registry/new-york/ui/chart.tsx
@@ -133,6 +133,7 @@ const ChartTooltipContent = React.forwardRef<
       color,
       nameKey,
       labelKey,
+      itemSorter = () => -1,
     },
     ref
   ) => {
@@ -174,11 +175,26 @@ const ChartTooltipContent = React.forwardRef<
       labelKey,
     ])
 
-    if (!active || !payload?.length) {
+    const sortedPayload = React.useMemo(() => {
+      return payload?.slice().sort((a, b) => {
+        const aValue = itemSorter(a)
+        const bValue = itemSorter(b)
+
+        if (aValue < bValue) {
+          return -1
+        }
+        if (aValue > bValue) {
+          return 1
+        }
+        return 0
+      })
+    }, [payload, itemSorter])
+
+    if (!active || !sortedPayload?.length) {
       return null
     }
 
-    const nestLabel = payload.length === 1 && indicator !== "dot"
+    const nestLabel = sortedPayload.length === 1 && indicator !== "dot"
 
     return (
       <div
@@ -190,7 +206,7 @@ const ChartTooltipContent = React.forwardRef<
       >
         {!nestLabel ? tooltipLabel : null}
         <div className="grid gap-1.5">
-          {payload.map((item, index) => {
+          {sortedPayload.map((item, index) => {
             const key = `${nameKey || item.name || item.dataKey || "value"}`
             const itemConfig = getPayloadConfigFromPayload(config, item, key)
             const indicatorColor = color || item.payload.fill || item.color


### PR DESCRIPTION
This pull request implements the `itemSorter` prop in the `ChartTooltip` component, allowing users to specify custom sorting logic for tooltip items. This enhancement mirrors the functionality available in Recharts' default tooltip component ([Recharts Tooltip Documentation](https://recharts.org/en-US/api/Tooltip#itemSorter)), providing greater flexibility and control over the display order of tooltip data.

**Changes Made:**

-    **Implemented `itemSorter` Prop:**
    - The `itemSorter` prop is a function of type `(item: Payload<ValueType, NameType>) => string | number`.
    - It allows users to define custom sorting criteria for tooltip items, similar to the existing feature in Recharts.

-    **Implemented Sorting Logic:**
    - Utilized JavaScript's native `Array.prototype.sort` method to sort the payload based on the provided `itemSorter` function.
    - Ensured the original payload remains unmodified by sorting a shallow copy of the array.