### PR TITLE
feat(shadcn): experimental append action

### DIFF
--- a/apps/www/public/schema/registry-item.json
+++ b/apps/www/public/schema/registry-item.json
@@ -85,6 +85,11 @@
           "target": {
             "type": "string",
             "description": "The target path of the file. This is the path to the file in the project."
+          },
+          "action": {
+            "type": "string",
+            "enum": ["append", "prepend"],
+            "description": "The action to perform on the target file. Can be append or prepend."
           }
         },
         "if": {

--- a/packages/shadcn/src/commands/build.ts
+++ b/packages/shadcn/src/commands/build.ts
@@ -65,6 +65,10 @@ export const build = new Command()
 
         // Loop through each file in the files array.
         for (const file of registryItem.files) {
+          if (file["content"]) {
+            continue
+          }
+
           file["content"] = await fs.readFile(
             path.resolve(resolvePaths.cwd, file.path),
             "utf-8"

--- a/packages/shadcn/src/registry/schema.ts
+++ b/packages/shadcn/src/registry/schema.ts
@@ -19,6 +19,10 @@ export const registryItemTypeSchema = z.enum([
   "registry:internal",
 ])
 
+export const registryItemFileActionSchema = z
+  .enum(["append", "prepend"])
+  .optional()
+
 export const registryItemFileSchema = z.discriminatedUnion("type", [
   // Target is required for registry:file and registry:page
   z.object({
@@ -26,12 +30,14 @@ export const registryItemFileSchema = z.discriminatedUnion("type", [
     content: z.string().optional(),
     type: z.enum(["registry:file", "registry:page"]),
     target: z.string(),
+    action: registryItemFileActionSchema,
   }),
   z.object({
     path: z.string(),
     content: z.string().optional(),
     type: registryItemTypeSchema.exclude(["registry:file", "registry:page"]),
     target: z.string().optional(),
+    action: registryItemFileActionSchema,
   }),
 ])
 


### PR DESCRIPTION
```json
{
  "files": [
    {
      "path": "example/.env",
      "type": "registry:file",
      "target": "~/.env",
      "content": "NAME_OF_ENV_VARIABLE=",
      "action": "append"
    }
  ]
}
```