### PR TITLE
fix(www): Resolve Vite error "'react-hook-form' does not provide export 'FieldValues'"

### DIFF
--- a/apps/www/registry/default/ui/form.tsx
+++ b/apps/www/registry/default/ui/form.tsx
@@ -5,9 +5,9 @@ import * as LabelPrimitive from "@radix-ui/react-label"
 import { Slot } from "@radix-ui/react-slot"
 import {
   Controller,
-  ControllerProps,
-  FieldPath,
-  FieldValues,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
   FormProvider,
   useFormContext,
 } from "react-hook-form"


### PR DESCRIPTION
when run `pnpm dlx shadcn@latest add form` and use form ui, this error displayed.

```text
[vite] The requested module 'react-hook-form' does not provide an export named 'FieldValues'
```

Upon investigating the cause, I found that there was an error related to vite's type import, so I will fix it as in this commit.

### environment when happened this error

- OS
  - Windows 11 Education 24H2
- Project
  - react-router@^7.2.0
  - vite@^5.4.11

### note

- local test passed(using `pnpm test` on Fedora Linux 41)
