### PR TITLE
fix color in Chart cards

### DIFF
--- a/apps/www/registry/default/example/cards/stats.tsx
+++ b/apps/www/registry/default/example/cards/stats.tsx
@@ -87,8 +87,9 @@ export function CardsStats() {
                     {
                       stroke: "var(--theme-primary)",
                       "--theme-primary": `hsl(${
-                        baseColor?.cssVars[mode === "dark" ? "dark" : "light"]
-                          .primary
+                        baseColor?.cssVars[mode === "dark" ? "dark" : "light"][
+                          "primary-foreground"
+                        ]
                       })`,
                     } as React.CSSProperties
                   }
@@ -117,8 +118,9 @@ export function CardsStats() {
                       fill: "var(--theme-primary)",
                       opacity: 1,
                       "--theme-primary": `hsl(${
-                        baseColor?.cssVars[mode === "dark" ? "dark" : "light"]
-                          .primary
+                        baseColor?.cssVars[mode === "dark" ? "dark" : "light"][
+                          "primary-foreground"
+                        ]
                       })`,
                     } as React.CSSProperties
                   }

--- a/apps/www/registry/new-york/example/cards/stats.tsx
+++ b/apps/www/registry/new-york/example/cards/stats.tsx
@@ -87,8 +87,9 @@ export function CardsStats() {
                     {
                       stroke: "var(--theme-primary)",
                       "--theme-primary": `hsl(${
-                        baseColor?.cssVars[mode === "dark" ? "dark" : "light"]
-                          .primary
+                        baseColor?.cssVars[mode === "dark" ? "dark" : "light"][
+                          "primary-foreground"
+                        ]
                       })`,
                     } as React.CSSProperties
                   }
@@ -117,8 +118,9 @@ export function CardsStats() {
                       fill: "var(--theme-primary)",
                       opacity: 1,
                       "--theme-primary": `hsl(${
-                        baseColor?.cssVars[mode === "dark" ? "dark" : "light"]
-                          .primary
+                        baseColor?.cssVars[mode === "dark" ? "dark" : "light"][
+                          "primary-foreground"
+                        ]
                       })`,
                     } as React.CSSProperties
                   }


### PR DESCRIPTION
Chart colors were low contrast, like the first image below. 

This change makes them higher contrast and easily visible, like the second image below.

![image](https://github.com/user-attachments/assets/0698ecf5-3ae4-493b-ab29-bc0eda98e9d3)
![image](https://github.com/user-attachments/assets/e605f3ff-6d76-427b-bbde-223ddd585eae)
