### PR TITLE
FIX hydration warning with next-theme

### DIFF
--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -78,7 +78,7 @@ interface RootLayoutProps {
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <>
-      <html lang="en" suppressHydrationWarning>
+      <html lang="en">
         <head />
         <body
           className={cn(

--- a/apps/www/components/providers.tsx
+++ b/apps/www/components/providers.tsx
@@ -2,8 +2,14 @@
 
 import * as React from "react"
 import { Provider as JotaiProvider } from "jotai"
-import { ThemeProvider as NextThemesProvider } from "next-themes"
+const NextThemesProvider = dynamic(
+	() => import('next-themes').then((e) => e.ThemeProvider),
+	{
+		ssr: false,
+	}
+)
 import { ThemeProviderProps } from "next-themes/dist/types"
+
 
 import { TooltipProvider } from "@/registry/new-york/ui/tooltip"
 

--- a/apps/www/content/docs/dark-mode/next.mdx
+++ b/apps/www/content/docs/dark-mode/next.mdx
@@ -39,7 +39,7 @@ import { ThemeProvider } from "@/components/theme-provider"
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <>
-      <html lang="en" suppressHydrationWarning>
+      <html lang="en">
         <head />
         <body>
           <ThemeProvider


### PR DESCRIPTION
This PR fixes the isssue : https://github.com/shadcn-ui/ui/issues/5552

By dynamically importing the next-theme, it :
- removes the hydration warning
- improve DX because you can now know if you have another hydration warning elsewhere