### PR TITLE
docs: Include specific instructions for setting up react app with javascript

### DIFF
--- a/apps/www/config/docs.ts
+++ b/apps/www/config/docs.ts
@@ -107,8 +107,13 @@ export const docsConfig: DocsConfig = {
           items: [],
         },
         {
-          title: "Vite",
+          title: "Vite (TypeScript)",
           href: "/docs/installation/vite",
+          items: [],
+        },
+        {
+          title: "Vite (JavaScript)",
+          href: "/docs/installation/vite-javascript",
           items: [],
         },
         {

--- a/apps/www/content/docs/installation/vite-javascript.mdx
+++ b/apps/www/content/docs/installation/vite-javascript.mdx
@@ -23,9 +23,32 @@ npm install -D tailwindcss postcss autoprefixer
 npx tailwindcss init -p
 ```
 
+Add this import header in your main css file, `src/index.css` in our case:
+
+```css {1-3} showLineNumbers
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* ... */
+```
+
+Configure the tailwind template paths in `tailwind.config.js`:
+
+```js {3}
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./index.html", "./src/**/*.{js,jsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+```
+
 ### Create jsconfig.json file
 
-```ts {11-16} showLineNumbers
+```js showLineNumbers
 {
   "files": [],
   "references": [
@@ -83,24 +106,6 @@ export default defineConfig({
     },
   },
 })
-```
-
-### Update index.css
-
-Add the following code to the top of the index.css file
-
-```bash
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-```
-
-### Update tailwind.config.js
-
-Update the following code inside of tailwind.config.js
-
-```bash
-content: ["./src/**/*.{js,jsx}"],
 ```
 
 ### Run the CLI

--- a/apps/www/content/docs/installation/vite-javascript.mdx
+++ b/apps/www/content/docs/installation/vite-javascript.mdx
@@ -1,0 +1,146 @@
+---
+title: Vite
+description: Install and configure Vite with JavaScript.
+---
+
+<Steps>
+
+### Create project
+
+Start by creating a new React project using `vite`:
+
+```bash
+npm create vite@latest
+```
+
+### Add Tailwind and its configuration
+
+Install `tailwindcss` and its peer dependencies, then generate your `tailwind.config.js` and `postcss.config.js` files:
+
+```bash
+npm install -D tailwindcss postcss autoprefixer
+
+npx tailwindcss init -p
+```
+
+### Create jsconfig.json file
+
+```ts {11-16} showLineNumbers
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./jsconfig.app.json"
+    }
+  ],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}
+```
+
+### Create jsconfig.app.json file
+
+Add the following code to the `jsconfig.app.json` file to resolve paths, for your IDE:
+
+```ts {4-9} showLineNumbers
+{
+  "compilerOptions": {
+    // ...
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    }
+    // ...
+  }
+}
+```
+
+### Update vite.config.js
+
+Add the following code to the vite.config.js so your app can resolve paths without error
+
+```bash
+# (so you can import "path" without error)
+npm i -D @types/node
+```
+
+```typescript
+import path from "path"
+import react from "@vitejs/plugin-react"
+import { defineConfig } from "vite"
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+})
+```
+
+### Update index.css
+
+Add the following code to the top of the index.css file
+
+```bash
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+### Update tailwind.config.js
+
+Update the following code inside of tailwind.config.js
+
+```bash
+content: ["./src/**/*.{js,jsx}"],
+```
+
+### Run the CLI
+
+Run the `shadcn-ui` init command to setup your project:
+
+```bash
+npx shadcn@latest init
+```
+
+### Configure components.json
+
+You will be asked a few questions to configure `components.json`:
+
+```txt showLineNumbers
+Which style would you like to use? › New York
+Which color would you like to use as base color? › Zinc
+Do you want to use CSS variables for colors? › no / yes
+```
+
+### That's it
+
+You can now start adding components to your project.
+
+```bash
+npx shadcn@latest add button
+```
+
+The command above will add the `Button` component to your project. You can then import it like this:
+
+```tsx {1,6} showLineNumbers
+import { Button } from "@/components/ui/button"
+
+export default function Home() {
+  return (
+    <div>
+      <Button>Click me</Button>
+    </div>
+  )
+}
+```
+
+</Steps>


### PR DESCRIPTION
- Currently, when installing Shadcn UI with a React app, the documentation only explains the installation process using Typescript (https://ui.shadcn.com/docs/installation/vite)
- This change will add specific instructions for installing Shadcn UI using Vite and Javascript


    - ![Screenshot 2024-11-13 at 1 58 12 PM](https://github.com/user-attachments/assets/5e2246bf-48b0-4e45-9acc-20909561c23c)
    - ![Screenshot 2024-11-13 at 1 58 23 PM](https://github.com/user-attachments/assets/e88a3d7c-93bf-43de-a8cf-6ffdc0f636ca)
    - ![Screenshot 2024-11-13 at 1 58 42 PM](https://github.com/user-attachments/assets/47583bb2-ce8d-47af-9df7-8ca3a212f54b)
    - ![Screenshot 2024-11-13 at 1 58 45 PM](https://github.com/user-attachments/assets/bfa28cea-1b46-4a4d-80ee-38f9aaaa7b20)
