### PR TITLE
Fix Dropdown Menu scroll issue

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/dropdown-menu.tsx
+++ b/apps/v4/registry/new-york-v4/ui/dropdown-menu.tsx
@@ -43,6 +43,8 @@ function DropdownMenuContent({
         sideOffset={sideOffset}
         className={cn(
           "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md",
+          "max-h-[var(--radix-dropdown-menu-content-available-height)]",
+          "overflow-y-auto",
           className
         )}
         {...props}

--- a/apps/www/registry/default/ui/dropdown-menu.tsx
+++ b/apps/www/registry/default/ui/dropdown-menu.tsx
@@ -65,9 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        "max-h-[var(--radix-dropdown-menu-content-available-height)]",
-        "overflow-y-auto",
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto",
         className
       )}
       {...props}

--- a/apps/www/registry/default/ui/dropdown-menu.tsx
+++ b/apps/www/registry/default/ui/dropdown-menu.tsx
@@ -66,6 +66,8 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "max-h-[var(--radix-dropdown-menu-content-available-height)]",
+        "overflow-y-auto",
         className
       )}
       {...props}

--- a/apps/www/registry/new-york/ui/dropdown-menu.tsx
+++ b/apps/www/registry/new-york/ui/dropdown-menu.tsx
@@ -67,6 +67,8 @@ const DropdownMenuContent = React.forwardRef<
       className={cn(
         "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "max-h-[var(--radix-dropdown-menu-content-available-height)]",
+        "overflow-y-auto",
         className
       )}
       {...props}


### PR DESCRIPTION
Fixes #149

Add scrolling capability to `DropdownMenuContent` component.

* Modify `apps/v4/registry/new-york-v4/ui/dropdown-menu.tsx` to include `max-h-[var(--radix-dropdown-menu-content-available-height)]` and `overflow-y-auto` properties in `DropdownMenuContent` className.
* Update `apps/www/registry/default/ui/dropdown-menu.tsx` to add `max-h-[var(--radix-dropdown-menu-content-available-height)]` and `overflow-y-auto` properties in `DropdownMenuContent` className.
* Change `apps/www/registry/new-york/ui/dropdown-menu.tsx` to include `max-h-[var(--radix-dropdown-menu-content-available-height)]` and `overflow-y-auto` properties in `DropdownMenuContent` className.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shadcn-ui/ui/pull/6677?shareId=bfca0250-3365-4acb-b679-5a1adda3f6e5).