### PR TITLE
fix(shadcn): change forwardRef type to match actual element

### DIFF
--- a/apps/www/registry/default/ui/alert.tsx
+++ b/apps/www/registry/default/ui/alert.tsx
@@ -33,7 +33,7 @@ const Alert = React.forwardRef<
 Alert.displayName = "Alert"
 
 const AlertTitle = React.forwardRef<
-  HTMLParagraphElement,
+  HTMLHeadingElement,
   React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
   <h5
@@ -45,8 +45,8 @@ const AlertTitle = React.forwardRef<
 AlertTitle.displayName = "AlertTitle"
 
 const AlertDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}


### PR DESCRIPTION
This is a bug spotted by AI code review bot. While this does not trigger any TypeScript complaints due to their same type structure, it is good to keep type annotation in sync with implementation.