### PR TITLE
fix(www sidebar-nav): refine hover and disabled styles for nav item tags

### DIFF
--- a/apps/www/components/sidebar-nav.tsx
+++ b/apps/www/components/sidebar-nav.tsx
@@ -50,17 +50,20 @@ export function DocsSidebarNavItems({
           <Link
             key={index}
             href={item.href}
-            className={cn(
-              "group flex w-full items-center px-2 py-1 font-normal text-foreground underline-offset-2 hover:underline",
-              item.disabled && "cursor-not-allowed opacity-60",
-              pathname === item.href && "underline"
-            )}
+            className="group flex w-full items-center px-2 py-1 font-normal text-foreground"
             target={item.external ? "_blank" : ""}
             rel={item.external ? "noreferrer" : ""}
           >
-            {item.title}
+            <span
+              className={cn(
+                "underline-offset-2 group-hover:underline",
+                pathname === item.href && "underline"
+              )}
+            >
+              {item.title}
+            </span>
             {item.label && (
-              <span className="ml-2 rounded-md bg-[#adfa1d] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
+              <span className="ml-2 rounded-md bg-[#adfa1d] px-1.5 py-0.5 text-xs leading-none text-[#000000]">
                 {item.label}
               </span>
             )}
@@ -68,14 +71,11 @@ export function DocsSidebarNavItems({
         ) : (
           <span
             key={index}
-            className={cn(
-              "flex w-full cursor-not-allowed items-center rounded-md p-2 text-muted-foreground hover:underline",
-              item.disabled && "cursor-not-allowed opacity-60"
-            )}
+            className="flex w-full cursor-not-allowed items-center rounded-md p-2 text-muted-foreground opacity-60"
           >
             {item.title}
             {item.label && (
-              <span className="ml-2 rounded-md bg-muted px-1.5 py-0.5 text-xs leading-none text-muted-foreground no-underline group-hover:no-underline">
+              <span className="ml-2 rounded-md bg-muted px-1.5 py-0.5 text-xs leading-none text-muted-foreground">
                 {item.label}
               </span>
             )}


### PR DESCRIPTION
Streamlined class assignments for improved consistency and maintainability. Hover effects now underline only titles with a span, excluding tags like "New" to avoid unwanted styling. Disabled elements have a unified appearance for better visual clarity, aligned with accessibility standards. These adjustments reduce CSS complexity and enhance styling accuracy.

🚧 examples using red bg to show off bug

example showing the bug:
![image](https://github.com/user-attachments/assets/5a9822cf-1a5f-4236-9e06-9c58ad5c52e9)

fixed example and also disabled with no underlines:
![image](https://github.com/user-attachments/assets/8854c479-4120-46ac-a03b-b2fd8ca0a81b)
![image](https://github.com/user-attachments/assets/0976299b-9ad7-42cd-a886-34811c7c967e)

