### PR TITLE
fix: modify incorrect selected style in commandItem

### DIFF
--- a/apps/www/registry/default/ui/command.tsx
+++ b/apps/www/registry/default/ui/command.tsx
@@ -119,7 +119,7 @@ const CommandItem = React.forwardRef<
     className={cn(
       "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       forcedSelected &&
-        "bg-accent group-hover/cmd:bg-transparent hover:!bg-accent",
+        "bg-accent text-accent-foreground group-hover/cmd:bg-transparent group-hover/cmd:text-foreground hover:!bg-accent hover:!text-accent-foreground",
       className
     )}
     data-selected={false}

--- a/apps/www/registry/default/ui/command.tsx
+++ b/apps/www/registry/default/ui/command.tsx
@@ -87,7 +87,7 @@ const CommandGroup = React.forwardRef<
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
-      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      "group/cmd overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
       className
     )}
     {...props}
@@ -110,14 +110,19 @@ CommandSeparator.displayName = CommandPrimitive.Separator.displayName
 
 const CommandItem = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item> & {
+    forcedSelected?: boolean
+  }
+>(({ className, forcedSelected, ...props }, ref) => (
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      forcedSelected &&
+        "bg-accent group-hover/cmd:bg-transparent hover:!bg-accent",
       className
     )}
+    data-selected={false}
     {...props}
   />
 ))

--- a/apps/www/registry/new-york/ui/command.tsx
+++ b/apps/www/registry/new-york/ui/command.tsx
@@ -81,7 +81,7 @@ const CommandEmpty = React.forwardRef<
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName
 
 const CommandGroup = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.Group>,
+  React.ElementRef<typeof CommandPrimitive.Group>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Group
@@ -109,7 +109,7 @@ const CommandSeparator = React.forwardRef<
 CommandSeparator.displayName = CommandPrimitive.Separator.displayName
 
 const CommandItem = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.Item>,
+  React.ElementRef<typeof CommandPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item> & {
     forcedSelected?: boolean
   }

--- a/apps/www/registry/new-york/ui/command.tsx
+++ b/apps/www/registry/new-york/ui/command.tsx
@@ -81,13 +81,13 @@ const CommandEmpty = React.forwardRef<
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName
 
 const CommandGroup = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Group>,
+  React.ComponentRef<typeof CommandPrimitive.Group>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
-      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      "group/cmd overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
       className
     )}
     {...props}
@@ -109,15 +109,20 @@ const CommandSeparator = React.forwardRef<
 CommandSeparator.displayName = CommandPrimitive.Separator.displayName
 
 const CommandItem = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
->(({ className, ...props }, ref) => (
+  React.ComponentRef<typeof CommandPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item> & {
+    forcedSelected?: boolean
+  }
+>(({ className, forcedSelected, ...props }, ref) => (
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      forcedSelected &&
+        "bg-accent group-hover/cmd:bg-transparent hover:!bg-accent",
       className
     )}
+    data-selected={false}
     {...props}
   />
 ))


### PR DESCRIPTION
## Description
### Changes
- Fixed the[ issue #6129](https://github.com/shadcn-ui/ui/issues/6129) where the first item was automatically selected when opening the Command menu
- Improved the visual feedback for selected and hovered items
- Implemented a more intuitive hover behavior using CSS-only solution

### Technical Details
1. Added `data-selected={false}` to CommandItem to prevent automatic selection behavior from cmdk library
2. Implemented group hover pattern using Tailwind's named groups (`group/cmd`)
3. Modified CommandItem styling to:
   ```css
   /* Base selected state */
   .selected { background-color: accent; }
   
   /* Remove background when group is hovered */
   .group-hover:bg-transparent
   
   /* Force background on direct hover */
   .hover:!bg-accent
   ```

The solution uses pure CSS instead of React state management for better performance and simpler implementation.

### Before
- First item was automatically selected on menu open
- Selected item's background persisted even when hovering other items
- Inconsistent visual feedback between selected and hovered states

### After
- No automatic selection on menu open
- Selected item's background disappears when hovering the menu
- Clear visual distinction between selected and hovered states
- Smooth transition between states

<img width="207" alt="스크린샷 2025-01-04 오후 5 06 04" src="https://github.com/user-attachments/assets/dd844a2a-e539-4805-93b3-560abc4d869b" />

### Implementation Notes
- Used Tailwind's named group feature (`group/cmd`) to prevent potential group styling conflicts
- Leveraged the `!` modifier in Tailwind to ensure hover styles take precedence
- Maintained existing accessibility features and keyboard navigation

### Testing Steps
1. Open the Command menu
   - Verify no item is automatically selected
2. Select an item
   - Confirm the background color is applied
3. Hover over the menu
   - Check if the selected item's background disappears
4. Hover over different items
   - Verify only the hovered item shows background color
5. Move mouse out of the menu
   - Confirm the selected item's background reappears