### PR TITLE
docs: update dark mode highlighting for Next.js

### DIFF
--- a/apps/www/content/docs/dark-mode/next.mdx
+++ b/apps/www/content/docs/dark-mode/next.mdx
@@ -31,9 +31,9 @@ export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
 
 ### Wrap your root layout
 
-Add the `ThemeProvider` to your root layout.
+Add the `ThemeProvider` to your root layout and include `suppressHydrationWarning` on the `<html>` tag to prevent hydration mismatch error.
 
-```tsx {1,9-11} title="app/layout.tsx"
+```tsx {1,6,9-14} title="app/layout.tsx"
 import { ThemeProvider } from "@/components/theme-provider"
 
 export default function RootLayout({ children }: RootLayoutProps) {


### PR DESCRIPTION
## Why

I missed to add the `suppressHydrationWarning` to my project. It takes me a while to figure out what's the root cause.
This PR make the docs more obvious. I hope this makes other people not forget about it.

**Before**:

<img width="718" alt="image" src="https://github.com/user-attachments/assets/267d295d-35e9-4dcd-9809-9592916da804">

**After**: 

<img width="729" alt="image" src="https://github.com/user-attachments/assets/014c1a37-255f-4a6e-b1d8-6769e7333301">

