### PR TITLE
Pretty code in heading

### DIFF
--- a/apps/v4/lib/fonts.ts
+++ b/apps/v4/lib/fonts.ts
@@ -14,7 +14,7 @@ const fontSans = FontSans({
 const fontMono = FontMono({
   subsets: ["latin"],
   variable: "--font-mono",
-  weight: ["400"],
+  weight: ["400", "700"],
 })
 
 const fontInter = Inter({

--- a/apps/v4/mdx-components.tsx
+++ b/apps/v4/mdx-components.tsx
@@ -228,7 +228,7 @@ export const mdxComponents = {
       return (
         <code
           className={cn(
-            "bg-muted relative rounded-md px-[0.3rem] py-[0.2rem] font-mono text-[0.8rem] outline-none",
+            "bg-muted relative rounded-md px-[0.3rem] py-[0.2rem] font-mono text-[0.8em] outline-none",
             className
           )}
           {...props}


### PR DESCRIPTION
This PR makes `code` in headings look prettier:

Before:
<img width="442" alt="Screenshot 2025-05-31 at 11 36 00" src="https://github.com/user-attachments/assets/8de0b6a6-9843-443f-8f1e-7db8509500d6" />

After:
<img width="442" alt="Screenshot 2025-05-31 at 11 30 42" src="https://github.com/user-attachments/assets/a893d12b-f52c-4fd0-9ff2-ae2edb498008" />
