### PR TITLE
feat(cli): --no-overwrite

### DIFF
--- a/packages/shadcn/src/commands/add.ts
+++ b/packages/shadcn/src/commands/add.ts
@@ -16,7 +16,7 @@ import { z } from "zod"
 export const addOptionsSchema = z.object({
   components: z.array(z.string()).optional(),
   yes: z.boolean(),
-  overwrite: z.boolean(),
+  overwrite: z.boolean().optional(),
   cwd: z.string(),
   all: z.boolean(),
   path: z.string().optional(),
@@ -32,7 +32,8 @@ export const add = new Command()
     "the components to add or a url to the component."
   )
   .option("-y, --yes", "skip confirmation prompt.", false)
-  .option("-o, --overwrite", "overwrite existing files.", false)
+  .option("-o, --overwrite", "overwrite existing files. (default: ask)")
+  .option("--no-overwrite", "never overwrite existing files.")
   .option(
     "-c, --cwd <cwd>",
     "the working directory. defaults to the current directory.",
@@ -114,7 +115,7 @@ export const add = new Command()
       if (errors[ERRORS.MISSING_DIR_OR_EMPTY_PROJECT]) {
         const { projectPath } = await createProject({
           cwd: options.cwd,
-          force: options.overwrite,
+          force: !!options.overwrite,
           srcDir: options.srcDir,
         })
         if (!projectPath) {

--- a/packages/shadcn/src/utils/add-components.ts
+++ b/packages/shadcn/src/utils/add-components.ts
@@ -18,7 +18,6 @@ export async function addComponents(
   }
 ) {
   options = {
-    overwrite: false,
     silent: false,
     isNewProject: false,
     ...options,

--- a/packages/shadcn/src/utils/updaters/update-files.ts
+++ b/packages/shadcn/src/utils/updaters/update-files.ts
@@ -43,7 +43,6 @@ export async function updateFiles(
     return
   }
   options = {
-    overwrite: false,
     force: false,
     silent: false,
     ...options,
@@ -84,14 +83,20 @@ export async function updateFiles(
     const existingFile = existsSync(filePath)
     if (existingFile && !options.overwrite) {
       filesCreatedSpinner.stop()
-      const { overwrite } = await prompts({
-        type: "confirm",
-        name: "overwrite",
-        message: `The file ${highlighter.info(
-          fileName
-        )} already exists. Would you like to overwrite?`,
-        initial: false,
-      })
+      let overwrite = false
+
+      const shouldAsk = typeof options.overwrite === "undefined"
+      if (shouldAsk) {
+        const answer = await prompts({
+          type: "confirm",
+          name: "overwrite",
+          message: `The file ${highlighter.info(
+            fileName
+          )} already exists. Would you like to overwrite?`,
+          initial: false,
+        })
+        overwrite = answer.overwrite
+      }
 
       if (!overwrite) {
         filesSkipped.push(path.relative(config.resolvedPaths.cwd, filePath))


### PR DESCRIPTION
Currently you can pass `--overwrite` to not be prompted about overwriting files and instead just always overwrite.
But there is no way to not be prompted, but to instead never overwrite.

This PR adds `--no-overwrite` to make it so that it never asks, it just assumes you always want to keep what you already have.

Specifying neither `--overwrite` nor `--no-overwrite` keeps the current behavior of asking the user if they want to overwrite or not.

This is a snippet of what the `--help` output looks like now
```
Options:
  -y, --yes          skip confirmation prompt. (default: false)
  -o, --overwrite    overwrite existing files. (default: ask)
  --no-overwrite     never overwrite existing files.
```