### PR TITLE
fix: typo error in docs example

### DIFF
--- a/apps/www/content/docs/registry/examples.mdx
+++ b/apps/www/content/docs/registry/examples.mdx
@@ -174,7 +174,7 @@ This blocks installs the `login-01` block from the shadcn/ui registry.
 
 ### Install a block and override primitives
 
-You can install a block fromt the shadcn/ui registry and override the primitives using your custom ones.
+You can install a block from the shadcn/ui registry and override the primitives using your custom ones.
 
 On `npx shadcn add`, the following will:
 


### PR DESCRIPTION
fixes type error 
"You can install a block fromt the shadcn/ui registry and override the primitives using your custom ones." to "You can install a block from the shadcn/ui registry and override the primitives using your custom ones."

fixes #7206
