### PR TITLE
Fix(Card v4): has variant updated for v4

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/card.tsx
+++ b/apps/v4/registry/new-york-v4/ui/card.tsx
@@ -20,7 +20,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-[data-slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 [&:has([data-slot=card-action])]:grid-cols-[1fr_auto] [.border-b]:pb-6",
         className
       )}
       {...props}


### PR DESCRIPTION
Looks like in v4 'has-' was changed to be ':has()' on the tailwind docs. The update is only present on the header for the docs, the rest is out of date.

I noticed this while trying to build a vite project utilizing both v4 and shadcn and was getting a minimized cs warning.

See the following: [https://tailwindcss.com/docs/hover-focus-and-other-states#has](https://tailwindcss.com/docs/hover-focus-and-other-states#has)