### PR TITLE
docs(www) : Add note about `suppressHydrationWarning` to dark-mode docs

### DIFF
--- a/apps/www/content/docs/dark-mode/next.mdx
+++ b/apps/www/content/docs/dark-mode/next.mdx
@@ -34,6 +34,7 @@ export function ThemeProvider({
 ### Wrap your root layout
 
 Add the `ThemeProvider` to your root layout.
+Make sure to include `suppressHydrationWarning` as a property on your `<html>` tag.
 
 ```tsx {1,9-11} title="app/layout.tsx"
 import { ThemeProvider } from "@/components/theme-provider"


### PR DESCRIPTION
It is pretty easy to not notice that you need to add `suppressHydrationWarning` to `html` tag, so I just added small note about it.