### PR TITLE
Fixes #5443: Update sidebar toggle logic to open/close correctly

### DIFF
--- a/apps/www/registry/default/block/demo-sidebar-controlled.tsx
+++ b/apps/www/registry/default/block/demo-sidebar-controlled.tsx
@@ -87,7 +87,7 @@ export default function AppSidebar() {
             variant="ghost"
           >
             {open ? <PanelLeftClose /> : <PanelLeftOpen />}
-            <span>{open ? "Open" : "Close"} Sidebar</span>
+            <span>{open ? "Close" : "Open"} Sidebar</span>
           </Button>
         </header>
       </SidebarInset>

--- a/apps/www/registry/new-york/block/demo-sidebar-controlled.tsx
+++ b/apps/www/registry/new-york/block/demo-sidebar-controlled.tsx
@@ -87,7 +87,7 @@ export default function AppSidebar() {
             variant="ghost"
           >
             {open ? <PanelLeftClose /> : <PanelLeftOpen />}
-            <span>{open ? "Open" : "Close"} Sidebar</span>
+            <span>{open ? "Close" : "Open"} Sidebar</span>
           </Button>
         </header>
       </SidebarInset>


### PR DESCRIPTION
This pull request fixes an issue with the sidebar toggle logic where the terms "Open sidebar" and "Close sidebar" were reversed. Now, the sidebar correctly displays "Open" when it's closed and "Close" when it's open.

Files Modified:

1. apps/www/registry/default/block/demo-sidebar-controlled.tsx
2. apps/www/registry/new-york/block/demo-sidebar-controlled.tsx

Changes:

I swapped the open and close states in the above files to ensure the correct behavior of the sidebar toggle button.
This fix addresses the issue raised in [#<issue_number>], ensuring a better user experience.

