### PR TITLE
fix(v4): fix form label and message text color

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/form.tsx
+++ b/apps/v4/registry/new-york-v4/ui/form.tsx
@@ -97,7 +97,7 @@ function FormLabel({
     <Label
       data-slot="form-label"
       data-error={!!error}
-      className={cn("data-[error=true]:text-destructive-foreground", className)}
+      className={cn("data-[error=true]:text-destructive", className)}
       htmlFor={formItemId}
       {...props}
     />
@@ -147,7 +147,7 @@ function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
     <p
       data-slot="form-message"
       id={formMessageId}
-      className={cn("text-destructive-foreground text-sm", className)}
+      className={cn("text-destructive text-sm", className)}
       {...props}
     >
       {body}


### PR DESCRIPTION
## As-is
<img width="377" alt="image" src="https://github.com/user-attachments/assets/cfd7a6e7-140c-4108-880f-136a96686e4b" />

## To-be
<img width="377" alt="image" src="https://github.com/user-attachments/assets/2e5dce01-dafa-4e0c-96b8-5361529cd940" />
