### PR TITLE
docs(Toast): add deprecation Callout

### DIFF
--- a/apps/www/content/docs/components/toast.mdx
+++ b/apps/www/content/docs/components/toast.mdx
@@ -7,6 +7,13 @@ links:
   api: https://www.radix-ui.com/docs/primitives/components/toast#api-reference
 ---
 
+<Callout>
+
+We're deprecating the `toast` component in favor of `sonner`.
+[Read more](https://ui.shadcn.com/docs/tailwind-v4#whats-new)
+
+</Callout>
+
 <ComponentPreview name="toast-demo" />
 
 ## Installation


### PR DESCRIPTION
Since the `toast` is being deprecated it would be good to add a Callout letting users know they might want to start using the Sonner component instead.