### PR TITLE
fix: update calendar.tsx to use PreviousMonthButton and NextMonthButt…

### DIFF
--- a/apps/www/registry/default/ui/calendar.tsx
+++ b/apps/www/registry/default/ui/calendar.tsx
@@ -54,10 +54,10 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        IconLeft: ({ className, ...props }) => (
+        PreviousMonthButton: ({ className, ...props }) => (
           <ChevronLeft className={cn("h-4 w-4", className)} {...props} />
         ),
-        IconRight: ({ className, ...props }) => (
+        NextMonthButton: ({ className, ...props }) => (
           <ChevronRight className={cn("h-4 w-4", className)} {...props} />
         ),
       }}


### PR DESCRIPTION
…on for react-day-picker

I ran into an type issue with my NextJS build where it seems that IconLeft and IconRight aren't listed in the types for react-day-picker and instead uses PreviousMonthButton and NextMonthButton.


https://daypicker.dev/api/type-aliases/CustomComponents
<img width="982" alt="Screenshot 2024-12-30 at 2 49 47 PM" src="https://github.com/user-attachments/assets/e71d25e5-d35d-459a-b4e9-dfcdf852c6a7" />
