### PR TITLE
docs:  Copied detailed style info from the Changelog to Components.json.

### DIFF
--- a/apps/www/content/docs/components-json.mdx
+++ b/apps/www/content/docs/components-json.mdx
@@ -33,7 +33,28 @@ You can see the JSON Schema for `components.json` [here](https://ui.shadcn.com/s
 
 ## style
 
-The style for your components. **This cannot be changed after initialization.**
+We are introducing a new concept called _Style_.
+
+_You can think of style as the visual foundation: shapes, icons, animations & typography._ A style comes with its own set of components, animations, icons and more.
+
+We are shipping two styles: `default` and `new-york` (with more coming soon).
+
+<Image
+  src="/images/style.jpg"
+  width="716"
+  height="402"
+  alt="Default vs New York style"
+  className="border rounded-lg overflow-hidden mt-6"
+/>
+
+The `default` style is the one you are used to. It's the one we've been using since the beginning of this project. It uses `lucide-react` for icons and `tailwindcss-animate` for animations.
+
+The `new-york` style is a new style. It ships with smaller buttons, cards with shadows and a new set of icons from [Radix Icons](https://icons.radix-ui.com).
+
+When you run the `init` command, you will be asked which style you would like to use. This is saved in your `components.json` file.
+
+
+**Important:** The selected style cannot be changed after initialization. 
 
 ```json title="components.json"
 {


### PR DESCRIPTION
  Purpose - Addressing issue #5431 

- Copied detailed style definitions from the Changelog to Components.json.
- Removed redundant entries from the Changelog to maintain clarity.
- This change improves the organization of style definitions and enhances maintainability.


