### PR TITLE
fix: block viewer copy install command

### DIFF
--- a/apps/www/components/block-viewer.tsx
+++ b/apps/www/components/block-viewer.tsx
@@ -64,10 +64,10 @@ type BlockViewerContext = {
   resizablePanelRef: React.RefObject<ImperativePanelHandle> | null
   tree: ReturnType<typeof createFileTreeForRegistryItemFiles> | null
   highlightedFiles:
-    | (z.infer<typeof registryItemFileSchema> & {
-        highlightedContent: string
-      })[]
-    | null
+  | (z.infer<typeof registryItemFileSchema> & {
+    highlightedContent: string
+  })[]
+  | null
 }
 
 const BlockViewerContext = React.createContext<BlockViewerContext | null>(null)
@@ -166,7 +166,7 @@ function BlockViewerToolbar() {
           className="hidden h-7 w-7 rounded-md border bg-transparent shadow-none md:flex lg:w-auto"
           size="sm"
           onClick={() => {
-            copyToClipboard(`npx shadcn@latest add ${name}`)
+            copyToClipboard(`npx shadcn@latest add ${item.name}`)
           }}
         >
           {isCopied ? <Check /> : <Terminal />}


### PR DESCRIPTION
When copying the install command from the blocks page, it only copies `npx shadcn@latest add `, foregoing the actual block name.

The issue is in the `copyToClipboard` function call in `block-viewer.tsx` where it doesn't reference `item.name`, only `name`.