### PR TITLE
fix(v4) #7038 padding added for SheetContent component in v4/registry/new-york/ui/sheet.tsx

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/sheet.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sheet.tsx
@@ -58,7 +58,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "bg-background p-4 data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&


### PR DESCRIPTION
Fix:
Added p-4 to SheetContent to match the previous behavior and ensure proper padding.

Affected Component(s):

v4/registry/new-york/ui/sheet.tsx


Before Submitting:
✅ Searched the documentation and existing issues.
✅ Verified the fix in the local environment.
