### PR TITLE
fix (mobile sidebar): Background color in sidebar (Only for mobile) doesn't get overwritten if we use className

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -187,7 +187,10 @@ function Sidebar({
           data-sidebar="sidebar"
           data-slot="sidebar"
           data-mobile="true"
-          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+          className={cn(
+            "bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden",
+            className
+          )}
           style={
             {
               "--sidebar-width": SIDEBAR_WIDTH_MOBILE,


### PR DESCRIPTION
When trying to use custom background color on the sidebar, it works correctly on big screen but shows grey/default color on mobile devices. 

**Found the issue was that Tailwind merge CN was missing only for mobile devices.**

### On Desktop :
![image](https://github.com/user-attachments/assets/c7d98deb-905d-4885-8e35-677ae8fcb4f3)

### On Mobile:
![image](https://github.com/user-attachments/assets/976e6783-6f8f-4a88-9cd4-70b572163a22)

