### PR TITLE
[New York] fix: Use `max` to handle custom maximum value

### DIFF
--- a/apps/www/registry/new-york/ui/progress.tsx
+++ b/apps/www/registry/new-york/ui/progress.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils"
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+>(({ className, value, max, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
@@ -19,7 +19,7 @@ const Progress = React.forwardRef<
   >
     <ProgressPrimitive.Indicator
       className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      style={{ transform: `translateX(-${max || 100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>
 ))


### PR DESCRIPTION
This pull request includes modifications to the `Progress` component in the `apps/www/registry/new-york/ui/progress.tsx` file. The most important changes involve using the `max` property on the component and updating the transformation style to use this property.

Key changes:

* Added a `max` property to the `Progress` component to allow customization of the maximum value. (`apps/www/registry/new-york/ui/progress.tsx`)
* Updated the transformation style of the `ProgressPrimitive.Indicator` to utilize the unused `max` property, providing more flexibility in progress calculation. (`apps/www/registry/new-york/ui/progress.tsx`)