### PR TITLE
Update getting-started.mdx - canary version is buggy

### DIFF
--- a/apps/www/content/docs/registry/getting-started.mdx
+++ b/apps/www/content/docs/registry/getting-started.mdx
@@ -119,10 +119,8 @@ You can read more about the registry item schema and file types in the [registry
 
 ### Install the shadcn CLI
 
-Note: the `build` command is currently only available in the `shadcn@canary` version of the CLI.
-
 ```bash
-npm install shadcn@canary
+npm install shadcn -D
 ```
 
 ### Add a build script


### PR DESCRIPTION
remove the canary version because it would add add unwanted files including shadcn components for no reason so by removing the canary from the installation it would work correctly

i was mislead by this doc and after fixing this it works