### PR TITLE
docs: fix grammatical errors chart.mdx

### DIFF
--- a/apps/www/content/docs/components/chart.mdx
+++ b/apps/www/content/docs/components/chart.mdx
@@ -193,7 +193,7 @@ You can now build your chart using Recharts components.
 
 <Callout className="mt-4 bg-amber-50 border-amber-200 dark:bg-amber-950/50 dark:border-amber-950">
 
-**Important:** Remember to set a `min-h-[VALUE]` on the `ChartContainer` component. This is required for the chart be responsive.
+**Important:** Remember to set a `min-h-[VALUE]` on the `ChartContainer` component. This is required for the chart to be responsive.
 
 </Callout>
 
@@ -412,7 +412,7 @@ Charts has built-in support for theming. You can use css variables (recommended)
     --chart-2: 173 58% 39%;
   }
 
-  .dark: {
+  .dark {
     --background: 240 10% 3.9%;
     --foreground: 0 0% 100%;
     // ...


### PR DESCRIPTION
The selector should not include a colon.