### PR TITLE
correct placement of login button

### DIFF
--- a/apps/www/app/(app)/examples/authentication/page.tsx
+++ b/apps/www/app/(app)/examples/authentication/page.tsx
@@ -30,7 +30,7 @@ export default function AuthenticationPage() {
           className="hidden dark:block"
         />
       </div>
-      <div className="container relative hidden h-[800px] flex-col items-center justify-center md:grid lg:max-w-none lg:grid-cols-2 lg:px-0">
+      <div className="container relative hidden h-[800px] flex-col items-center justify-center md:grid md:max-w-none lg:max-w-none lg:grid-cols-2 lg:px-0">
         <Link
           href="/examples/authentication"
           className={cn(


### PR DESCRIPTION
For medium size pages there is a max-width for the container, causing the UI to be left aligned. Making sure the container width stays maximum fixes this problem