### PR TITLE
fix: checkbox vertical shift in tasks example page

### DIFF
--- a/apps/www/app/(app)/examples/tasks/components/columns.tsx
+++ b/apps/www/app/(app)/examples/tasks/components/columns.tsx
@@ -21,7 +21,7 @@ export const columns: ColumnDef<Task>[] = [
         }
         onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
         aria-label="Select all"
-        className="translate-y-[2px]"
+        className="align-top"
       />
     ),
     cell: ({ row }) => (
@@ -29,7 +29,7 @@ export const columns: ColumnDef<Task>[] = [
         checked={row.getIsSelected()}
         onCheckedChange={(value) => row.toggleSelected(!!value)}
         aria-label="Select row"
-        className="translate-y-[2px]"
+        className="align-top"
       />
     ),
     enableSorting: false,


### PR DESCRIPTION
Addresses #6431 

- In order to make things consistent across browsers, aligned checkbox to the top in the cell
- Removed translate-y-[2px] because it was redundant