### PR TITLE
Fix highlighted code in `docs/dark-mode/next.mdx`

### DIFF
--- a/apps/www/content/docs/dark-mode/next.mdx
+++ b/apps/www/content/docs/dark-mode/next.mdx
@@ -35,7 +35,7 @@ export function ThemeProvider({
 
 Add the `ThemeProvider` to your root layout.
 
-```tsx {1,9-11} title="app/layout.tsx"
+```tsx {1,9-13,15} title="app/layout.tsx"
 import { ThemeProvider } from "@/components/theme-provider"
 
 export default function RootLayout({ children }: RootLayoutProps) {


### PR DESCRIPTION
The highlighted code in step 3 is not accurate to what is being added in this step.

https://ui.shadcn.com/docs/dark-mode/next

<img src="https://github.com/user-attachments/assets/190f09da-9d9c-488f-918b-8239a394b9fb" width="400px"/>
