### PR TITLE
docs(navigation-menu): use asChild with Link and remove deprecated legacyBehavior

### DIFF
--- a/apps/www/content/docs/components/navigation-menu.mdx
+++ b/apps/www/content/docs/components/navigation-menu.mdx
@@ -87,11 +87,11 @@ import { navigationMenuTriggerStyle } from "@/components/ui/navigation-menu"
 
 ```tsx {3-5}
 <NavigationMenuItem>
-  <Link href="/docs" legacyBehavior passHref>
-    <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+  <NavigationMenuLink asChild>
+    <Link href="/docs" className={navigationMenuTriggerStyle()}>
       Documentation
-    </NavigationMenuLink>
-  </Link>
+    </Link>
+  </NavigationMenuLink>
 </NavigationMenuItem>
 ```
 


### PR DESCRIPTION
## Description

This pull request updates the `NavigationMenu` example to:

- Use the `asChild` prop on `NavigationMenuLink` when wrapping a Next.js `<Link />` component
- Remove the deprecated `legacyBehavior` and `passHref` props

## Why

- [`legacyBehavior`](https://nextjs.org/docs/pages/api-reference/components/link#legacybehavior) is deprecated in Next.js and will be removed in a future release. Thus example should be updated to not use legacyBehavior.