### PR TITLE
refactor(calendar): update date in card preview to use current year and month

### DIFF
--- a/apps/www/components/cards/calendar.tsx
+++ b/apps/www/components/cards/calendar.tsx
@@ -5,7 +5,8 @@ import { addDays } from "date-fns"
 import { Calendar } from "@/registry/new-york/ui/calendar"
 import { Card, CardContent } from "@/registry/new-york/ui/card"
 
-const start = new Date(2023, 5, 5)
+const now = new Date()
+const start = new Date(now.getFullYear(), now.getMonth(), 5)
 
 export function CardsCalendar() {
   return (


### PR DESCRIPTION
Adjusts homepage preview calendar block to use the current year and month, rather than June 2023.