### PR TITLE
Fix chart radar label custom dark mode

### DIFF
--- a/apps/www/__registry__/new-york/blocks/chart-radar-label-custom.tsx
+++ b/apps/www/__registry__/new-york/blocks/chart-radar-label-custom.tsx
@@ -81,7 +81,7 @@ export default function Component() {
                     fontWeight={500}
                     {...props}
                   >
-                    <tspan>{data.desktop}</tspan>
+                    <tspan className="fill-muted-foreground">{data.desktop}</tspan>
                     <tspan className="fill-muted-foreground">/</tspan>
                     <tspan>{data.mobile}</tspan>
                     <tspan

--- a/apps/www/__registry__/new-york/blocks/chart-radar-label-custom.tsx
+++ b/apps/www/__registry__/new-york/blocks/chart-radar-label-custom.tsx
@@ -83,7 +83,7 @@ export default function Component() {
                   >
                     <tspan className="fill-muted-foreground">{data.desktop}</tspan>
                     <tspan className="fill-muted-foreground">/</tspan>
-                    <tspan>{data.mobile}</tspan>
+                    <tspan className="fill-muted-foreground">{data.mobile}</tspan>
                     <tspan
                       x={x}
                       dy={"1rem"}


### PR DESCRIPTION
The custom label for chart radar is not visible in dark mode. This is a simple fix show it in dark mode using class "fill-muted-foreground".