### PR TITLE
theming.mdx - update tw config example to match generated shad config

### DIFF
--- a/apps/www/content/docs/theming.mdx
+++ b/apps/www/content/docs/theming.mdx
@@ -164,13 +164,15 @@ To add new colors, you need to add them to your CSS file and to your `tailwind.c
 }
 ```
 
-```js {5-6} title="tailwind.config.js"
+```js {5-8} title="tailwind.config.js"
 module.exports = {
   theme: {
     extend: {
       colors: {
-        warning: "hsl(var(--warning))",
-        "warning-foreground": "hsl(var(--warning-foreground))",
+        warning: {
+          DEFAULT: 'hsl(var(--warning))',
+          foreground: 'hsl(var(--warning-foreground))',
+        },
       },
     },
   },


### PR DESCRIPTION
Current tailwind color config example cannot be copy-pasted directly into file, will not maintain consistency with the shad generated colors in that config.

This updates the example config to follow the same pattern as the generated config.