### PR TITLE
fix(tooltip): remove redundant TooltipProvider wrapper (#7166)

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/tooltip.tsx
+++ b/apps/v4/registry/new-york-v4/ui/tooltip.tsx
@@ -21,11 +21,7 @@ function TooltipProvider({
 function Tooltip({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return (
-    <TooltipProvider>
-      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
-    </TooltipProvider>
-  )
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
 }
 
 function TooltipTrigger({


### PR DESCRIPTION
## Summary
  - Fixes issue #7166 by removing the redundant TooltipProvider wrapper from the Tooltip component
  - Prevents performance degradation caused by nested TooltipProviders when users follow documentation examples

## Details
  The `Tooltip` component in the v4 New York theme was internally wrapping itself with a `TooltipProvider`, but the documentation
  also instructs users to wrap their tooltips with `TooltipProvider`. This created nested providers, causing potential performance
  issues when using multiple tooltips.

  This PR removes the internal `TooltipProvider` wrapper from the `Tooltip` component implementation to match the other theme
  styles and align with the documentation examples.

## Testing
  The component now works as expected with the documented usage pattern without creating redundant provider nesting.