### PR TITLE
docs(sidebar): fix typo in sidebar documentation

### DIFF
--- a/apps/www/content/docs/components/sidebar.mdx
+++ b/apps/www/content/docs/components/sidebar.mdx
@@ -342,11 +342,11 @@ The `SidebarProvider` component is used to provide the sidebar context to the `S
 
 ### Props
 
-| Name          | Type                      | Description                                  |
-| ------------- | ------------------------- | -------------------------------------------- |
-| `defaultOpen` | `boolean`                 | Default open state of the sidebar.           |
-| `open`        | `boolean`                 | Open state of the sidebar (controlled).      |
-| `onOpenChange`| `(open: boolean) => void` | Sets open state of the sidebar (controlled). |
+| Name           | Type                      | Description                                  |
+| -------------- | ------------------------- | -------------------------------------------- |
+| `defaultOpen`  | `boolean`                 | Default open state of the sidebar.           |
+| `open`         | `boolean`                 | Open state of the sidebar (controlled).      |
+| `onOpenChange` | `(open: boolean) => void` | Sets open state of the sidebar (controlled). |
 
 ### Width
 
@@ -1301,7 +1301,7 @@ Here are some tips for styling the sidebar based on different states.
 
 You can find more tips on using states for styling in this [Twitter thread](https://x.com/shadcn/status/1842329158879420864).
 
-## Chanelog
+## Changelog
 
 ### 2024-10-20 Typo in `useSidebar` hook.
 


### PR DESCRIPTION
# Description

This PR intends to fix minor typo in the `sidebar` documentation. 