### PR TITLE
Fix: Resolved duplicate hex value for violet-950 and indigo-950

### DIFF
--- a/apps/www/registry/registry-colors.ts
+++ b/apps/www/registry/registry-colors.ts
@@ -1231,7 +1231,7 @@ export const colors = {
     },
     {
       scale: 950,
-      hex: "#1e1b4b",
+      hex: "#2e1065",
       rgb: "rgb(46,16,101)",
       hsl: "hsl(261.2,72.6%,22.9%)",
     },


### PR DESCRIPTION
This PR resolves an issue where the violet-950 and indigo-950 colors in the Tailwind CSS color configuration shared the same hex value. The correct hex value for violet-950 has been applied.