### PR TITLE
fix: remove unwanted browser scrollbar by setting overflowX to hidden in SidebarContext.Provider

### DIFF
--- a/apps/www/registry/default/ui/sidebar.tsx
+++ b/apps/www/registry/default/ui/sidebar.tsx
@@ -143,6 +143,7 @@ const SidebarProvider = React.forwardRef<
               {
                 "--sidebar-width": SIDEBAR_WIDTH,
                 "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+                overflowX: "hidden",
                 ...style,
               } as React.CSSProperties
             }


### PR DESCRIPTION
## Changes ##
- Added `overflowX: "hidden"` to the wrapper inside `SidebarContext.Provider` to prevent horizontal overflow that was causing an unwanted browser scrollbar.
- Fixes [7365](https://github.com/shadcn-ui/ui/issues/7365)