### PR TITLE
docs(www): add with view transitions section into astro dark mode

### DIFF
--- a/apps/www/content/docs/dark-mode/astro.mdx
+++ b/apps/www/content/docs/dark-mode/astro.mdx
@@ -121,7 +121,7 @@ import { ModeToggle } from '@/components/ModeToggle';
 
 ## With View transitions
 
-When using Astro [view transitions](https://docs.astro.build/en/guides/view-transitions), theme will not persist between page navigation. To make it work, we need to modify previous script . See [explains](https://docs.astro.build/en/guides/view-transitions/#astrobefore-swap).
+When using Astro [view transitions](https://docs.astro.build/en/guides/view-transitions), theme will not persist between page navigation. To make it work, we need to modify previous script. See [explains](https://docs.astro.build/en/guides/view-transitions/#astrobefore-swap).
 
 <Steps>
 

--- a/apps/www/content/docs/dark-mode/astro.mdx
+++ b/apps/www/content/docs/dark-mode/astro.mdx
@@ -118,3 +118,53 @@ import { ModeToggle } from '@/components/ModeToggle';
 ```
 
 </Steps>
+
+## With View transitions
+
+When using Astro [view transitions](https://docs.astro.build/en/guides/view-transitions), theme will not persist between page navigation. To make it work, we need to modify previous script . See [explains](https://docs.astro.build/en/guides/view-transitions/#astrobefore-swap).
+
+<Steps>
+
+### Modify theme script
+
+```astro showLineNumbers {6,23-30} title="src/pages/index.astro"
+---
+import '../styles/globals.css'
+---
+
+<script is:inline>
+  const setDarkMode = (document) => {
+    const getThemePreference = () => {
+      if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
+        return localStorage.getItem('theme');
+      }
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    };
+    const isDark = getThemePreference() === 'dark';
+    document.documentElement.classList[isDark ? 'add' : 'remove']('dark');
+
+    if (typeof localStorage !== 'undefined') {
+      const observer = new MutationObserver(() => {
+        const isDark = document.documentElement.classList.contains('dark');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      });
+      observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+    }
+  }
+
+  setDarkMode(document)
+
+  document.addEventListener('astro:before-swap', (event) => {
+    // Pass the incoming document to set the theme on it
+    setDarkMode(event.newDocument)
+  })
+</script>
+
+<html lang="en">
+	<body>
+      <h1>Astro</h1>
+	</body>
+</html>
+```
+
+</Steps>


### PR DESCRIPTION
adding this
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/3487a4a3-b863-413a-b142-b30a815b27c6" />


## Before
![Kapture 2025-04-14 at 17 30 05](https://github.com/user-attachments/assets/cb36cfe3-a143-493c-b499-876bbe06f350)


## After
![Kapture 2025-04-14 at 17 26 46](https://github.com/user-attachments/assets/6ea6f0ad-bfc9-433b-8b6b-fcac81681f9e)


