### PR TITLE
fix(shadcn): components.json utils alias

### DIFF
--- a/packages/shadcn/src/utils/transformers/transform-import.ts
+++ b/packages/shadcn/src/utils/transformers/transform-import.ts
@@ -5,23 +5,24 @@ export const transformImport: Transformer = async ({ sourceFile, config }) => {
   const importDeclarations = sourceFile.getImportDeclarations()
 
   for (const importDeclaration of importDeclarations) {
-    const moduleSpecifier = updateImportAliases(
-      importDeclaration.getModuleSpecifierValue(),
-      config
-    )
-
-    importDeclaration.setModuleSpecifier(moduleSpecifier)
+    const moduleSpecifierValue = importDeclaration.getModuleSpecifierValue()
 
     // Replace `import { cn } from "@/lib/utils"`
-    if (moduleSpecifier == "@/lib/utils") {
+    if (moduleSpecifierValue === "@/lib/utils") {
       const namedImports = importDeclaration.getNamedImports()
       const cnImport = namedImports.find((i) => i.getName() === "cn")
+
       if (cnImport) {
         importDeclaration.setModuleSpecifier(
-          moduleSpecifier.replace(/^@\/lib\/utils/, config.aliases.utils)
+          moduleSpecifierValue.replace(/^@\/lib\/utils/, config.aliases.utils)
         )
+
+        continue
       }
     }
+
+    const moduleSpecifier = updateImportAliases(moduleSpecifierValue, config)
+    importDeclaration.setModuleSpecifier(moduleSpecifier)
   }
 
   return sourceFile


### PR DESCRIPTION
Take care of `@/lib/utils/` imports first, and then the registry imports to respect a custom "utils" alias in `components.json`

Fixes https://github.com/shadcn-ui/ui/issues/5544