### PR TITLE
fix(command-menu): use correct package manager in copied payload

### DIFF
--- a/apps/v4/components/command-menu.tsx
+++ b/apps/v4/components/command-menu.tsx
@@ -56,7 +56,15 @@ export function CommandMenu({
         const componentName = item.url.split("/").pop()
         setSelectedType("component")
         setCopyPayload(
-          `${packageManager} dlx shadcn@latest add ${componentName}`
+          `${
+            packageManager === "pnpm"
+              ? "pnpm dlx"
+              : packageManager === "npm"
+                ? "npx"
+                : packageManager === "yarn"
+                  ? "yarn"
+                  : "bunx --bun"
+          } shadcn@latest add ${componentName}`
         )
       } else {
         setSelectedType("page")


### PR DESCRIPTION
Previously, the command menu always defaulted to `[packageManager] dlx shadcn@latest add [componentName]`, regardless of the selected package manager.

This has been fixed to use the correct command for each:

- **pnpm**: `pnpm dlx shadcn@latest add [componentName]`  
- **npm**: `npx shadcn@latest add [componentName]`  
- **yarn**: `yarn shadcn@latest add [componentName]`  
- **bun**: `bunx --bun shadcn@latest add [componentName]`

Of course, this may not be the preferred approach of the maintainers, so feel free to modify as you see fit.