### PR TITLE
fix: svg props casing to camelCase

### DIFF
--- a/apps/www/components/mobile-nav.tsx
+++ b/apps/www/components/mobile-nav.tsx
@@ -27,13 +27,13 @@ export function MobileNav() {
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
-            stroke-width="1.5"
+            strokeWidth="1.5"
             stroke="currentColor"
             className="size-6"
           >
             <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
+              strokeLinecap="round"
+              strokeLinejoin="round"
               d="M3.75 9h16.5m-16.5 6.75h16.5"
             />
           </svg>


### PR DESCRIPTION
There were some svg warnings while running the apps/www regarding using not using camelCase in main-nav.tsx