### PR TITLE
fix(cli): detect vinxi-based frameworks (@tanstack/start, SolidStart, ...)

### DIFF
--- a/packages/shadcn/src/utils/get-project-info.ts
+++ b/packages/shadcn/src/utils/get-project-info.ts
@@ -46,7 +46,7 @@ export async function getProjectInfo(cwd: string): Promise<ProjectInfo | null> {
     aliasPrefix,
     packageJson,
   ] = await Promise.all([
-    fg.glob("**/{next,vite,astro}.config.*|gatsby-config.*|composer.json", {
+    fg.glob("**/{next,vite,astro,app}.config.*|gatsby-config.*|composer.json", {
       cwd,
       deep: 3,
       ignore: PROJECT_SHARED_IGNORE,
@@ -108,6 +108,17 @@ export async function getProjectInfo(cwd: string): Promise<ProjectInfo | null> {
   ) {
     type.framework = FRAMEWORKS["remix"]
     return type
+  }
+
+  // Vinxi-based (such as @tanstack/start and @solidjs/solid-start)
+  // They are vite-based, and the same configurations used for Vite should work flawlessly
+  const appConfig = configFiles.find((file) => file.startsWith("app.config"))
+  if (appConfig?.length) {
+    const appConfigContents = await fs.readFile(path.resolve(cwd, appConfig), "utf8")
+    if (appConfigContents.includes('defineConfig')) {
+      type.framework = FRAMEWORKS["vite"]
+      return type
+    }
   }
 
   // Vite.


### PR DESCRIPTION
This PR adds CLI support for [vinxi](https://github.com/nksaraf/vinxi)-based projects, such as [@tanstack/start](https://tanstack.com/start/latest) and [Solid Start](https://start.solidjs.com/).

Thanks to the fact that those projects are essentially Vite projects, not many changes were necessary, and adding the `app.config.*` to the detection logic is all that was really necessary. Just to be on the safe side, I also added a simple check that the said file does contain a `defineConfig` string (and is actually a Vinxi-based config), as the name `app.config.*` tends to be quite generic.

This has been tested in a barebones @tanstack/start project, and the result [can be viewed here](https://github.com/KitsuneDev/shadcn-cli-tanstack-example). Each commit represents a step of the setup process, following the instructions [from the docs.](https://ui.shadcn.com/docs/installation/vite)