### PR TITLE
feat: added flag to bypass dependency conflicts

### DIFF
--- a/packages/shadcn/src/commands/add.ts
+++ b/packages/shadcn/src/commands/add.ts
@@ -22,6 +22,7 @@ export const addOptionsSchema = z.object({
   path: z.string().optional(),
   silent: z.boolean(),
   srcDir: z.boolean().optional(),
+  forceInstall: z.boolean().optional(),
 })
 
 export const add = new Command()
@@ -46,6 +47,7 @@ export const add = new Command()
     "use the src directory when creating a new project.",
     false
   )
+  .option("-fi, --forceInstall", "force install dependencies", false)
   .action(async (components, opts) => {
     try {
       const options = addOptionsSchema.parse({

--- a/packages/shadcn/src/commands/init.ts
+++ b/packages/shadcn/src/commands/init.ts
@@ -34,6 +34,7 @@ export const initOptionsSchema = z.object({
   silent: z.boolean(),
   isNewProject: z.boolean(),
   srcDir: z.boolean().optional(),
+  forceInstall: z.boolean().optional(),
 })
 
 export const init = new Command()
@@ -57,6 +58,7 @@ export const init = new Command()
     "use the src directory when creating a new project.",
     false
   )
+  .option("-fi, --forceInstall", "force install dependencies", false)
   .action(async (components, opts) => {
     try {
       const options = initOptionsSchema.parse({
@@ -136,6 +138,7 @@ export async function runInit(
     silent: options.silent,
     isNewProject:
       options.isNewProject || projectInfo?.framework.name === "next-app",
+    forceInstall: options.forceInstall,
   })
 
   // If a new project is using src dir, let's update the tailwind content config.

--- a/packages/shadcn/src/utils/add-components.ts
+++ b/packages/shadcn/src/utils/add-components.ts
@@ -15,12 +15,14 @@ export async function addComponents(
     overwrite?: boolean
     silent?: boolean
     isNewProject?: boolean
+    forceInstall?: boolean
   }
 ) {
   options = {
     overwrite: false,
     silent: false,
     isNewProject: false,
+    forceInstall: false,
     ...options,
   }
 
@@ -44,6 +46,7 @@ export async function addComponents(
 
   await updateDependencies(tree.dependencies, config, {
     silent: options.silent,
+    forceInstall: options.forceInstall,
   })
   await updateFiles(tree.files, config, {
     overwrite: options.overwrite,

--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -9,6 +9,7 @@ export async function updateDependencies(
   config: Config,
   options: {
     silent?: boolean
+    forceInstall?: boolean
   }
 ) {
   dependencies = Array.from(new Set(dependencies))
@@ -18,6 +19,7 @@ export async function updateDependencies(
 
   options = {
     silent: false,
+    forceInstall: false,
     ...options,
   }
 
@@ -27,7 +29,9 @@ export async function updateDependencies(
   const packageManager = await getPackageManager(config.resolvedPaths.cwd)
   await execa(
     packageManager,
-    [packageManager === "npm" ? "install" : "add", ...dependencies],
+    [packageManager === "npm" ? "install" : "add", 
+      options.forceInstall ? "--force" : "",
+      ...dependencies],
     {
       cwd: config.resolvedPaths.cwd,
     }


### PR DESCRIPTION
This PR adds the `--forceInstall` flag to bypass dependency conflicts during installation.

Related issues: #5515, #5513, #5499, #5217, #4047