### PR TITLE
Patch 5

### DIFF
--- a/apps/www/registry/default/ui/command.tsx
+++ b/apps/www/registry/default/ui/command.tsx
@@ -70,10 +70,10 @@ CommandList.displayName = CommandPrimitive.List.displayName
 const CommandEmpty = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Empty>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
->((props, ref) => (
+>(({ className, ...props }, ref) => (
   <CommandPrimitive.Empty
     ref={ref}
-    className="py-6 text-center text-sm"
+    className={cn("py-6 text-center text-sm", className)}
     {...props}
   />
 ))

--- a/apps/www/registry/new-york/ui/command.tsx
+++ b/apps/www/registry/new-york/ui/command.tsx
@@ -70,10 +70,10 @@ CommandList.displayName = CommandPrimitive.List.displayName
 const CommandEmpty = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Empty>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
->((props, ref) => (
+>(({ className, ...props }, ref) => (
   <CommandPrimitive.Empty
     ref={ref}
-    className="py-6 text-center text-sm"
+    className={cn("py-6 text-center text-sm", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
### PR Title:  
`refactor(registry): merge className props in CommandEmpty component`

---

### Description:  
This PR introduces a small but essential refactor in the `CommandEmpty` component located in `command.tsx`. Previously, the `className` prop was passed directly to the component, which caused any custom `className` provided to overwrite the default `className`.  

To fix this, I updated the implementation to extract the `className` prop and merge it with the default classes using the `cn` utility. This ensures that custom `className` values are appended rather than overwriting the defaults.

---

### Changes Made:  
- Updated the `CommandEmpty` component to merge `className` props instead of overwriting them:  
  ```ts
  const CommandEmpty = React.forwardRef<
    React.ElementRef<typeof CommandPrimitive.Empty>,
    React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
  >(({ className, ...props }, ref) => (
    <CommandPrimitive.Empty
      ref={ref}
      className={cn("py-6 text-center text-sm", className)}
      {...props}
    />
  ));
  ```

---

### Benefits:  
- Prevents overwriting default styles when a `className` prop is provided.
- Ensures consistent styling across components while allowing customizations.

---

### Steps to Test:  
1. Use the `CommandEmpty` component in a project and pass a `className` prop.
2. Verify that the default `className` values are preserved and the custom classes are appended correctly.

---

### Checklist:  
- [x] Verified that the component's behavior is consistent after the changes.
- [x] Tested merging of `className` values in various scenarios.
- [x] No breaking changes introduced.  