### PR TITLE
chore(switch): make it RTL compatible

### DIFF
--- a/apps/www/registry/default/ui/switch.tsx
+++ b/apps/www/registry/default/ui/switch.tsx
@@ -19,7 +19,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0 rtl:data-[state=checked]:-translate-x-5"
       )}
     />
   </SwitchPrimitives.Root>


### PR DESCRIPTION
This PR simply adds `rtl:data-[state=checked]:-translate-x-5` to make the switch not break when in RTL