### PR TITLE
Fix top margin of sidebar in sidebar-16 for tailwind v4

### DIFF
--- a/apps/www/registry/default/blocks/sidebar-16/components/app-sidebar.tsx
+++ b/apps/www/registry/default/blocks/sidebar-16/components/app-sidebar.tsx
@@ -155,7 +155,7 @@ const data = {
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   return (
     <Sidebar
-      className="top-[--header-height] !h-[calc(100svh-var(--header-height))]"
+      className="top-[var(--header-height)] !h-[calc(100svh-var(--header-height))]"
       {...props}
     >
       <SidebarHeader>


### PR DESCRIPTION
Correct: ``top-[var(--header-height)] `` or ``top-(--header-height)``.  

Wrong: ``top-[--header-height]``.


See: https://tailwindcss.com/docs/adding-custom-styles#using-arbitrary-values

I spent too long debugging this.