### PR TITLE
fix: SelectPrimitive.Viewport misalignment

### DIFF
--- a/apps/www/registry/default/ui/select.tsx
+++ b/apps/www/registry/default/ui/select.tsx
@@ -88,7 +88,7 @@ const SelectContent = React.forwardRef<
         className={cn(
           "p-1",
           position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[calc(var(--radix-select-trigger-width)-2px)]"
         )}
       >
         {children}

--- a/apps/www/registry/new-york/ui/select.tsx
+++ b/apps/www/registry/new-york/ui/select.tsx
@@ -88,7 +88,7 @@ const SelectContent = React.forwardRef<
         className={cn(
           "p-1",
           position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[calc(var(--radix-select-trigger-width)-2px)]"
         )}
       >
         {children}


### PR DESCRIPTION
Problem:
Because of the way viewport width is calculated, `Select.Content` is slightly misaligned to the trigger in the default configuration. Since the default config uses border width of 1px, 2px of adjustment is needed.

Solution:
Use CSS function `calc()` to make width 2px narrow. My guess is, no user will intentionally want 2 more pixels of width in exchange for that misalignment.

![Screenshot 2024-11-06 at 14 21 07](https://github.com/user-attachments/assets/6ea44334-4e44-4ca5-be5c-d7ab4adabafa)

Instead of:
```min-w-[var(--radix-select-trigger-width)]```

We remove 2 pixels from the width with:
```min-w-[calc(var(--radix-select-trigger-width))]```

```tsx
<SelectPrimitive.Viewport
  className={cn(
    "p-1",
    position === "popper" &&
      "h-[var(--radix-select-trigger-height)] w-full min-w-[calc(var(--radix-select-trigger-width)-2px)]"
  )}
>
```

Admittedly this wouldn't work for the bigger border widths but with bigger border widths, you might not want it to eat it from the viewport width. It also stops looking misaligned depending on how big the borders are. There is a significantly more complicated solution to this but I think fixing the default look of the component is enough. Rest can be up to the user.
