### PR TITLE
fix(docs): resolve link issue in documentation pages

### DIFF
--- a/apps/www/content/docs/installation/next.mdx
+++ b/apps/www/content/docs/installation/next.mdx
@@ -5,7 +5,7 @@ description: Install and configure Next.js.
 
 <Callout>
 
-**If you're using Next.js 15, see the [Next.js 15 + React 19](/docs/installation/react-19) guide.**
+**If you're using Next.js 15, see the [Next.js 15 + React 19](/docs/react-19) guide.**
 
 </Callout>
 


### PR DESCRIPTION
Updated broken link in documentation routing file. 
This ensures that the correct content is loaded based on the slug.