### PR TITLE
feat: add star rating component

### DIFF
--- a/apps/v4/app/(app)/page.tsx
+++ b/apps/v4/app/(app)/page.tsx
@@ -31,6 +31,7 @@ import { PaginationDemo } from "@/components/pagination-demo"
 import { PopoverDemo } from "@/components/popover-demo"
 import { ProgressDemo } from "@/components/progress-demo"
 import { RadioGroupDemo } from "@/components/radio-group-demo"
+import RatingDemo from "@/components/rating-demo"
 import { ResizableDemo } from "@/components/resizable-demo"
 import { ScrollAreaDemo } from "@/components/scroll-area-demo"
 import { SelectDemo } from "@/components/select-demo"
@@ -145,6 +146,9 @@ export default function SinkPage() {
       </ComponentWrapper>
       <ComponentWrapper name="radio-group">
         <RadioGroupDemo />
+      </ComponentWrapper>
+      <ComponentWrapper name="rating">
+        <RatingDemo />
       </ComponentWrapper>
       <ComponentWrapper name="resizable">
         <ResizableDemo />

--- a/apps/v4/components/rating-demo.tsx
+++ b/apps/v4/components/rating-demo.tsx
@@ -1,0 +1,68 @@
+import React from "react"
+import { Heart } from "lucide-react"
+
+import {
+  Rating,
+  RatingIcon,
+  RatingItem,
+  RatingLabel,
+} from "@/registry/new-york-v4/ui/rating"
+
+const demoData = [
+  {
+    label: "Poor",
+    icon: "😭",
+  },
+
+  {
+    label: "Bad",
+    icon: "😔",
+  },
+  {
+    label: "Not Bad",
+    icon: "😁",
+  },
+  {
+    label: "Great",
+    icon: "😊",
+  },
+  {
+    label: "Awesome",
+    icon: "🤩",
+  },
+]
+
+const RatingDemo = () => {
+  return (
+    <div className="grid gap-4">
+      <Rating size={30} defaultValue={3} />
+
+      <Rating className="gap-2">
+        {demoData.map((_, i) => (
+          <RatingItem className="flex flex-col" key={i} value={i + 1}>
+            <RatingIcon
+              className="text-5xl"
+              activeIcon={<Heart size={30} fill="gold" />}
+              icon={<Heart size={30} />}
+            />
+          </RatingItem>
+        ))}
+      </Rating>
+
+      <Rating name="rating" defaultValue={3} showActive>
+        {demoData.map((data, i) => (
+          <RatingItem className="flex flex-col" key={i} value={i + 1}>
+            <RatingIcon
+              activeColor="red"
+              className="text-5xl"
+              icon={data.icon}
+            />
+            <RatingLabel>{data.label}</RatingLabel>
+          </RatingItem>
+        ))}
+      </Rating>
+    </div>
+  )
+}
+
+export default RatingDemo

--- a/apps/v4/registry.json
+++ b/apps/v4/registry.json
@@ -454,6 +454,19 @@
       ]
     },
     {
+      "name": "rating",
+      "type": "registry:ui",
+      "dependencies": [
+        "lucide-react"
+      ],
+      "files": [
+        {
+          "path": "registry/new-york-v4/ui/rating.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "resizable",
       "type": "registry:ui",
       "dependencies": [

--- a/apps/v4/registry/new-york-v4/ui/rating.tsx
+++ b/apps/v4/registry/new-york-v4/ui/rating.tsx
@@ -1,0 +1,329 @@
+"use client"
+
+import * as React from "react"
+import { StarIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const RatingContext = React.createContext<{
+  value: number
+  onChange: (value: number) => void
+  hoverValue: number
+  onHover: (value: number) => void
+  size: number
+  color: string
+  max: number
+  showActive: boolean
+  name?: string
+}>({
+  value: 0,
+  onChange: () => {},
+  hoverValue: 0,
+  onHover: () => {},
+  size: 20,
+  color: "gold",
+  max: 5,
+  showActive: false,
+  name: undefined,
+})
+
+export interface RatingProps {
+  value?: number
+  defaultValue?: number
+  onChange?: (value: number) => void
+  onValueChange?: (value: number) => void
+  size?: number
+  color?: string
+  max?: number
+  className?: string
+  showActive?: boolean
+  name?: string
+  disabled?: boolean
+  required?: boolean
+  form?: string
+  children?: React.ReactNode
+}
+
+const Rating = React.forwardRef<HTMLDivElement, RatingProps>(
+  (
+    {
+      value: controlledValue,
+      defaultValue = 0,
+      onChange,
+      onValueChange,
+      size = 20,
+      color = "gold",
+      max = 5,
+      className,
+      showActive = false,
+      name,
+      disabled = false,
+      required = false,
+      form,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [internalValue, setInternalValue] = React.useState(defaultValue)
+    const [hoverValue, setHoverValue] = React.useState(0)
+
+    const inputRef = React.useRef<HTMLInputElement>(null)
+
+    const isControlled = controlledValue !== undefined
+    const value = isControlled ? controlledValue : internalValue
+
+    const handleChange = React.useCallback(
+      (newValue: number) => {
+        if (!isControlled) {
+          setInternalValue(newValue)
+        }
+        onChange?.(newValue)
+        onValueChange?.(newValue)
+      },
+      [isControlled, onChange, onValueChange]
+    )
+
+    const contextValue = React.useMemo(
+      () => ({
+        value,
+        onChange: handleChange,
+        hoverValue,
+        onHover: setHoverValue,
+        size,
+        color,
+        max,
+        showActive,
+        name,
+      }),
+      [value, handleChange, hoverValue, size, color, max, showActive, name]
+    )
+
+    const hasChildren = React.Children.count(children) > 0
+
+    return (
+      <RatingContext.Provider value={contextValue}>
+        <div
+          ref={ref}
+          className={cn(
+            "flex items-center gap-1 transition-colors",
+            disabled && "cursor-not-allowed opacity-50",
+            className
+          )}
+          onMouseLeave={() => !disabled && setHoverValue(0)}
+          {...props}
+        >
+          {name && (
+            <input
+              ref={inputRef}
+              type="number"
+              name={name}
+              value={value}
+              min={0}
+              max={max}
+              required={required}
+              disabled={disabled}
+              form={form}
+              onChange={(e) => handleChange(Number(e.target.value))}
+              className="sr-only"
+              aria-hidden="true"
+            />
+          )}
+
+          {hasChildren ? children : <RatingGroup disabled={disabled} />}
+        </div>
+      </RatingContext.Provider>
+    )
+  }
+)
+Rating.displayName = "Rating"
+
+const useRating = () => {
+  const context = React.useContext(RatingContext)
+  if (!context) {
+    throw new Error("useRating must be used within a Rating component")
+  }
+  return context
+}
+
+const RatingGroup: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
+  const { max } = useRating()
+
+  return (
+    <>
+      {Array.from({ length: max }).map((_, i) => (
+        <RatingItem key={i} value={i + 1} disabled={disabled}>
+          <RatingIcon />
+        </RatingItem>
+      ))}
+    </>
+  )
+}
+export interface RatingItemProps {
+  value: number
+  className?: string
+  disabled?: boolean
+  children?: React.ReactNode
+}
+
+const RatingItem = React.forwardRef<HTMLDivElement, RatingItemProps>(
+  ({ value, className, disabled, children, ...props }, ref) => {
+    const {
+      onChange,
+      onHover,
+      value: contextValue,
+      hoverValue,
+      showActive,
+    } = useRating()
+
+    const isActive = showActive
+      ? hoverValue
+        ? hoverValue === value
+        : contextValue === value
+      : hoverValue
+        ? hoverValue >= value
+        : contextValue >= value
+
+    const handleClick = () => {
+      if (!disabled) {
+        onChange(value)
+      }
+    }
+
+    const handleMouseEnter = () => {
+      if (!disabled) {
+        onHover(value)
+      }
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "flex items-center transition-transform",
+          !disabled && "cursor-pointer hover:scale-110",
+          isActive ? "data-[active=true]:scale-110" : "",
+          className
+        )}
+        onClick={handleClick}
+        onMouseEnter={handleMouseEnter}
+        data-active={isActive}
+        data-disabled={disabled}
+        aria-disabled={disabled}
+        {...props}
+      >
+        {React.Children.map(children, (child) =>
+          React.isValidElement(child)
+            ? React.cloneElement(child as React.ReactElement<any>, {
+                isActive,
+                disabled,
+              })
+            : child
+        )}
+      </div>
+    )
+  }
+)
+RatingItem.displayName = "RatingItem"
+
+export interface RatingIconProps {
+  isActive?: boolean
+  icon?: React.ReactNode
+  activeIcon?: React.ReactNode
+  activeColor?: string
+  inactiveColor?: string
+  disabled?: boolean
+  className?: string
+}
+
+const RatingIcon = React.forwardRef<HTMLDivElement, RatingIconProps>(
+  (
+    {
+      isActive,
+      icon,
+      activeIcon,
+      activeColor,
+      inactiveColor = "transparent",
+      disabled,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    const { color, size } = useRating()
+
+    const fillColor = isActive ? activeColor || color : inactiveColor
+    const strokeColor = activeColor || color
+
+    const renderIcon = () => {
+      if (isActive && activeIcon) {
+        return activeIcon
+      }
+
+      if (icon) {
+        return icon
+      }
+
+      return (
+        <StarIcon
+          size={size}
+          color={strokeColor}
+          fill={isActive ? fillColor : inactiveColor}
+        />
+      )
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "transition-opacity",
+          isActive
+            ? "data-[active=true]:opacity-100"
+            : "data-[active=false]:opacity-75",
+          disabled && "opacity-50",
+          className
+        )}
+        data-active={isActive}
+        data-disabled={disabled}
+        {...props}
+      >
+        {renderIcon()}
+      </div>
+    )
+  }
+)
+RatingIcon.displayName = "RatingIcon"
+
+export interface RatingLabelProps {
+  className?: string
+  children?: React.ReactNode
+  isActive?: boolean
+  disabled?: boolean
+}
+
+const RatingLabel = React.forwardRef<HTMLParagraphElement, RatingLabelProps>(
+  ({ className, children, isActive, disabled, ...props }, ref) => {
+    return (
+      <p
+        ref={ref}
+        className={cn(
+          "mt-1 text-xs transition-opacity",
+          isActive
+            ? "data-[active=true]:opacity-100"
+            : "data-[active=false]:opacity-60",
+          disabled && "opacity-50",
+          className
+        )}
+        data-active={isActive}
+        data-disabled={disabled}
+        {...props}
+      >
+        {children}
+      </p>
+    )
+  }
+)
+RatingLabel.displayName = "RatingLabel"
+
+export { Rating, RatingItem, RatingIcon, RatingLabel }

--- a/apps/www/config/docs.ts
+++ b/apps/www/config/docs.ts
@@ -333,6 +333,11 @@ export const docsConfig: DocsConfig = {
           items: [],
         },
         {
+          title: "Rating",
+          href: "/docs/components/rating",
+          items: [],
+        },
+        {
           title: "Resizable",
           href: "/docs/components/resizable",
           items: [],

--- a/apps/www/content/docs/components/rating.mdx
+++ b/apps/www/content/docs/components/rating.mdx
@@ -1,0 +1,83 @@
+---
+title: Rating
+description: A star rating component that provide ratings through clickable stars or custom icons.
+component: true
+---
+
+<ComponentPreview
+  name="rating-demo"
+  description="A star rating component with 5 stars."
+/>
+
+## Installation
+
+<CodeTabs>
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add rating
+```
+
+</TabsContent>
+
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Install the following dependencies:</Step>
+
+```bash
+npm install lucide-react
+```
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<ComponentSource name="rating" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</CodeTabs>
+
+## Usage
+
+```tsx
+import { Rating, RatingIcon, RatingItem } from "@/components/ui/rating"
+```
+
+### Basic Usage
+
+```tsx
+<Rating defaultValue={3} />
+```
+
+### Custom Icons
+
+```tsx
+import { HeartIcon } from "lucide-react"
+import { Rating, RatingItem, RatingIcon } from "@/components/ui/rating"
+
+export function RatingCustomIcons() {
+  return (
+    <Rating>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <RatingItem key={i} value={i + 1}>
+           <RatingIcon
+              className="text-5xl"
+              activeIcon={<Heart size={30} fill="gold" />}
+              icon={<Heart size={30} />} />
+
+        </RatingItem>
+      ))}
+    </Rating>
+  )
+}
+```

--- a/apps/www/registry/default/examples/rating-demo.tsx
+++ b/apps/www/registry/default/examples/rating-demo.tsx
@@ -1,0 +1,68 @@
+import React from "react"
+import { Heart } from "lucide-react"
+
+import {
+  Rating,
+  RatingIcon,
+  RatingItem,
+  RatingLabel,
+} from "@/registry/new-york/ui/rating"
+
+const demoData = [
+  {
+    label: "Poor",
+    icon: "😭",
+  },
+
+  {
+    label: "Bad",
+    icon: "😔",
+  },
+  {
+    label: "Not Bad",
+    icon: "😁",
+  },
+  {
+    label: "Great",
+    icon: "😊",
+  },
+  {
+    label: "Awesome",
+    icon: "🤩",
+  },
+]
+
+const RatingDemo = () => {
+  return (
+    <div className="grid gap-4">
+      <Rating size={30} defaultValue={3} />
+
+      <Rating className="gap-2">
+        {demoData.map((_, i) => (
+          <RatingItem className="flex flex-col" key={i} value={i + 1}>
+            <RatingIcon
+              className="text-5xl"
+              activeIcon={<Heart size={30} fill="gold" />}
+              icon={<Heart size={30} />}
+            />
+          </RatingItem>
+        ))}
+      </Rating>
+
+      <Rating name="rating" defaultValue={3} showActive>
+        {demoData.map((data, i) => (
+          <RatingItem className="flex flex-col" key={i} value={i + 1}>
+            <RatingIcon
+              activeColor="red"
+              className="text-5xl"
+              icon={data.icon}
+            />
+            <RatingLabel>{data.label}</RatingLabel>
+          </RatingItem>
+        ))}
+      </Rating>
+    </div>
+  )
+}
+
+export default RatingDemo

--- a/apps/www/registry/default/internal/sink/page.tsx
+++ b/apps/www/registry/default/internal/sink/page.tsx
@@ -212,6 +212,9 @@ export default function SinkPage() {
             <ComponentWrapper name="RadioGroup">
               <RadioGroupDemo />
             </ComponentWrapper>
+            <ComponentWrapper name="Rating">
+              {/* <Ratingdemo /> */}
+            </ComponentWrapper>
             <ComponentWrapper name="Resizable" className="col-span-2">
               <ResizableHandleDemo />
             </ComponentWrapper>

--- a/apps/www/registry/default/ui/rating.tsx
+++ b/apps/www/registry/default/ui/rating.tsx
@@ -1,0 +1,329 @@
+"use client"
+
+import * as React from "react"
+import { StarIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const RatingContext = React.createContext<{
+  value: number
+  onChange: (value: number) => void
+  hoverValue: number
+  onHover: (value: number) => void
+  size: number
+  color: string
+  max: number
+  showActive: boolean
+  name?: string
+}>({
+  value: 0,
+  onChange: () => {},
+  hoverValue: 0,
+  onHover: () => {},
+  size: 20,
+  color: "gold",
+  max: 5,
+  showActive: false,
+  name: undefined,
+})
+
+export interface RatingProps {
+  value?: number
+  defaultValue?: number
+  onChange?: (value: number) => void
+  onValueChange?: (value: number) => void
+  size?: number
+  color?: string
+  max?: number
+  className?: string
+  showActive?: boolean
+  name?: string
+  disabled?: boolean
+  required?: boolean
+  form?: string
+  children?: React.ReactNode
+}
+
+const Rating = React.forwardRef<HTMLDivElement, RatingProps>(
+  (
+    {
+      value: controlledValue,
+      defaultValue = 0,
+      onChange,
+      onValueChange,
+      size = 20,
+      color = "gold",
+      max = 5,
+      className,
+      showActive = false,
+      name,
+      disabled = false,
+      required = false,
+      form,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [internalValue, setInternalValue] = React.useState(defaultValue)
+    const [hoverValue, setHoverValue] = React.useState(0)
+
+    const inputRef = React.useRef<HTMLInputElement>(null)
+
+    const isControlled = controlledValue !== undefined
+    const value = isControlled ? controlledValue : internalValue
+
+    const handleChange = React.useCallback(
+      (newValue: number) => {
+        if (!isControlled) {
+          setInternalValue(newValue)
+        }
+        onChange?.(newValue)
+        onValueChange?.(newValue)
+      },
+      [isControlled, onChange, onValueChange]
+    )
+
+    const contextValue = React.useMemo(
+      () => ({
+        value,
+        onChange: handleChange,
+        hoverValue,
+        onHover: setHoverValue,
+        size,
+        color,
+        max,
+        showActive,
+        name,
+      }),
+      [value, handleChange, hoverValue, size, color, max, showActive, name]
+    )
+
+    const hasChildren = React.Children.count(children) > 0
+
+    return (
+      <RatingContext.Provider value={contextValue}>
+        <div
+          ref={ref}
+          className={cn(
+            "flex items-center gap-1 transition-colors",
+            disabled && "cursor-not-allowed opacity-50",
+            className
+          )}
+          onMouseLeave={() => !disabled && setHoverValue(0)}
+          {...props}
+        >
+          {name && (
+            <input
+              ref={inputRef}
+              type="number"
+              name={name}
+              value={value}
+              min={0}
+              max={max}
+              required={required}
+              disabled={disabled}
+              form={form}
+              onChange={(e) => handleChange(Number(e.target.value))}
+              className="sr-only"
+              aria-hidden="true"
+            />
+          )}
+
+          {hasChildren ? children : <RatingGroup disabled={disabled} />}
+        </div>
+      </RatingContext.Provider>
+    )
+  }
+)
+Rating.displayName = "Rating"
+
+const useRating = () => {
+  const context = React.useContext(RatingContext)
+  if (!context) {
+    throw new Error("useRating must be used within a Rating component")
+  }
+  return context
+}
+
+const RatingGroup: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
+  const { max } = useRating()
+
+  return (
+    <>
+      {Array.from({ length: max }).map((_, i) => (
+        <RatingItem key={i} value={i + 1} disabled={disabled}>
+          <RatingIcon />
+        </RatingItem>
+      ))}
+    </>
+  )
+}
+export interface RatingItemProps {
+  value: number
+  className?: string
+  disabled?: boolean
+  children?: React.ReactNode
+}
+
+const RatingItem = React.forwardRef<HTMLDivElement, RatingItemProps>(
+  ({ value, className, disabled, children, ...props }, ref) => {
+    const {
+      onChange,
+      onHover,
+      value: contextValue,
+      hoverValue,
+      showActive,
+    } = useRating()
+
+    const isActive = showActive
+      ? hoverValue
+        ? hoverValue === value
+        : contextValue === value
+      : hoverValue
+      ? hoverValue >= value
+      : contextValue >= value
+
+    const handleClick = () => {
+      if (!disabled) {
+        onChange(value)
+      }
+    }
+
+    const handleMouseEnter = () => {
+      if (!disabled) {
+        onHover(value)
+      }
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "flex items-center transition-transform",
+          !disabled && "cursor-pointer hover:scale-110",
+          isActive ? "data-[active=true]:scale-110" : "",
+          className
+        )}
+        onClick={handleClick}
+        onMouseEnter={handleMouseEnter}
+        data-active={isActive}
+        data-disabled={disabled}
+        aria-disabled={disabled}
+        {...props}
+      >
+        {React.Children.map(children, (child) =>
+          React.isValidElement(child)
+            ? React.cloneElement(child as React.ReactElement<any>, {
+                isActive,
+                disabled,
+              })
+            : child
+        )}
+      </div>
+    )
+  }
+)
+RatingItem.displayName = "RatingItem"
+
+export interface RatingIconProps {
+  isActive?: boolean
+  icon?: React.ReactNode
+  activeIcon?: React.ReactNode
+  activeColor?: string
+  inactiveColor?: string
+  disabled?: boolean
+  className?: string
+}
+
+const RatingIcon = React.forwardRef<HTMLDivElement, RatingIconProps>(
+  (
+    {
+      isActive,
+      icon,
+      activeIcon,
+      activeColor,
+      inactiveColor = "transparent",
+      disabled,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    const { color, size } = useRating()
+
+    const fillColor = isActive ? activeColor || color : inactiveColor
+    const strokeColor = activeColor || color
+
+    const renderIcon = () => {
+      if (isActive && activeIcon) {
+        return activeIcon
+      }
+
+      if (icon) {
+        return icon
+      }
+
+      return (
+        <StarIcon
+          size={size}
+          color={strokeColor}
+          fill={isActive ? fillColor : inactiveColor}
+        />
+      )
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "transition-opacity",
+          isActive
+            ? "data-[active=true]:opacity-100"
+            : "data-[active=false]:opacity-75",
+          disabled && "opacity-50",
+          className
+        )}
+        data-active={isActive}
+        data-disabled={disabled}
+        {...props}
+      >
+        {renderIcon()}
+      </div>
+    )
+  }
+)
+RatingIcon.displayName = "RatingIcon"
+
+export interface RatingLabelProps {
+  className?: string
+  children?: React.ReactNode
+  isActive?: boolean
+  disabled?: boolean
+}
+
+const RatingLabel = React.forwardRef<HTMLParagraphElement, RatingLabelProps>(
+  ({ className, children, isActive, disabled, ...props }, ref) => {
+    return (
+      <p
+        ref={ref}
+        className={cn(
+          "mt-1 text-xs transition-opacity",
+          isActive
+            ? "data-[active=true]:opacity-100"
+            : "data-[active=false]:opacity-60",
+          disabled && "opacity-50",
+          className
+        )}
+        data-active={isActive}
+        data-disabled={disabled}
+        {...props}
+      >
+        {children}
+      </p>
+    )
+  }
+)
+RatingLabel.displayName = "RatingLabel"
+
+export { Rating, RatingItem, RatingIcon, RatingLabel }

--- a/apps/www/registry/new-york/examples/rating-demo.tsx
+++ b/apps/www/registry/new-york/examples/rating-demo.tsx
@@ -1,0 +1,68 @@
+import React from "react"
+import { Heart } from "lucide-react"
+
+import {
+  Rating,
+  RatingIcon,
+  RatingItem,
+  RatingLabel,
+} from "@/registry/new-york/ui/rating"
+
+const demoData = [
+  {
+    label: "Poor",
+    icon: "😭",
+  },
+
+  {
+    label: "Bad",
+    icon: "😔",
+  },
+  {
+    label: "Not Bad",
+    icon: "😁",
+  },
+  {
+    label: "Great",
+    icon: "😊",
+  },
+  {
+    label: "Awesome",
+    icon: "🤩",
+  },
+]
+
+const RatingDemo = () => {
+  return (
+    <div className="grid gap-4">
+      <Rating size={30} defaultValue={3} />
+
+      <Rating className="gap-2">
+        {demoData.map((_, i) => (
+          <RatingItem className="flex flex-col" key={i} value={i + 1}>
+            <RatingIcon
+              className="text-5xl"
+              activeIcon={<Heart size={30} fill="gold" />}
+              icon={<Heart size={30} />}
+            />
+          </RatingItem>
+        ))}
+      </Rating>
+
+      <Rating name="rating" defaultValue={3} showActive>
+        {demoData.map((data, i) => (
+          <RatingItem className="flex flex-col" key={i} value={i + 1}>
+            <RatingIcon
+              activeColor="red"
+              className="text-5xl"
+              icon={data.icon}
+            />
+            <RatingLabel>{data.label}</RatingLabel>
+          </RatingItem>
+        ))}
+      </Rating>
+    </div>
+  )
+}
+
+export default RatingDemo

--- a/apps/www/registry/new-york/ui/rating.tsx
+++ b/apps/www/registry/new-york/ui/rating.tsx
@@ -1,0 +1,329 @@
+"use client"
+
+import * as React from "react"
+import { StarIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const RatingContext = React.createContext<{
+  value: number
+  onChange: (value: number) => void
+  hoverValue: number
+  onHover: (value: number) => void
+  size: number
+  color: string
+  max: number
+  showActive: boolean
+  name?: string
+}>({
+  value: 0,
+  onChange: () => {},
+  hoverValue: 0,
+  onHover: () => {},
+  size: 20,
+  color: "gold",
+  max: 5,
+  showActive: false,
+  name: undefined,
+})
+
+export interface RatingProps {
+  value?: number
+  defaultValue?: number
+  onChange?: (value: number) => void
+  onValueChange?: (value: number) => void
+  size?: number
+  color?: string
+  max?: number
+  className?: string
+  showActive?: boolean
+  name?: string
+  disabled?: boolean
+  required?: boolean
+  form?: string
+  children?: React.ReactNode
+}
+
+const Rating = React.forwardRef<HTMLDivElement, RatingProps>(
+  (
+    {
+      value: controlledValue,
+      defaultValue = 0,
+      onChange,
+      onValueChange,
+      size = 20,
+      color = "gold",
+      max = 5,
+      className,
+      showActive = false,
+      name,
+      disabled = false,
+      required = false,
+      form,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [internalValue, setInternalValue] = React.useState(defaultValue)
+    const [hoverValue, setHoverValue] = React.useState(0)
+
+    const inputRef = React.useRef<HTMLInputElement>(null)
+
+    const isControlled = controlledValue !== undefined
+    const value = isControlled ? controlledValue : internalValue
+
+    const handleChange = React.useCallback(
+      (newValue: number) => {
+        if (!isControlled) {
+          setInternalValue(newValue)
+        }
+        onChange?.(newValue)
+        onValueChange?.(newValue)
+      },
+      [isControlled, onChange, onValueChange]
+    )
+
+    const contextValue = React.useMemo(
+      () => ({
+        value,
+        onChange: handleChange,
+        hoverValue,
+        onHover: setHoverValue,
+        size,
+        color,
+        max,
+        showActive,
+        name,
+      }),
+      [value, handleChange, hoverValue, size, color, max, showActive, name]
+    )
+
+    const hasChildren = React.Children.count(children) > 0
+
+    return (
+      <RatingContext.Provider value={contextValue}>
+        <div
+          ref={ref}
+          className={cn(
+            "flex items-center gap-1 transition-colors",
+            disabled && "cursor-not-allowed opacity-50",
+            className
+          )}
+          onMouseLeave={() => !disabled && setHoverValue(0)}
+          {...props}
+        >
+          {name && (
+            <input
+              ref={inputRef}
+              type="number"
+              name={name}
+              value={value}
+              min={0}
+              max={max}
+              required={required}
+              disabled={disabled}
+              form={form}
+              onChange={(e) => handleChange(Number(e.target.value))}
+              className="sr-only"
+              aria-hidden="true"
+            />
+          )}
+
+          {hasChildren ? children : <RatingGroup disabled={disabled} />}
+        </div>
+      </RatingContext.Provider>
+    )
+  }
+)
+Rating.displayName = "Rating"
+
+const useRating = () => {
+  const context = React.useContext(RatingContext)
+  if (!context) {
+    throw new Error("useRating must be used within a Rating component")
+  }
+  return context
+}
+
+const RatingGroup: React.FC<{ disabled?: boolean }> = ({ disabled }) => {
+  const { max } = useRating()
+
+  return (
+    <>
+      {Array.from({ length: max }).map((_, i) => (
+        <RatingItem key={i} value={i + 1} disabled={disabled}>
+          <RatingIcon />
+        </RatingItem>
+      ))}
+    </>
+  )
+}
+export interface RatingItemProps {
+  value: number
+  className?: string
+  disabled?: boolean
+  children?: React.ReactNode
+}
+
+const RatingItem = React.forwardRef<HTMLDivElement, RatingItemProps>(
+  ({ value, className, disabled, children, ...props }, ref) => {
+    const {
+      onChange,
+      onHover,
+      value: contextValue,
+      hoverValue,
+      showActive,
+    } = useRating()
+
+    const isActive = showActive
+      ? hoverValue
+        ? hoverValue === value
+        : contextValue === value
+      : hoverValue
+      ? hoverValue >= value
+      : contextValue >= value
+
+    const handleClick = () => {
+      if (!disabled) {
+        onChange(value)
+      }
+    }
+
+    const handleMouseEnter = () => {
+      if (!disabled) {
+        onHover(value)
+      }
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "flex items-center transition-transform",
+          !disabled && "cursor-pointer hover:scale-110",
+          isActive ? "data-[active=true]:scale-110" : "",
+          className
+        )}
+        onClick={handleClick}
+        onMouseEnter={handleMouseEnter}
+        data-active={isActive}
+        data-disabled={disabled}
+        aria-disabled={disabled}
+        {...props}
+      >
+        {React.Children.map(children, (child) =>
+          React.isValidElement(child)
+            ? React.cloneElement(child as React.ReactElement<any>, {
+                isActive,
+                disabled,
+              })
+            : child
+        )}
+      </div>
+    )
+  }
+)
+RatingItem.displayName = "RatingItem"
+
+export interface RatingIconProps {
+  isActive?: boolean
+  icon?: React.ReactNode
+  activeIcon?: React.ReactNode
+  activeColor?: string
+  inactiveColor?: string
+  disabled?: boolean
+  className?: string
+}
+
+const RatingIcon = React.forwardRef<HTMLDivElement, RatingIconProps>(
+  (
+    {
+      isActive,
+      icon,
+      activeIcon,
+      activeColor,
+      inactiveColor = "transparent",
+      disabled,
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    const { color, size } = useRating()
+
+    const fillColor = isActive ? activeColor || color : inactiveColor
+    const strokeColor = activeColor || color
+
+    const renderIcon = () => {
+      if (isActive && activeIcon) {
+        return activeIcon
+      }
+
+      if (icon) {
+        return icon
+      }
+
+      return (
+        <StarIcon
+          size={size}
+          color={strokeColor}
+          fill={isActive ? fillColor : inactiveColor}
+        />
+      )
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "transition-opacity",
+          isActive
+            ? "data-[active=true]:opacity-100"
+            : "data-[active=false]:opacity-75",
+          disabled && "opacity-50",
+          className
+        )}
+        data-active={isActive}
+        data-disabled={disabled}
+        {...props}
+      >
+        {renderIcon()}
+      </div>
+    )
+  }
+)
+RatingIcon.displayName = "RatingIcon"
+
+export interface RatingLabelProps {
+  className?: string
+  children?: React.ReactNode
+  isActive?: boolean
+  disabled?: boolean
+}
+
+const RatingLabel = React.forwardRef<HTMLParagraphElement, RatingLabelProps>(
+  ({ className, children, isActive, disabled, ...props }, ref) => {
+    return (
+      <p
+        ref={ref}
+        className={cn(
+          "mt-1 text-xs transition-opacity",
+          isActive
+            ? "data-[active=true]:opacity-100"
+            : "data-[active=false]:opacity-60",
+          disabled && "opacity-50",
+          className
+        )}
+        data-active={isActive}
+        data-disabled={disabled}
+        {...props}
+      >
+        {children}
+      </p>
+    )
+  }
+)
+RatingLabel.displayName = "RatingLabel"
+
+export { Rating, RatingItem, RatingIcon, RatingLabel }

--- a/apps/www/registry/registry-examples.ts
+++ b/apps/www/registry/registry-examples.ts
@@ -907,6 +907,7 @@ export const examples: Registry["items"] = [
       },
     ],
   },
+
   {
     name: "radio-group-form",
     type: "registry:example",
@@ -914,6 +915,17 @@ export const examples: Registry["items"] = [
     files: [
       {
         path: "examples/radio-group-form.tsx",
+        type: "registry:example",
+      },
+    ],
+  },
+  {
+    name: "rating-demo",
+    type: "registry:example",
+    registryDependencies: ["rating"],
+    files: [
+      {
+        path: "examples/rating-demo.tsx",
         type: "registry:example",
       },
     ],

--- a/apps/www/registry/registry-ui.ts
+++ b/apps/www/registry/registry-ui.ts
@@ -363,6 +363,17 @@ export const ui: Registry["items"] = [
     ],
   },
   {
+    name: "rating",
+    type: "registry:ui",
+    dependencies: ["lucide-react"],
+    files: [
+      {
+        path: "ui/rating.tsx",
+        type: "registry:ui",
+      },
+    ],
+  },
+  {
     name: "resizable",
     type: "registry:ui",
     dependencies: ["react-resizable-panels"],


### PR DESCRIPTION
### Overview

This PR introduces a new Rating component that visually represents numerical ratings using star icons (by default).

### Motivation

- The component library currently lacks a built-in solution for displaying ratings.
- This addresses a community request in [issue #7203](https://github.com/shadcn-ui/ui/issues/7203) and [PR #2350](https://github.com/shadcn-ui/ui/pull/2350).

### Implementation Details

- Uses the Lucide React icon set for the default star icons.
- Designed to be flexible and customizable for future enhancements.

### Feedback

I’d love to hear thoughts on the implementation, and potential improvements — open to suggestions!

https://github.com/user-attachments/assets/b4e752dc-6fdc-4070-a63e-9eb05ccc451f


