### PR TITLE
docs(Manual Installation): Change ` to " in CSS variables to prevent conflicts with Prettier formatting

### DIFF
--- a/apps/www/content/docs/installation/manual.mdx
+++ b/apps/www/content/docs/installation/manual.mdx
@@ -83,8 +83,8 @@ module.exports = {
         },
       },
       borderRadius: {
-        lg: `var(--radius)`,
-        md: `calc(var(--radius) - 2px)`,
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
       },
     },


### PR DESCRIPTION
Change ` to " in CSS variables to prevent conflicts with Prettier formatting

If users manually add this package and have Prettier configured, it may reformat ` to " in CSS files, potentially causing issues with the radius variable not applying correctly.
