### PR TITLE
Fix utils import transform when workspace alias does not start with `@`

### DIFF
--- a/packages/shadcn/src/utils/transformers/transform-import.ts
+++ b/packages/shadcn/src/utils/transformers/transform-import.ts
@@ -6,8 +6,8 @@ export const transformImport: Transformer = async ({
   config,
   isRemote,
 }) => {
-  const workspaceAlias = config.aliases?.utils?.split("/")[0]?.slice(1)
-  const utilsImport = `@${workspaceAlias}/lib/utils`
+  const workspaceAlias = config.aliases?.utils?.split("/")[0]
+  const utilsImport = `${workspaceAlias}/lib/utils`
 
   const importDeclarations = sourceFile.getImportDeclarations()
 

--- a/packages/shadcn/test/utils/transform-import.test.ts
+++ b/packages/shadcn/test/utils/transform-import.test.ts
@@ -2,6 +2,38 @@ import { expect, test } from "vitest"
 
 import { transform } from "../../src/utils/transformers"
 
+
+test.only('transform nested workspace folder for utils, website/src/utils', async () => {
+  expect(
+    await transform({
+      filename: "test.ts",
+
+      raw: `import { Button } from "website/src/components/ui/button"
+      import { Box } from "website/src/components/box"
+      import { cn } from "website/src/utils"
+    `,
+      config: {
+        tsx: true,
+        tailwind: {
+          baseColor: "neutral",
+          cssVariables: true,
+        },
+        aliases: {
+          components: "website/src/components",
+          lib: "website/src/lib",
+          utils: "website/src/utils",
+        },
+      },
+    })
+  ).toMatchInlineSnapshot(`
+    "import { Button } from "website/src/components/ui/button"
+          import { Box } from "website/src/components/box"
+          import { cn } from "website/src/utils"
+        "
+  `)
+
+})
+
 test("transform import", async () => {
   expect(
     await transform({


### PR DESCRIPTION
The code was assuming the workspace to always start with `@`, this is not always the case

Fix https://github.com/shadcn-ui/ui/issues/7348