### PR TITLE
fix(www): added space at the end of code block

### DIFF
--- a/apps/www/components/code-block-command.tsx
+++ b/apps/www/components/code-block-command.tsx
@@ -85,7 +85,7 @@ export function CodeBlockCommand({
               <TabsContent key={key} value={key} className="mt-0">
                 <pre className="px-4 py-5">
                   <code
-                    className="relative font-mono text-sm leading-none"
+                    className="relative w-fit !pr-4 font-mono text-sm leading-none"
                     data-language="bash"
                   >
                     {value}


### PR DESCRIPTION
This is how code block command looks now (https://ui.shadcn.com/docs/installation/tanstack-router):
<img width="646" alt="image" src="https://github.com/user-attachments/assets/6775b10d-a09a-46ea-b200-44bcbb3506a1" />
When fully scrolled the text touches the right border

Fix: 
<img width="652" alt="image" src="https://github.com/user-attachments/assets/1e460eb2-a01d-40a7-b4ac-f1e2954f5ffc" />
It is more clear here that the code ends and it looks better when the text is not touching the border