### PR TITLE
feat(shadcn): add --base-color flag

### DIFF
--- a/.changeset/fluffy-years-knock.md
+++ b/.changeset/fluffy-years-knock.md
@@ -1,0 +1,5 @@
+---
+"shadcn": minor
+---
+
+add --base-color flag

--- a/packages/shadcn/src/registry/api.ts
+++ b/packages/shadcn/src/registry/api.ts
@@ -27,6 +27,29 @@ const agent = process.env.https_proxy
 
 const registryCache = new Map<string, Promise<any>>()
 
+export const BASE_COLORS = [
+  {
+    name: "neutral",
+    label: "Neutral",
+  },
+  {
+    name: "gray",
+    label: "Gray",
+  },
+  {
+    name: "zinc",
+    label: "Zinc",
+  },
+  {
+    name: "stone",
+    label: "Stone",
+  },
+  {
+    name: "slate",
+    label: "Slate",
+  },
+] as const
+
 export async function getRegistryIndex() {
   try {
     const [result] = await fetchRegistry(["index.json"])
@@ -75,28 +98,7 @@ export async function getRegistryItem(name: string, style: string) {
 }
 
 export async function getRegistryBaseColors() {
-  return [
-    {
-      name: "neutral",
-      label: "Neutral",
-    },
-    {
-      name: "gray",
-      label: "Gray",
-    },
-    {
-      name: "zinc",
-      label: "Zinc",
-    },
-    {
-      name: "stone",
-      label: "Stone",
-    },
-    {
-      name: "slate",
-      label: "Slate",
-    },
-  ]
+  return BASE_COLORS
 }
 
 export async function getRegistryBaseColor(baseColor: string) {


### PR DESCRIPTION
adds a `--base-color` flag to the `init` command:

```bash
npx shadcn@latest init --base-color stone
```