### PR TITLE
docs(Drawer): pass asChild to DrawerClose to avoid nested buttons

### DIFF
--- a/apps/www/content/docs/components/drawer.mdx
+++ b/apps/www/content/docs/components/drawer.mdx
@@ -75,7 +75,7 @@ import {
     </DrawerHeader>
     <DrawerFooter>
       <Button>Submit</Button>
-      <DrawerClose>
+      <DrawerClose asChild>
         <Button variant="outline">Cancel</Button>
       </DrawerClose>
     </DrawerFooter>


### PR DESCRIPTION
fixes #6205 