### PR TITLE
docs: [Sidebar Component] add missing installation step in the sidebar component documentation

### DIFF
--- a/apps/www/content/docs/components/sidebar.mdx
+++ b/apps/www/content/docs/components/sidebar.mdx
@@ -122,6 +122,26 @@ We'll go over the colors later in the [theming section](/docs/components/sidebar
 }
 ```
 
+<Step>Add the Sidebar tailwind config into `tailwind.config.js`</Step>
+
+Add the following object in the `theme.extend.colors` section of your `tailwind.config.js` file
+this config enable sidebar related style utilities like bg-sidebar
+
+```javascript title="tailwind.config.js"
+// ...
+sidebar: {
+  DEFAULT: 'hsl(var(--sidebar-background))',
+  foreground: 'hsl(var(--sidebar-foreground))',
+  primary: 'hsl(var(--sidebar-primary))',
+  'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
+  accent: 'hsl(var(--sidebar-accent))',
+  'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
+  border: 'hsl(var(--sidebar-border))',
+  ring: 'hsl(var(--sidebar-ring))',
+},
+// ...
+```
+
 </Steps>
 
 </TabsContent>


### PR DESCRIPTION
**Issue:** When adding the sidebar component manually to an existing project, the sidebar styles are not applied.

**Cause:** The current setup guide for sidebar components is missing the step to add the sidebar config in to `tailwind.config.js`

**Solution:** I've added the step in the sidebar documentation explaining how to activate sidebar related styles utilities

![image](https://github.com/user-attachments/assets/7e0d9b7e-d6f8-4200-9175-d4ed37725023)
