### PR TITLE
fix(www): code block command overflow

### DIFF
--- a/apps/www/components/code-block-command.tsx
+++ b/apps/www/components/code-block-command.tsx
@@ -79,20 +79,22 @@ export function CodeBlockCommand({
             })}
           </TabsList>
         </div>
-        {Object.entries(tabs).map(([key, value]) => {
-          return (
-            <TabsContent key={key} value={key} className="mt-0">
-              <pre className="px-4 py-5">
-                <code
-                  className="relative font-mono text-sm leading-none"
-                  data-language="bash"
-                >
-                  {value}
-                </code>
-              </pre>
-            </TabsContent>
-          )
-        })}
+        <div className="overflow-x-auto">
+          {Object.entries(tabs).map(([key, value]) => {
+            return (
+              <TabsContent key={key} value={key} className="mt-0">
+                <pre className="px-4 py-5">
+                  <code
+                    className="relative font-mono text-sm leading-none"
+                    data-language="bash"
+                  >
+                    {value}
+                  </code>
+                </pre>
+              </TabsContent>
+            )
+          })}
+        </div>
       </Tabs>
       <Button
         size="icon"


### PR DESCRIPTION
fixes this:

<img width="668" alt="image" src="https://github.com/user-attachments/assets/c0f206ff-b5c8-4f49-83e7-83ef72e30a6f" />

(in <https://ui.shadcn.com/docs/installation/tanstack-router>)

after:

<img width="642" alt="image" src="https://github.com/user-attachments/assets/95d0e488-4afb-4992-b557-62cd253107ae" />
