### PR TITLE
feat(monorepo): add Docker support docs and update templates for shadcn/ui monorepo

### DIFF
--- a/apps/www/content/docs/monorepo.mdx
+++ b/apps/www/content/docs/monorepo.mdx
@@ -168,6 +168,52 @@ turbo.json
 
 By following these requirements, the CLI will be able to install ui components, blocks, libs and hooks to the correct paths and handle imports for you.
 
+## Docker Support
+
+Below is a quick guide to running your shadcn/ui monorepo project in Docker.
+
+### Prerequisites
+
+- **Docker:** Ensure [Docker](https://docker.com) is installed and running.
+- **Next.js Configuration:** Update `next.config.mjs` to enable a standalone build:
+
+  ```js
+  export default {
+    output: "standalone",
+    // other settings
+  }
+  ```
+
+### Build the Image
+
+From the repository root, run:
+
+```bash
+docker build -t shadcn-ui-web -f apps/web/Dockerfile .
+```
+
+### Run the Container
+
+To launch the container, run:
+
+```bash
+docker run -p 3000:3000 shadcn-ui-web
+```
+
+Alternatively, if you are using Docker Compose:
+
+```bash
+docker compose up --build -d
+```
+
+Then, visit [http://localhost:3000](http://localhost:3000) in your browser.
+
+### Notes
+
+- The Dockerfile is set up as a multi-stage build to ensure a minimal, secure runtime image. You can check out our [Dockerfile](https://github.com/shadcn-ui/ui/blob/main/templates/monorepo-next/apps/web/Dockerfile) for more details.
+
+- For more guidance on using Turbo Repo with Docker, please refer to the [Turbo Repo docs](https://turbo.build/repo/docs/guides/tools/docker).
+
 ## Help us improve monorepo support
 
 We're releasing monorepo support in the CLI as **experimental**. Help us improve it by testing it out and sending feedback.

--- a/templates/monorepo-next/README.md
+++ b/templates/monorepo-next/README.md
@@ -29,3 +29,17 @@ To use the components in your app, import them from the `ui` package.
 ```tsx
 import { Button } from "@workspace/ui/components/ui/button"
 ```
+
+## Using Docker
+
+If you want to use Docker for development, you can uncomment the following line in the `next.config.mjs` file:
+
+```mjs
+output: "standalone", // Uncomment this line if you use Docker
+```
+
+And then run the following command:
+
+```bash
+docker compose up --build -d
+```

--- a/templates/monorepo-next/apps/web/Dockerfile
+++ b/templates/monorepo-next/apps/web/Dockerfile
@@ -1,0 +1,85 @@
+###############################################################################
+# Base Images
+###############################################################################
+# Use Node.js 20 Alpine for both build and runtime stages.
+# - base-build: Includes build dependencies (e.g. libc6-compat) for compiling assets.
+# - base-runner: A minimal runtime image without build dependencies.
+FROM node:20-alpine AS base-build
+# Update APK and install libc6-compat in one layer.
+RUN apk update && apk add --no-cache libc6-compat
+
+FROM node:20-alpine AS base-runner
+
+###############################################################################
+# Builder Stage
+###############################################################################
+# Install build tools and prune the monorepo for the web scope.
+FROM base-build AS builder
+WORKDIR /app
+
+# Install Turbo CLI globally for monorepo task orchestration.
+RUN npm install -g turbo
+
+# Copy the entire monorepo into the container.
+COPY . .
+
+# Prune the repository for the 'web' package, optimizing for Docker.
+RUN turbo prune --scope=web --docker
+
+###############################################################################
+# Installer Stage
+###############################################################################
+# Install Node.js dependencies and build the web application.
+FROM base-build AS installer
+WORKDIR /app
+
+# Copy pruned project files and the pnpm lockfile from the builder stage.
+COPY --from=builder /app/out/json/ .
+COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
+
+# Install Corepack, enable it, and prepare pnpm (matching the version in package.json).
+RUN npm install -g corepack@latest \
+  && corepack enable \
+  && corepack prepare pnpm@9.12.3 --activate
+
+# Install dependencies using pnpm with a frozen lockfile.
+RUN pnpm install --frozen-lockfile
+
+# Copy the complete pruned project files needed for the build.
+COPY --from=builder /app/out/full/ .
+
+# Ensure that the public directory exists for static assets.
+RUN mkdir -p /app/apps/web/public
+
+# Build the web application using Turbo, filtering for the 'web' package.
+RUN pnpm dlx turbo run build --filter=web
+
+###############################################################################
+# Runner Stage (Final Image)
+###############################################################################
+# Create a minimal runtime environment with only the necessary runtime assets.
+FROM base-runner AS runner
+WORKDIR /app
+
+# Create a dedicated non-root user for security.
+RUN addgroup --system --gid 1001 nodejs \
+  && adduser --system --uid 1001 nextjs
+
+# Switch to the non-root user.
+USER nextjs
+
+# Copy configuration files and metadata from the installer stage.
+COPY --from=installer /app/apps/web/next.config.mjs .
+COPY --from=installer /app/apps/web/package.json .
+
+# Copy the built Next.js server, static assets, and public files.
+# The --chown flag sets correct ownership for the non-root user.
+COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
+COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
+COPY --from=installer --chown=nextjs:nodejs /app/apps/web/public ./apps/web/public
+
+# Expose the default Next.js port.
+EXPOSE 3000
+
+# Start the Next.js server.
+CMD ["node", "apps/web/server.js"]

--- a/templates/monorepo-next/apps/web/next.config.mjs
+++ b/templates/monorepo-next/apps/web/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ["@workspace/ui"],
+  // output: "standalone", // Uncomment this line if you use Docker
 }
 
 export default nextConfig

--- a/templates/monorepo-next/docker-compose.yml
+++ b/templates/monorepo-next/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: ./apps/web/Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped
+    networks:
+      - my_network
+
+networks:
+  my_network:
+    name: my_network
+    driver: bridge


### PR DESCRIPTION
I've been using the monorepo setup for a while now and thought it would be helpful to add Docker support to speed up project spin-up. This PR introduces experimental Docker documentation and updates the template files to simplify building and running a shadcn/ui monorepo project in Docker.

### What’s Included

- **Docker Support in Docs:**  
  A new "Docker Support" section has been added to `monorepo.mdx`. It outlines the prerequisites (like having Docker installed), explains how to configure Next.js for a standalone build, and provides the commands to build and run the image.

- **Updated README:**  
  The monorepo template README now includes a Docker section with a quick-start guide.

- **New Dockerfile:**  
  A Dockerfile for the web workspace (`apps/web/Dockerfile`) has been added, which uses a multi-stage build to ensure a small and secure runtime image extended from the [Turborepo Docker](https://turbo.build/repo/docs/guides/tools/docker) docs.

- **docker-compose.yml:**  
  A new docker-compose file (`docker-compose.yml`) is included to simplify deployment.

- **Next.js Config Reminder:**  
  A note in `next.config.mjs` reminds users to uncomment the standalone output line when using Docker.

All changes have been tested.

### Why This?

Previously, running a monorepo project in Docker required manual tweaking. This update might streamline the process, reducing hassle—especially for self-hosting setups. Since this support is experimental, any feedback or suggestions are more than welcome!
