### PR TITLE
Add failing test for using multipath aliases

### DIFF
--- a/packages/shadcn/test/utils/transform-import.test.ts
+++ b/packages/shadcn/test/utils/transform-import.test.ts
@@ -143,3 +143,33 @@ import { Foo } from "bar"
     })
   ).toMatchSnapshot()
 })
+
+test("transform import - multi path aliases", async () => {
+  const aliases = {
+    "components": "@custom-alias/nested/ui/components/ui",
+    "utils": "@custom-alias/nested/ui/lib/utils",
+    "ui": "@custom-alias/nested/ui/components/ui"
+  }
+  const actual = await transform({
+    filename: "test.ts",
+    raw: `import * as React from "react"
+import { Foo } from "bar"
+  import { Button } from "@/registry/new-york/ui/button"
+  import { Label} from "ui/label"
+  import { Box } from "@/registry/new-york/box"
+  import { useViewport } from "@/registry/new-york/hooks/use-viewport"
+
+  import { cn } from "@/lib/utils"
+  import { bar } from "@/lib/utils/bar"
+  `,
+    config: {
+      tsx: true,
+      aliases,
+    },
+  })
+
+  expect(actual).toContain(`import { cn } from "${aliases.utils}"`)
+  expect(actual).toContain(`import { Button } from "${aliases.ui}/button"`)
+  expect(actual).toContain(`import { Box } from "${aliases.components}/box"`)
+  expect(actual).toContain(`import { useViewport } from "${aliases.ui}/hooks/use-viewport"`)
+})


### PR DESCRIPTION
A regression was introduced [here](https://github.com/shadcn-ui/ui/pull/5678/files#r1921906914) making multipath aliases to not resolve correctly. In the thread there is also a comment pointing to the specific line. This PR adds a failing test that should be passing to correctly resolve multipath aliases.

I didn't include the actual revert of the original code in case it was introduced to fix something else, but feel free to ask anything needed 🤝