### PR TITLE
fix: code diff display in dropdown-menu documentation

### DIFF
--- a/apps/www/content/docs/components/dropdown-menu.mdx
+++ b/apps/www/content/docs/components/dropdown-menu.mdx
@@ -111,8 +111,8 @@ const DropdownMenuItem = React.forwardRef<
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Item
     ref={ref}
-    className={cn(
-      "relative ... gap-2 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+    className={cn(  
++     "relative ... gap-2 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -125,18 +125,17 @@ const DropdownMenuItem = React.forwardRef<
 
 Added `gap-2 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0` to the `<DropdownMenuSubTrigger />` to automatically style icon inside.
 
-Add the following classes to the `cva` call in your `dropdown-menu.tsx` file.
+Add the following classes to the `cn` call in your `dropdown-menu.tsx` file.
 
-```tsx title="dropdown-menu.tsx"
+```diff title="dropdown-menu.tsx"
 <DropdownMenuPrimitive.SubTrigger
   ref={ref}
   className={cn(
-    "flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
++   "flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
     inset && "pl-8",
     className
   )}
-  {...props}
->
+  {...props}>
   {/* ... */}
 </DropdownMenuPrimitive.SubTrigger>
 ```


### PR DESCRIPTION
Hi,

While reading the documentation for the [Dropdown Menu](https://ui.shadcn.com/docs/components/dropdown-menu) component, I noticed some syntax highlighting issues in the changelog section that might be a bit confusing :

The code blocks in the section are visually inconsistent. One block is missing the “+” sign to emphasize the added code, another block uses `tsx` syntax highlighting, which doesn’t align with the purpose of the section that suggests developers to add additional tailwind styles.

To address these issues, I made the following changes:
- Updated both code blocks in the section with `diff` syntax highlighting for code display consistency.
- Added “+” signs to emphasize changes.
- Replaced the `cva` reference in the second paragraph of the 2024-10-25... changelog with `cn`. The `cva` function seems not used in the associated code block, but cn is.

Please refer to the following screenshots for the changes I made on the doc, with left one is before change, and the right one is after change:
<div align='center'>
<img width=45% alt="before" src="https://github.com/user-attachments/assets/5e577155-c3ad-4288-bb23-fa1d2ecb6e68">
<img width=45%  alt="after" src="https://github.com/user-attachments/assets/dd80e6b4-7414-40cf-ae73-4d96f810b33e">
</div>

Thanks for considering my PR, and please let me know if you have any feedback or additional suggestions!