### PR TITLE
[Bug] - Shortcut to open/close sidebar does not work when capslock is active

### DIFF
--- a/apps/www/registry/default/ui/sidebar.tsx
+++ b/apps/www/registry/default/ui/sidebar.tsx
@@ -100,7 +100,7 @@ const SidebarProvider = React.forwardRef<
     React.useEffect(() => {
       const handleKeyDown = (event: KeyboardEvent) => {
         if (
-          event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+          event.key.toLowerCase() === SIDEBAR_KEYBOARD_SHORTCUT &&
           (event.metaKey || event.ctrlKey)
         ) {
           event.preventDefault()


### PR DESCRIPTION
When capslock is active, the shortcut for opening/closing the sidebar does not work because the "keydown" event returns "B" instead of "b", which breaks the listener's conditional.

Forcing the comparison in lowerCase solves the problem, allowing the shortcut to be served with or without active capslock.