### PR TITLE
refactor: :recycle: redirect components href to sidebar

### DIFF
--- a/apps/www/config/docs.ts
+++ b/apps/www/config/docs.ts
@@ -14,7 +14,7 @@ export const docsConfig: DocsConfig = {
     },
     {
       title: "Components",
-      href: "/docs/components/accordion",
+      href: "/docs/components/sidebar",
     },
     {
       title: "Blocks",

--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -20,12 +20,12 @@ const nextConfig = {
     return [
       {
         source: "/components",
-        destination: "/docs/components/accordion",
+        destination: "/docs/components/sidebar",
         permanent: true,
       },
       {
         source: "/docs/components",
-        destination: "/docs/components/accordion",
+        destination: "/docs/components/sidebar",
         permanent: true,
       },
       {


### PR DESCRIPTION
Redirecting to sidebar instead of accordion component when clicking the components link in the header or going to `/docs/components`.

