### PR TITLE
Avatar should keep the image ratio and just cover the container

### DIFF
--- a/apps/www/registry/default/ui/avatar.tsx
+++ b/apps/www/registry/default/ui/avatar.tsx
@@ -26,7 +26,7 @@ const AvatarImage = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
-    className={cn("aspect-square h-full w-full", className)}
+    className={cn("aspect-square h-full w-full object-cover", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
Before:
<img width="167" alt="image" src="https://github.com/user-attachments/assets/74003dd5-d67b-410a-902d-aad86b9d33e8" />

After:
<img width="186" alt="image" src="https://github.com/user-attachments/assets/7e95b828-ac71-4dc3-872e-f2144900dd61" />
