### PR TITLE
fix(www): theme page pageheader border on large screens

### DIFF
--- a/apps/www/app/(app)/themes/layout.tsx
+++ b/apps/www/app/(app)/themes/layout.tsx
@@ -26,7 +26,7 @@ export default function ThemesLayout({
         defaultTheme="zinc"
         className="relative flex w-full flex-col items-start md:flex-row"
       >
-        <PageHeader>
+        <PageHeader className="w-full">
           <Announcement />
           <PageHeaderHeading className="hidden md:block">
             Add colors. Make it yours.


### PR DESCRIPTION
Theme page on large screens at page-header not covering the full width of parent themes-provider hence the border-bottom on large screen was not full.