### PR TITLE
fix: Add `npm:` specifier when install dependencies with Deno

### DIFF
--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -60,7 +60,7 @@ export async function updateDependencies(
     [
       packageManager === "npm" ? "install" : "add",
       ...(packageManager === "npm" && flag ? [`--${flag}`] : []),
-      ...dependencies,
+      ...(packageManager === "deno" ? dependencies.map((dep) => `npm:${dep}`) : dependencies),
     ],
     {
       cwd: config.resolvedPaths.cwd,


### PR DESCRIPTION
fix #6890