### PR TITLE
fix: Update file extension handling in toAliasedImport function

### DIFF
--- a/packages/shadcn/src/utils/updaters/update-files.ts
+++ b/packages/shadcn/src/utils/updaters/update-files.ts
@@ -588,10 +588,16 @@ export function toAliasedImport(
   rel = rel.split(path.sep).join("/") // e.g. "button/index.tsx"
 
   // 3️⃣ Strip code-file extensions, keep others (css, json, etc.)
-  const ext = path.posix.extname(rel)
+  //    We use `lastIndexOf('.')` so that multi-dot filenames (e.g. "message-demo.const.tsx") are split correctly on the final dot.
+  const lastDotIndex = rel.lastIndexOf(".")
+  let ext = ""
+  let noExt = rel
+  if (lastDotIndex !== -1) {
+    ext = rel.slice(lastDotIndex)      // e.g. ".tsx"
+    noExt = rel.slice(0, lastDotIndex) // e.g. "message-demo.const"
+  }
   const codeExts = [".ts", ".tsx", ".js", ".jsx"]
   const keepExt = codeExts.includes(ext) ? "" : ext
-  let noExt = rel.slice(0, rel.length - ext.length)
 
   // 4️⃣ Collapse "/index" to its directory
   if (noExt.endsWith("/index")) {


### PR DESCRIPTION
#7548 fix

This pull request refines the `toAliasedImport` function in `update-files.ts` to handle multi-dot filenames more robustly. The key change ensures that the file extension is correctly identified even for filenames with multiple dots.

### Improvements to file extension handling:

* [`packages/shadcn/src/utils/updaters/update-files.ts`](diffhunk://#diff-83ec4a6d1f6c63f83bb0ebebb2d6e3bf8caad5d4c614e369786fd9c967c1ba07L591-L594): Updated the logic to determine the file extension by using `lastIndexOf('.')`, ensuring that multi-dot filenames (e.g., `message-demo.const.tsx`) are split correctly on the final dot. This change also adjusts how the remaining portion of the filename is calculated.