### PR TITLE
fix(shadcn): fixes form error color to use text-destructive-foreground

### DIFF
--- a/apps/www/registry/default/ui/form.tsx
+++ b/apps/www/registry/default/ui/form.tsx
@@ -95,7 +95,7 @@ const FormLabel = React.forwardRef<
   return (
     <Label
       ref={ref}
-      className={cn(error && "text-destructive", className)}
+      className={cn(error && "text-destructive-foreground", className)}
       htmlFor={formItemId}
       {...props}
     />

--- a/apps/www/registry/new-york/ui/form.tsx
+++ b/apps/www/registry/new-york/ui/form.tsx
@@ -95,7 +95,7 @@ const FormLabel = React.forwardRef<
   return (
     <Label
       ref={ref}
-      className={cn(error && "text-destructive", className)}
+      className={cn(error && "text-destructive-foreground", className)}
       htmlFor={formItemId}
       {...props}
     />


### PR DESCRIPTION
### What does this PR do?
- Changes the color for errors in forms to use `text-destructive-foreground` instead of `text-destructive`

### Preview
Before:

<img width="511" alt="image" src="https://github.com/user-attachments/assets/ef2badbc-3a9d-480a-8c4d-060bb2d22d33" />

After:

<img width="507" alt="image" src="https://github.com/user-attachments/assets/a8d66df4-a3dc-4e10-b0ac-47a2e2056553" />

### Explanation:

If I understand correctly, generally:
- `--destructive` is for the background color and
- `--destructive-foreground` is for the text of destructive components

Testing with [catppuccin](https://github.com/catppuccin/catppuccin) mocha colors

```css
@layer base {
  .dark {
    --background: 240 21% 15%;
    --foreground: 226 64% 88%;
    --destructive: 240 23% 9%;
    --destructive-foreground: 343 81% 75%;
  }
}
```

Here is how a toast looks with these colors as a sanity check.

<img width="421" alt="image" src="https://github.com/user-attachments/assets/1083f421-08da-490b-b021-760003586abc" />

Hopefully this makes sense, let me know if I'm misunderstanding something, new to shadcn.

