### PR TITLE
docs(www): Added background scaling for Drawer component

### DIFF
--- a/apps/www/content/docs/components/drawer.mdx
+++ b/apps/www/content/docs/components/drawer.mdx
@@ -83,6 +83,16 @@ import {
 </Drawer>
 ```
 
+### Background Scaling
+
+You can get the background to zoom and scale when the drawer is open by adding the `data-vaul-drawer-wrapper=""` attribute to the root component of your application.
+
+```tsx showLineNumbers
+<div id="app" data-vaul-drawer-wrapper="">
+  {children}
+</div>
+```
+
 ## Examples
 
 ### Responsive Dialog


### PR DESCRIPTION
i had to search for this every time i wanted to use the drawer component in a project, so figured it would be better to add it to the docs.