### PR TITLE
fix(shadcn): Sidebar onOpenChange not working properly on mobile view.

### DIFF
--- a/apps/www/registry/default/ui/sidebar.tsx
+++ b/apps/www/registry/default/ui/sidebar.tsx
@@ -72,14 +72,12 @@ const SidebarProvider = React.forwardRef<
     const [_openMobile, _setOpenMobile] = React.useState(false)
 
     // This is the internal state of the sidebar.
-    // We use openProp and setOpenProp for control from outside the component.
     const [_open, _setOpen] = React.useState(defaultOpen)
 
     // Unified open state that considers both mobile and desktop scenarios
     const open = openProp ?? (isMobile ? _openMobile : _open)
 
     // Unified state update function to handle both mobile and desktop states
-    // This reduces code duplication and ensures consistent state updates
     const updateOpenState = React.useCallback(
       (value: boolean) => {
         if (setOpenProp) {

--- a/apps/www/registry/default/ui/sidebar.tsx
+++ b/apps/www/registry/default/ui/sidebar.tsx
@@ -68,25 +68,48 @@ const SidebarProvider = React.forwardRef<
     ref
   ) => {
     const isMobile = useIsMobile()
-    const [openMobile, setOpenMobile] = React.useState(false)
+    // State for mobile sidebar
+    const [_openMobile, _setOpenMobile] = React.useState(false)
 
     // This is the internal state of the sidebar.
     // We use openProp and setOpenProp for control from outside the component.
     const [_open, _setOpen] = React.useState(defaultOpen)
-    const open = openProp ?? _open
+
+    // Unified open state that considers both mobile and desktop scenarios
+    const open = openProp ?? (isMobile ? _openMobile : _open)
+
+    // Unified state update function to handle both mobile and desktop states
+    // This reduces code duplication and ensures consistent state updates
+    const updateOpenState = React.useCallback(
+      (value: boolean) => {
+        if (setOpenProp) {
+          setOpenProp(value)
+        }
+        if (isMobile) {
+          _setOpenMobile(value)
+        } else {
+          _setOpen(value)
+          // This sets the cookie to keep the sidebar state.
+          document.cookie = `${SIDEBAR_COOKIE_NAME}=${value}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+        }
+      },
+      [isMobile, setOpenProp]
+    )
+
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {
         const openState = typeof value === "function" ? value(open) : value
-        if (setOpenProp) {
-          setOpenProp(openState)
-        } else {
-          _setOpen(openState)
-        }
-
-        // This sets the cookie to keep the sidebar state.
-        document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+        updateOpenState(openState)
       },
-      [setOpenProp, open]
+      [open, updateOpenState]
+    )
+
+    const setOpenMobile = React.useCallback(
+      (value: boolean | ((value: boolean) => boolean)) => {
+        const openState = typeof value === "function" ? value(_openMobile) : value
+        updateOpenState(openState)
+      },
+      [_openMobile, updateOpenState]
     )
 
     // Helper to toggle the sidebar.
@@ -122,11 +145,11 @@ const SidebarProvider = React.forwardRef<
         open,
         setOpen,
         isMobile,
-        openMobile,
+        openMobile: _openMobile,
         setOpenMobile,
         toggleSidebar,
       }),
-      [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+      [state, open, setOpen, isMobile, _openMobile, setOpenMobile, toggleSidebar]
     )
 
     return (

--- a/apps/www/registry/new-york/ui/sidebar.tsx
+++ b/apps/www/registry/new-york/ui/sidebar.tsx
@@ -72,14 +72,12 @@ const SidebarProvider = React.forwardRef<
     const [_openMobile, _setOpenMobile] = React.useState(false)
 
     // This is the internal state of the sidebar.
-    // We use openProp and setOpenProp for control from outside the component.
     const [_open, _setOpen] = React.useState(defaultOpen)
 
     // Unified open state that considers both mobile and desktop scenarios
     const open = openProp ?? (isMobile ? _openMobile : _open)
 
     // Unified state update function to handle both mobile and desktop states
-    // This reduces code duplication and ensures consistent state updates
     const updateOpenState = React.useCallback(
       (value: boolean) => {
         if (setOpenProp) {

--- a/apps/www/registry/new-york/ui/sidebar.tsx
+++ b/apps/www/registry/new-york/ui/sidebar.tsx
@@ -68,25 +68,48 @@ const SidebarProvider = React.forwardRef<
     ref
   ) => {
     const isMobile = useIsMobile()
-    const [openMobile, setOpenMobile] = React.useState(false)
+    // State for mobile sidebar
+    const [_openMobile, _setOpenMobile] = React.useState(false)
 
     // This is the internal state of the sidebar.
     // We use openProp and setOpenProp for control from outside the component.
     const [_open, _setOpen] = React.useState(defaultOpen)
-    const open = openProp ?? _open
+
+    // Unified open state that considers both mobile and desktop scenarios
+    const open = openProp ?? (isMobile ? _openMobile : _open)
+
+    // Unified state update function to handle both mobile and desktop states
+    // This reduces code duplication and ensures consistent state updates
+    const updateOpenState = React.useCallback(
+      (value: boolean) => {
+        if (setOpenProp) {
+          setOpenProp(value)
+        }
+        if (isMobile) {
+          _setOpenMobile(value)
+        } else {
+          _setOpen(value)
+          // This sets the cookie to keep the sidebar state.
+          document.cookie = `${SIDEBAR_COOKIE_NAME}=${value}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+        }
+      },
+      [isMobile, setOpenProp]
+    )
+
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {
         const openState = typeof value === "function" ? value(open) : value
-        if (setOpenProp) {
-          setOpenProp(openState)
-        } else {
-          _setOpen(openState)
-        }
-
-        // This sets the cookie to keep the sidebar state.
-        document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+        updateOpenState(openState)
       },
-      [setOpenProp, open]
+      [open, updateOpenState]
+    )
+
+    const setOpenMobile = React.useCallback(
+      (value: boolean | ((value: boolean) => boolean)) => {
+        const openState = typeof value === "function" ? value(_openMobile) : value
+        updateOpenState(openState)
+      },
+      [_openMobile, updateOpenState]
     )
 
     // Helper to toggle the sidebar.
@@ -122,11 +145,11 @@ const SidebarProvider = React.forwardRef<
         open,
         setOpen,
         isMobile,
-        openMobile,
+        openMobile: _openMobile,
         setOpenMobile,
         toggleSidebar,
       }),
