### PR TITLE
chore(examples/tasks): add type safety to data-table with RowSelectionState

### DIFF
--- a/apps/www/app/(app)/examples/tasks/components/data-table.tsx
+++ b/apps/www/app/(app)/examples/tasks/components/data-table.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import {
   ColumnDef,
   ColumnFiltersState,
+  RowSelectionState,
   SortingState,
   VisibilityState,
   flexRender,
@@ -37,7 +38,7 @@ export function DataTable<TData, TValue>({
   columns,
   data,
 }: DataTableProps<TData, TValue>) {
-  const [rowSelection, setRowSelection] = React.useState({})
+  const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({})
   const [columnVisibility, setColumnVisibility] =
     React.useState<VisibilityState>({})
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(


### PR DESCRIPTION
- Adds proper typing for RowSelectionState in useState hook
- Improves type safety when handling row selections
- Maintains backwards compatibility with existing implementations

This change helps prevent potential runtime errors by ensuring proper typing of the row selection state.

Ref: https://tanstack.com/table/latest/docs/guide/row-selection#manage-row-selection-state