### PR TITLE
fix(components, docs): export toast function from Sonner for monorepo compatibility

### DIFF
--- a/apps/www/content/docs/components/sonner.mdx
+++ b/apps/www/content/docs/components/sonner.mdx
@@ -93,7 +93,7 @@ export default function RootLayout({ children }) {
 ## Usage
 
 ```tsx
-import { toast } from "sonner"
+import { toast } from "@/components/ui/sonner"
 ```
 
 ```tsx

--- a/apps/www/registry/default/ui/sonner.tsx
+++ b/apps/www/registry/default/ui/sonner.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useTheme } from "next-themes"
-import { Toaster as Sonner } from "sonner"
+import { Toaster as Sonner, toast } from "sonner"
 
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
@@ -28,4 +28,4 @@ const Toaster = ({ ...props }: ToasterProps) => {
   )
 }
 
-export { Toaster }
+export { Toaster, toast }

--- a/apps/www/registry/new-york/ui/sonner.tsx
+++ b/apps/www/registry/new-york/ui/sonner.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useTheme } from "next-themes"
-import { Toaster as Sonner } from "sonner"
+import { Toaster as Sonner, toast } from "sonner"
 
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
@@ -28,4 +28,4 @@ const Toaster = ({ ...props }: ToasterProps) => {
   )
 }
 
-export { Toaster }
+export { Toaster, toast }


### PR DESCRIPTION
# Issue Description
When creating a new Next.js project with a monorepo structure using the shadcn CLI, components are placed in the `packages` directory. However, this creates an inconsistency with the documentation for the toast functionality, which currently instructs users to import the `toast` function from a path in the `apps` directory:

<img width="698" alt="image" src="https://github.com/user-attachments/assets/9cc5ee2f-6b7d-4f68-b45c-e772dd68e813" />

This import path doesn't work in monorepo setups, causing confusion for users.

# Proposed Solution
This PR exports the `toast` function directly from the Sonner component, making the import path consistent across both standard and monorepo project structures. 

Changes include:
- Modifying the Sonner component to export the `toast` function
- Updating the relevant documentation to reflect the new recommended import path