### PR TITLE
Updating Dark Mode documentation to add the SupressHydrationWarning

### DIFF
--- a/apps/www/content/docs/dark-mode/next.mdx
+++ b/apps/www/content/docs/dark-mode/next.mdx
@@ -33,7 +33,7 @@ export function ThemeProvider({
 
 ### Wrap your root layout
 
-Add the `ThemeProvider` to your root layout.
+Add the `ThemeProvider` to your root layout and the `suppressHydrationWarning` to the html tag.
 
 ```tsx {1,9-11} title="app/layout.tsx"
 import { ThemeProvider } from "@/components/theme-provider"


### PR DESCRIPTION
This pull request includes a small change to the `apps/www/content/docs/dark-mode/next.mdx` file. The change updates the documentation to include the `suppressHydrationWarning` attribute to the HTML tag in the root layout.

* [`apps/www/content/docs/dark-mode/next.mdx`](diffhunk://#diff-72e308946f5ff72259dbfa2b989d98e089416a7821deda4bb8bd8cb2780a380eL36-R36): Updated the documentation to add the `suppressHydrationWarning` attribute to the HTML tag in the root layout.