### PR TITLE
fix(shadcn): fix transformRsc to account for '

### DIFF
--- a/.changeset/friendly-mangos-fetch.md
+++ b/.changeset/friendly-mangos-fetch.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+fix transofmrRsc for handling use client

--- a/packages/shadcn/src/utils/transformers/transform-rsc.ts
+++ b/packages/shadcn/src/utils/transformers/transform-rsc.ts
@@ -1,6 +1,8 @@
 import { Transformer } from "@/src/utils/transformers"
 import { SyntaxKind } from "ts-morph"
 
+const directiveRegex = /^["']use client["']$/g
+
 export const transformRsc: Transformer = async ({ sourceFile, config }) => {
   if (config.rsc) {
     return sourceFile
@@ -8,7 +10,7 @@ export const transformRsc: Transformer = async ({ sourceFile, config }) => {
 
   // Remove "use client" from the top of the file.
   const first = sourceFile.getFirstChildByKind(SyntaxKind.ExpressionStatement)
-  if (first?.getText() === `"use client"`) {
+  if (first && directiveRegex.test(first.getText())) {
     first.remove()
   }
 

--- a/packages/shadcn/test/utils/__snapshots__/transform-rsc.test.ts.snap
+++ b/packages/shadcn/test/utils/__snapshots__/transform-rsc.test.ts.snap
@@ -29,3 +29,27 @@ import { Foo } from "bar"
 "use client"
     "
 `;
+
+exports[`transform rsc 5`] = `
+"'use client'
+
+      import * as React from 'react'
+import { Foo } from 'bar'
+    "
+`;
+
+exports[`transform rsc 6`] = `
+"import * as React from 'react'
+import { Foo } from 'bar'
+    "
+`;
+
+exports[`transform rsc 7`] = `
+"'use foo'
+
+      import * as React from 'react'
+import { Foo } from 'bar'
+
+'use client'
+    "
+`;

--- a/packages/shadcn/test/utils/transform-rsc.test.ts
+++ b/packages/shadcn/test/utils/transform-rsc.test.ts
@@ -62,4 +62,52 @@ import { Foo } from "bar"
       },
     })
   ).toMatchSnapshot()
+
+
+  expect(
+    await transform({
+      filename: "test.ts",
+      raw: `'use client'
+
+      import * as React from 'react'
+import { Foo } from 'bar'
+    `,
+      config: {
+        tsx: true,
+        rsc: true,
+      },
+    })
+  ).toMatchSnapshot()
+
+  expect(
+    await transform({
+      filename: "test.ts",
+      raw: `'use client'
+
+      import * as React from 'react'
+import { Foo } from 'bar'
+    `,
+      config: {
+        tsx: true,
+        rsc: false,
+      },
+    })
+  ).toMatchSnapshot()
+
+  expect(
+    await transform({
+      filename: "test.ts",
+      raw: `'use foo'
+
+      import * as React from 'react'
+import { Foo } from 'bar'
+
+'use client'
+    `,
+      config: {
+        tsx: true,
+        rsc: false,
+      },
+    })
+  ).toMatchSnapshot()
 })


### PR DESCRIPTION
For external registry files that use single quote formatting, the `'use client'` directive will not be removed for projects with `rsc: false` configured due to the `transformRsc` util

This PR updates the equality check to a regex to fix this use case

## Sandbox env
https://codesandbox.io/p/devbox/dark-hill-lht8mm
1. Run `pnpx shadcn@latest add http://localhost:3000/registry/custom-button.json`
2. Output `custom-button.tsx` will still have the directive even though `rsc` is set to `false` in the `components.json`