### PR TITLE
chore(eslint): use imported `tailwindcssAnimate`

### DIFF
--- a/packages/cli/src/utils/templates.ts
+++ b/packages/cli/src/utils/templates.ts
@@ -131,6 +131,7 @@ module.exports = {
 }`
 
 export const TAILWIND_CONFIG_TS = `import type { Config } from "tailwindcss"
+import tailwindcssAnimate from "tailwindcss-animate"
 
 const config = {
   darkMode: ["class"],
@@ -166,12 +167,13 @@ const config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 } satisfies Config
 
 export default config`
 
 export const TAILWIND_CONFIG_TS_WITH_VARIABLES = `import type { Config } from "tailwindcss"
+import tailwindcssAnimate from "tailwindcss-animate"
 
 const config = {
   darkMode: ["class"],
@@ -247,7 +249,7 @@ const config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 } satisfies Config
 
 export default config`


### PR DESCRIPTION
People with the following settings

```.eslintrc.json
"rules": {
  "@typescript-eslint/no-require-imports": "error"
}
```

will get the error:

```
A `require()` style import is forbidden.eslint@typescript-eslint/no-require-imports
```