### PR TITLE
fix: style issue related to team switcher in sidebar component

### DIFF
--- a/apps/www/registry/default/block/sidebar-07/components/team-switcher.tsx
+++ b/apps/www/registry/default/block/sidebar-07/components/team-switcher.tsx
@@ -40,7 +40,7 @@ export function TeamSwitcher({
               size="lg"
               className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
             >
-              <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
+              <div className="flex aspect-square size-8 shrink-0 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
                 <activeTeam.logo className="size-4" />
               </div>
               <div className="grid flex-1 text-left text-sm leading-tight">

--- a/apps/www/registry/default/v0/sidebar-07.tsx
+++ b/apps/www/registry/default/v0/sidebar-07.tsx
@@ -224,7 +224,7 @@ export default function Page() {
                     size="lg"
                     className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
                   >
-                    <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
+                    <div className="flex aspect-square size-8 shrink-0 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
                       <activeTeam.logo className="size-4" />
                     </div>
                     <div className="grid flex-1 text-left text-sm leading-tight">

--- a/apps/www/registry/new-york/v0/sidebar-07.tsx
+++ b/apps/www/registry/new-york/v0/sidebar-07.tsx
@@ -224,7 +224,7 @@ export default function Page() {
                     size="lg"
                     className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
                   >
-                    <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
+                    <div className="flex aspect-square size-8 shrink-0 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
                       <activeTeam.logo className="size-4" />
                     </div>
                     <div className="grid flex-1 text-left text-sm leading-tight">


### PR DESCRIPTION
Hello, this PR provides a fix for the style issue of icons within buttons in the current sidebar component. Two examples are provided below to demonstrate the effect of this fix:

Before the fix:

![showcase-2-shadcn-before](https://github.com/user-attachments/assets/f6696207-2c9f-4789-9d03-537caa3402c2)

After the fix:

![showcase-2-shadcn-after](https://github.com/user-attachments/assets/d4873751-1632-421d-bd8c-3159d52946b6)
