### PR TITLE
fix(app): update Dialog import to resolve interaction issue

### DIFF
--- a/apps/www/app/(app)/examples/playground/components/preset-actions.tsx
+++ b/apps/www/app/(app)/examples/playground/components/preset-actions.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import * as React from "react"
-import { Dialog } from "@radix-ui/react-dialog"
 import { MoreHorizontal } from "lucide-react"
 
 import { toast } from "@/registry/new-york/hooks/use-toast"
@@ -16,6 +15,7 @@ import {
 } from "@/registry/new-york/ui/alert-dialog"
 import { Button } from "@/registry/new-york/ui/button"
 import {
+  Dialog,
   DialogContent,
   DialogDescription,
   DialogFooter,


### PR DESCRIPTION
---

### PR Title:  
`fix(app): update Dialog import to resolve interaction issue`

---

### Description:  
This PR fixes a bug in the `preset-actions.tsx` file located at `app/(app)/examples/playground/components/`. The issue was caused by importing the `Dialog` component from `@radix-ui/react-dialog` instead of the correct path, `@/registry/new-york/ui/dialog`.  

This incorrect import caused the dialog to malfunction, resulting in the page becoming non-interactable after closing the dialog.  

---

### Changes Made:  
- Updated the import statement for the `Dialog` component in `preset-actions.tsx` to use the correct path:  
  ```ts
  import { Dialog } from "@/registry/new-york/ui/dialog";
  ```
- Verified the fix to ensure the dialog behaves as expected and no longer causes page interaction issues.

---

### Steps to Test:  
1. Navigate to the playground example in the app:  
   `app/(app)/examples/playground/components/preset-actions.tsx`.
2. Open the dialog and close it.
3. Confirm that the page remains interactable and no issues arise.

---

### Linked Issues (if any):  
- None reported, discovered during development/testing.

---

### Checklist:  
- [x] Code changes are tested and verified.
- [x] No new dependencies added.