### PR TITLE
Docs: fix tailwind class name value

### DIFF
--- a/apps/www/content/docs/installation/manual.mdx
+++ b/apps/www/content/docs/installation/manual.mdx
@@ -83,8 +83,8 @@ module.exports = {
         },
       },
       borderRadius: {
-        lg: `var(--radius)`,
-        md: `calc(var(--radius) - 2px)`,
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
       },
     },


### PR DESCRIPTION
When I copied this code snippet, the lg and md didn't work since my prettier format corrected it as "`var(--radius)`" thus adding " before and after the `
```
lg: `var(--radius)`,
md: `calc(var(--radius) - 2px)`,
sm: "calc(var(--radius) - 4px)"
```