### PR TITLE
fix|doc: force install latest tailwind with vite

### DIFF
--- a/apps/www/content/docs/installation/vite.mdx
+++ b/apps/www/content/docs/installation/vite.mdx
@@ -21,7 +21,7 @@ npm create vite@latest
 ### Add Tailwind CSS
 
 ```bash
-npm install tailwindcss @tailwindcss/vite
+npm install tailwindcss@latest @tailwindcss/vite
 ```
 
 Replace everything in `src/index.css` with the following:


### PR DESCRIPTION
`npx` (`pnpm dlx`, specifically) might install an older version of tailwind, sometimes. This is to force install the latest version of tailwind.

I'm very much a novice here, just trying to be helpful. Do let me know if I should do anything differently.