### PR TITLE
fix: extract tailwind v4 prefix from css file

### DIFF
--- a/packages/shadcn/test/fixtures/config-v4/package.json
+++ b/packages/shadcn/test/fixtures/config-v4/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "test-cli-config-v4",
+  "version": "1.0.0",
+  "main": "index.js",
+  "author": "shadcn",
+  "license": "MIT",
+  "dependencies": {
+    "tailwindcss": "^4"
+  }
+}

--- a/packages/shadcn/test/fixtures/config-v4/tailwind.css
+++ b/packages/shadcn/test/fixtures/config-v4/tailwind.css
@@ -1,0 +1,1 @@
+@import "tailwindcss" prefix(shadcn);

--- a/packages/shadcn/test/utils/get-project-info.test.ts
+++ b/packages/shadcn/test/utils/get-project-info.test.ts
@@ -15,6 +15,7 @@ describe("get project info", async () => {
         isTsx: true,
         tailwindConfigFile: "tailwind.config.ts",
         tailwindCssFile: "app/globals.css",
+        tailwindCssPrefix: null,
         tailwindVersion: "v3",
         aliasPrefix: "@",
       },
@@ -28,6 +29,7 @@ describe("get project info", async () => {
         isTsx: true,
         tailwindConfigFile: "tailwind.config.ts",
         tailwindCssFile: "src/app/styles.css",
+        tailwindCssPrefix: null,
         tailwindVersion: "v3",
         aliasPrefix: "#",
       },
@@ -41,6 +43,7 @@ describe("get project info", async () => {
         isTsx: true,
         tailwindConfigFile: "tailwind.config.ts",
         tailwindCssFile: "styles/globals.css",
+        tailwindCssPrefix: null,
         tailwindVersion: "v4",
         aliasPrefix: "~",
       },
@@ -54,6 +57,7 @@ describe("get project info", async () => {
         isTsx: true,
         tailwindConfigFile: "tailwind.config.ts",
         tailwindCssFile: "src/styles/globals.css",
+        tailwindCssPrefix: null,
         tailwindVersion: "v4",
         aliasPrefix: "@",
       },
@@ -67,6 +71,7 @@ describe("get project info", async () => {
         isTsx: true,
         tailwindConfigFile: "tailwind.config.ts",
         tailwindCssFile: "src/styles/globals.css",
+        tailwindCssPrefix: null,
         tailwindVersion: "v3",
         aliasPrefix: "~",
       },
@@ -80,6 +85,7 @@ describe("get project info", async () => {
         isTsx: true,
         tailwindConfigFile: "tailwind.config.ts",
         tailwindCssFile: "src/styles/globals.css",
+        tailwindCssPrefix: null,
         tailwindVersion: "v3",
         aliasPrefix: "~",
       },
@@ -93,6 +99,7 @@ describe("get project info", async () => {
         isTsx: true,
         tailwindConfigFile: "tailwind.config.ts",
         tailwindCssFile: "app/tailwind.css",
+        tailwindCssPrefix: null,
         tailwindVersion: "v3",
         aliasPrefix: "~",
       },
@@ -106,6 +113,7 @@ describe("get project info", async () => {
         isTsx: true,
         tailwindConfigFile: "tailwind.config.ts",
         tailwindCssFile: "app/tailwind.css",
+        tailwindCssPrefix: null,
         tailwindVersion: "v3",
         aliasPrefix: "~",
       },
@@ -119,14 +127,29 @@ describe("get project info", async () => {
         isTsx: true,
         tailwindConfigFile: "tailwind.config.js",
         tailwindCssFile: "src/index.css",
+        tailwindCssPrefix: null,
         tailwindVersion: "v3",
         aliasPrefix: null,
       },
     },
+    {
+      name: "config-v4",
+      type: {
+        framework: FRAMEWORKS['manual'],
+        isSrcDir: false,
+        isRSC: false,
+        isTsx: false,
+        tailwindConfigFile: null,
+        tailwindCssFile: "tailwind.css",
+        tailwindCssPrefix: "shadcn",
+        tailwindVersion: "v4",
+        aliasPrefix: '@',
+      },
+    }
   ])(`getProjectType($name) -> $type`, async ({ name, type }) => {
     expect(
       await getProjectInfo(
-        path.resolve(__dirname, `../fixtures/frameworks/${name}`)
+        path.resolve(__dirname, '../fixtures', type.framework.name !== 'manual' ? `frameworks/${name}` : name)
       )
     ).toStrictEqual(type)
   })

--- a/packages/shadcn/test/utils/get-tailwind-css-file.test.ts
+++ b/packages/shadcn/test/utils/get-tailwind-css-file.test.ts
@@ -42,6 +42,20 @@ describe("get tailwindcss file", async () => {
       await getTailwindCssFile(
         path.resolve(__dirname, `../fixtures/frameworks/${name}`)
       )
-    ).toBe(file)
+    ).toEqual({
+      file,
+      prefix: null,
+    })
+  })
+
+  test(`getTailwindCssFile(config-v4) -> tailwind.css`, async () => {
+    expect(
+      await getTailwindCssFile(
+        path.resolve(__dirname, `../fixtures/config-v4`)
+      )
+    ).toEqual({
+      file: "tailwind.css",
+      prefix: "shadcn",
+    })
   })
 })


### PR DESCRIPTION
In Tailwind v4, you can set your Tailwind prefix via a function in the CSS import: https://tailwindcss.com/docs/styling-with-utility-classes#using-the-prefix-option

Tailwind prefix option is strictly set to only lowercase characters ([a-z]): https://github.com/tailwindlabs/tailwindcss/blob/ad001199f6e3ce64472de1b3d5f5a424c9d065c8/packages/%40tailwindcss-upgrade/src/template/codemods/prefix.ts#L117