### PR TITLE
fix: remove extra mx-2 from SidebarSeparator to prevent border overflow in Tailwind v4

### DIFF
--- a/apps/www/registry/default/ui/sidebar.tsx
+++ b/apps/www/registry/default/ui/sidebar.tsx
@@ -398,7 +398,7 @@ const SidebarSeparator = React.forwardRef<
     <Separator
       ref={ref}
       data-sidebar="separator"
-      className={cn("mx-2 w-auto bg-sidebar-border", className)}
+      className={cn("w-auto bg-sidebar-border", className)}
       {...props}
     />
   )


### PR DESCRIPTION
# Fix Sidebar Separator Overflow Issue

This PR fixes a visual bug where the horizontal separator in the sidebar extended beyond the border after upgrading to Tailwind CSS v4 and React 19.

## Issue Description
The `mx-2` class on the `SidebarSeparator` component caused the separator to overflow the sidebar border, creating unwanted spacing and visual inconsistency.

## Solution
Removed the `mx-2` class from the `SidebarSeparator` component. The separator now aligns properly with the sidebar borders.

## Testing Instructions
1. Open the sidebar and inspect the separator
2. Verify the separator no longer overflows the sidebar borders
3. Check alignment in different sidebar states
4. Test across various screen sizes

## Expected Results
- Separator should be flush with sidebar borders
- No visual overflow or unwanted spacing
- Consistent appearance across all states and screen sizes