### PR TITLE
fix(cli): React 19 link includes ")"

### DIFF
--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -34,7 +34,7 @@ export async function updateDependencies(
   if (isUsingReact19(config) && packageManager === "npm") {
     dependenciesSpinner.stopAndPersist()
     logger.warn(
-      "\nIt looks like you are using React 19. \nSome packages may fail to install due to peer dependency issues in npm (see https://ui.shadcn.com/react-19).\n"
+      "\nIt looks like you are using React 19. \nSome packages may fail to install due to peer dependency issues in npm. See: https://ui.shadcn.com/react-19.\n"
     )
     const confirmation = await prompts([
       {


### PR DESCRIPTION
Link in cli install sends users to "https://ui.shadcn.com/react-19)" instead of "https://ui.shadcn.com/react-19", which doesn't exist

<img width="1108" alt="image" src="https://github.com/user-attachments/assets/470f0ab4-036d-4784-80ba-8f8a92a2ca95" />
