### PR TITLE
fix(v4): "Toggle" sidebar menu now scrolls to Toggle component, not Checkbox toggle

### DIFF
--- a/apps/v4/components/checkbox-demo.tsx
+++ b/apps/v4/components/checkbox-demo.tsx
@@ -20,12 +20,12 @@ export function CheckboxDemo() {
         </div>
       </div>
       <div className="flex items-start gap-3">
-        <Checkbox id="toggle" disabled />
-        <Label htmlFor="toggle">Enable notifications</Label>
+        <Checkbox id="notifications" disabled />
+        <Label htmlFor="notifications">Enable notifications</Label>
       </div>
       <Label className="hover:bg-accent/50 flex items-start gap-3 rounded-lg border p-3 has-[[aria-checked=true]]:border-blue-600 has-[[aria-checked=true]]:bg-blue-50 dark:has-[[aria-checked=true]]:border-blue-900 dark:has-[[aria-checked=true]]:bg-blue-950">
         <Checkbox
-          id="toggle-2"
+          id="notifications-2"
           defaultChecked
           className="data-[state=checked]:border-blue-600 data-[state=checked]:bg-blue-600 data-[state=checked]:text-white dark:data-[state=checked]:border-blue-700 dark:data-[state=checked]:bg-blue-700"
         />


### PR DESCRIPTION
CheckboxDemo had same `id="toggle"` as AppSidebar Toggle's menu item