### PR TITLE
feat: expose canScrollPrev and canScrollNext with carousel render prop

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/carousel.tsx
+++ b/apps/v4/registry/new-york-v4/ui/carousel.tsx
@@ -19,6 +19,12 @@ type CarouselProps = {
   plugins?: CarouselPlugin
   orientation?: "horizontal" | "vertical"
   setApi?: (api: CarouselApi) => void
+  children?:
+    | React.ReactNode
+    | ((props: {
+        canScrollNext: boolean
+        canScrollPrev: boolean
+      }) => React.ReactNode)
 }
 
 type CarouselContextProps = {
@@ -50,7 +56,7 @@ function Carousel({
   className,
   children,
   ...props
-}: React.ComponentProps<"div"> & CarouselProps) {
+}: Omit<React.ComponentProps<"div">, "children"> & CarouselProps) {
   const [carouselRef, api] = useEmblaCarousel(
     {
       ...opts,
@@ -126,7 +132,9 @@ function Carousel({
         data-slot="carousel"
         {...props}
       >
-        {children}
+        {typeof children === "function"
+          ? children({ canScrollNext, canScrollPrev })
+          : children}
       </div>
     </CarouselContext.Provider>
   )

--- a/apps/www/registry/default/ui/carousel.tsx
+++ b/apps/www/registry/default/ui/carousel.tsx
@@ -19,6 +19,12 @@ type CarouselProps = {
   plugins?: CarouselPlugin
   orientation?: "horizontal" | "vertical"
   setApi?: (api: CarouselApi) => void
+  children?:
+    | React.ReactNode
+    | ((props: {
+        canScrollNext: boolean
+        canScrollPrev: boolean
+      }) => React.ReactNode)
 }
 
 type CarouselContextProps = {
@@ -44,7 +50,7 @@ function useCarousel() {
 
 const Carousel = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & CarouselProps
+  Omit<React.HTMLAttributes<HTMLDivElement>, "children"> & CarouselProps
 >(
   (
     {
@@ -142,7 +148,9 @@ const Carousel = React.forwardRef<
           aria-roledescription="carousel"
           {...props}
         >
-          {children}
+          {typeof children === "function"
+            ? children({ canScrollNext, canScrollPrev })
+            : children}
         </div>
       </CarouselContext.Provider>
     )

--- a/apps/www/registry/new-york/ui/carousel.tsx
+++ b/apps/www/registry/new-york/ui/carousel.tsx
@@ -19,6 +19,12 @@ type CarouselProps = {
   plugins?: CarouselPlugin
   orientation?: "horizontal" | "vertical"
   setApi?: (api: CarouselApi) => void
+  children?:
+    | React.ReactNode
+    | ((props: {
+        canScrollNext: boolean
+        canScrollPrev: boolean
+      }) => React.ReactNode)
 }
 
 type CarouselContextProps = {
@@ -44,7 +50,7 @@ function useCarousel() {
 
 const Carousel = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & CarouselProps
+  Omit<React.HTMLAttributes<HTMLDivElement>, "children"> & CarouselProps
 >(
   (
     {
@@ -142,7 +148,9 @@ const Carousel = React.forwardRef<
           aria-roledescription="carousel"
           {...props}
         >
-          {children}
+          {typeof children === "function"
+            ? children({ canScrollNext, canScrollPrev })
+            : children}
         </div>
       </CarouselContext.Provider>
     )


### PR DESCRIPTION
this pr add the functionality to conditionally render navigation button without calling the `useCarousel` hook externally.

```tsx
<Carousel>
  {({ canScrollNext, canScrollPrev }) => (
    <>
      <CarouselContent>
        <CarouselItem>Slide 1</CarouselItem>
        <CarouselItem>Slide 2</CarouselItem>
      </CarouselContent>
      {/* Custom navigation using the scroll states */}
      {canScrollPrev && <CarouselPrevious />}
      {canScrollNext && <CarouselNext />}
    </>
  )}
</Carousel>
tsx```