### PR TITLE
Fixed:Sidebar has extra space at bottom when framed

### DIFF
--- a/apps/www/components/mobile-nav.tsx
+++ b/apps/www/components/mobile-nav.tsx
@@ -64,7 +64,7 @@ export function MobileNav() {
           <Icons.logo className="mr-2 h-4 w-4" />
           <span className="font-bold">{siteConfig.name}</span>
         </MobileLink>
-        <ScrollArea className="my-4 h-[calc(100vh-8rem)] pb-10 pl-6">
+        <ScrollArea className="my-4 h-[calc(100vh-3rem)] pb-10 pl-6">
           <div className="flex flex-col space-y-3">
             {docsConfig.mainNav?.map(
               (item) =>


### PR DESCRIPTION
**Fixed: #5410**

**Sidebar has extra space at bottom when framed has been fixed**
![image](https://github.com/user-attachments/assets/0eb5fa2e-f6d4-4883-be8a-5a8aa62219f7)
