### PR TITLE
fix : select component when empty value is passed 

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/select.tsx
+++ b/apps/v4/registry/new-york-v4/ui/select.tsx
@@ -103,6 +103,10 @@ function SelectItem({
   children,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  const modifiedProps = {
+    ...props,
+    value: props.value === "" ? "__no_user_input_for_value__" : props.value,
+  }
   return (
     <SelectPrimitive.Item
       data-slot="select-item"
@@ -110,7 +114,7 @@ function SelectItem({
         "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
-      {...props}
+      {...modifiedProps}
     >
       <span className="absolute right-2 flex size-3.5 items-center justify-center">
         <SelectPrimitive.ItemIndicator>


### PR DESCRIPTION
#7247 
**Handled empty value in SelectItem component:**

- If props.value is an empty string (""), it is now replaced with a unique placeholder "__no_user_input_for_value__" when spreading props into SelectPrimitive.Item.

**Why:**

- Prevents issues caused by empty values in the select component.
- Ensures consistency and avoids potential crashes or unexpected behaviors when no value is provided. 
- The placeholder string is unique enough (__no_user_input_for_value__) to avoid collisions with real user inputs.