### PR TITLE
feat: support styling for heading link

### DIFF
--- a/apps/www/styles/globals.css
+++ b/apps/www/styles/globals.css
@@ -120,3 +120,10 @@
     @apply px-4;
   }
 }
+
+h1, h2 {
+  span.icon-link::before {
+    content: "#";
+    @apply pr-2;
+  }
+}


### PR DESCRIPTION
This PR enhances the documentation by adding clickable anchor links to each heading (h1 & h2). 

Currently, while anchor links are generated via `rehypeAutolinkHeadings`, they are not accessible due to missing styles. This makes it difficult for users to obtain direct links to specific headings, hindering navigation and sharing.

Below is the example scenario, where I wanted to share useSidebar. Which as mentioned, is already a [valid link](https://ui.shadcn.com/docs/components/sidebar#usesidebar) but had no entry point.

<img width="753" alt="Screenshot 2024-10-20 at 3 53 12 PM" src="https://github.com/user-attachments/assets/058bffb3-233f-4266-aa42-99fcdc2b69c3">

Thanks so much for ShadCN!! ❤️ 