### PR TITLE
fix(components): copy to clipboard issue on tooltip component

### DIFF
--- a/apps/www/registry/default/ui/tooltip.tsx
+++ b/apps/www/registry/default/ui/tooltip.tsx
@@ -19,7 +19,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 [&>span]:select-none",
       className
     )}
     {...props}

--- a/apps/www/registry/new-york/ui/tooltip.tsx
+++ b/apps/www/registry/new-york/ui/tooltip.tsx
@@ -20,7 +20,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 [&>span]:select-none",
         className
       )}
       {...props}


### PR DESCRIPTION
When I use the tooltip component, I encountered an issue when trying to copy text from the popup by double-click.
<img width="153" alt="截屏2024-12-19 16 39 12" src="https://github.com/user-attachments/assets/32f71f84-bda7-4793-8bba-0ed0d30f1a50" />
In this scenario, when I double-click "66925386371" to select it  and press ctrl+c to copy, but I got text "6692538637166925386371".
This happens because radix tooltip has a invisible dom who has same text value, so double-click action will select this invisible text also.

<img width="879" alt="截屏2024-12-19 16 40 26" src="https://github.com/user-attachments/assets/78c6fec8-9043-4cd8-b148-3ad8b74e9944" />

This pr fix this issue, i set `[&>span]:select-none` on `TooltipPrimitive.Content`, invisible text will not be selected.