### PR TITLE
chore: update react-day-picker version to match updated calendar component

### DIFF
--- a/apps/v4/content/docs/components/calendar.mdx
+++ b/apps/v4/content/docs/components/calendar.mdx
@@ -41,7 +41,7 @@ npx shadcn@latest add calendar
 <Step>Install the following dependencies:</Step>
 
 ```bash
-npm install react-day-picker@8.10.1 date-fns
+npm install react-day-picker date-fns
 ```
 
 <Step>Add the `Button` component to your project.</Step>

--- a/apps/www/content/docs/components/calendar.mdx
+++ b/apps/www/content/docs/components/calendar.mdx
@@ -39,7 +39,7 @@ npx shadcn@latest add calendar
 <Step>Install the following dependencies:</Step>
 
 ```bash
-npm install react-day-picker@8.10.1 date-fns
+npm install react-day-picker date-fns
 ```
 
 <Step>Add the `Button` component to your project.</Step>

--- a/apps/www/public/registry/index.json
+++ b/apps/www/public/registry/index.json
@@ -79,7 +79,7 @@
   {
     "name": "calendar",
     "dependencies": [
-      "react-day-picker@8.10.1",
+      "react-day-picker",
       "date-fns"
     ],
     "registryDependencies": [

--- a/apps/www/public/registry/styles/default/calendar.json
+++ b/apps/www/public/registry/styles/default/calendar.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar",
   "dependencies": [
-    "react-day-picker@8.10.1",
+    "react-day-picker",
     "date-fns"
   ],
   "registryDependencies": [

--- a/apps/www/public/registry/styles/new-york/calendar.json
+++ b/apps/www/public/registry/styles/new-york/calendar.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar",
   "dependencies": [
-    "react-day-picker@8.10.1",
+    "react-day-picker",
     "date-fns"
   ],
   "registryDependencies": [


### PR DESCRIPTION
Previously, the react-day-picker dependency was locked to version 8 due to compatibility with the old calendar component. However, since the calendar component has been updated, it is no longer necessary to pin the package to the old version.