### PR TITLE
docs: Update Dark Mode Next.js Docs - Fix ThemeProviderProps import

### DIFF
--- a/apps/www/content/docs/dark-mode/next.mdx
+++ b/apps/www/content/docs/dark-mode/next.mdx
@@ -21,8 +21,7 @@ npm install next-themes
 "use client"
 
 import * as React from "react"
-import { ThemeProvider as NextThemesProvider } from "next-themes"
-import { type ThemeProviderProps } from "next-themes/dist/types"
+import {ThemeProvider as NextThemesProvider, ThemeProviderProps} from "next-themes"
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return <NextThemesProvider {...props}>{children}</NextThemesProvider>


### PR DESCRIPTION
This PR updates the example code for creating a ThemeProvider for Dark Mode with Next.js.

It removes the reference to `next-themes/dist/types`, and instead chooses to import `ThemeProviderProps` directly from `next-themes`