### PR TITLE
fix: npx shadcn@latest init --force --silent --yes --defaults fails to initialize project

### DIFF
--- a/packages/shadcn/src/commands/init.ts
+++ b/packages/shadcn/src/commands/init.ts
@@ -358,7 +358,7 @@ async function promptForMinimalConfig(
   opts: z.infer<typeof initOptionsSchema>
 ) {
   let style = defaultConfig.style
-  let baseColor = opts.baseColor
+  let baseColor = opts.baseColor ?? defaultConfig.tailwind.baseColor
   let cssVariables = defaultConfig.tailwind.cssVariables
 
   if (!opts.defaults) {


### PR DESCRIPTION
Addresses #7071 

The issue was
```
Validation failed:
- tailwind: Required
```

It was caused by `baseColor = null` when initializing project with `--defaults` which broke `zod` validation.