### PR TITLE
fix: command dependency cmdk React 19 support

### DIFF
--- a/apps/v4/registry.json
+++ b/apps/v4/registry.json
@@ -244,7 +244,7 @@
       "name": "command",
       "type": "registry:ui",
       "dependencies": [
-        "cmdk@1.0.0"
+        "cmdk@^1.0.4"
       ],
       "registryDependencies": [
         "dialog"

--- a/apps/www/public/r/index.json
+++ b/apps/www/public/r/index.json
@@ -220,7 +220,7 @@
     "name": "command",
     "type": "registry:ui",
     "dependencies": [
-      "cmdk@1.0.0"
+      "cmdk@^1.0.4"
     ],
     "registryDependencies": [
       "dialog"

--- a/apps/www/public/r/styles/default/command.json
+++ b/apps/www/public/r/styles/default/command.json
@@ -4,7 +4,7 @@
   "type": "registry:ui",
   "author": "shadcn (https://ui.shadcn.com)",
   "dependencies": [
-    "cmdk@1.0.0"
+    "cmdk@^1.0.4"
   ],
   "registryDependencies": [
     "dialog"

--- a/apps/www/public/r/styles/new-york/command.json
+++ b/apps/www/public/r/styles/new-york/command.json
@@ -4,7 +4,7 @@
   "type": "registry:ui",
   "author": "shadcn (https://ui.shadcn.com)",
   "dependencies": [
-    "cmdk@1.0.0"
+    "cmdk@^1.0.4"
   ],
   "registryDependencies": [
     "dialog"

--- a/apps/www/public/registry/index.json
+++ b/apps/www/public/registry/index.json
@@ -147,7 +147,7 @@
   {
     "name": "command",
     "dependencies": [
-      "cmdk@1.0.0"
+      "cmdk@^1.0.4"
     ],
     "registryDependencies": [
       "dialog"

--- a/apps/www/public/registry/styles/default/command.json
+++ b/apps/www/public/registry/styles/default/command.json
@@ -1,7 +1,7 @@
 {
   "name": "command",
   "dependencies": [
-    "cmdk@1.0.0"
+    "cmdk@^1.0.4"
   ],
   "registryDependencies": [
     "dialog"

--- a/apps/www/public/registry/styles/new-york/command.json
+++ b/apps/www/public/registry/styles/new-york/command.json
@@ -1,7 +1,7 @@
 {
   "name": "command",
   "dependencies": [
-    "cmdk@1.0.0"
+    "cmdk@^1.0.4"
   ],
   "registryDependencies": [
     "dialog"

--- a/apps/www/registry/registry-ui.ts
+++ b/apps/www/registry/registry-ui.ts
@@ -181,7 +181,7 @@ export const ui: Registry["items"] = [
   {
     name: "command",
     type: "registry:ui",
-    dependencies: ["cmdk@1.0.0"],
+    dependencies: ["cmdk@^1.0.4"],
     registryDependencies: ["dialog"],
     files: [
       {


### PR DESCRIPTION
Fixes https://github.com/shadcn-ui/ui/issues/6601 https://github.com/shadcn-ui/ui/issues/6597 https://github.com/shadcn-ui/ui/issues/6200

Using the shadcn CLI `npx shadcn@latest add command` installs `cmdk@1.0.0` which is not compatible with React 19 and has type errors.

```
Type 'ForwardRefExoticComponent<Children & Pick<Pick<DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "key" | keyof HTMLAttributes<...>> & { ...; } & { ...; }, "key" | ... 1 more ... | keyof HTMLAttributes<...>> & { ...; } & RefAttributes<...>> & { ...; }' does not satisfy the constraint 'ElementType<any, keyof IntrinsicElements>'.
  Type 'ForwardRefExoticComponent<Children & Pick<Pick<DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "key" | keyof HTMLAttributes<...>> & { ...; } & { ...; }, "key" | ... 1 more ... | keyof HTMLAttributes<...>> & { ...; } & RefAttributes<...>> & { ...; }' is not assignable to type 'FunctionComponent<any>'.
    Type 'ReactNode' is not assignable to type 'ReactNode | Promise<ReactNode>'.
      Type 'ReactElement<any, string | JSXElementConstructor<any>>' is not assignable to type 'ReactNode | Promise<ReactNode>'.
        Property 'children' is missing in type 'ReactElement<any, string | JSXElementConstructor<any>>' but required in type 'ReactPortal'.ts(2344)
```

Updating to `cmdk@1.0.4`(latest version) fixes these errors.