### PR TITLE
fix(toast): refactor 'actionTypes' to resolve ESLint error

### DIFF
--- a/apps/www/registry/new-york/hooks/use-toast.ts
+++ b/apps/www/registry/new-york/hooks/use-toast.ts
@@ -18,12 +18,12 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement
 }
 
-const actionTypes = {
+type ActionType = {
   ADD_TOAST: "ADD_TOAST",
   UPDATE_TOAST: "UPDATE_TOAST",
   DISMISS_TOAST: "DISMISS_TOAST",
   REMOVE_TOAST: "REMOVE_TOAST",
-} as const
+};
 
 let count = 0
 
@@ -31,8 +31,6 @@ function genId() {
   count = (count + 1) % Number.MAX_SAFE_INTEGER
   return count.toString()
 }
-
-type ActionType = typeof actionTypes
 
 type Action =
   | {


### PR DESCRIPTION
This PR refactors the actionTypes constant in use-toast.ts to address an ESLint warning (@typescript-eslint/no-unused-vars). Previously, actionTypes was declared as a constant object but only used for its type definition, leading to the linting error.

Changes made:
	•	Replaced the actionTypes constant with a type declaration (ActionType).
	•	Removed the unused actionTypes constant to comply with ESLint rules.