### PR TITLE
docs(www): add instructions to setup worskpace steps

### DIFF
--- a/apps/www/content/docs/blocks.mdx
+++ b/apps/www/content/docs/blocks.mdx
@@ -29,6 +29,12 @@ git checkout -b username/my-new-block
 pnpm install
 ```
 
+### Start the dev CLI
+
+```bash
+pnpm shadcn:dev
+```
+
 ### Start the dev server
 
 ```bash


### PR DESCRIPTION
This Pull Request resolves Issue #6365, which reported an error when trying to access blocks in the local development environment. The documentation has been updated to include an additional step: running the `pnpm shadcn:dev` command. This command is necessary to properly initialize the blocks in the local environment and avoid loading errors.

#### **Changes made**  
- Added the `pnpm shadcn:dev` command to the documentation as a required step for correctly running blocks in the local development environment.