### PR TITLE
refactor: eslint error on input element

### DIFF
--- a/apps/www/registry/new-york/ui/input.tsx
+++ b/apps/www/registry/new-york/ui/input.tsx
@@ -2,10 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
-
-const Input = React.forwardRef<HTMLInputElement, InputProps>(
+const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
   ({ className, type, ...props }, ref) => {
     return (
       <input


### PR DESCRIPTION
An interface declaring no members is equivalent to its supertype. eslint(@typescript-eslint/no-empty-object-type)