### PR TITLE
chore: update working url

### DIFF
--- a/apps/www/content/docs/registry/registry-json.mdx
+++ b/apps/www/content/docs/registry/registry-json.mdx
@@ -84,4 +84,4 @@ The `items` in your registry. Each item must implement the [registry-item schema
 }
 ```
 
-See the [registry-item schema documentation](/docs/registry/registry-item) for more information.
+See the [registry-item schema documentation](/docs/registry/registry-item-json) for more information.


### PR DESCRIPTION
the older url threw 404 so changed it to correct url

steps:
- landed at https://ui.shadcn.com/docs/registry/registry-json
- went to https://ui.shadcn.com/docs/registry/registry-item from the prev page - (throws 404)