### PR TITLE
fix: ensure block component name is copied in shadcn

### DIFF
--- a/apps/www/components/block-viewer.tsx
+++ b/apps/www/components/block-viewer.tsx
@@ -166,7 +166,7 @@ function BlockViewerToolbar() {
           className="hidden h-7 w-7 rounded-md border bg-transparent shadow-none md:flex lg:w-auto"
           size="sm"
           onClick={() => {
-            copyToClipboard(`npx shadcn@latest add ${name}`)
+            copyToClipboard(`npx shadcn@latest add ${item.name}`)
           }}
         >
           {isCopied ? <Check /> : <Terminal />}


### PR DESCRIPTION
This pull request fixes an issue in the Shadcn website where copying the block component did not include the component's name. The update ensures that the name is now properly copied along with the rest of the component data.

Whenever the block got copied it exclude the block name. 

For example if you copy any block it will only give you `npx shadcn@latest add ` it will skip the name of the block.

