### PR TITLE
BUG FIX: Carousel-Spacing example has interchanged margin and padding

### DIFF
--- a/apps/www/registry/default/examples/carousel-spacing.tsx
+++ b/apps/www/registry/default/examples/carousel-spacing.tsx
@@ -12,9 +12,9 @@ import {
 export default function CarouselSpacing() {
   return (
     <Carousel className="w-full max-w-sm">
-      <CarouselContent className="-ml-1">
+      <CarouselContent className="-pl-1">
         {Array.from({ length: 5 }).map((_, index) => (
-          <CarouselItem key={index} className="pl-1 md:basis-1/2 lg:basis-1/3">
+          <CarouselItem key={index} className="ml-1 md:basis-1/2 lg:basis-1/3">
             <div className="p-1">
               <Card>
                 <CardContent className="flex aspect-square items-center justify-center p-6">


### PR DESCRIPTION
Carousel-Spacing example has interchanged margin and padding values causing UI to break.

In the example for Carousel Spacing, the CarouselContent is given a -ml-1 and the child CarouselItem is given a pl-1 className. This will not work, because the CarouselItem needs a margin (to have gap between adjacent items) and the CarouselContent needs a -pl-1 to offset the extra margin introduced by the first child.

The values were interchanged in the example. I've corrected it by placing -pl-1 in the CarouselContent and ml-1 in CarouselItem.

Earlier - 
![image](https://github.com/user-attachments/assets/d8ad2936-ab0c-434f-b7f2-f9b7df62cf37)
After Updating-
![image](https://github.com/user-attachments/assets/e8a412b3-5e27-47a8-94e5-6f9387e323b5)
