### PR TITLE
Fix chart tooltip spacing when using longer names

### DIFF
--- a/apps/www/registry/default/ui/chart.tsx
+++ b/apps/www/registry/default/ui/chart.tsx
@@ -228,7 +228,7 @@ const ChartTooltipContent = React.forwardRef<
                     )}
                     <div
                       className={cn(
-                        "flex flex-1 justify-between leading-none",
+                        "flex flex-1 justify-between leading-none gap-1.5",
                         nestLabel ? "items-end" : "items-center"
                       )}
                     >


### PR DESCRIPTION
### Describe the bug

If the name in the tooltip is longer than ~13 chars, the name and the number next to it have no appropriate spacing.

![image](https://github.com/user-attachments/assets/ae6494a2-f875-436a-b6cb-9a0032b2fef2)

or 

![image](https://github.com/user-attachments/assets/41e7fd4f-5fd5-47fe-8299-f137a8dc4fd3)

### Affected component/components

- Charts

### How to reproduce

Use a longer name in the tooltip

### What was done in this PR

Fixed the spacing between tooltip name and number.

With the applied fixes the tooltip looks like this:

![image](https://github.com/user-attachments/assets/19556b80-47c7-4e2c-8d0a-f29916149b0b)
