### PR TITLE
fix(tailwind-prefix): resolve prefixing issue for Tailwind CSS v4 compatibility

### DIFF
--- a/packages/shadcn/src/utils/transformers/transform-tw-prefix.ts
+++ b/packages/shadcn/src/utils/transformers/transform-tw-prefix.ts
@@ -174,18 +174,19 @@ export function applyPrefix(input: string, prefix: string = "") {
   const classNames = input.split(" ")
   const prefixed: string[] = []
   for (let className of classNames) {
-    const [variant, value, modifier] = splitClassName(className)
-    if (variant) {
-      modifier
-        ? prefixed.push(`${variant}:${prefix}${value}/${modifier}`)
-        : prefixed.push(`${variant}:${prefix}${value}`)
-    } else {
-      modifier
-        ? prefixed.push(`${prefix}${value}/${modifier}`)
-        : prefixed.push(`${prefix}${value}`)
-    }
-  }
-  return prefixed.join(" ")
+    prefixed.push(`${prefix}:${className}`);
+  //   const [variant, value, modifier] = splitClassName(className)
+  //   if (variant) {
+  //     modifier
+  //       ? prefixed.push(`${variant}:${prefix}${value}/${modifier}`)
+  //       : prefixed.push(`${variant}:${prefix}${value}`)
+  //   } else {
+  //     modifier
+  //       ? prefixed.push(`${prefix}${value}/${modifier}`)
+  //       : prefixed.push(`${prefix}${value}`)
+  //   }
+  // }
+  // return prefixed.join(" ")
 }
 
 export function applyPrefixesCss(css: string, prefix: string) {

--- a/packages/shadcn/src/utils/transformers/transform-tw-prefix.ts
+++ b/packages/shadcn/src/utils/transformers/transform-tw-prefix.ts
@@ -171,22 +171,14 @@ export const transformTwPrefixes: Transformer = async ({
 }
 
 export function applyPrefix(input: string, prefix: string = "") {
-  const classNames = input.split(" ")
-  const prefixed: string[] = []
-  for (let className of classNames) {
-    prefixed.push(`${prefix}:${className}`);
-  //   const [variant, value, modifier] = splitClassName(className)
-  //   if (variant) {
-  //     modifier
-  //       ? prefixed.push(`${variant}:${prefix}${value}/${modifier}`)
-  //       : prefixed.push(`${variant}:${prefix}${value}`)
-  //   } else {
-  //     modifier
-  //       ? prefixed.push(`${prefix}${value}/${modifier}`)
-  //       : prefixed.push(`${prefix}${value}`)
-  //   }
-  // }
-  // return prefixed.join(" ")
+  return input
+    .split(" ")
+    .map((className) =>
+      className.indexOf(`${prefix}:`) === 0
+        ? className
+        : `${prefix}:${className.trim()}`
+    )
+    .join(" ");
 }
 
 export function applyPrefixesCss(css: string, prefix: string) {


### PR DESCRIPTION
1. Fixed incorrect prefix application causing issues with Tailwind CSS v4.
2. Optimized implementation using map() for better performance and readability.

Fixes: #6687 