### PR TITLE
fix: enhance resolveImport to return directory for file imports

### DIFF
--- a/packages/shadcn/src/utils/resolve-import.ts
+++ b/packages/shadcn/src/utils/resolve-import.ts
@@ -1,13 +1,24 @@
+import { dirname } from 'path';
 import { createMatchPath, type ConfigLoaderSuccessResult } from "tsconfig-paths"
 
 export async function resolveImport(
   importPath: string,
   config: Pick<ConfigLoaderSuccessResult, "absoluteBaseUrl" | "paths">
 ) {
-  return createMatchPath(config.absoluteBaseUrl, config.paths)(
+  const matchPath = createMatchPath(
+    config.absoluteBaseUrl,
+    config.paths
+  )(
     importPath,
     undefined,
     () => true,
     [".ts", ".tsx"]
-  )
+  );
+
+  // if the matchPath is a file then return the containing directory
+  if (matchPath?.endsWith(".ts") || matchPath?.endsWith(".tsx")) {
+    return dirname(matchPath)
+  }
+
+  return matchPath
 }

--- a/packages/shadcn/test/utils/resolve-import.test.ts
+++ b/packages/shadcn/test/utils/resolve-import.test.ts
@@ -79,3 +79,12 @@ test("resolve import without base url", async () => {
     path.resolve(cwd, "foo/bar")
   )
 })
+
+test("resolve import with file extension", async () => {
+  const cwd = path.resolve(__dirname, "../fixtures/with-base-url")
+  const config = (await loadConfig(cwd)) as ConfigLoaderSuccessResult
+
+  expect(await resolveImport("@/components/ui/index.ts", config)).toEqual(
+    path.resolve(cwd, "components/ui")
+  )
+})


### PR DESCRIPTION
This is helpful if the tsconfig path resolves to an index.ts(x) file.

In some projects the tsconfig paths are set to resolve to index.ts files, and the shadcn path resolution succeeds on either a file or directory because the index.ts file exists.

This is an issue because shadcn resolution path needs to be a folder to work correctly.

This change resolves the directory above a resolved ts(x) file.