### PR TITLE
feat(shadcn): --config-dir. Support separate dir for components.json

### DIFF
--- a/packages/shadcn/src/commands/add.ts
+++ b/packages/shadcn/src/commands/add.ts
@@ -18,6 +18,7 @@ export const addOptionsSchema = z.object({
   yes: z.boolean(),
   overwrite: z.boolean(),
   cwd: z.string(),
+  configDir: z.string(),
   all: z.boolean(),
   path: z.string().optional(),
   silent: z.boolean(),
@@ -37,6 +38,11 @@ export const add = new Command()
     "-c, --cwd <cwd>",
     "the working directory. defaults to the current directory.",
     process.cwd()
+  )
+  .option(
+    "-d, --config-dir <config-dir>",
+    "directory containing `components.json`. relative to `cwd`.",
+    "."
   )
   .option("-a, --all", "add all available components", false)
   .option("-p, --path <path>", "the path to add the component to.")

--- a/packages/shadcn/src/preflights/preflight-add.ts
+++ b/packages/shadcn/src/preflights/preflight-add.ts
@@ -24,7 +24,11 @@ export async function preFlightAdd(options: z.infer<typeof addOptionsSchema>) {
   }
 
   // Check for existing components.json file.
-  if (!fs.existsSync(path.resolve(options.cwd, "components.json"))) {
+  if (
+    !fs.existsSync(
+      path.resolve(options.cwd, options.configDir, "components.json")
+    )
+  ) {
     errors[ERRORS.MISSING_CONFIG] = true
     return {
       errors,
@@ -33,7 +37,7 @@ export async function preFlightAdd(options: z.infer<typeof addOptionsSchema>) {
   }
 
   try {
-    const config = await getConfig(options.cwd)
+    const config = await getConfig(options.cwd, options.configDir)
 
     return {
       errors,

--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -58,8 +58,8 @@ export const configSchema = rawConfigSchema.extend({
 
 export type Config = z.infer<typeof configSchema>
 
-export async function getConfig(cwd: string) {
-  const config = await getRawConfig(cwd)
+export async function getConfig(cwd: string, configDir: string) {
+  const config = await getRawConfig(cwd, configDir)
 
   if (!config) {
     return null
@@ -115,9 +115,12 @@ export async function resolveConfigPaths(cwd: string, config: RawConfig) {
   })
 }
 
-export async function getRawConfig(cwd: string): Promise<RawConfig | null> {
+export async function getRawConfig(
+  cwd: string,
+  configDir: string
+): Promise<RawConfig | null> {
   try {
-    const configResult = await explorer.search(cwd)
+    const configResult = await explorer.search(path.resolve(cwd, configDir))
 
     if (!configResult) {
       return null
@@ -125,7 +128,7 @@ export async function getRawConfig(cwd: string): Promise<RawConfig | null> {
 
     return rawConfigSchema.parse(configResult.config)
   } catch (error) {
-    const componentPath = `${cwd}/components.json`
+    const componentPath = `${path.resolve(cwd, configDir)}/components.json`
     throw new Error(
       `Invalid configuration found in ${highlighter.info(componentPath)}.`
     )

--- a/packages/shadcn/test/utils/get-config.test.ts
+++ b/packages/shadcn/test/utils/get-config.test.ts
@@ -5,11 +5,14 @@ import { getConfig, getRawConfig } from "../../src/utils/get-config"
 
 test("get raw config", async () => {
   expect(
-    await getRawConfig(path.resolve(__dirname, "../fixtures/config-none"))
+    await getRawConfig(path.resolve(__dirname, "../fixtures/config-none"), ".")
   ).toEqual(null)
 
   expect(
-    await getRawConfig(path.resolve(__dirname, "../fixtures/config-partial"))
+    await getRawConfig(
+      path.resolve(__dirname, "../fixtures/config-partial"),
+      "."
+    )
   ).toEqual({
     style: "default",
     tailwind: {
@@ -27,21 +30,21 @@ test("get raw config", async () => {
   })
 
   expect(
-    getRawConfig(path.resolve(__dirname, "../fixtures/config-invalid"))
+    getRawConfig(path.resolve(__dirname, "../fixtures/config-invalid"), ".")
   ).rejects.toThrowError()
 })
 
 test("get config", async () => {
   expect(
-    await getConfig(path.resolve(__dirname, "../fixtures/config-none"))
+    await getConfig(path.resolve(__dirname, "../fixtures/config-none"), ".")
   ).toEqual(null)
 
   expect(
-    getConfig(path.resolve(__dirname, "../fixtures/config-invalid"))
+    getConfig(path.resolve(__dirname, "../fixtures/config-invalid"), ".")
   ).rejects.toThrowError()
 
   expect(
-    await getConfig(path.resolve(__dirname, "../fixtures/config-partial"))
+    await getConfig(path.resolve(__dirname, "../fixtures/config-partial"), ".")
   ).toEqual({
     style: "default",
     tailwind: {
@@ -89,7 +92,7 @@ test("get config", async () => {
   })
 
   expect(
-    await getConfig(path.resolve(__dirname, "../fixtures/config-full"))
+    await getConfig(path.resolve(__dirname, "../fixtures/config-full"), ".")
   ).toEqual({
     style: "new-york",
     rsc: false,
@@ -141,7 +144,7 @@ test("get config", async () => {
   })
 
   expect(
-    await getConfig(path.resolve(__dirname, "../fixtures/config-jsx"))
+    await getConfig(path.resolve(__dirname, "../fixtures/config-jsx"), ".")
   ).toEqual({
     style: "default",
     tailwind: {

--- a/packages/shadcn/test/utils/get-item-target-path.test.ts
+++ b/packages/shadcn/test/utils/get-item-target-path.test.ts
@@ -7,8 +7,10 @@ import { getItemTargetPath } from "../../src/utils/registry"
 test("get item target path", async () => {
   // Full config.
   let appDir = path.resolve(__dirname, "../fixtures/config-full")
+  const configDir = "."
+
   expect(
-    await getItemTargetPath(await getConfig(appDir), {
+    await getItemTargetPath(await getConfig(appDir, configDir), {
       type: "registry:ui",
     })
   ).toEqual(path.resolve(appDir, "./src/ui"))
@@ -16,7 +18,7 @@ test("get item target path", async () => {
   // Partial config.
   appDir = path.resolve(__dirname, "../fixtures/config-partial")
   expect(
-    await getItemTargetPath(await getConfig(appDir), {
+    await getItemTargetPath(await getConfig(appDir, configDir), {
       type: "registry:ui",
     })
   ).toEqual(path.resolve(appDir, "./components/ui"))
@@ -24,7 +26,7 @@ test("get item target path", async () => {
   // JSX.
   appDir = path.resolve(__dirname, "../fixtures/config-jsx")
   expect(
-    await getItemTargetPath(await getConfig(appDir), {
+    await getItemTargetPath(await getConfig(appDir, configDir), {
       type: "registry:ui",
     })
   ).toEqual(path.resolve(appDir, "./components/ui"))
@@ -32,7 +34,7 @@ test("get item target path", async () => {
   // Custom paths.
   appDir = path.resolve(__dirname, "../fixtures/config-ui")
   expect(
-    await getItemTargetPath(await getConfig(appDir), {
+    await getItemTargetPath(await getConfig(appDir, configDir), {
       type: "registry:ui",
     })
   ).toEqual(path.resolve(appDir, "./src/ui"))


### PR DESCRIPTION
This PR adds a new CLI option `--config-dir` to specify a directory containing the `components.json` file.

I like to keep my config files in a `config` directory. That's where I already have my tailwind config and I'd like to put `components.json` in there as well to keep the root of my project a little cleaner :)

With the previous CLI I could do this by using the `--cwd` option. But now with the new CLI the `--cwd` dir needs to be the directory that contains `package.json`.