### PR TITLE
fix(v3): 6888 - Remove unnecessary 'use client' directives from UI components

### DIFF
--- a/apps/www/registry/default/examples/checkbox-demo.tsx
+++ b/apps/www/registry/default/examples/checkbox-demo.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import { Checkbox } from "@/registry/default/ui/checkbox"
 
 export default function CheckboxDemo() {

--- a/apps/www/registry/default/examples/checkbox-with-text.tsx
+++ b/apps/www/registry/default/examples/checkbox-with-text.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import { Checkbox } from "@/registry/default/ui/checkbox"
 
 export default function CheckboxWithText() {

--- a/apps/www/registry/new-york/examples/checkbox-demo.tsx
+++ b/apps/www/registry/new-york/examples/checkbox-demo.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import { Checkbox } from "@/registry/new-york/ui/checkbox"
 
 export default function CheckboxDemo() {

--- a/apps/www/registry/new-york/examples/checkbox-with-text.tsx
+++ b/apps/www/registry/new-york/examples/checkbox-with-text.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import { Checkbox } from "@/registry/new-york/ui/checkbox"
 
 export default function CheckboxWithText() {

--- a/apps/www/registry/new-york/internal/sink/components/checkbox-demo.tsx
+++ b/apps/www/registry/new-york/internal/sink/components/checkbox-demo.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import { Checkbox } from "@/registry/new-york/ui/checkbox"
 
 export function CheckboxDemo() {

--- a/apps/www/registry/new-york/ui/accordion.tsx
+++ b/apps/www/registry/new-york/ui/accordion.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as AccordionPrimitive from "@radix-ui/react-accordion"
 import { ChevronDown } from "lucide-react"

--- a/apps/www/registry/new-york/ui/alert-dialog.tsx
+++ b/apps/www/registry/new-york/ui/alert-dialog.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 

--- a/apps/www/registry/new-york/ui/aspect-ratio.tsx
+++ b/apps/www/registry/new-york/ui/aspect-ratio.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as AspectRatioPrimitive from "@radix-ui/react-aspect-ratio"
 
 const AspectRatio = AspectRatioPrimitive.Root

--- a/apps/www/registry/new-york/ui/avatar.tsx
+++ b/apps/www/registry/new-york/ui/avatar.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as AvatarPrimitive from "@radix-ui/react-avatar"
 

--- a/apps/www/registry/new-york/ui/checkbox.tsx
+++ b/apps/www/registry/new-york/ui/checkbox.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
 import { Check } from "lucide-react"

--- a/apps/www/registry/new-york/ui/collapsible.tsx
+++ b/apps/www/registry/new-york/ui/collapsible.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
 
 const Collapsible = CollapsiblePrimitive.Root

--- a/apps/www/registry/new-york/ui/context-menu.tsx
+++ b/apps/www/registry/new-york/ui/context-menu.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
 import { Check, ChevronRight, Circle } from "lucide-react"

--- a/apps/www/registry/new-york/ui/dialog.tsx
+++ b/apps/www/registry/new-york/ui/dialog.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"

--- a/apps/www/registry/new-york/ui/dropdown-menu.tsx
+++ b/apps/www/registry/new-york/ui/dropdown-menu.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronRight, Circle } from "lucide-react"

--- a/apps/www/registry/new-york/ui/hover-card.tsx
+++ b/apps/www/registry/new-york/ui/hover-card.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
 

--- a/apps/www/registry/new-york/ui/label.tsx
+++ b/apps/www/registry/new-york/ui/label.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/apps/www/registry/new-york/ui/menubar.tsx
+++ b/apps/www/registry/new-york/ui/menubar.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as MenubarPrimitive from "@radix-ui/react-menubar"
 import { Check, ChevronRight, Circle } from "lucide-react"

--- a/apps/www/registry/new-york/ui/popover.tsx
+++ b/apps/www/registry/new-york/ui/popover.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as PopoverPrimitive from "@radix-ui/react-popover"
 

--- a/apps/www/registry/new-york/ui/progress.tsx
+++ b/apps/www/registry/new-york/ui/progress.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as ProgressPrimitive from "@radix-ui/react-progress"
 

--- a/apps/www/registry/new-york/ui/radio-group.tsx
+++ b/apps/www/registry/new-york/ui/radio-group.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
 import { Circle } from "lucide-react"

--- a/apps/www/registry/new-york/ui/scroll-area.tsx
+++ b/apps/www/registry/new-york/ui/scroll-area.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 

--- a/apps/www/registry/new-york/ui/select.tsx
+++ b/apps/www/registry/new-york/ui/select.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
 import { Check, ChevronDown, ChevronUp } from "lucide-react"

--- a/apps/www/registry/new-york/ui/separator.tsx
+++ b/apps/www/registry/new-york/ui/separator.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as SeparatorPrimitive from "@radix-ui/react-separator"
 

--- a/apps/www/registry/new-york/ui/sheet.tsx
+++ b/apps/www/registry/new-york/ui/sheet.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/apps/www/registry/new-york/ui/slider.tsx
+++ b/apps/www/registry/new-york/ui/slider.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as SliderPrimitive from "@radix-ui/react-slider"
 

--- a/apps/www/registry/new-york/ui/switch.tsx
+++ b/apps/www/registry/new-york/ui/switch.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as SwitchPrimitives from "@radix-ui/react-switch"
 

--- a/apps/www/registry/new-york/ui/tabs.tsx
+++ b/apps/www/registry/new-york/ui/tabs.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
 

--- a/apps/www/registry/new-york/ui/toggle-group.tsx
+++ b/apps/www/registry/new-york/ui/toggle-group.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group"
 import { type VariantProps } from "class-variance-authority"

--- a/apps/www/registry/new-york/ui/toggle.tsx
+++ b/apps/www/registry/new-york/ui/toggle.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as TogglePrimitive from "@radix-ui/react-toggle"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/apps/www/registry/new-york/ui/tooltip.tsx
+++ b/apps/www/registry/new-york/ui/tooltip.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 


### PR DESCRIPTION
Removes redundant 'use client' directives from various UI component files to optimize client-side performance.

Fixes #6888