### PR TITLE
docs(www): update toast manual installation

### DIFF
--- a/apps/www/__registry__/index.tsx
+++ b/apps/www/__registry__/index.tsx
@@ -717,6 +717,22 @@ export const Index: Record<string, any> = {
       subcategory: "",
       chunks: []
     },
+    "toaster": {
+      name: "toaster",
+      description: "",
+      type: "registry:ui",
+      registryDependencies: undefined,
+      files: [{
+        path: "registry/new-york/ui/toaster.tsx",
+        type: "registry:ui",
+        target: ""
+      }],
+      component: React.lazy(() => import("@/registry/new-york/ui/toaster.tsx")),
+      source: "",
+      category: "",
+      subcategory: "",
+      chunks: []
+    },
     "toggle": {
       name: "toggle",
       description: "",
@@ -6205,6 +6221,22 @@ export const Index: Record<string, any> = {
         target: ""
       }],
       component: React.lazy(() => import("@/registry/default/ui/toast.tsx")),
+      source: "",
+      category: "",
+      subcategory: "",
+      chunks: []
+    },
+    "toaster": {
+      name: "toaster",
+      description: "",
+      type: "registry:ui",
+      registryDependencies: undefined,
+      files: [{
+        path: "registry/default/ui/toaster.tsx",
+        type: "registry:ui",
+        target: ""
+      }],
+      component: React.lazy(() => import("@/registry/default/ui/toaster.tsx")),
       source: "",
       category: "",
       subcategory: "",

--- a/apps/www/content/docs/components/toast.mdx
+++ b/apps/www/content/docs/components/toast.mdx
@@ -67,11 +67,11 @@ npm install @radix-ui/react-toast
 
 `toaster.tsx`
 
-<ComponentSource name="toast" fileName="toaster" />
+<ComponentSource name="toaster" />
 
-`use-toast.tsx`
+`use-toast.ts`
 
-<ComponentSource name="toast" fileName="use-toast" />
+<ComponentSource name="use-toast" />
 
 <Step>Update the import paths to match your project setup.</Step>
 

--- a/apps/www/public/r/index.json
+++ b/apps/www/public/r/index.json
@@ -669,6 +669,16 @@
     ]
   },
   {
+    "name": "toaster",
+    "type": "registry:ui",
+    "files": [
+      {
+        "path": "ui/toaster.tsx",
+        "type": "registry:ui"
+      }
+    ]
+  },
+  {
     "name": "toggle",
     "type": "registry:ui",
     "dependencies": [

--- a/apps/www/public/r/styles/default/toaster.json
+++ b/apps/www/public/r/styles/default/toaster.json
@@ -1,0 +1,12 @@
+{
+  "name": "toaster",
+  "type": "registry:ui",
+  "files": [
+    {
+      "path": "ui/toaster.tsx",
+      "content": "\"use client\"\n\nimport { useToast } from \"@/registry/default/hooks/use-toast\"\nimport {\n  Toast,\n  ToastClose,\n  ToastDescription,\n  ToastProvider,\n  ToastTitle,\n  ToastViewport,\n} from \"@/registry/default/ui/toast\"\n\nexport function Toaster() {\n  const { toasts } = useToast()\n\n  return (\n    <ToastProvider>\n      {toasts.map(function ({ id, title, description, action, ...props }) {\n        return (\n          <Toast key={id} {...props}>\n            <div className=\"grid gap-1\">\n              {title && <ToastTitle>{title}</ToastTitle>}\n              {description && (\n                <ToastDescription>{description}</ToastDescription>\n              )}\n            </div>\n            {action}\n            <ToastClose />\n          </Toast>\n        )\n      })}\n      <ToastViewport />\n    </ToastProvider>\n  )\n}\n",
+      "type": "registry:ui",
+      "target": ""
+    }
+  ]
+}

--- a/apps/www/public/r/styles/new-york/toaster.json
+++ b/apps/www/public/r/styles/new-york/toaster.json
@@ -1,0 +1,12 @@
+{
+  "name": "toaster",
+  "type": "registry:ui",
+  "files": [
+    {
+      "path": "ui/toaster.tsx",
+      "content": "\"use client\"\n\nimport { useToast } from \"@/registry/new-york/hooks/use-toast\"\nimport {\n  Toast,\n  ToastClose,\n  ToastDescription,\n  ToastProvider,\n  ToastTitle,\n  ToastViewport,\n} from \"@/registry/new-york/ui/toast\"\n\nexport function Toaster() {\n  const { toasts } = useToast()\n\n  return (\n    <ToastProvider>\n      {toasts.map(function ({ id, title, description, action, ...props }) {\n        return (\n          <Toast key={id} {...props}>\n            <div className=\"grid gap-1\">\n              {title && <ToastTitle>{title}</ToastTitle>}\n              {description && (\n                <ToastDescription>{description}</ToastDescription>\n              )}\n            </div>\n            {action}\n            <ToastClose />\n          </Toast>\n        )\n      })}\n      <ToastViewport />\n    </ToastProvider>\n  )\n}\n",
+      "type": "registry:ui",
+      "target": ""
+    }
+  ]
+}

--- a/apps/www/registry/registry-ui.ts
+++ b/apps/www/registry/registry-ui.ts
@@ -576,6 +576,16 @@ export const ui: Registry = [
     ],
   },
   {
+    name: "toaster",
+    type: "registry:ui",
+    files: [
+      {
+        path: "ui/toaster.tsx",
+        type: "registry:ui",
+      },
+    ],
+  },
+  {
     name: "toggle",
     type: "registry:ui",
     dependencies: ["@radix-ui/react-toggle"],


### PR DESCRIPTION
Hello, I'm making my first and small contribution to the docs here. Congrats for this amazing project, it is very cool!

I was manually installing the Toast component and I noticed the `toaster.tsx` and `use-toast.ts` file were missing, and I realized the `use-toast` title extension should be `.ts` instead of `.tsx`.

<img width="826" alt="Screenshot 2024-12-08 at 22 31 04" src="https://github.com/user-attachments/assets/8419b027-6b7f-41dc-8ab0-0cb200fade1f"><br>


I have updated ComponentSources for the `toast.mdx` file to work with the name property instead of filename, and included the toaster in the ui registry as it was missing.

Not sure if this is the best approach, let me know about it.

Thanks!
