### PR TITLE
packages/shadcn: use identifiable user agent in registry requests

### DIFF
--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -142,6 +142,7 @@ async function fetchRegistry(paths: string[]) {
       paths.map(async (path) => {
         const response = await fetch(`${baseUrl}/registry/${path}`, {
           agent,
+          userAgent: "shadcn/ui cli",
         })
         return await response.json()
       })

--- a/packages/shadcn/src/registry/api.ts
+++ b/packages/shadcn/src/registry/api.ts
@@ -1,5 +1,5 @@
 import path from "path"
-import { Config } from "@/src/utils/get-config"
+import type { Config } from "@/src/utils/get-config"
 import { handleError } from "@/src/utils/handle-error"
 import { highlighter } from "@/src/utils/highlighter"
 import { logger } from "@/src/utils/logger"
@@ -13,7 +13,6 @@ import {
   iconsSchema,
   registryBaseColorSchema,
   registryIndexSchema,
-  registryItemFileSchema,
   registryItemSchema,
   registryResolvedItemsTreeSchema,
   stylesSchema,
@@ -176,7 +175,12 @@ export async function fetchRegistry(paths: string[]) {
     const results = await Promise.all(
       paths.map(async (path) => {
         const url = getRegistryUrl(path)
-        const response = await fetch(url, { agent })
+        const response = await fetch(url, {
+          agent,
+          headers: {
+            "User-Agent": "shadcn/ui cli",
+          },
+        })
 
         if (!response.ok) {
           const errorMessages: { [key: number]: string } = {

--- a/packages/shadcn/src/utils/create-project.ts
+++ b/packages/shadcn/src/utils/create-project.ts
@@ -196,7 +196,11 @@ async function createMonorepoProject(
     // Get the template.
     const templatePath = path.join(os.tmpdir(), `shadcn-template-${Date.now()}`)
     await fs.ensureDir(templatePath)
-    const response = await fetch(MONOREPO_TEMPLATE_URL)
+    const response = await fetch(MONOREPO_TEMPLATE_URL, {
+      headers: {
+        "User-Agent": "shadcn/ui cli",
+      },
+    })
     if (!response.ok) {
       throw new Error(`Failed to download template: ${response.statusText}`)
     }


### PR DESCRIPTION
A custom UA is good practice and allows sysadmins to differentiate it from other traffic