### PR TITLE
fix(toast): simplify state management using useSyncExternalStore

### DIFF
--- a/apps/www/registry/default/hooks/use-toast.ts
+++ b/apps/www/registry/default/hooks/use-toast.ts
@@ -171,18 +171,20 @@ function toast({ ...props }: Toast) {
   }
 }
 
-function useToast() {
-  const [state, setState] = React.useState<State>(memoryState)
+function subscribe(listener: (state: State) => void) {
+  listeners.push(listener)
 
-  React.useEffect(() => {
-    listeners.push(setState)
-    return () => {
-      const index = listeners.indexOf(setState)
-      if (index > -1) {
-        listeners.splice(index, 1)
-      }
+  return () => {
+    const index = listeners.indexOf(listener)
+
+    if (index > -1) {
+      listeners.splice(index, 1)
     }
-  }, [state])
+  }
+}
+
+function useToast() {
+  const state = React.useSyncExternalStore(subscribe, () => memoryState)
 
   return {
     ...state,

--- a/apps/www/registry/new-york/hooks/use-toast.ts
+++ b/apps/www/registry/new-york/hooks/use-toast.ts
@@ -171,18 +171,20 @@ function toast({ ...props }: Toast) {
   }
 }
 
-function useToast() {
-  const [state, setState] = React.useState<State>(memoryState)
+function subscribe(listener: (state: State) => void) {
+  listeners.push(listener)
 
-  React.useEffect(() => {
-    listeners.push(setState)
-    return () => {
-      const index = listeners.indexOf(setState)
-      if (index > -1) {
-        listeners.splice(index, 1)
-      }
+  return () => {
+    const index = listeners.indexOf(listener)
+
+    if (index > -1) {
+      listeners.splice(index, 1)
     }
-  }, [state])
+  }
+}
+
+function useToast() {
+  const state = React.useSyncExternalStore(subscribe, () => memoryState)
 
   return {
     ...state,


### PR DESCRIPTION
I encountered the following warning while using `toast` inside `useTransition`

```
Detected a large number of updates inside startTransition. If this is due to a subscription please re-write it to use React provided hooks. Otherwise concurrent mode guarantees are off the table.
```

I identified that this issue occurs because the `state` inside `useTransition` is included as a dependency in `useEffect`, causing unintended re-renders.
To resolve this, I used `useSyncExternalStore` to synchronize the `state`.