### PR TITLE
fix(hooks): useIsMobile hook should be consistent with CSS media query behavior

### DIFF
--- a/apps/www/public/r/styles/default/use-mobile.json
+++ b/apps/www/public/r/styles/default/use-mobile.json
@@ -6,7 +6,7 @@
   "files": [
     {
       "path": "hooks/use-mobile.tsx",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = (e: MediaQueryListEvent | MediaQueryList) => {\n      setIsMobile(e.matches)\n    }\n    mql.addEventListener(\"change\", onChange)\n    onChange(mql)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
       "type": "registry:hook",
       "target": ""
     }

--- a/apps/www/registry/default/hooks/use-mobile.tsx
+++ b/apps/www/registry/default/hooks/use-mobile.tsx
@@ -7,11 +7,11 @@ export function useIsMobile() {
 
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    const onChange = (e: MediaQueryListEvent | MediaQueryList) => {
+      setIsMobile(e.matches)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    onChange(mql)
     return () => mql.removeEventListener("change", onChange)
   }, [])
 


### PR DESCRIPTION
Fixes #6123

Using the `matches` boolean on the media query change event produces better behavior at breakpoint boundaries, because for example `window.innerWidth` includes the scrollbar width, and comparing this does not always behave exactly like a CSS media query. There may also be the possibility of a race conditions due to a re-layout when checking window.innerWidth itself: https://gist.github.com/paulirish/5d52fb081b3570c81e3a

