### PR TITLE
Fix: Enable Shadcn UI Initialization by Aligning TanStack Start Dependency

### DIFF
--- a/packages/shadcn/src/utils/get-project-info.ts
+++ b/packages/shadcn/src/utils/get-project-info.ts
@@ -125,7 +125,7 @@ export async function getProjectInfo(cwd: string): Promise<ProjectInfo | null> {
     [
       ...Object.keys(packageJson?.dependencies ?? {}),
       ...Object.keys(packageJson?.devDependencies ?? {}),
-    ].find((dep) => dep.startsWith("@tanstack/start"))
+    ].find((dep) => dep.startsWith("@tanstack/react-start"))
   ) {
     type.framework = FRAMEWORKS["tanstack-start"]
     return type


### PR DESCRIPTION
**Issue:**
When attempting to run shadcn-ui@latest init (or similar initialization commands) in our project, we encountered the error: "We could not detect a supported framework." This occurred because Shadcn UI's internal detection logic is currently looking for the @tanstack/start package, while our project correctly uses the updated @tanstack/react-start. This discrepancy prevented Shadcn UI from recognizing TanStack Start as a valid framework in our setup.



