### PR TITLE
fix(shadcn-ui): fix Tailwind 4 prefix ordering (#7175)

### DIFF
--- a/packages/shadcn/src/utils/transformers/transform-tw-prefix.ts
+++ b/packages/shadcn/src/utils/transformers/transform-tw-prefix.ts
@@ -171,21 +171,10 @@ export const transformTwPrefixes: Transformer = async ({
 }
 
 export function applyPrefix(input: string, prefix: string = "") {
-  const classNames = input.split(" ")
-  const prefixed: string[] = []
-  for (let className of classNames) {
-    const [variant, value, modifier] = splitClassName(className)
-    if (variant) {
-      modifier
-        ? prefixed.push(`${variant}:${prefix}${value}/${modifier}`)
-        : prefixed.push(`${variant}:${prefix}${value}`)
-    } else {
-      modifier
-        ? prefixed.push(`${prefix}${value}/${modifier}`)
-        : prefixed.push(`${prefix}${value}`)
-    }
-  }
-  return prefixed.join(" ")
+  return input
+    .split(" ")
+    .map((className) => `${prefix}${className}`)
+    .join(" ")
 }
 
 export function applyPrefixesCss(css: string, prefix: string) {

--- a/packages/shadcn/test/utils/__snapshots__/transform-tw-prefix.test.ts.snap
+++ b/packages/shadcn/test/utils/__snapshots__/transform-tw-prefix.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`transform tailwind prefix 1`] = `
 "import * as React from "react"
             export function Foo() {
-                return <div className="tw-bg-background hover:tw-bg-muted tw-text-primary-foreground sm:focus:tw-text-accent-foreground">foo</div>
+                return <div className="tw:bg-background tw:hover:bg-muted tw:text-primary-foreground tw:sm:focus:text-accent-foreground">foo</div>
             }
         "
 `;
@@ -11,7 +11,7 @@ exports[`transform tailwind prefix 1`] = `
 exports[`transform tailwind prefix 2`] = `
 "import * as React from "react"
 export function Foo() {
-	return <div className="tw-bg-white hover:tw-bg-stone-100 tw-text-stone-50 sm:focus:tw-text-stone-900 dark:tw-bg-stone-950 dark:hover:tw-bg-stone-800 dark:tw-text-stone-900 dark:sm:focus:tw-text-stone-50">foo</div>
+	return <div className="tw:bg-white tw:hover:bg-stone-100 tw:text-stone-50 tw:sm:focus:text-stone-900 tw:dark:bg-stone-950 tw:dark:hover:bg-stone-800 tw:dark:text-stone-900 tw:dark:sm:focus:text-stone-50">foo</div>
 }
     "
 `;
@@ -19,7 +19,7 @@ export function Foo() {
 exports[`transform tailwind prefix 3`] = `
 "import * as React from "react"
 export function Foo() {
-	return <div className={cn("tw-bg-white hover:tw-bg-stone-100 dark:tw-bg-stone-950 dark:hover:tw-bg-stone-800", true && "tw-text-stone-50 sm:focus:tw-text-stone-900 dark:tw-text-stone-900 dark:sm:focus:tw-text-stone-50")}>foo</div>
+	return <div className={cn("tw:bg-white tw:hover:bg-stone-100 tw:dark:bg-stone-950 tw:dark:hover:bg-stone-800", true && "tw:text-stone-50 tw:sm:focus:text-stone-900 tw:dark:text-stone-900 tw:dark:sm:focus:text-stone-50")}>foo</div>
 }
     "
 `;
@@ -27,7 +27,7 @@ export function Foo() {
 exports[`transform tailwind prefix 4`] = `
 "import * as React from "react"
 export function Foo() {
-	return <div className={cn("tw-bg-background hover:tw-bg-muted", true && "tw-text-primary-foreground sm:focus:tw-text-accent-foreground")}>foo</div>
+	return <div className={cn("tw:bg-background tw:hover:bg-muted", true && "tw:text-primary-foreground tw:sm:focus:text-accent-foreground")}>foo</div>
 }
     "
 `;
@@ -105,10 +105,10 @@ exports[`transform tailwind prefix 5`] = `
  
 @layer base {
   * {
-    @apply tw-border-border;
+    @apply tw:border-border;
   }
   body {
-    @apply tw-bg-background tw-text-foreground;
+    @apply tw:bg-background tw:text-foreground;
   }
 }"
 `;

--- a/packages/shadcn/test/utils/apply-prefix.test.ts
+++ b/packages/shadcn/test/utils/apply-prefix.test.ts
@@ -6,37 +6,37 @@ describe("apply tailwind prefix", () => {
   test.each([
     {
       input: "bg-slate-800 text-gray-500",
-      output: "tw-bg-slate-800 tw-text-gray-500",
+      output: "tw:bg-slate-800 tw:text-gray-500",
     },
     {
       input: "hover:dark:bg-background dark:text-foreground",
-      output: "hover:dark:tw-bg-background dark:tw-text-foreground",
+      output: "tw:hover:dark:bg-background tw:dark:text-foreground",
     },
     {
       input:
         "rounded-lg border border-slate-200 bg-white text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
       output:
-        "tw-rounded-lg tw-border tw-border-slate-200 tw-bg-white tw-text-slate-950 tw-shadow-sm dark:tw-border-slate-800 dark:tw-bg-slate-950 dark:tw-text-slate-50",
+        "tw:rounded-lg tw:border tw:border-slate-200 tw:bg-white tw:text-slate-950 tw:shadow-sm tw:dark:border-slate-800 tw:dark:bg-slate-950 tw:dark:text-slate-50",
     },
     {
       input:
         "text-red-500 border-red-500/50 dark:border-red-500 [&>svg]:text-red-500 text-red-500 dark:text-red-900 dark:border-red-900/50 dark:dark:border-red-900 dark:[&>svg]:text-red-900 dark:text-red-900",
       output:
-        "tw-text-red-500 tw-border-red-500/50 dark:tw-border-red-500 [&>svg]:tw-text-red-500 tw-text-red-500 dark:tw-text-red-900 dark:tw-border-red-900/50 dark:dark:tw-border-red-900 dark:[&>svg]:tw-text-red-900 dark:tw-text-red-900",
+        "tw:text-red-500 tw:border-red-500/50 tw:dark:border-red-500 tw:[&>svg]:text-red-500 tw:text-red-500 tw:dark:text-red-900 tw:dark:border-red-900/50 tw:dark:dark:border-red-900 tw:dark:[&>svg]:text-red-900 tw:dark:text-red-900",
     },
     {
       input:
         "flex h-full w-full items-center justify-center rounded-full bg-muted",
       output:
-        "tw-flex tw-h-full tw-w-full tw-items-center tw-justify-center tw-rounded-full tw-bg-muted",
+        "tw:flex tw:h-full tw:w-full tw:items-center tw:justify-center tw:rounded-full tw:bg-muted",
     },
     {
       input:
         "absolute right-4 top-4 bg-primary rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary",
       output:
-        "tw-absolute tw-right-4 tw-top-4 tw-bg-primary tw-rounded-sm tw-opacity-70 tw-ring-offset-background tw-transition-opacity hover:tw-opacity-100 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-ring focus:tw-ring-offset-2 disabled:tw-pointer-events-none data-[state=open]:tw-bg-secondary",
+        "tw:absolute tw:right-4 tw:top-4 tw:bg-primary tw:rounded-sm tw:opacity-70 tw:ring-offset-background tw:transition-opacity tw:hover:opacity-100 tw:focus:outline-none tw:focus:ring-2 tw:focus:ring-ring tw:focus:ring-offset-2 tw:disabled:pointer-events-none tw:data-[state=open]:bg-secondary",
     },
   ])(`applyTwPrefix($input) -> $output`, ({ input, output }) => {
-    expect(applyPrefix(input, "tw-")).toBe(output)
+    expect(applyPrefix(input, "tw:")).toBe(output)
   })
 })

--- a/packages/shadcn/test/utils/transform-tw-prefix.test.ts
+++ b/packages/shadcn/test/utils/transform-tw-prefix.test.ts
@@ -16,7 +16,7 @@ test("transform tailwind prefix", async () => {
       config: {
         tailwind: {
           baseColor: "stone",
-          prefix: "tw-",
+          prefix: "tw:",
         },
         aliases: {
           components: "@/components",
@@ -39,7 +39,7 @@ export function Foo() {
         tailwind: {
           baseColor: "stone",
           cssVariables: false,
-          prefix: "tw-",
+          prefix: "tw:",
         },
         aliases: {
           components: "@/components",
@@ -62,7 +62,7 @@ export function Foo() {
         tailwind: {
           baseColor: "stone",
           cssVariables: false,
-          prefix: "tw-",
+          prefix: "tw:",
         },
         aliases: {
           components: "@/components",
@@ -85,7 +85,7 @@ export function Foo() {
         tailwind: {
           baseColor: "stone",
           cssVariables: false,
-          prefix: "tw-",
+          prefix: "tw:",
         },
         aliases: {
           components: "@/components",
@@ -99,7 +99,7 @@ export function Foo() {
   expect(
     applyPrefixesCss(
       "@tailwind base;\n@tailwind components;\n@tailwind utilities;\n \n@layer base {\n  :root {\n    --background: 0 0% 100%;\n    --foreground: 224 71.4% 4.1%;\n \n    --muted: 220 14.3% 95.9%;\n    --muted-foreground: 220 8.9% 46.1%;\n \n    --popover: 0 0% 100%;\n    --popover-foreground: 224 71.4% 4.1%;\n \n    --card: 0 0% 100%;\n    --card-foreground: 224 71.4% 4.1%;\n \n    --border: 220 13% 91%;\n    --input: 220 13% 91%;\n \n    --primary: 220.9 39.3% 11%;\n    --primary-foreground: 210 20% 98%;\n \n    --secondary: 220 14.3% 95.9%;\n    --secondary-foreground: 220.9 39.3% 11%;\n \n    --accent: 220 14.3% 95.9%;\n    --accent-foreground: 220.9 39.3% 11%;\n \n    --destructive: 0 84.2% 60.2%;\n    --destructive-foreground: 210 20% 98%;\n \n    --ring: 217.9 10.6% 64.9%;\n \n    --radius: 0.5rem;\n  }\n \n  .dark {\n    --background: 224 71.4% 4.1%;\n    --foreground: 210 20% 98%;\n \n    --muted: 215 27.9% 16.9%;\n    --muted-foreground: 217.9 10.6% 64.9%;\n \n    --popover: 224 71.4% 4.1%;\n    --popover-foreground: 210 20% 98%;\n \n    --card: 224 71.4% 4.1%;\n    --card-foreground: 210 20% 98%;\n \n    --border: 215 27.9% 16.9%;\n    --input: 215 27.9% 16.9%;\n \n    --primary: 210 20% 98%;\n    --primary-foreground: 220.9 39.3% 11%;\n \n    --secondary: 215 27.9% 16.9%;\n    --secondary-foreground: 210 20% 98%;\n \n    --accent: 215 27.9% 16.9%;\n    --accent-foreground: 210 20% 98%;\n \n    --destructive: 0 62.8% 30.6%;\n    --destructive-foreground: 0 85.7% 97.3%;\n \n    --ring: 215 27.9% 16.9%;\n  }\n}\n \n@layer base {\n  * {\n    @apply border-border;\n  }\n  body {\n    @apply bg-background text-foreground;\n  }\n}",
-      "tw-"
+      "tw:"
     )
   ).toMatchSnapshot()
 })


### PR DESCRIPTION
## Commit Log

- revised the applyPrefix function to use the Tailwind 4 prefix syntax, which states "Prefixes now look like variants and are always at the beginning of the class name" by simply prepending the prefix to any class name
- revised the associated unit tests to match the Tailwind 4 prefix standard of "tw:" with a colon instead of "tw-" with a dash

## Notes

- this PR resolves #7175
- source code and unit tests were written to assume Tailwind 4 is the only version used, so if this needs to support Tailwind 3 then the `applyPrefix` function needs to be revised to support that conditional