### PR TITLE
docs: remove isolated remix page from installation guides

### DIFF
--- a/apps/www/config/docs.ts
+++ b/apps/www/config/docs.ts
@@ -138,11 +138,6 @@ export const docsConfig: DocsConfig = {
           items: [],
         },
         {
-          title: "Remix",
-          href: "/docs/installation/remix",
-          items: [],
-        },
-        {
           title: "Astro",
           href: "/docs/installation/astro",
           items: [],

--- a/apps/www/content/docs/installation/react-router.mdx
+++ b/apps/www/content/docs/installation/react-router.mdx
@@ -3,6 +3,12 @@ title: React Router
 description: Install and configure shadcn/ui for React Router.
 ---
 
+<Callout>
+
+**Note:** This guide is for React Router. For Remix, see the [Remix](/docs/installation/remix) guide.
+
+</Callout>
+
 <Steps>
 
 ### Create project


### PR DESCRIPTION
First of all, thank you for creating an amazing library.
While looking at the documentation, I found some odd behavior and made this PR.

https://ui.shadcn.com/docs/tailwind-v4

# Summary

The installation guide for `remix` was not listed, but was included in the next step link from `react-router`.
To fix this inconsistency, I decided to add a link to the `remix` guide on the `react router` page.

