### PR TITLE
docs(www): fix radix-ui npmjs url

### DIFF
--- a/apps/www/content/docs/react-19.mdx
+++ b/apps/www/content/docs/react-19.mdx
@@ -136,7 +136,7 @@ To make it easy for you track the progress of the upgrade, I've created a table 
 
 | Package                                                                            | Status | Note                                                        |
 | ---------------------------------------------------------------------------------- | ------ | ----------------------------------------------------------- |
-| [radix-ui](https://www.npmjs.com/package/@radix-ui/react-icons)                    | ✅     |                                                             |
+| [radix-ui](https://www.npmjs.com/package/radix-ui)                                 | ✅     |                                                             |
 | [lucide-react](https://www.npmjs.com/package/lucide-react)                         | ✅     |                                                             |
 | [class-variance-authority](https://www.npmjs.com/package/class-variance-authority) | ✅     | Does not list React 19 as a peer dependency.                |
 | [tailwindcss-animate](https://www.npmjs.com/package/tailwindcss-animate)           | ✅     | Does not list React 19 as a peer dependency.                |


### PR DESCRIPTION
## Descriptions

This PR fixes the radix-ui package URL in the React 19 page from radix icons to the radix-ui package.

Although Shadcn uses each primitive package separately, I think `radix-ui` would be the best package to link to if we're going to link only one package.

## Changes:

Nothing, really. Just changed the radix-ui URL, which is less than a single line of the documentation. 