### PR TITLE
docs: update source code for use-toast and toaster components

### DIFF
--- a/apps/www/content/docs/components/toast.mdx
+++ b/apps/www/content/docs/components/toast.mdx
@@ -67,11 +67,11 @@ npm install @radix-ui/react-toast
 
 `toaster.tsx`
 
-<ComponentSource name="toast" fileName="toaster" />
+<ComponentSource src="registry/default/ui/toaster.tsx" />
 
 `use-toast.tsx`
 
-<ComponentSource name="toast" fileName="use-toast" />
+<ComponentSource name="use-toast" fileName="use-toast" />
 
 <Step>Update the import paths to match your project setup.</Step>
 


### PR DESCRIPTION
This PR fixes #7443 and #7450

In summary, the issue is that the toast documentation shows the same code in both `use-toast.ts`, `toaster.tsx` and `toast.tsx`.

My approach was simply following the convention established for the internal `<ComponentSource />` component.

https://github.com/user-attachments/assets/89e8e5ae-a686-4366-bed5-a71cf284b69e

