### PR TITLE
Home page examples tab always active issue fixed

### DIFF
--- a/apps/www/components/examples-nav.tsx
+++ b/apps/www/components/examples-nav.tsx
@@ -70,8 +70,8 @@ export function ExamplesNav({ className, ...props }: ExamplesNavProps) {
               key={example.href}
               className={cn(
                 "flex h-7 items-center justify-center rounded-full px-4 text-center text-sm transition-colors hover:text-primary",
-                pathname?.startsWith(example.href) ||
-                  (index === 0 && pathname === "/")
+                pathname === example.href ||
+                  (index === 0 && pathname === "/" && example.href === "/")
                   ? "bg-muted font-medium text-primary"
                   : "text-muted-foreground"
               )}


### PR DESCRIPTION
![Screenshot 2024-11-01 150313](https://github.com/user-attachments/assets/4f47e0f4-69e5-464b-adf8-4230dfddc3c1)
