### PR TITLE
fix: init in an src based next application did not update the content array in tailwind

### DIFF
--- a/packages/shadcn/src/commands/init.ts
+++ b/packages/shadcn/src/commands/init.ts
@@ -140,7 +140,7 @@ export async function runInit(
 
   // If a new project is using src dir, let's update the tailwind content config.
   // TODO: Handle this per framework.
-  if (options.isNewProject && options.srcDir) {
+  if ((options.isNewProject || projectInfo?.framework.name === "next-app") && options.srcDir) {
     await updateTailwindContent(
       ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
       fullConfig,


### PR DESCRIPTION
Since options.isNewProject is hardcoded to false, in an src folder the content array is not updated when initializing shadcn.

Currently the array ends up as

```
    content: ["./src/app/**/*.{js,ts,jsx,tsx,mdx}"],
```

While it should have been 

```
    content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
```

I used the same or statement that is used in addComponents to determine if it is a new project or not.

Reproduction:

```
bunx create-next-app@15.0.1 \
  --typescript \
  --tailwind \
  --eslint \
  --src-dir \
  --turbopack \
  --import-alias '@/*' \
  --empty \
  --use-bun \
  --app <project-name>

cd <project-name>

bunx shadcn@latest init \
  --defaults \
  --src-dir \
  --yes

cat tailwind.config.ts
```