### PR TITLE
fix(shadcn): support unknown fields in components.json

### DIFF
--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -40,7 +40,7 @@ export const rawConfigSchema = z
     }),
     iconLibrary: z.string().optional(),
   })
-  .strict()
+  .passthrough()
 
 export type RawConfig = z.infer<typeof rawConfigSchema>
 


### PR DESCRIPTION
Currently, adding any unknown field to components.json will break the CLI. This is a quick fix to allow more flexibility.