### PR TITLE
fix(tsconfig): support import alias paths without leading ./

### DIFF
--- a/packages/shadcn/src/utils/get-project-info.ts
+++ b/packages/shadcn/src/utils/get-project-info.ts
@@ -173,7 +173,10 @@ export async function getTsConfigAliasPrefix(cwd: string) {
       paths.includes("./*") ||
       paths.includes("./src/*") ||
       paths.includes("./app/*") ||
-      paths.includes("./resources/js/*") // Laravel.
+      paths.includes("./resources/js/*") || // Laravel.
+      paths.includes("src/*") ||
+      paths.includes("app/*") ||
+      paths.includes("resources/js/*")
     ) {
       return alias.replace(/\/\*$/, "") ?? null
     }


### PR DESCRIPTION
## Problem  
The CLI was too strict when checking import alias paths in `tsconfig.json`. It only worked if the path started with `./`.  

## Solution  
We updated the `getTsConfigAliasPrefix` function so it now works with paths both with and without `./`.  

Example:  

```json
{
  "compilerOptions": {
    "baseUrl": ".",
    "paths": {
      "~/*": ["./src/*"],  // This worked before
      "~/*": ["src/*"]     // Now this works too
    }
  }
}
