### PR TITLE
fix: (Astro) Resolve `verbatimModuleSyntax` TypeScript Error when using `sidebar.tsx`

### DIFF
--- a/apps/www/registry/default/ui/sidebar.tsx
+++ b/apps/www/registry/default/ui/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { VariantProps, cva } from "class-variance-authority"
+import { type VariantProps, cva } from "class-variance-authority"
 import { PanelLeft } from "lucide-react"
 
 import { useIsMobile } from "@/registry/default/hooks/use-mobile"

--- a/apps/www/registry/new-york/ui/sidebar.tsx
+++ b/apps/www/registry/new-york/ui/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { VariantProps, cva } from "class-variance-authority"
+import { type VariantProps, cva } from "class-variance-authority"
 import { PanelLeft } from "lucide-react"
 
 import { useIsMobile } from "@/registry/new-york/hooks/use-mobile"


### PR DESCRIPTION
Closes: #5669

## The Problem

TypeScript enables [verbatimModuleSyntax](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) by default which results in TypeScript throwing the following error in default Astro projects:
- `[ERROR] [vite] The requested module 'class-variance-authority' does not provide an export named 'VariantProps'`

## Solution

Simply add the `type` keyword to resolve the error.

```diff
import * as React from "react"
import { Slot } from "@radix-ui/react-slot"
+ import { type VariantProps, cva } from "class-variance-authority"
import { PanelLeft } from "lucide-react"
```

## Reproducing the Error
```bash
npm create astro@latest repro
cd ./repro

# then follow the shadcn Astro installation tutorial here: https://ui.shadcn.com/docs/installation/astro

npx shadcn@latest add sidebar
```

```tsx
// app-sidebar.tsx
import {
  Sidebar,
  SidebarContent,
  SidebarFooter,
  SidebarGroup,
  SidebarHeader,
} from '@/components/ui/sidebar';

export function AppSidebar() {
  return (
    <Sidebar>
      <SidebarHeader />
      <SidebarContent>
        <SidebarGroup />
        <SidebarGroup />
      </SidebarContent>
      <SidebarFooter />
    </Sidebar>
  );
}
```

```tsx
// src/pages/index.astro
---
import '@/styles/globals.css';
import Welcome from '../components/Welcome.astro';
import Layout from '../layouts/Layout.astro';
import { AppSidebar } from '@/components/custom/app-sidebar';
import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';

// Welcome to Astro! Wondering what to do next? Check out the Astro documentation at https://docs.astro.build
// Don't want to use any of this? Delete everything in this file, the `assets`, `components`, and `layouts` directories, and start fresh.
---

<Layout>
  <SidebarProvider>
    <AppSidebar />
    <main>
      <SidebarTrigger />
      <Welcome />
    </main>
  </SidebarProvider>
</Layout>
```

### Logs

```bash
npm run dev -- --verbose

19:51:58 [ERROR] [vite] The requested module 'class-variance-authority' does not provide an export named 'VariantProps'
  Location:
    [PROJECT_DIR]/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:52053:15
  Stack trace:
    at analyzeImportedModDifference (file:///[PROJECT_DIR]/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:52053:15)
    at async ssrImport (file:///[PROJECT_DIR]/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:52914:16)
    at async instantiateModule (file:///[PROJECT_DIR]/node_modules/vite/dist/node/chunks/dep-CB_7IfJ-.js:52972:5)
  vite:time 1654.24ms / +2s
  vite:resolve 0.43ms /@vite/client -> [PROJECT_DIR]/node_modules/vite/dist/client/client.mjs +136ms
  vite:load 1.21ms [fs] /@vite/client +100ms
  vite:resolve 0.19ms @vite/env -> [PROJECT_DIR]/node_modules/vite/dist/client/env.mjs +11ms
  vite:import-analysis 3.47ms [1 imports rewritten] node_modules/vite/dist/client/client.mjs +112ms
  vite:transform 13.06ms /@vite/client +113ms
  vite:time 19.13ms /@vite/client +33ms
  vite:load 7.26ms [fs] /node_modules/vite/dist/client/env.mjs +20ms
  vite:import-analysis 0.05ms [no imports] node_modules/vite/dist/client/env.mjs +8ms
  vite:transform 1.33ms /node_modules/vite/dist/client/env.mjs +8ms
  vite:cache [memory] /@vite/client +158ms
  vite:time 0.73ms /@vite/client +9ms
  vite:cache [304] /node_modules/vite/dist/client/env.mjs +0ms
  vite:time 0.43ms /node_modules/vite/dist/client/env.mjs +4ms
  ```