### PR TITLE
fix: Unable to Install shadcn/ui Components Using Yarn #7514

### DIFF
--- a/apps/v4/lib/highlight-code.ts
+++ b/apps/v4/lib/highlight-code.ts
@@ -39,7 +39,7 @@ export const transformers = [
         // npx.
         if (raw.startsWith("npx")) {
           node.properties["__npm__"] = raw
-          node.properties["__yarn__"] = raw.replace("npx", "yarn")
+          node.properties["__yarn__"] = raw.replace("npx", "yarn dlx")
           node.properties["__pnpm__"] = raw.replace("npx", "pnpm dlx")
           node.properties["__bun__"] = raw.replace("npx", "bunx --bun")
         }

--- a/apps/www/lib/rehype-npm-command.ts
+++ b/apps/www/lib/rehype-npm-command.ts
@@ -69,7 +69,10 @@ export function rehypeNpmCommand() {
       ) {
         const npmCommand = node.properties?.["__rawString__"]
         node.properties["__npmCommand__"] = npmCommand
-        node.properties["__yarnCommand__"] = npmCommand
+        node.properties["__yarnCommand__"] = npmCommand.replace(
+          "npx",
+          "yarn dlx"
+        )
         node.properties["__pnpmCommand__"] = npmCommand.replace(
           "npx",
           "pnpm dlx"


### PR DESCRIPTION
@shadcn and @Jacksonmills 
I saw few open issues on repo because they were not able to add the components with shadcn cli via yarn. The issue has been discussed in detain in #7514 . 

In short summary, people were using yarn shadcn@latest add <component> without installing the shadcn cli locally first and they were confused because npx shadcn@latest add <component> was working properly.

We should provide yarn dlx shadcn@latest add <component> instead of simple yarn because people will not be installing cli locally in most cases.

Beginners were really struggling with this issue. Please see if you can merge this PR.

Right now docs are looking like this after changes. 

<img width="656" alt="Screenshot 2025-06-01 at 9 58 59 AM" src="https://github.com/user-attachments/assets/8abc6e39-49e3-41c4-91ba-ef6f2c0366ca" />
