### PR TITLE
fix: Alert components that include a shape and exclude a Title aren't vertically centered #7473

### DIFF
--- a/apps/www/registry/default/ui/alert.tsx
+++ b/apps/www/registry/default/ui/alert.tsx
@@ -50,7 +50,7 @@ const AlertDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    className={cn("text-sm [&_p]:leading-relaxed items-center", className)}
     {...props}
   />
 ))

--- a/apps/www/registry/new-york/ui/alert.tsx
+++ b/apps/www/registry/new-york/ui/alert.tsx
@@ -50,7 +50,7 @@ const AlertDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    className={cn("text-sm [&_p]:leading-relaxed items-center", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
Fixed this issue by using "items-center" class in alert.tsx in default and new-york themes. I published some images on the original bug request on #7473