### PR TITLE
fix:  Fix the null value check order in the useFormField hook

### DIFF
--- a/apps/www/registry/default/ui/form.tsx
+++ b/apps/www/registry/default/ui/form.tsx
@@ -46,11 +46,11 @@ const useFormField = () => {
   const itemContext = React.useContext(FormItemContext)
   const { getFieldState, formState } = useFormContext()
 
-  const fieldState = getFieldState(fieldContext.name, formState)
-
   if (!fieldContext) {
     throw new Error("useFormField should be used within <FormField>")
   }
+
+  const fieldState = getFieldState(fieldContext.name, formState)
 
   const { id } = itemContext
 


### PR DESCRIPTION
Move the null value check of FieldContext to before accessing its properties to prevent potential null pointer exceptions when the FormField context does not exist. This ensures that the existence of fieldContext.name is verified before using it, improving the robustness of the component.