### PR TITLE
Fix: Default Button Child Variant Redirect

### DIFF
--- a/apps/www/registry/default/examples/button-as-child.tsx
+++ b/apps/www/registry/default/examples/button-as-child.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/registry/default/ui/button"
 export default function ButtonAsChild() {
   return (
     <Button asChild>
-      <Link href="/login">Login</Link>
+      <Link href="#">Login</Link>
     </Button>
   )
 }

--- a/apps/www/registry/new-york/examples/button-as-child.tsx
+++ b/apps/www/registry/new-york/examples/button-as-child.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/registry/new-york/ui/button"
 export default function ButtonAsChild() {
   return (
     <Button asChild>
-      <Link href="/login">Login</Link>
+      <Link href="#">Login</Link>
     </Button>
   )
 }


### PR DESCRIPTION
The default button `asChild` variant incorrectly redirected to `/login` (non-existent), leading to a broken UX (404 page).

This PR changes the redirect to `#` (page refresh) for a better user experience.

Key changes:

*   Updated redirect target.
*   Prevented broken links.
