### PR TITLE
docs(www): fix combobox-form code example, pass `value` instead of `label` as prop 

### DIFF
--- a/apps/www/registry/default/examples/combobox-form.tsx
+++ b/apps/www/registry/default/examples/combobox-form.tsx
@@ -102,7 +102,7 @@ export default function ComboboxForm() {
                       <CommandGroup>
                         {languages.map((language) => (
                           <CommandItem
-                            value={language.label}
+                            value={language.value}
                             key={language.value}
                             onSelect={() => {
                               form.setValue("language", language.value)


### PR DESCRIPTION
Modifies the "combobox-form" code example: https://ui.shadcn.com/docs/components/combobox#form

In the current code example, `language.label` gets passed down as a prop to the `CommandItem` component.
```tsx
  {languages.map((language) => (
    <CommandItem
      value={language.label}  // <--- here
      key={language.value}
      onSelect={() => {
        form.setValue("language", language.value)
      }}
    >
    // ...
```

This PR modifies this snippet so that it passes `language.value` as a prop instead:
```tsx
  {languages.map((language) => (
    <CommandItem
      value={language.value}  // <--- here
      key={language.value}
      onSelect={() => {
        form.setValue("language", language.value)
      }}
    >
    // ...
```