### PR TITLE
Fix item alignment in TabList

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/tabs.tsx
+++ b/apps/v4/registry/new-york-v4/ui/tabs.tsx
@@ -26,7 +26,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-1",
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-stretch justify-center rounded-lg p-1",
         className
       )}
       {...props}


### PR DESCRIPTION
Without this the trigger can be misaligned showing a sliver of the background color from the tab list.

Not super obvious but you can see in this screenshot especially well above the "fragments" tab there's a sliver of the darker background showing through. 
Before:

![image](https://github.com/user-attachments/assets/5853fe78-3191-4568-8ba4-b2c305b7a26f)


After:

![image](https://github.com/user-attachments/assets/ee2cdc72-622d-4ba7-b6a7-c703200b7b50)

The upper row of tabs is also misaligned but it's hard to tell. Here it is zoomed:

![image](https://github.com/user-attachments/assets/b269b921-62f1-4039-af8d-be6cd669167c)

