### PR TITLE
fix:docs sidebar nav item scroll into view:#6551

### DIFF
--- a/apps/www/components/docs-nav.tsx
+++ b/apps/www/components/docs-nav.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import * as React from "react"
+
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { SidebarNavItem } from "types/nav"
@@ -16,7 +18,7 @@ export function DocsNav({ config }: { config: DocsConfig }) {
     <div className="flex flex-col gap-6">
       {items.map((item, index) => (
         <div key={index} className="flex flex-col gap-1">
-          <h4 className="rounded-md px-2 py-1 text-sm font-semibold">
+          <h4 className="px-2 py-1 text-sm font-semibold rounded-md">
             {item.title}{" "}
             {item.label && (
               <span className="ml-2 rounded-md bg-[#adfa1d] px-1.5 py-0.5 text-xs font-normal leading-none text-[#000000] no-underline group-hover:no-underline">
@@ -44,25 +46,7 @@ function DocsNavItems({
     <div className="grid grid-flow-row auto-rows-max gap-0.5 text-sm">
       {items.map((item, index) =>
         item.href && !item.disabled ? (
-          <Link
-            key={index}
-            href={item.href}
-            className={cn(
-              "group flex h-8 w-full items-center rounded-lg px-2 font-normal text-foreground underline-offset-2 hover:bg-accent hover:text-accent-foreground",
-              item.disabled && "cursor-not-allowed opacity-60",
-              pathname === item.href &&
-                "bg-accent font-medium text-accent-foreground"
-            )}
-            target={item.external ? "_blank" : ""}
-            rel={item.external ? "noreferrer" : ""}
-          >
-            {item.title}
-            {item.label && (
-              <span className="ml-2 rounded-md bg-[#adfa1d] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
-                {item.label}
-              </span>
-            )}
-          </Link>
+          <DocNavItem key={index} item={item} pathname={pathname} />
         ) : (
           <span
             key={index}
@@ -82,4 +66,52 @@ function DocsNavItems({
       )}
     </div>
   ) : null
+}
+
+function DocNavItem({
+  item,
+  pathname,
+}: {
+  item: SidebarNavItem
+  pathname: string | null
+}) {
+  const navItemRef = React.useRef<HTMLAnchorElement>(null)
+
+  React.useLayoutEffect(() => {
+    const sidebarContainer = navItemRef.current?.closest(".no-scrollbar")
+    if (pathname === item.href && navItemRef.current && sidebarContainer) {
+      const itemRect = navItemRef.current.getBoundingClientRect()
+      const containerRect = sidebarContainer.getBoundingClientRect()
+
+      if (itemRect.bottom > containerRect.bottom) {
+        sidebarContainer.scrollTo({
+          top:
+            navItemRef.current.offsetTop - sidebarContainer?.clientHeight / 2,
+          behavior: "smooth",
+        })
+      }
+    }
+  }, [])
+
+  if (!item.href) return null
+  return (
+    <Link
+      ref={navItemRef}
+      href={item.href}
+      className={cn(
+        "group flex h-8 w-full items-center rounded-lg px-2 font-normal text-foreground underline-offset-2 hover:bg-accent hover:text-accent-foreground",
+        item.disabled && "cursor-not-allowed opacity-60",
+        pathname === item.href && "bg-accent font-medium text-accent-foreground"
+      )}
+      target={item.external ? "_blank" : ""}
+      rel={item.external ? "noreferrer" : ""}
+    >
+      {item.title}
+      {item.label && (
+        <span className="ml-2 rounded-md bg-[#adfa1d] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
+          {item.label}
+        </span>
+      )}
+    </Link>
+  )
 }


### PR DESCRIPTION
Fixed the sidebar nav on docs page not scrolling into view on page refresh. 

Exported the sidebar nav item Link into a mew component.
Used scrollTo method to dynamically scroll the sidebar nav item into view when it isnt in view as scrollIntoView method was scrolling the main content element as well. 
Added behaviour "smooth". I could replace it with "instant" if required.