-      [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+      [state, open, setOpen, isMobile, _openMobile, setOpenMobile, toggleSidebar]
     )
 
     return (


### PR DESCRIPTION
### Problem

When using the Sidebar component for mobile views, the `onOpenChange` callback function fails to trigger properly during toggle operations.

You can try it here: https://codesandbox.io/p/devbox/z484pw

```typescript
// When using sidebar on mobile.
<SidebarProvider onOpenChange={/* callback not triggering */}>
  <Sidebar />
</SidebarProvider>
```

### Solution

The solution involves centralizing state management through a unified `updateOpenState` function and properly handling both mobile and desktop scenarios. This ensures consistent state updates and proper callback triggering.

### Implementation Details

Original code had separate state management paths:

```typescript
const [openMobile, setOpenMobile] = React.useState(false)
const [_open, _setOpen] = React.useState(defaultOpen)
```

Updated code introduces unified state handling :

```typescript
const updateOpenState = React.useCallback(
  (value: boolean) => {
    if (setOpenProp) {
      setOpenProp(value)
    }
    if (isMobile) {
      _setOpenMobile(value)
    } else {
      _setOpen(value)
      // Cookie management for desktop
    }
  },
  [isMobile, setOpenProp]
)
```

### Key Changes

1. Unified state management through `updateOpenState`
2. Consolidated open state determination:
 ```typescript
 const open = openProp ?? (isMobile ? _openMobile : _open)
 ```
 
### Notes

Let me know if you need any clarification on the implementation details!