### PR TITLE
Fix: Separate `VariantProps` and `cva` imports to comply with `verbatimModuleSyntax`

### DIFF
--- a/apps/www/registry/default/ui/sidebar.tsx
+++ b/apps/www/registry/default/ui/sidebar.tsx
@@ -2,9 +2,9 @@
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { VariantProps, cva } from "class-variance-authority"
+import { cva } from "class-variance-authority";
+import type { VariantProps } from "class-variance-authority"; 
 import { PanelLeft } from "lucide-react"
-
 import { useIsMobile } from "@/registry/default/hooks/use-mobile"
 import { cn } from "@/registry/default/lib/utils"
 import { Button } from "@/registry/default/ui/button"


### PR DESCRIPTION
This commit resolves a TypeScript build issue caused by the combined import of `VariantProps` (a type) and `cva` (a runtime value) from `class-variance-authority`.

### Context
When `verbatimModuleSyntax` is enabled, TypeScript enforces strict separation of type-only imports (`import type`) and runtime imports (`import`). The current code:

`import { VariantProps, cva } from "class-variance-authority";`


causes the following build error in strict TypeScript environments (e.g., Vercel deployments):

`Type error: 'VariantProps' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.`

**Changes Made**
Updated the import statement to:

```
import { cva } from "class-variance-authority"; // For runtime use
import type { VariantProps } from "class-variance-authority"; // For type-checking only
```

This ensures compliance with verbatimModuleSyntax while preserving the functionality of the existing code.
Testing Performed:
- Verified locally with TypeScript and ESLint to ensure no new errors are introduced.
-  Successfully deployed to Vercel, confirming the build error is resolved.