### PR TITLE
fix: accordion rotates any svg element in the trigger

### DIFF
--- a/apps/www/registry/default/ui/accordion.tsx
+++ b/apps/www/registry/default/ui/accordion.tsx
@@ -28,13 +28,13 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline group",
         className
       )}
       {...props}
     >
       {children}
-      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
+      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200  group-data-[state=open]:rotate-180" />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
 ))


### PR DESCRIPTION
If you put in any additional icon / SVG in the accordion trigger it too will rotate. This uses [Tailwind `group`](https://tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-parent-state) to only rotate the `ChevronDown`.