### PR TITLE
feat: actually install the dev dependencies

### DIFF
--- a/packages/shadcn/src/utils/add-components.ts
+++ b/packages/shadcn/src/utils/add-components.ts
@@ -42,7 +42,7 @@ export async function addComponents(
     silent: options.silent,
   })
 
-  await updateDependencies(tree.dependencies, config, {
+  await updateDependencies(tree.dependencies, tree.devDependencies, config, {
     silent: options.silent,
   })
   await updateFiles(tree.files, config, {

--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -6,6 +6,7 @@ import { execa } from "execa"
 
 export async function updateDependencies(
   dependencies: RegistryItem["dependencies"],
+  devDependencies: RegistryItem["devDependencies"],
   config: Config,
   options: {
     silent?: boolean
@@ -28,6 +29,13 @@ export async function updateDependencies(
   await execa(
     packageManager,
     [packageManager === "npm" ? "install" : "add", ...dependencies],
+    {
+      cwd: config.resolvedPaths.cwd,
+    }
+  )
+  await execa(
+    packageManager,
+    [packageManager === "npm" ? "install" : "add", "-D", ...devDependencies],
     {
       cwd: config.resolvedPaths.cwd,
     }


### PR DESCRIPTION
While devDependencies is part of the registry schema, there is no function that actually does something with them. 

I added an extra parameter to pass it along and install it in the same spinner as the regular dependencies