### PR TITLE
docs(www): fix sheet size setup

### DIFF
--- a/apps/www/content/docs/components/sheet.mdx
+++ b/apps/www/content/docs/components/sheet.mdx
@@ -90,7 +90,7 @@ You can adjust the size of the sheet using CSS classes:
 ```tsx {3}
 <Sheet>
   <SheetTrigger>Open</SheetTrigger>
-  <SheetContent className="w-[400px] sm:w-[540px]">
+  <SheetContent className="w-[400px] sm:w-[540px] sm:max-w-[540px]">
     <SheetHeader>
       <SheetTitle>Are you absolutely sure?</SheetTitle>
       <SheetDescription>


### PR DESCRIPTION
### 📝 What does this PR do?

This PR updates the documentation to correctly demonstrate how to set width for `<SheetContent>`, overriding the default `w-3/4` from [sheet component](https://github.com/shadcn-ui/ui/blob/main/apps/www/registry/new-york/ui/sheet.tsx#L43).

### 🔧 What was changed

In the code example, updated:

```tsx
<SheetContent className="w-[400px] sm:w-[540px]">
```

to:

```tsx
<SheetContent className="w-[400px] sm:w-[540px] sm:max-w-[540px]">
```

This ensures the example shows how to correctly set custom width for `sheet`

<br/>

ref: https://github.com/shadcn-ui/ui/blob/main/apps/www/registry/new-york/ui/sheet.tsx#L43