### PR TITLE
fix(carousel): clean up reInit event listener to prevent memory leak

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/carousel.tsx
+++ b/apps/v4/registry/new-york-v4/ui/carousel.tsx
@@ -100,6 +100,7 @@ function Carousel({
     api.on("select", onSelect)
 
     return () => {
+      api?.off("reInit", onSelect)
       api?.off("select", onSelect)
     }
   }, [api, onSelect])

--- a/apps/www/registry/default/ui/carousel.tsx
+++ b/apps/www/registry/default/ui/carousel.tsx
@@ -116,6 +116,7 @@ const Carousel = React.forwardRef<
       api.on("select", onSelect)
 
       return () => {
+        api?.off("reInit", onSelect)
         api?.off("select", onSelect)
       }
     }, [api, onSelect])

--- a/apps/www/registry/new-york/ui/carousel.tsx
+++ b/apps/www/registry/new-york/ui/carousel.tsx
@@ -116,6 +116,7 @@ const Carousel = React.forwardRef<
       api.on("select", onSelect)
 
       return () => {
+        api?.off("reInit", onSelect)
         api?.off("select", onSelect)
       }
     }, [api, onSelect])


### PR DESCRIPTION
### Summary

This PR fixes a potential memory leak in the `Carousel` component.

The event listener `api.on('reInit', onSelect)` was being registered but not removed on unmount. This could lead to duplicated event bindings or memory issues.

### Fix

I added the following cleanup to ensure proper teardown:

```tsx
React.useEffect(() => {
  if (!api) return
  onSelect(api)
  api.on("reInit", onSelect)
  api.on("select", onSelect)

  return () => {
    api?.off("reInit", onSelect)**  // cleanup added
    api?.off("select", onSelect)**  
  }
}, [api, onSelect])
