### PR TITLE
Fix(sidebar): ensure accessibility by adding hidden DialogTitle

### DIFF
--- a/apps/www/registry/default/ui/sidebar.tsx
+++ b/apps/www/registry/default/ui/sidebar.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/registry/default/lib/utils"
 import { Button } from "@/registry/default/ui/button"
 import { Input } from "@/registry/default/ui/input"
 import { Separator } from "@/registry/default/ui/separator"
-import { Sheet, SheetContent } from "@/registry/default/ui/sheet"
+import { Sheet, SheetContent, SheetTitle } from "@/registry/default/ui/sheet"
 import { Skeleton } from "@/registry/default/ui/skeleton"
 import {
   Tooltip,
@@ -207,6 +207,7 @@ const Sidebar = React.forwardRef<
             }
             side={side}
           >
+            <SheetTitle className="hidden">sidebar</SheetTitle>
             <div className="flex h-full w-full flex-col">{children}</div>
           </SheetContent>
         </Sheet>


### PR DESCRIPTION
Added a hidden DialogTitle to the DialogContent inside Sidebar component to improve accessibility for screen reader users, following Radix UI guidelines. The title is hidden by default to meet the requirement without affecting the visible UI. This ensures compliance with accessibility best practices. 

For more details, refer to Radix UI's documentation: https://radix-ui.com/primitives/docs/components/dialog.

![image](https://github.com/user-attachments/assets/a8b94f88-a3ef-42f0-b0b8-e1cd7edf1efc)
