### PR TITLE
docs: fix prop name

### DIFF
--- a/apps/www/content/docs/components/sidebar.mdx
+++ b/apps/www/content/docs/components/sidebar.mdx
@@ -346,7 +346,7 @@ The `SidebarProvider` component is used to provide the sidebar context to the `S
 | ------------- | ------------------------- | -------------------------------------------- |
 | `defaultOpen` | `boolean`                 | Default open state of the sidebar.           |
 | `open`        | `boolean`                 | Open state of the sidebar (controlled).      |
-| `setOpen`     | `(open: boolean) => void` | Sets open state of the sidebar (controlled). |
+| `onOpenChange`| `(open: boolean) => void` | Sets open state of the sidebar (controlled). |
 
 ### Width
 


### PR DESCRIPTION
it's typo

![image](https://github.com/user-attachments/assets/8a9a13c5-6f2e-40c7-be01-0068744adc40)
