### PR TITLE
feat(dialog): add close button aria label prop for accessibility

### DIFF
--- a/apps/www/registry/default/ui/dialog.tsx
+++ b/apps/www/registry/default/ui/dialog.tsx
@@ -31,8 +31,10 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    closeBtnAriaLabel?: string;
+  }
+>(({ className, children, closeBtnAriaLabel, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -46,7 +48,7 @@ const DialogContent = React.forwardRef<
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">{closeBtnAriaLabel || "Close"}</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>

--- a/apps/www/registry/new-york/ui/dialog.tsx
+++ b/apps/www/registry/new-york/ui/dialog.tsx
@@ -31,8 +31,10 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    closeBtnAriaLabel?: string;
+  }
+>(({ className, children, closeBtnAriaLabel, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -46,7 +48,7 @@ const DialogContent = React.forwardRef<
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">{closeBtnAriaLabel || "Close"}</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>


### PR DESCRIPTION
Proposal to improve the accessibility of the `Dialog` component by adding an optional `closeBtnAriaLabel` prop. This prop allows for a customizable aria-label for the close button, enhancing screen reader support. I have run into the hard-coded "Close" label for multiple accessibility test, so likely would be useful for others as well. 

Accessibility improvements:

* [`apps/www/registry/default/ui/dialog.tsx`](diffhunk://#diff-cda72a694f26824ab77061d06e6cf1b521199459865f801e5610756f5fe027c0L34-R37): Added an optional `closeBtnAriaLabel` prop to `DialogContent` and used it to set the aria-label for the close button. If not provided, it defaults to "Close". [[1]](diffhunk://#diff-cda72a694f26824ab77061d06e6cf1b521199459865f801e5610756f5fe027c0L34-R37) [[2]](diffhunk://#diff-cda72a694f26824ab77061d06e6cf1b521199459865f801e5610756f5fe027c0L49-R51)
* [`apps/www/registry/new-york/ui/dialog.tsx`](diffhunk://#diff-92d1c85c8b7a12f080c4e6bf494467893fe44ff21bfd36576be8348b9f267dffL34-R37): Added an optional `closeBtnAriaLabel` prop to `DialogContent` and used it to set the aria-label for the close button. If not provided, it defaults to "Close". [[1]](diffhunk://#diff-92d1c85c8b7a12f080c4e6bf494467893fe44ff21bfd36576be8348b9f267dffL34-R37) [[2]](diffhunk://#diff-92d1c85c8b7a12f080c4e6bf494467893fe44ff21bfd36576be8348b9f267dffL49-R51)