### PR TITLE
fix: allow silent mode with npm on React 19

### DIFF
--- a/.changeset/curly-impalas-give.md
+++ b/.changeset/curly-impalas-give.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+allow silent mode with npm

--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -32,7 +32,7 @@ export async function updateDependencies(
   // Offer to use --force or --legacy-peer-deps if using React 19 with npm.
   let flag = ""
   if (isUsingReact19(config) && packageManager === "npm") {
-    if(options.silent) {
+    if (options.silent) {
       flag = "force"
     } else {
       dependenciesSpinner.stopAndPersist()
@@ -50,10 +50,10 @@ export async function updateDependencies(
           ],
         },
       ])
-  
+
       if (confirmation) {
         flag = confirmation.flag
-      }  
+      }
     }
   }
 

--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -32,24 +32,28 @@ export async function updateDependencies(
   // Offer to use --force or --legacy-peer-deps if using React 19 with npm.
   let flag = ""
   if (isUsingReact19(config) && packageManager === "npm") {
-    dependenciesSpinner.stopAndPersist()
-    logger.warn(
-      "\nIt looks like you are using React 19. \nSome packages may fail to install due to peer dependency issues in npm (see https://ui.shadcn.com/react-19).\n"
-    )
-    const confirmation = await prompts([
-      {
-        type: "select",
-        name: "flag",
-        message: "How would you like to proceed?",
-        choices: [
-          { title: "Use --force", value: "force" },
-          { title: "Use --legacy-peer-deps", value: "legacy-peer-deps" },
-        ],
-      },
-    ])
-
-    if (confirmation) {
-      flag = confirmation.flag
+    if(options.silent) {
+      flag = "force"
+    } else {
+      dependenciesSpinner.stopAndPersist()
+      logger.warn(
+        "\nIt looks like you are using React 19. \nSome packages may fail to install due to peer dependency issues in npm (see https://ui.shadcn.com/react-19).\n"
+      )
+      const confirmation = await prompts([
+        {
+          type: "select",
+          name: "flag",
+          message: "How would you like to proceed?",
+          choices: [
+            { title: "Use --force", value: "force" },
+            { title: "Use --legacy-peer-deps", value: "legacy-peer-deps" },
+          ],
+        },
+      ])
+  
+      if (confirmation) {
+        flag = confirmation.flag
+      }  
     }
   }
 


### PR DESCRIPTION
This change honors the silent flag by setting `--force` if `--silent` is on and components are being added to a React 19 project using `npm`. 