### PR TITLE
fix(www): update use-toast file extension in docs and fix component source fileName resolution

### DIFF
--- a/apps/www/content/docs/components/toast.mdx
+++ b/apps/www/content/docs/components/toast.mdx
@@ -69,7 +69,7 @@ npm install @radix-ui/react-toast
 
 <ComponentSource name="toast" fileName="toaster" />
 
-`use-toast.tsx`
+`use-toast.ts`
 
 <ComponentSource name="toast" fileName="use-toast" />
 

--- a/apps/www/lib/rehype-component.ts
+++ b/apps/www/lib/rehype-component.ts
@@ -37,15 +37,10 @@ export function rehypeComponent() {
             } else {
               const component = Index[style.name][name]
               src = fileName
-                ? component.files.find((file: unknown) => {
-                    if (typeof file === "string") {
-                      return (
-                        file.endsWith(`${fileName}.tsx`) ||
-                        file.endsWith(`${fileName}.ts`)
-                      )
-                    }
-                    return false
-                  }) || component.files[0]?.path
+                ? component.files.find((file: { path: string, type: string, target: string }) => (
+                    file.path.endsWith(`${fileName}.tsx`) ||
+                    file.path.endsWith(`${fileName}.ts`)
+                  ))?.path || component.files[0]?.path
                 : component.files[0]?.path
             }
 


### PR DESCRIPTION
## Description

Fixes: https://github.com/shadcn-ui/ui/issues/7320

- Updates the `Toast` docs to use the correct file extension for `use-toast.ts`.
- Fixes an issue in `rehype-component.ts` where the path provided by `fileName` is not correctly resolved.
  - This affected the `toaster.tsx` and `use-toast.ts` component sources in manual installation documentation.

## Screenshots
With these changes, the documentation now displays the correct `Toast` component/hook files.

<img width="663" alt="Screenshot 2025-05-02 at 1 06 58 PM" src="https://github.com/user-attachments/assets/f10f1e09-fd29-4fc3-ae91-f365d53c7d1a" />
<img width="658" alt="Screenshot 2025-05-02 at 1 07 09 PM" src="https://github.com/user-attachments/assets/8aaf4515-3b9c-4f1b-9443-24dde7ceeb45" />
