### PR TITLE
chore: migrate from classRegex to classFunctions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,12 +3,7 @@
     { "pattern": "apps/*/" },
     { "pattern": "packages/*/" }
   ],
-  "tailwindCSS.experimental.classRegex": [
-    ["cva\\(((?:[^()]|\\([^()]*\\))*)\\)", "[\"'`]?([^\"'`]+)[\"'`]?"],
-    ["cn\\(((?:[^()]|\\([^()]*\\))*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]
-    // "cva\\(([^)]*)\\)",
-    // "[\"'`]([^\"'`]*).*?[\"'`]"
-  ],
+  "tailwindCSS.classFunctions": ["cva", "cn"],
   "vitest.debugExclude": [
     "<node_internals>/**",
     "**/node_modules/**",


### PR DESCRIPTION
Migrate from classRegex to classFunctions.

### Additional context

https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1258
