### PR TITLE
fix(layout): add word-break for long words in messages

### DIFF
--- a/apps/www/components/cards/chat.tsx
+++ b/apps/www/components/cards/chat.tsx
@@ -132,7 +132,7 @@ export function CardsChat() {
               <div
                 key={index}
                 className={cn(
-                  "flex w-max max-w-[75%] flex-col gap-2 rounded-lg px-3 py-2 text-sm",
+                  "flex w-max max-w-[75%] flex-col gap-2 rounded-lg px-3 py-2 text-sm break-words",
                   message.role === "user"
                     ? "ml-auto bg-primary text-primary-foreground"
                     : "bg-muted"


### PR DESCRIPTION
## What
Fixes a layout issue in the message container where long words without spaces caused the layout to break. Added Tailwind's `break-words` utility to prevent overflow.

## Why
This issue was reported in [#7250](https://github.com/daoch/ui/issues/7250). Without the `break-words` utility, long words would overflow and cause layout issues, especially in the chat/message view.

## How
Applied Tailwind's `break-words` utility class to the message container `div` to ensure that long words are properly wrapped or truncated, preventing layout breaks.

## Screenshots
#### Before
![image](https://github.com/user-attachments/assets/ef1cb4dc-219a-4e7a-9df1-9e0f4c9cc354)

#### After
![image](https://github.com/user-attachments/assets/fa3bfedc-2d7c-4a9b-af77-2808a0af4504)


## Related issue
Closes #7250
