### PR TITLE
fix(tanstack): fix paths value in tsconfig and check for tanstack start in devDeps also 

### DIFF
--- a/.changeset/spotty-plants-juggle.md
+++ b/.changeset/spotty-plants-juggle.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+fix tanstack check

--- a/apps/www/content/docs/installation/tanstack.mdx
+++ b/apps/www/content/docs/installation/tanstack.mdx
@@ -94,7 +94,7 @@ Add the following code to the `tsconfig.json` file to resolve paths.
     "strictNullChecks": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./app/*"]
     }
   }
 }

--- a/packages/shadcn/src/utils/get-project-info.ts
+++ b/packages/shadcn/src/utils/get-project-info.ts
@@ -119,7 +119,7 @@ export async function getProjectInfo(cwd: string): Promise<ProjectInfo | null> {
   // TanStack Start.
   if (
     configFiles.find((file) => file.startsWith("app.config."))?.length &&
-    Object.keys(packageJson?.dependencies ?? {}).find((dep) =>
+    [...Object.keys(packageJson?.dependencies ?? {}), ...Object.keys(packageJson?.devDependencies ?? {})].find((dep) =>
       dep.startsWith("@tanstack/start")
     )
   ) {

--- a/packages/shadcn/src/utils/get-project-info.ts
+++ b/packages/shadcn/src/utils/get-project-info.ts
@@ -119,9 +119,10 @@ export async function getProjectInfo(cwd: string): Promise<ProjectInfo | null> {
   // TanStack Start.
   if (
     configFiles.find((file) => file.startsWith("app.config."))?.length &&
-    [...Object.keys(packageJson?.dependencies ?? {}), ...Object.keys(packageJson?.devDependencies ?? {})].find((dep) =>
-      dep.startsWith("@tanstack/start")
-    )
+    [
+      ...Object.keys(packageJson?.dependencies ?? {}),
+      ...Object.keys(packageJson?.devDependencies ?? {}),
+    ].find((dep) => dep.startsWith("@tanstack/start"))
   ) {
     type.framework = FRAMEWORKS["tanstack-start"]
     return type


### PR DESCRIPTION
I tried the shadcn tanstack start guide with tailwindcss v4. Found two issues. One was incorrect paths in tsconfig and another being tanstack start is not detected if it is present as dev dependency. Fixed those.