### PR TITLE
fix: right sidebar behavior on desktop

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { VariantProps, cva } from "class-variance-authority"
-import { PanelLeftIcon } from "lucide-react"
+import { PanelLeftIcon, PanelRightIcon } from "lucide-react"
 
 import { useIsMobile } from "@/registry/new-york-v4/hooks/use-mobile"
 import { cn } from "@/registry/new-york-v4/lib/utils"
@@ -207,7 +207,10 @@ function Sidebar({
 
   return (
     <div
-      className="group peer text-sidebar-foreground hidden md:block"
+      className={cn(
+        "group peer text-sidebar-foreground hidden md:block",
+        side === "right" && "order-last"
+      )}
       data-state={state}
       data-collapsible={state === "collapsed" ? collapsible : ""}
       data-variant={variant}
@@ -253,11 +256,16 @@ function Sidebar({
   )
 }
 
+interface SidebarTriggerProps extends React.ComponentProps<typeof Button> {
+  side?: "left" | "right";
+}
+
 function SidebarTrigger({
   className,
   onClick,
+  side = "left",
   ...props
-}: React.ComponentProps<typeof Button>) {
+}: SidebarTriggerProps) {
   const { toggleSidebar } = useSidebar()
 
   return (
@@ -273,7 +281,7 @@ function SidebarTrigger({
       }}
       {...props}
     >
-      <PanelLeftIcon />
+      {side === "right" ? <PanelRightIcon /> : <PanelLeftIcon />}
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   )


### PR DESCRIPTION
Using the default Sidebar component as described in [this guide](https://ui.shadcn.com/docs/components/sidebar), i.e. `npx shadcn@latest add sidebar`.

When setting the Sidebar side to "right" on a desktop app, the window gap is still on the left side, resulting in bad UI behavior. This PR fixes that by putting the gap on the right side.

Before:
https://github.com/user-attachments/assets/6881ed5b-966b-4589-bd0f-718c1069e879

After:
https://github.com/user-attachments/assets/a8c994fe-c122-4126-96ad-c0792bd4973b

