### PR TITLE
fix(components): update the utils path of sidebar components to correct

### DIFF
--- a/apps/www/registry/default/ui/sidebar.tsx
+++ b/apps/www/registry/default/ui/sidebar.tsx
@@ -6,7 +6,7 @@ import { VariantProps, cva } from "class-variance-authority"
 import { PanelLeft } from "lucide-react"
 
 import { useIsMobile } from "@/registry/default/hooks/use-mobile"
-import { cn } from "@/registry/default/lib/utils"
+import { cn } from "@/lib/utils"
 import { Button } from "@/registry/default/ui/button"
 import { Input } from "@/registry/default/ui/input"
 import { Separator } from "@/registry/default/ui/separator"

--- a/apps/www/registry/new-york/ui/sidebar.tsx
+++ b/apps/www/registry/new-york/ui/sidebar.tsx
@@ -6,7 +6,7 @@ import { VariantProps, cva } from "class-variance-authority"
 import { PanelLeft } from "lucide-react"
 
 import { useIsMobile } from "@/registry/new-york/hooks/use-mobile"
-import { cn } from "@/registry/new-york/lib/utils"
+import { cn } from "@/lib/utils"
 import { Button } from "@/registry/new-york/ui/button"
 import { Input } from "@/registry/new-york/ui/input"
 import { Separator } from "@/registry/new-york/ui/separator"


### PR DESCRIPTION
 When I use `pnpm dlx shadcn@latest add sidebar --overwrite` to add sidebar component into my repo, the utils path of the component always incorrect, cause i updated the utils path in `components.json` in my repo, like this: 
```
    "aliases": {
        "components": "@/components",
        "utils": "@/shadcn/utils",
        "ui": "@/shadcn/ui",
        "lib": "@/shadcn/lib",
        "hooks": "@/shadcn/hooks"
    },
```
The utils path of sidebar component will output `import { cn } from "@/shadcn/lib/utils"`.
`import { cn } from "@/shadcn/utils"`. is my expected