### PR TITLE
fix(dialog-close-focus): changed focus classes to focus-visible (SMALL FIX) 

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/dialog.tsx
+++ b/apps/v4/registry/new-york-v4/ui/dialog.tsx
@@ -63,7 +63,7 @@ function DialogContent({
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+        <DialogPrimitive.Close className="ring-offset-background focus-visible:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
           <XIcon />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>


### PR DESCRIPTION
### Problem:
Dialog close button gets a focus ring once you click to close the dialog. This should be set to focus-visible.

Changed utility classes from `focus:` to `focus-visible:`


### Before
![Screenshot 2025-05-22 at 16 25 58](https://github.com/user-attachments/assets/c12ce05a-2c1d-491b-9e14-d303eb91b544)

### After
![Screenshot 2025-05-22 at 16 27 11](https://github.com/user-attachments/assets/336ac11b-e01f-4ef0-978d-9e3c75f34f0c)
![Screenshot 2025-05-22 at 16 27 50](https://github.com/user-attachments/assets/06b6c382-32ba-4653-ba9e-d41d6b231db3)





