### PR TITLE
refactor: Use type-only import for ToasterProps

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/sonner.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sonner.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useTheme } from "next-themes"
-import { Toaster as Sonner, ToasterProps } from "sonner"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()


### PR DESCRIPTION
Updates ToasterProps import to type ToasterProps for improved compatibility and to resolve #7525 