### PR TITLE
fix(cli): prevent incorrect URL parsing in React 19 message

### DIFF
--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -34,7 +34,7 @@ export async function updateDependencies(
   if (isUsingReact19(config) && packageManager === "npm") {
     dependenciesSpinner.stopAndPersist()
     logger.warn(
-      "\nIt looks like you are using React 19. \nSome packages may fail to install due to peer dependency issues in npm (see https://ui.shadcn.com/react-19).\n"
+      "\nIt looks like you are using React 19. \nSome packages may fail to install due to peer dependency issues in npm (see https://ui.shadcn.com/react-19 ).\n"
     )
     const confirmation = await prompts([
       {


### PR DESCRIPTION
## Summary
This PR fixes the issue where the React 19 documentation link incorrectly includes a closing parenthesis when clicked. 

## Changes
- Added a space before the closing parenthesis to prevent it from being included in the URL when clicked.

## Testing
- Verified the link now opens correctly when clicked.

### Before
<img width="993" alt="image" src="https://github.com/user-attachments/assets/39c35f63-7d5a-4185-b47a-21198af86399" />

### After
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/d5025a31-0e25-4125-83a1-16f11cfd9c8d" />

