### PR TITLE
fix: update carousel flex direction on using rtl

### DIFF
--- a/apps/www/registry/default/ui/carousel.tsx
+++ b/apps/www/registry/default/ui/carousel.tsx
@@ -161,7 +161,7 @@ const CarouselContent = React.forwardRef<
       <div
         ref={ref}
         className={cn(
-          "flex",
+          "flex rtl:flex-row-reverse",
           orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
           className
         )}


### PR DESCRIPTION
during my development with with the carousel noticed a bug where carousel item disappear when in rtl mode this simple flex direction change was the fix needed