### PR TITLE
feat - Added a callback function support in Sidebar

### DIFF
--- a/apps/www/content/docs/components/sidebar.mdx
+++ b/apps/www/content/docs/components/sidebar.mdx
@@ -342,11 +342,12 @@ The `SidebarProvider` component is used to provide the sidebar context to the `S
 
 ### Props
 
-| Name          | Type                      | Description                                  |
-| ------------- | ------------------------- | -------------------------------------------- |
-| `defaultOpen` | `boolean`                 | Default open state of the sidebar.           |
-| `open`        | `boolean`                 | Open state of the sidebar (controlled).      |
-| `onOpenChange`| `(open: boolean) => void` | Sets open state of the sidebar (controlled). |
+| Name          | Type                                           | Description                                                  |
+| ------------- | -------------------------                      | --------------------------------------------                 |
+| `defaultOpen` | `boolean`                                      | Default open state of the sidebar.                           |
+| `open`        | `boolean`                                      | Open state of the sidebar (controlled).                      |
+| `onOpenChange`| `(open: boolean) => void`                      | Sets open state of the sidebar (controlled).                 |
+| `callback`    | `(open: boolean, openMobile: boolean) => void` | Get the state updates of the sidebar such as open and openMobile|
 
 ### Width
 

--- a/apps/www/registry/default/ui/sidebar.tsx
+++ b/apps/www/registry/default/ui/sidebar.tsx
@@ -53,6 +53,7 @@ const SidebarProvider = React.forwardRef<
     defaultOpen?: boolean
     open?: boolean
     onOpenChange?: (open: boolean) => void
+    callback?: (open: boolean, openMobile: boolean) => void
   }
 >(
   (
@@ -63,6 +64,7 @@ const SidebarProvider = React.forwardRef<
       className,
       style,
       children,
+      callback,
       ...props
     },
     ref
@@ -116,6 +118,9 @@ const SidebarProvider = React.forwardRef<
     // We add a state so that we can do data-state="expanded" or "collapsed".
     // This makes it easier to style the sidebar with Tailwind classes.
     const state = open ? "expanded" : "collapsed"
+
+    // Added a callback to send the state data SidebarProvider, access via callback function
+    callback?.(open, openMobile)
 
     const contextValue = React.useMemo<SidebarContext>(
       () => ({


### PR DESCRIPTION
Added a `callback` function support in Sidebar which return internal state update of the Sidebar open `state` and `openMobile` state.

Usages Example: 
```
const [sideBarOpen, setSideBarOpen] = useState(true); // Use anywhere in component.
    return (
        <SidebarProvider callback={function (open, openMobile) {
            if (!open) {
                setTimeout(function () {
                    setSideBarOpen(open);
                }, 200);
            } else {
                setSideBarOpen(open)
            }
        }}>
  <SidebarProvider/>
```