### PR TITLE
feat: add migrate radix command

### DIFF
--- a/.changeset/stupid-planes-guess.md
+++ b/.changeset/stupid-planes-guess.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+add migrate-radix

--- a/packages/shadcn/src/commands/migrate.ts
+++ b/packages/shadcn/src/commands/migrate.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import { migrateIcons } from "@/src/migrations/migrate-icons"
+import { migrateRadix } from "@/src/migrations/migrate-radix"
 import { preFlightMigrate } from "@/src/preflights/preflight-migrate"
 import * as ERRORS from "@/src/utils/errors"
 import { handleError } from "@/src/utils/handle-error"
@@ -11,6 +12,10 @@ export const migrations = [
   {
     name: "icons",
     description: "migrate your ui components to a different icon library.",
+  },
+  {
+    name: "radix",
+    description: "migrate from individual Radix UI packages to the unified radix-ui package.",
   },
 ] as const
 
@@ -81,6 +86,10 @@ export const migrate = new Command()
 
       if (options.migration === "icons") {
         await migrateIcons(config)
+      }
+
+      if (options.migration === "radix") {
+        await migrateRadix(config)
       }
     } catch (error) {
       logger.break()

--- a/packages/shadcn/src/commands/migrate.ts
+++ b/packages/shadcn/src/commands/migrate.ts
@@ -22,6 +22,7 @@ export const migrations = [
 export const migrateOptionsSchema = z.object({
   cwd: z.string(),
   list: z.boolean(),
+  yes: z.boolean(),
   migration: z
     .string()
     .refine(
@@ -45,12 +46,14 @@ export const migrate = new Command()
     process.cwd()
   )
   .option("-l, --list", "list all migrations.", false)
+  .option("-y, --yes", "skip confirmation prompt.", false)
   .action(async (migration, opts) => {
     try {
       const options = migrateOptionsSchema.parse({
         cwd: path.resolve(opts.cwd),
         migration,
         list: opts.list,
+        yes: opts.yes,
       })
 
       if (options.list || !options.migration) {
@@ -89,7 +92,7 @@ export const migrate = new Command()
       }
 
       if (options.migration === "radix") {
-        await migrateRadix(config)
+        await migrateRadix(config, { yes: options.yes })
       }
     } catch (error) {
       logger.break()

--- a/packages/shadcn/src/migrations/migrate-radix.test.ts
+++ b/packages/shadcn/src/migrations/migrate-radix.test.ts
@@ -439,6 +439,175 @@ export const DialogRoot = Root`
     expect(result.content.trim()).toBe(expected.trim())
     expect(result.replacedPackages).toEqual(["@radix-ui/react-dialog"])
   })
+
+  it("should handle real-world shadcn/ui patterns from registry files", async () => {
+    // This test captures all the actual import patterns found in the shadcn/ui registry
+    const input = `import * as AccordionPrimitive from "@radix-ui/react-accordion"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+import * as AspectRatioPrimitive from "@radix-ui/react-aspect-ratio"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+import { Slot } from "@radix-ui/react-slot"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import * as MenubarPrimitive from "@radix-ui/react-menubar"
+import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+import * as SwitchPrimitive from "@radix-ui/react-switch"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+import * as TogglePrimitive from "@radix-ui/react-toggle"
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+export const Accordion = AccordionPrimitive.Root
+export const AlertDialog = AlertDialogPrimitive.Root
+export const Button = Slot`
+
+    const expected = `import { Accordion as AccordionPrimitive, AlertDialog as AlertDialogPrimitive, AspectRatio as AspectRatioPrimitive, Avatar as AvatarPrimitive, Slot, Checkbox as CheckboxPrimitive, Collapsible as CollapsiblePrimitive, ContextMenu as ContextMenuPrimitive, Dialog as DialogPrimitive, DropdownMenu as DropdownMenuPrimitive, HoverCard as HoverCardPrimitive, Label as LabelPrimitive, Menubar as MenubarPrimitive, NavigationMenu as NavigationMenuPrimitive, Popover as PopoverPrimitive, Progress as ProgressPrimitive, RadioGroup as RadioGroupPrimitive, ScrollArea as ScrollAreaPrimitive, Select as SelectPrimitive, Separator as SeparatorPrimitive, Slider as SliderPrimitive, Switch as SwitchPrimitive, Tabs as TabsPrimitive, Toggle as TogglePrimitive, ToggleGroup as ToggleGroupPrimitive, Tooltip as TooltipPrimitive } from "radix-ui";
+
+export const Accordion = AccordionPrimitive.Root
+export const AlertDialog = AlertDialogPrimitive.Root
+export const Button = Slot`
+
+    const result = await migrateRadixFile(input)
+    expect(result.content.trim()).toBe(expected.trim())
+    expect(result.replacedPackages).toEqual([
+      "@radix-ui/react-accordion",
+      "@radix-ui/react-alert-dialog", 
+      "@radix-ui/react-aspect-ratio",
+      "@radix-ui/react-avatar",
+      "@radix-ui/react-slot",
+      "@radix-ui/react-checkbox",
+      "@radix-ui/react-collapsible",
+      "@radix-ui/react-context-menu",
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-dropdown-menu",
+      "@radix-ui/react-hover-card",
+      "@radix-ui/react-label",
+      "@radix-ui/react-menubar",
+      "@radix-ui/react-navigation-menu",
+      "@radix-ui/react-popover",
+      "@radix-ui/react-progress",
+      "@radix-ui/react-radio-group",
+      "@radix-ui/react-scroll-area",
+      "@radix-ui/react-select",
+      "@radix-ui/react-separator",
+      "@radix-ui/react-slider",
+      "@radix-ui/react-switch",
+      "@radix-ui/react-tabs",
+      "@radix-ui/react-toggle",
+      "@radix-ui/react-toggle-group",
+      "@radix-ui/react-tooltip"
+    ])
+  })
+
+  it("should handle the special sheet.tsx pattern from registry", async () => {
+    // In shadcn/ui, sheet.tsx imports from react-dialog instead of a dedicated sheet package
+    const input = `import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { cn } from "@/lib/utils"
+
+export const Sheet = SheetPrimitive.Root
+export const SheetTrigger = SheetPrimitive.Trigger`
+
+    const expected = `import { Dialog as SheetPrimitive } from "radix-ui";
+import { cn } from "@/lib/utils"
+
+export const Sheet = SheetPrimitive.Root
+export const SheetTrigger = SheetPrimitive.Trigger`
+
+    const result = await migrateRadixFile(input)
+    expect(result.content.trim()).toBe(expected.trim())
+    expect(result.replacedPackages).toEqual(["@radix-ui/react-dialog"])
+  })
+
+  it("should handle form.tsx mixed pattern from registry", async () => {
+    // form.tsx uses both namespace and named imports
+    const input = `import * as LabelPrimitive from "@radix-ui/react-label"
+import { Slot } from "@radix-ui/react-slot"
+
+export const FormLabel = LabelPrimitive.Root
+export const FormControl = Slot`
+
+    const expected = `import { Label as LabelPrimitive, Slot } from "radix-ui";
+
+export const FormLabel = LabelPrimitive.Root
+export const FormControl = Slot`
+
+    const result = await migrateRadixFile(input)
+    expect(result.content.trim()).toBe(expected.trim())
+    expect(result.replacedPackages).toEqual(["@radix-ui/react-label", "@radix-ui/react-slot"])
+  })
+
+  it("should handle all 26 packages used in shadcn/ui registry", async () => {
+    // Test that we correctly handle all packages found in the registry analysis
+    const allPackages = [
+      "@radix-ui/react-accordion",
+      "@radix-ui/react-alert-dialog", 
+      "@radix-ui/react-aspect-ratio",
+      "@radix-ui/react-avatar",
+      "@radix-ui/react-checkbox",
+      "@radix-ui/react-collapsible",
+      "@radix-ui/react-context-menu",
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-dropdown-menu",
+      "@radix-ui/react-hover-card",
+      "@radix-ui/react-label",
+      "@radix-ui/react-menubar",
+      "@radix-ui/react-navigation-menu",
+      "@radix-ui/react-popover",
+      "@radix-ui/react-progress",
+      "@radix-ui/react-radio-group",
+      "@radix-ui/react-scroll-area",
+      "@radix-ui/react-select",
+      "@radix-ui/react-separator",
+      "@radix-ui/react-slider",
+      "@radix-ui/react-slot",
+      "@radix-ui/react-switch",
+      "@radix-ui/react-tabs",
+      "@radix-ui/react-toggle",
+      "@radix-ui/react-toggle-group",
+      "@radix-ui/react-tooltip"
+    ]
+    
+    // Create import statements for all packages
+    const imports = allPackages.map(pkg => {
+      const componentName = pkg.replace("@radix-ui/react-", "")
+        .split("-")
+        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+        .join("")
+      
+      if (pkg === "@radix-ui/react-slot") {
+        return `import { Slot } from "${pkg}"`
+      }
+      return `import * as ${componentName}Primitive from "${pkg}"`
+    }).join("\n")
+    
+    const result = await migrateRadixFile(imports)
+    
+    // Should contain all 26 packages in replacedPackages
+    expect(result.replacedPackages).toHaveLength(26)
+    expect(result.replacedPackages.sort()).toEqual(allPackages.sort())
+    
+    // Should be a single unified import from radix-ui
+    expect(result.content).toContain('from "radix-ui";')
+    expect(result.content.startsWith("import {")).toBe(true)
+    expect(result.content).toContain("Slot") // Slot should be included as named import
+    expect(result.content).toContain("Accordion as AccordionPrimitive") // Namespace should be aliased
+    
+    // Should have transformed all imports into a single statement
+    const importLines = result.content.split('\n').filter(line => line.includes('import'))
+    expect(importLines).toHaveLength(1)
+  })
 })
 
 describe("migrateRadix - package.json updates", () => {

--- a/packages/shadcn/src/migrations/migrate-radix.test.ts
+++ b/packages/shadcn/src/migrations/migrate-radix.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { promises as fs } from "fs"
+import path from "path"
+
+import { migrateRadixFile, migrateRadix } from "./migrate-radix"
+
+// Mock dependencies
+vi.mock("fs", () => ({
+  promises: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    mkdtemp: vi.fn(),
+  },
+}))
+
+vi.mock("fast-glob", () => ({
+  default: vi.fn(),
+}))
+
+vi.mock("prompts", () => ({
+  default: vi.fn(),
+}))
+
+vi.mock("@/src/utils/spinner", () => ({
+  spinner: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn(),
+    fail: vi.fn(),
+    text: "",
+  })),
+}))
+
+vi.mock("@/src/utils/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+vi.mock("@/src/utils/get-package-manager", () => ({
+  getPackageManager: vi.fn(),
+}))
+
+vi.mock("@/src/utils/get-package-info", () => ({
+  getPackageInfo: vi.fn(),
+}))
+
+const mockFs = fs as any
+const mockConfig = {
+  resolvedPaths: {
+    cwd: "/test-project",
+    ui: "/test-project/components",
+  },
+}
+
+beforeEach(() => {
+  // Mock mkdtemp to return a valid temp directory path
+  mockFs.mkdtemp.mockResolvedValue("/tmp/shadcn-test")
+})
+
+describe("migrateRadixFile", () => {
+  it("should migrate namespace imports", async () => {
+    const input = `import * as DialogPrimitive from "@radix-ui/react-dialog"
+import * as SelectPrimitive from "@radix-ui/react-select"
+
+export const Dialog = DialogPrimitive.Root
+export const Select = SelectPrimitive.Root`
+
+    const expected = `import { Dialog as DialogPrimitive, Select as SelectPrimitive } from "radix-ui";
+export const Dialog = DialogPrimitive.Root
+export const Select = SelectPrimitive.Root`
+
+    const result = await migrateRadixFile(input)
+    expect(result.trim()).toBe(expected.trim())
+  })
+
+  it("should migrate named imports", async () => {
+    const input = `import { Root, Trigger } from "@radix-ui/react-dialog"
+import { Content } from "@radix-ui/react-select"
+
+export const DialogRoot = Root
+export const DialogTrigger = Trigger
+export const SelectContent = Content`
+
+    const expected = `import { Root, Trigger, Content } from "radix-ui";
+export const DialogRoot = Root
+export const DialogTrigger = Trigger
+export const SelectContent = Content`
+
+    const result = await migrateRadixFile(input)
+    expect(result.trim()).toBe(expected.trim())
+  })
+
+  it("should handle mixed import types", async () => {
+    const input = `import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { Root as SelectRoot } from "@radix-ui/react-select"
+import { useState } from "react"
+
+export const Dialog = DialogPrimitive.Root
+export const Select = SelectRoot`
+
+    const expected = `import { Dialog as DialogPrimitive, Root as SelectRoot } from "radix-ui";
+import { useState } from "react"
+
+export const Dialog = DialogPrimitive.Root
+export const Select = SelectRoot`
+
+    const result = await migrateRadixFile(input)
+    expect(result.trim()).toBe(expected.trim())
+  })
+
+  it("should not modify non-Radix imports", async () => {
+    const input = `import React from "react"
+import { clsx } from "clsx"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+
+export const Dialog = DialogPrimitive.Root`
+
+    const result = await migrateRadixFile(input)
+    expect(result).toContain('import React from "react"')
+    expect(result).toContain('import { clsx } from "clsx"')
+    expect(result).toContain('import { Dialog as DialogPrimitive } from "radix-ui"')
+    expect(result).not.toContain('@radix-ui/react-dialog')
+  })
+
+  it("should handle files with no Radix imports", async () => {
+    const input = `import React from "react"
+import { clsx } from "clsx"
+
+export const Component = () => <div>Hello</div>`
+
+    const result = await migrateRadixFile(input)
+    expect(result.trim()).toBe(input.trim())
+  })
+
+  it("should preserve import position in file", async () => {
+    const input = `"use client"
+
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { useState } from "react"
+
+export const Dialog = DialogPrimitive.Root`
+
+    const expected = `"use client"
+
+import { Dialog as DialogPrimitive } from "radix-ui";
+import { useState } from "react"
+
+export const Dialog = DialogPrimitive.Root`
+
+    const result = await migrateRadixFile(input)
+    expect(result.trim()).toBe(expected.trim())
+  })
+
+  it("should handle multiple Radix imports without node removal errors", async () => {
+    const input = `"use client"
+
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { useState } from "react"
+
+export const DropdownMenu = DropdownMenuPrimitive.Root
+export const Dialog = DialogPrimitive.Root`
+
+    const expected = `"use client"
+
+import { DropdownMenu as DropdownMenuPrimitive, Dialog as DialogPrimitive } from "radix-ui";
+import { useState } from "react"
+
+export const DropdownMenu = DropdownMenuPrimitive.Root
+export const Dialog = DialogPrimitive.Root`
+
+    const result = await migrateRadixFile(input)
+    expect(result.trim()).toBe(expected.trim())
+  })
+})
+
+describe("migrateRadix - package.json updates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("should update package.json with Radix dependencies", async () => {
+    const mockPackageJson = {
+      name: "test-project", 
+      dependencies: {
+        "react": "^18.0.0",
+        "@radix-ui/react-dialog": "^1.0.0",
+        "@radix-ui/react-select": "^1.0.0",
+        "other-package": "^1.0.0"
+      },
+      devDependencies: {
+        "@radix-ui/react-toast": "^1.0.0"
+      }
+    }
+
+    const expectedPackageJson = {
+      name: "test-project",
+      dependencies: {
+        "react": "^18.0.0", 
+        "other-package": "^1.0.0",
+        "radix-ui": "latest"
+      },
+      devDependencies: {}
+    }
+
+    // Mock package info
+    const { getPackageInfo } = await import("@/src/utils/get-package-info")
+    vi.mocked(getPackageInfo).mockReturnValue(mockPackageJson)
+    
+    // Mock file system
+    mockFs.writeFile.mockResolvedValue(undefined)
+    
+    // Mock fast-glob to return empty files
+    const fg = await import("fast-glob")
+    vi.mocked(fg.default).mockResolvedValue([])
+    
+    // Mock prompts to confirm migration
+    const prompts = await import("prompts")
+    vi.mocked(prompts.default).mockResolvedValue({ confirm: true })
+    
+    // Mock package manager detection
+    const { getPackageManager } = await import("@/src/utils/get-package-manager")
+    vi.mocked(getPackageManager).mockResolvedValue("npm")
+
+    await migrateRadix(mockConfig)
+
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      "/test-project/package.json",
+      JSON.stringify(expectedPackageJson, null, 2) + "\n"
+    )
+  })
+
+  it("should handle package.json with no Radix dependencies", async () => {
+    const mockPackageJson = {
+      name: "test-project",
+      dependencies: {
+        "react": "^18.0.0",
+        "other-package": "^1.0.0"
+      }
+    }
+
+    const { getPackageInfo } = await import("@/src/utils/get-package-info")
+    vi.mocked(getPackageInfo).mockReturnValue(mockPackageJson)
+    
+    const fg = await import("fast-glob")
+    vi.mocked(fg.default).mockResolvedValue([])
+    
+    const prompts = await import("prompts")
+    vi.mocked(prompts.default).mockResolvedValue({ confirm: true })
+
+    await migrateRadix(mockConfig)
+
+    // Should not write the file if no Radix packages found
+    expect(mockFs.writeFile).not.toHaveBeenCalledWith(
+      "/test-project/package.json",
+      expect.any(String)
+    )
+  })
+
+  it("should handle missing package.json gracefully", async () => {
+    const { getPackageInfo } = await import("@/src/utils/get-package-info")
+    vi.mocked(getPackageInfo).mockReturnValue(null)
+    
+    const fg = await import("fast-glob")
+    vi.mocked(fg.default).mockResolvedValue([])
+    
+    const prompts = await import("prompts")
+    vi.mocked(prompts.default).mockResolvedValue({ confirm: true })
+
+    // Should not throw
+    await expect(migrateRadix(mockConfig)).resolves.not.toThrow()
+  })
+
+  it("should show correct install command for different package managers", async () => {
+    const mockPackageJson = {
+      name: "test-project", 
+      dependencies: {
+        "@radix-ui/react-dialog": "^1.0.0",
+      }
+    }
+
+    const { getPackageInfo } = await import("@/src/utils/get-package-info")
+    vi.mocked(getPackageInfo).mockReturnValue(mockPackageJson)
+    
+    const { getPackageManager } = await import("@/src/utils/get-package-manager")
+    vi.mocked(getPackageManager).mockResolvedValue("pnpm")
+    
+    const { logger } = await import("@/src/utils/logger")
+    
+    mockFs.writeFile.mockResolvedValue(undefined)
+    
+    const fg = await import("fast-glob")
+    vi.mocked(fg.default).mockResolvedValue([])
+    
+    const prompts = await import("prompts")
+    vi.mocked(prompts.default).mockResolvedValue({ confirm: true })
+
+    await migrateRadix(mockConfig)
+
+    expect(logger.info).toHaveBeenCalledWith("  pnpm install")
+  })
+})

--- a/packages/shadcn/src/migrations/migrate-radix.test.ts
+++ b/packages/shadcn/src/migrations/migrate-radix.test.ts
@@ -1,8 +1,7 @@
-import { describe, expect, it, vi, beforeEach } from "vitest"
 import { promises as fs } from "fs"
-import path from "path"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { migrateRadixFile, migrateRadix } from "./migrate-radix"
+import { migrateRadix, migrateRadixFile } from "./migrate-radix"
 
 // Mock dependencies
 vi.mock("fs", () => ({
@@ -46,11 +45,33 @@ vi.mock("@/src/utils/get-package-info", () => ({
   getPackageInfo: vi.fn(),
 }))
 
+vi.mock("@/src/utils/updaters/update-dependencies", () => ({
+  updateDependencies: vi.fn(),
+}))
+
 const mockFs = fs as any
 const mockConfig = {
+  style: "default",
+  rsc: false,
+  tsx: true,
+  tailwind: {
+    css: "app/globals.css",
+    baseColor: "slate",
+    cssVariables: true,
+  },
+  aliases: {
+    components: "@/components",
+    utils: "@/lib/utils",
+  },
   resolvedPaths: {
     cwd: "/test-project",
     ui: "/test-project/components",
+    tailwindConfig: "/test-project/tailwind.config.js",
+    tailwindCss: "/test-project/app/globals.css",
+    utils: "/test-project/lib/utils",
+    components: "/test-project/components",
+    lib: "/test-project/lib",
+    hooks: "/test-project/hooks",
   },
 }
 
@@ -74,7 +95,10 @@ export const Select = SelectPrimitive.Root`
 
     const result = await migrateRadixFile(input)
     expect(result.content.trim()).toBe(expected.trim())
-    expect(result.replacedPackages).toEqual(["@radix-ui/react-dialog", "@radix-ui/react-select"])
+    expect(result.replacedPackages).toEqual([
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-select",
+    ])
   })
 
   it("should migrate named imports", async () => {
@@ -93,7 +117,10 @@ export const SelectContent = Content`
 
     const result = await migrateRadixFile(input)
     expect(result.content.trim()).toBe(expected.trim())
-    expect(result.replacedPackages).toEqual(["@radix-ui/react-dialog", "@radix-ui/react-select"])
+    expect(result.replacedPackages).toEqual([
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-select",
+    ])
   })
 
   it("should handle mixed import types", async () => {
@@ -113,7 +140,10 @@ export const Select = SelectRoot`
 
     const result = await migrateRadixFile(input)
     expect(result.content.trim()).toBe(expected.trim())
-    expect(result.replacedPackages).toEqual(["@radix-ui/react-dialog", "@radix-ui/react-select"])
+    expect(result.replacedPackages).toEqual([
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-select",
+    ])
   })
 
   it("should not modify non-Radix imports", async () => {
@@ -126,8 +156,10 @@ export const Dialog = DialogPrimitive.Root`
     const result = await migrateRadixFile(input)
     expect(result.content).toContain('import React from "react"')
     expect(result.content).toContain('import { clsx } from "clsx"')
-    expect(result.content).toContain('import { Dialog as DialogPrimitive } from "radix-ui"')
-    expect(result.content).not.toContain('@radix-ui/react-dialog')
+    expect(result.content).toContain(
+      'import { Dialog as DialogPrimitive } from "radix-ui"'
+    )
+    expect(result.content).not.toContain("@radix-ui/react-dialog")
     expect(result.replacedPackages).toEqual(["@radix-ui/react-dialog"])
   })
 
@@ -183,7 +215,10 @@ export const Dialog = DialogPrimitive.Root`
 
     const result = await migrateRadixFile(input)
     expect(result.content.trim()).toBe(expected.trim())
-    expect(result.replacedPackages).toEqual(["@radix-ui/react-dropdown-menu", "@radix-ui/react-dialog"])
+    expect(result.replacedPackages).toEqual([
+      "@radix-ui/react-dropdown-menu",
+      "@radix-ui/react-dialog",
+    ])
   })
 
   it("should preserve single quotes if used in original imports", async () => {
@@ -200,7 +235,10 @@ export const Select = SelectPrimitive.Root`
 
     const result = await migrateRadixFile(input)
     expect(result.content.trim()).toBe(expected.trim())
-    expect(result.replacedPackages).toEqual(["@radix-ui/react-dialog", "@radix-ui/react-select"])
+    expect(result.replacedPackages).toEqual([
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-select",
+    ])
   })
 
   it("should preserve mixed quote styles from first import", async () => {
@@ -217,7 +255,10 @@ export const Select = SelectPrimitive.Root`
 
     const result = await migrateRadixFile(input)
     expect(result.content.trim()).toBe(expected.trim())
-    expect(result.replacedPackages).toEqual(["@radix-ui/react-dialog", "@radix-ui/react-select"])
+    expect(result.replacedPackages).toEqual([
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-select",
+    ])
   })
 
   it("should handle type-only imports", async () => {
@@ -237,7 +278,10 @@ export const Dialog = DialogPrimitive.Root`
 
     const result = await migrateRadixFile(input)
     expect(result.content.trim()).toBe(expected.trim())
-    expect(result.replacedPackages).toEqual(["@radix-ui/react-dialog", "@radix-ui/react-select"])
+    expect(result.replacedPackages).toEqual([
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-select",
+    ])
   })
 
   it("should handle mixed type and value imports", async () => {
@@ -290,7 +334,10 @@ export const ChevronDown = ChevronDownIcon`
 
     const result = await migrateRadixFile(input)
     expect(result.content.trim()).toBe(expected.trim())
-    expect(result.replacedPackages).toEqual(["@radix-ui/react-dialog", "@radix-ui/react-select"])
+    expect(result.replacedPackages).toEqual([
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-select",
+    ])
   })
 
   it("should not migrate type imports from @radix-ui/react-icons", async () => {
@@ -334,7 +381,10 @@ export type Props = IconProps`
 
     const result = await migrateRadixFile(input)
     expect(result.content.trim()).toBe(expected.trim())
-    expect(result.replacedPackages).toEqual(["@radix-ui/react-dialog", "@radix-ui/react-select"])
+    expect(result.replacedPackages).toEqual([
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-select",
+    ])
   })
 
   it("should handle multi-line imports", async () => {
@@ -358,7 +408,10 @@ export const SelectValue = Value`
 
     const result = await migrateRadixFile(input)
     expect(result.content.trim()).toBe(expected.trim())
-    expect(result.replacedPackages).toEqual(["@radix-ui/react-dialog", "@radix-ui/react-select"])
+    expect(result.replacedPackages).toEqual([
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-select",
+    ])
   })
 
   it("should handle multi-line imports with mixed formatting", async () => {
@@ -379,7 +432,10 @@ export const Select = SelectPrimitive.Root`
 
     const result = await migrateRadixFile(input)
     expect(result.content.trim()).toBe(expected.trim())
-    expect(result.replacedPackages).toEqual(["@radix-ui/react-dialog", "@radix-ui/react-select"])
+    expect(result.replacedPackages).toEqual([
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-select",
+    ])
   })
 
   it("should handle multi-line type imports", async () => {
@@ -400,14 +456,17 @@ export type Props = DialogProps`
 
     const result = await migrateRadixFile(input)
     expect(result.content.trim()).toBe(expected.trim())
-    expect(result.replacedPackages).toEqual(["@radix-ui/react-dialog", "@radix-ui/react-select"])
+    expect(result.replacedPackages).toEqual([
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-select",
+    ])
   })
 
   it("should handle complex multi-line imports with comments and extra whitespace", async () => {
     const input = `import {
   Root,   // Main component
   Trigger,
-  
+
   Content,   // Content component
 } from "@radix-ui/react-dialog"
 
@@ -473,17 +532,17 @@ export const Accordion = AccordionPrimitive.Root
 export const AlertDialog = AlertDialogPrimitive.Root
 export const Button = Slot`
 
-    const expected = `import { Accordion as AccordionPrimitive, AlertDialog as AlertDialogPrimitive, AspectRatio as AspectRatioPrimitive, Avatar as AvatarPrimitive, Slot, Checkbox as CheckboxPrimitive, Collapsible as CollapsiblePrimitive, ContextMenu as ContextMenuPrimitive, Dialog as DialogPrimitive, DropdownMenu as DropdownMenuPrimitive, HoverCard as HoverCardPrimitive, Label as LabelPrimitive, Menubar as MenubarPrimitive, NavigationMenu as NavigationMenuPrimitive, Popover as PopoverPrimitive, Progress as ProgressPrimitive, RadioGroup as RadioGroupPrimitive, ScrollArea as ScrollAreaPrimitive, Select as SelectPrimitive, Separator as SeparatorPrimitive, Slider as SliderPrimitive, Switch as SwitchPrimitive, Tabs as TabsPrimitive, Toggle as TogglePrimitive, ToggleGroup as ToggleGroupPrimitive, Tooltip as TooltipPrimitive } from "radix-ui";
+    const expected = `import { Accordion as AccordionPrimitive, AlertDialog as AlertDialogPrimitive, AspectRatio as AspectRatioPrimitive, Avatar as AvatarPrimitive, Slot as SlotPrimitive, Checkbox as CheckboxPrimitive, Collapsible as CollapsiblePrimitive, ContextMenu as ContextMenuPrimitive, Dialog as DialogPrimitive, DropdownMenu as DropdownMenuPrimitive, HoverCard as HoverCardPrimitive, Label as LabelPrimitive, Menubar as MenubarPrimitive, NavigationMenu as NavigationMenuPrimitive, Popover as PopoverPrimitive, Progress as ProgressPrimitive, RadioGroup as RadioGroupPrimitive, ScrollArea as ScrollAreaPrimitive, Select as SelectPrimitive, Separator as SeparatorPrimitive, Slider as SliderPrimitive, Switch as SwitchPrimitive, Tabs as TabsPrimitive, Toggle as TogglePrimitive, ToggleGroup as ToggleGroupPrimitive, Tooltip as TooltipPrimitive } from "radix-ui";
 
 export const Accordion = AccordionPrimitive.Root
 export const AlertDialog = AlertDialogPrimitive.Root
-export const Button = Slot`
+export const Button = SlotPrimitive.Slot`
 
     const result = await migrateRadixFile(input)
     expect(result.content.trim()).toBe(expected.trim())
     expect(result.replacedPackages).toEqual([
       "@radix-ui/react-accordion",
-      "@radix-ui/react-alert-dialog", 
+      "@radix-ui/react-alert-dialog",
       "@radix-ui/react-aspect-ratio",
       "@radix-ui/react-avatar",
       "@radix-ui/react-slot",
@@ -507,7 +566,7 @@ export const Button = Slot`
       "@radix-ui/react-tabs",
       "@radix-ui/react-toggle",
       "@radix-ui/react-toggle-group",
-      "@radix-ui/react-tooltip"
+      "@radix-ui/react-tooltip",
     ])
   })
 
@@ -538,21 +597,24 @@ import { Slot } from "@radix-ui/react-slot"
 export const FormLabel = LabelPrimitive.Root
 export const FormControl = Slot`
 
-    const expected = `import { Label as LabelPrimitive, Slot } from "radix-ui";
+    const expected = `import { Label as LabelPrimitive, Slot as SlotPrimitive } from "radix-ui";
 
 export const FormLabel = LabelPrimitive.Root
-export const FormControl = Slot`
+export const FormControl = SlotPrimitive.Slot`
 
     const result = await migrateRadixFile(input)
     expect(result.content.trim()).toBe(expected.trim())
-    expect(result.replacedPackages).toEqual(["@radix-ui/react-label", "@radix-ui/react-slot"])
+    expect(result.replacedPackages).toEqual([
+      "@radix-ui/react-label",
+      "@radix-ui/react-slot",
+    ])
   })
 
   it("should handle all 26 packages used in shadcn/ui registry", async () => {
     // Test that we correctly handle all packages found in the registry analysis
     const allPackages = [
       "@radix-ui/react-accordion",
-      "@radix-ui/react-alert-dialog", 
+      "@radix-ui/react-alert-dialog",
       "@radix-ui/react-aspect-ratio",
       "@radix-ui/react-avatar",
       "@radix-ui/react-checkbox",
@@ -576,37 +638,194 @@ export const FormControl = Slot`
       "@radix-ui/react-tabs",
       "@radix-ui/react-toggle",
       "@radix-ui/react-toggle-group",
-      "@radix-ui/react-tooltip"
+      "@radix-ui/react-tooltip",
     ]
-    
+
     // Create import statements for all packages
-    const imports = allPackages.map(pkg => {
-      const componentName = pkg.replace("@radix-ui/react-", "")
-        .split("-")
-        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
-        .join("")
-      
-      if (pkg === "@radix-ui/react-slot") {
-        return `import { Slot } from "${pkg}"`
-      }
-      return `import * as ${componentName}Primitive from "${pkg}"`
-    }).join("\n")
-    
+    const imports = allPackages
+      .map((pkg) => {
+        const componentName = pkg
+          .replace("@radix-ui/react-", "")
+          .split("-")
+          .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+          .join("")
+
+        if (pkg === "@radix-ui/react-slot") {
+          return `import { Slot } from "${pkg}"`
+        }
+        return `import * as ${componentName}Primitive from "${pkg}"`
+      })
+      .join("\n")
+
     const result = await migrateRadixFile(imports)
-    
+
     // Should contain all 26 packages in replacedPackages
     expect(result.replacedPackages).toHaveLength(26)
     expect(result.replacedPackages.sort()).toEqual(allPackages.sort())
-    
+
     // Should be a single unified import from radix-ui
     expect(result.content).toContain('from "radix-ui";')
     expect(result.content.startsWith("import {")).toBe(true)
-    expect(result.content).toContain("Slot") // Slot should be included as named import
+    expect(result.content).toContain("Slot as SlotPrimitive") // Slot should be aliased as SlotPrimitive
     expect(result.content).toContain("Accordion as AccordionPrimitive") // Namespace should be aliased
-    
+
     // Should have transformed all imports into a single statement
-    const importLines = result.content.split('\n').filter(line => line.includes('import'))
+    const importLines = result.content
+      .split("\n")
+      .filter((line) => line.includes("import"))
     expect(importLines).toHaveLength(1)
+  })
+
+  it("should transform Slot usage in ternary expressions", async () => {
+    const input = `import { Slot } from "@radix-ui/react-slot"
+
+const Button = ({ asChild, children }) => {
+  const Comp = asChild ? Slot : "button"
+  const Element = asChild ? Slot : "div"
+  return <Comp>{children}</Comp>
+}`
+
+    const expected = `import { Slot as SlotPrimitive } from "radix-ui";
+
+const Button = ({ asChild, children }) => {
+  const Comp = asChild ? SlotPrimitive.Slot : "button"
+  const Element = asChild ? SlotPrimitive.Slot : "div"
+  return <Comp>{children}</Comp>
+}`
+
+    const result = await migrateRadixFile(input)
+    expect(result.content.trim()).toBe(expected.trim())
+    expect(result.replacedPackages).toEqual(["@radix-ui/react-slot"])
+  })
+
+  it("should handle Slot usage with different spacing patterns", async () => {
+    const input = `import { Slot } from "@radix-ui/react-slot"
+
+const Button = ({ asChild }) => {
+  const Comp1 = asChild ? Slot : "button"
+  const Comp2 = asChild?Slot:"button"
+  const Comp3 = asChild  ?  Slot  :  "button"
+  return null
+}`
+
+    const expected = `import { Slot as SlotPrimitive } from "radix-ui";
+
+const Button = ({ asChild }) => {
+  const Comp1 = asChild ? SlotPrimitive.Slot : "button"
+  const Comp2 = asChild?SlotPrimitive.Slot:"button"
+  const Comp3 = asChild  ?  SlotPrimitive.Slot  :  "button"
+  return null
+}`
+
+    const result = await migrateRadixFile(input)
+    expect(result.content.trim()).toBe(expected.trim())
+    expect(result.replacedPackages).toEqual(["@radix-ui/react-slot"])
+  })
+
+  it("should handle custom Slot aliases differently", async () => {
+    const input = `import { Slot as SlotComponent } from "@radix-ui/react-slot"
+
+const Button = ({ asChild }) => {
+  const Comp = asChild ? Slot : "button"
+  const Element = asChild ? SlotComponent : "div"
+  return null
+}`
+
+    const expected = `import { Slot as SlotComponent } from "radix-ui";
+
+const Button = ({ asChild }) => {
+  const Comp = asChild ? Slot : "button"
+  const Element = asChild ? SlotComponent : "div"
+  return null
+}`
+
+    const result = await migrateRadixFile(input)
+    expect(result.content.trim()).toBe(expected.trim())
+    expect(result.replacedPackages).toEqual(["@radix-ui/react-slot"])
+  })
+
+  it("should transform all Slot references but preserve string literals", async () => {
+    const input = `import { Slot } from "@radix-ui/react-slot"
+
+const Button = ({ asChild }) => {
+  const SlotName = "Slot"
+  const someSlot = slot
+  const Comp = asChild ? Slot : "button"
+  return <Slot />
+}`
+
+    const expected = `import { Slot as SlotPrimitive } from "radix-ui";
+
+const Button = ({ asChild }) => {
+  const SlotName = "Slot"
+  const someSlot = slot
+  const Comp = asChild ? SlotPrimitive.Slot : "button"
+  return <SlotPrimitive.Slot />
+}`
+
+    const result = await migrateRadixFile(input)
+    expect(result.content.trim()).toBe(expected.trim())
+    expect(result.replacedPackages).toEqual(["@radix-ui/react-slot"])
+  })
+
+  it("should transform React.ComponentProps<typeof Slot>", async () => {
+    const input = `import { Slot } from "@radix-ui/react-slot"
+import React from "react"
+
+type ButtonProps = React.ComponentProps<typeof Slot> & {
+  variant?: string
+}
+
+const Button = ({ asChild, ...props }: ButtonProps) => {
+  const Comp = asChild ? Slot : "button"
+  return <Comp {...props} />
+}`
+
+    const expected = `import { Slot as SlotPrimitive } from "radix-ui";
+import React from "react"
+
+type ButtonProps = React.ComponentProps<typeof SlotPrimitive.Slot> & {
+  variant?: string
+}
+
+const Button = ({ asChild, ...props }: ButtonProps) => {
+  const Comp = asChild ? SlotPrimitive.Slot : "button"
+  return <Comp {...props} />
+}`
+
+    const result = await migrateRadixFile(input)
+    expect(result.content.trim()).toBe(expected.trim())
+    expect(result.replacedPackages).toEqual(["@radix-ui/react-slot"])
+  })
+
+  it("should transform ComponentProps<typeof Slot> without React prefix", async () => {
+    const input = `import { Slot } from "@radix-ui/react-slot"
+import { ComponentProps } from "react"
+
+type ButtonProps = ComponentProps<typeof Slot> & {
+  variant?: string
+}
+
+const Button = ({ asChild, ...props }: ButtonProps) => {
+  const Comp = asChild ? Slot : "button"
+  return <Comp {...props} />
+}`
+
+    const expected = `import { Slot as SlotPrimitive } from "radix-ui";
+import { ComponentProps } from "react"
+
+type ButtonProps = ComponentProps<typeof SlotPrimitive.Slot> & {
+  variant?: string
+}
+
+const Button = ({ asChild, ...props }: ButtonProps) => {
+  const Comp = asChild ? SlotPrimitive.Slot : "button"
+  return <Comp {...props} />
+}`
+
+    const result = await migrateRadixFile(input)
+    expect(result.content.trim()).toBe(expected.trim())
+    expect(result.replacedPackages).toEqual(["@radix-ui/react-slot"])
   })
 })
 
@@ -617,52 +836,58 @@ describe("migrateRadix - package.json updates", () => {
 
   it("should update package.json with Radix dependencies", async () => {
     const mockPackageJson = {
-      name: "test-project", 
+      name: "test-project",
       dependencies: {
-        "react": "^18.0.0",
+        react: "^18.0.0",
         "@radix-ui/react-dialog": "^1.0.0",
         "@radix-ui/react-select": "^1.0.0",
-        "other-package": "^1.0.0"
+        "other-package": "^1.0.0",
       },
       devDependencies: {
-        "@radix-ui/react-toast": "^1.0.0"
-      }
+        "@radix-ui/react-toast": "^1.0.0",
+      },
     }
 
     const expectedPackageJson = {
       name: "test-project",
       dependencies: {
-        "react": "^18.0.0", 
+        react: "^18.0.0",
         "other-package": "^1.0.0",
-        "radix-ui": "latest"
+        "radix-ui": "latest",
       },
       devDependencies: {
-        "@radix-ui/react-toast": "^1.0.0"
-      }
+        "@radix-ui/react-toast": "^1.0.0",
+      },
     }
 
     // Mock package info
     const { getPackageInfo } = await import("@/src/utils/get-package-info")
     vi.mocked(getPackageInfo).mockReturnValue(mockPackageJson)
-    
+
     // Mock file system
     mockFs.writeFile.mockResolvedValue(undefined)
-    
+
     // Mock fast-glob to return files with Radix imports
     const fg = await import("fast-glob")
     vi.mocked(fg.default).mockResolvedValue(["dialog.tsx", "select.tsx"])
-    
+
     // Mock file reads to return content with Radix imports
     mockFs.readFile
-      .mockResolvedValueOnce('import * as DialogPrimitive from "@radix-ui/react-dialog"')
-      .mockResolvedValueOnce('import * as SelectPrimitive from "@radix-ui/react-select"')
-    
+      .mockResolvedValueOnce(
+        'import * as DialogPrimitive from "@radix-ui/react-dialog"'
+      )
+      .mockResolvedValueOnce(
+        'import * as SelectPrimitive from "@radix-ui/react-select"'
+      )
+
     // Mock prompts to confirm migration
     const prompts = await import("prompts")
     vi.mocked(prompts.default).mockResolvedValue({ confirm: true })
-    
+
     // Mock package manager detection
-    const { getPackageManager } = await import("@/src/utils/get-package-manager")
+    const { getPackageManager } = await import(
+      "@/src/utils/get-package-manager"
+    )
     vi.mocked(getPackageManager).mockResolvedValue("npm")
 
     await migrateRadix(mockConfig)
@@ -677,42 +902,49 @@ describe("migrateRadix - package.json updates", () => {
     const mockPackageJson = {
       name: "test-project",
       dependencies: {
-        "react": "^18.0.0",
-        "other-package": "^1.0.0"
-      }
+        react: "^18.0.0",
+        "other-package": "^1.0.0",
+      },
     }
 
     const { getPackageInfo } = await import("@/src/utils/get-package-info")
     vi.mocked(getPackageInfo).mockReturnValue(mockPackageJson)
-    
+
+    const { updateDependencies } = await import(
+      "@/src/utils/updaters/update-dependencies"
+    )
+
     const fg = await import("fast-glob")
     vi.mocked(fg.default).mockResolvedValue(["component.tsx"])
-    
+
     // Mock file read to return content with no Radix imports
     mockFs.readFile.mockResolvedValue('import React from "react"')
-    
+
     const prompts = await import("prompts")
     vi.mocked(prompts.default).mockResolvedValue({ confirm: true })
 
-    await migrateRadix(mockConfig)
+    await migrateRadix(mockConfig as any)
 
     // Should not write the file if no Radix packages found
     expect(mockFs.writeFile).not.toHaveBeenCalledWith(
       "/test-project/package.json",
       expect.any(String)
     )
+
+    // Should not attempt to install dependencies
+    expect(updateDependencies).not.toHaveBeenCalled()
   })
 
   it("should handle missing package.json gracefully", async () => {
     const { getPackageInfo } = await import("@/src/utils/get-package-info")
     vi.mocked(getPackageInfo).mockReturnValue(null)
-    
+
     const fg = await import("fast-glob")
     vi.mocked(fg.default).mockResolvedValue(["component.tsx"])
-    
+
     // Mock file read
     mockFs.readFile.mockResolvedValue('import React from "react"')
-    
+
     const prompts = await import("prompts")
     vi.mocked(prompts.default).mockResolvedValue({ confirm: true })
 
@@ -720,79 +952,87 @@ describe("migrateRadix - package.json updates", () => {
     await expect(migrateRadix(mockConfig)).resolves.not.toThrow()
   })
 
-  it("should show correct install command for different package managers", async () => {
+  it("should automatically install radix-ui dependency", async () => {
     const mockPackageJson = {
-      name: "test-project", 
+      name: "test-project",
       dependencies: {
         "@radix-ui/react-dialog": "^1.0.0",
-      }
+      },
     }
 
     const { getPackageInfo } = await import("@/src/utils/get-package-info")
     vi.mocked(getPackageInfo).mockReturnValue(mockPackageJson)
-    
-    const { getPackageManager } = await import("@/src/utils/get-package-manager")
-    vi.mocked(getPackageManager).mockResolvedValue("pnpm")
-    
-    const { logger } = await import("@/src/utils/logger")
-    
+
+    const { updateDependencies } = await import(
+      "@/src/utils/updaters/update-dependencies"
+    )
+
     mockFs.writeFile.mockResolvedValue(undefined)
-    
+
     const fg = await import("fast-glob")
     vi.mocked(fg.default).mockResolvedValue(["dialog.tsx"])
-    
+
     // Mock file read to return content with Radix imports
-    mockFs.readFile.mockResolvedValue('import * as DialogPrimitive from "@radix-ui/react-dialog"')
-    
+    mockFs.readFile.mockResolvedValue(
+      'import * as DialogPrimitive from "@radix-ui/react-dialog"'
+    )
+
     const prompts = await import("prompts")
     vi.mocked(prompts.default).mockResolvedValue({ confirm: true })
 
     await migrateRadix(mockConfig)
 
-    expect(logger.info).toHaveBeenCalledWith("    pnpm install")
+    expect(updateDependencies).toHaveBeenCalledWith(
+      ["radix-ui"],
+      [],
+      mockConfig,
+      { silent: false }
+    )
   })
 
   it("should only remove packages that were found in source files", async () => {
     const mockPackageJson = {
-      name: "test-project", 
+      name: "test-project",
       dependencies: {
-        "react": "^18.0.0",
+        react: "^18.0.0",
         "@radix-ui/react-dialog": "^1.0.0",
         "@radix-ui/react-select": "^1.0.0",
         "@radix-ui/react-toast": "^1.0.0", // This one is NOT in source files
-        "other-package": "^1.0.0"
-      }
+        "other-package": "^1.0.0",
+      },
     }
 
     const expectedPackageJson = {
       name: "test-project",
       dependencies: {
-        "react": "^18.0.0", 
+        react: "^18.0.0",
         "@radix-ui/react-toast": "^1.0.0", // Should remain since not found in source
         "other-package": "^1.0.0",
-        "radix-ui": "latest"
-      }
+        "radix-ui": "latest",
+      },
     }
 
     const { getPackageInfo } = await import("@/src/utils/get-package-info")
     vi.mocked(getPackageInfo).mockReturnValue(mockPackageJson)
-    
-    const { getPackageManager } = await import("@/src/utils/get-package-manager")
+
+    const { getPackageManager } = await import(
+      "@/src/utils/get-package-manager"
+    )
     vi.mocked(getPackageManager).mockResolvedValue("npm")
-    
+
     mockFs.writeFile.mockResolvedValue(undefined)
-    
+
     // Mock fast-glob to return files with only dialog and select imports
     const fg = await import("fast-glob")
     vi.mocked(fg.default).mockResolvedValue(["dialog.tsx"])
-    
+
     // Mock file read to return content with only dialog and select
     mockFs.readFile.mockResolvedValue(`
       import * as DialogPrimitive from "@radix-ui/react-dialog"
       import * as SelectPrimitive from "@radix-ui/react-select"
       export const Dialog = DialogPrimitive.Root
     `)
-    
+
     const prompts = await import("prompts")
     vi.mocked(prompts.default).mockResolvedValue({ confirm: true })
 
@@ -806,39 +1046,43 @@ describe("migrateRadix - package.json updates", () => {
 
   it("should not remove @radix-ui/react-icons from package.json", async () => {
     const mockPackageJson = {
-      name: "test-project", 
+      name: "test-project",
       dependencies: {
-        "react": "^18.0.0",
+        react: "^18.0.0",
         "@radix-ui/react-dialog": "^1.0.0",
         "@radix-ui/react-icons": "^1.3.0", // Should NOT be removed
-        "other-package": "^1.0.0"
-      }
+        "other-package": "^1.0.0",
+      },
     }
 
     const expectedPackageJson = {
       name: "test-project",
       dependencies: {
-        "react": "^18.0.0", 
+        react: "^18.0.0",
         "@radix-ui/react-icons": "^1.3.0", // Should remain
         "other-package": "^1.0.0",
-        "radix-ui": "latest"
-      }
+        "radix-ui": "latest",
+      },
     }
 
     const { getPackageInfo } = await import("@/src/utils/get-package-info")
     vi.mocked(getPackageInfo).mockReturnValue(mockPackageJson)
-    
-    const { getPackageManager } = await import("@/src/utils/get-package-manager")
+
+    const { getPackageManager } = await import(
+      "@/src/utils/get-package-manager"
+    )
     vi.mocked(getPackageManager).mockResolvedValue("npm")
-    
+
     mockFs.writeFile.mockResolvedValue(undefined)
-    
+
     const fg = await import("fast-glob")
     vi.mocked(fg.default).mockResolvedValue(["dialog.tsx"])
-    
+
     // Mock file read to return content with dialog imports but NOT icons
-    mockFs.readFile.mockResolvedValue('import * as DialogPrimitive from "@radix-ui/react-dialog"')
-    
+    mockFs.readFile.mockResolvedValue(
+      'import * as DialogPrimitive from "@radix-ui/react-dialog"'
+    )
+
     const prompts = await import("prompts")
     vi.mocked(prompts.default).mockResolvedValue({ confirm: true })
 

--- a/packages/shadcn/src/migrations/migrate-radix.ts
+++ b/packages/shadcn/src/migrations/migrate-radix.ts
@@ -1,0 +1,229 @@
+import { randomBytes } from "crypto"
+import { promises as fs } from "fs"
+import { tmpdir } from "os"
+import path from "path"
+import { Config } from "@/src/utils/get-config"
+import { getPackageInfo } from "@/src/utils/get-package-info"
+import { getPackageManager } from "@/src/utils/get-package-manager"
+import { highlighter } from "@/src/utils/highlighter"
+import { logger } from "@/src/utils/logger"
+import { spinner } from "@/src/utils/spinner"
+import fg from "fast-glob"
+import prompts from "prompts"
+import { Project, ScriptKind } from "ts-morph"
+
+export async function migrateRadix(config: Config) {
+  if (!config.resolvedPaths.ui) {
+    throw new Error(
+      "We could not find a valid `ui` path in your `components.json` file. Please ensure you have a valid `ui` path in your `components.json` file."
+    )
+  }
+
+  const uiPath = config.resolvedPaths.ui
+  const files = await fg("**/*.{js,ts,jsx,tsx}", {
+    cwd: uiPath,
+  })
+
+  const { confirm } = await prompts({
+    type: "confirm",
+    name: "confirm",
+    initial: true,
+    message: `We will migrate ${highlighter.info(
+      files.length
+    )} files in ${highlighter.info(
+      `./${path.relative(config.resolvedPaths.cwd, uiPath)}`
+    )} from individual Radix UI packages to the unified ${highlighter.info(
+      "radix-ui"
+    )} package. Continue?`,
+  })
+
+  if (!confirm) {
+    logger.info("Migration cancelled.")
+    process.exit(0)
+  }
+
+  const migrationSpinner = spinner(`Migrating Radix UI imports...`)?.start()
+
+  await Promise.all(
+    files.map(async (file) => {
+      migrationSpinner.text = `Migrating ${file}...`
+
+      const filePath = path.join(uiPath, file)
+      const fileContent = await fs.readFile(filePath, "utf-8")
+
+      const content = await migrateRadixFile(fileContent)
+
+      await fs.writeFile(filePath, content)
+    })
+  )
+
+  migrationSpinner.succeed("Source files migrated.")
+
+  // Update package.json dependencies
+  const packageSpinner = spinner(`Updating package.json...`)?.start()
+
+  try {
+    const packageJson = getPackageInfo(config.resolvedPaths.cwd, false)
+    
+    if (!packageJson) {
+      packageSpinner.fail("Could not read package.json")
+      logger.warn("Could not update package.json. You may need to manually replace @radix-ui/react-* packages with radix-ui")
+      return
+    }
+
+    const radixPackages: string[] = []
+
+    // Check dependencies
+    if (packageJson.dependencies) {
+      for (const [pkg, version] of Object.entries(packageJson.dependencies)) {
+        if (pkg.startsWith("@radix-ui/react-")) {
+          radixPackages.push(pkg)
+          delete packageJson.dependencies[pkg]
+        }
+      }
+    }
+
+    // Check devDependencies
+    if (packageJson.devDependencies) {
+      for (const [pkg, version] of Object.entries(packageJson.devDependencies)) {
+        if (pkg.startsWith("@radix-ui/react-")) {
+          radixPackages.push(pkg)
+          delete packageJson.devDependencies[pkg]
+        }
+      }
+    }
+
+    // Add radix-ui if we found any Radix packages
+    if (radixPackages.length > 0) {
+      if (!packageJson.dependencies) {
+        packageJson.dependencies = {}
+      }
+      packageJson.dependencies["radix-ui"] = "latest"
+
+      const packageJsonPath = path.join(config.resolvedPaths.cwd, "package.json")
+      await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2) + "\n")
+      
+      packageSpinner.succeed(`Updated package.json: removed ${radixPackages.length} Radix packages, added radix-ui`)
+      logger.info(`Removed packages: ${radixPackages.join(", ")}`)
+      
+      // Detect package manager and show appropriate install command
+      const packageManager = await getPackageManager(config.resolvedPaths.cwd)
+      const installCommand = getInstallCommand(packageManager)
+      
+      logger.info("Run your package manager to install the new dependency:")
+      logger.info(`  ${installCommand}`)
+    } else {
+      packageSpinner.succeed("No Radix UI packages found in package.json")
+    }
+  } catch (error) {
+    packageSpinner.fail("Failed to update package.json")
+    logger.warn("Could not update package.json. You may need to manually replace @radix-ui/react-* packages with radix-ui")
+  }
+
+  logger.info("Migration complete!")
+}
+
+function getInstallCommand(packageManager: "yarn" | "pnpm" | "bun" | "npm" | "deno"): string {
+  switch (packageManager) {
+    case "yarn":
+      return "yarn install"
+    case "pnpm":
+      return "pnpm install"
+    case "bun":
+      return "bun install"
+    case "deno":
+      return "deno install"
+    case "npm":
+    default:
+      return "npm install"
+  }
+}
+
+export async function migrateRadixFile(content: string) {
+  const dir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-"))
+  const project = new Project({
+    compilerOptions: {},
+  })
+
+  const tempFile = path.join(
+    dir,
+    `shadcn-radix-${randomBytes(4).toString("hex")}.tsx`
+  )
+  const sourceFile = project.createSourceFile(tempFile, content, {
+    scriptKind: ScriptKind.TSX,
+  })
+
+  const radixImportsToAdd: Array<{ name: string; alias?: string }> = []
+  const radixPackagePattern = /^@radix-ui\/react-(.+)$/
+  let firstRadixImport: any = undefined
+  const radixImportsToRemove: any[] = []
+
+  // First pass: collect all imports and find first Radix import
+  const importDeclarations = sourceFile.getImportDeclarations()
+  for (const importDeclaration of importDeclarations) {
+    const moduleSpecifier = importDeclaration.getModuleSpecifier()?.getText()
+    if (!moduleSpecifier) continue
+
+    const cleanModuleSpecifier = moduleSpecifier.slice(1, -1) // Remove quotes
+    const match = cleanModuleSpecifier.match(radixPackagePattern)
+
+    if (!match) continue
+
+    // Track the first Radix import node
+    if (!firstRadixImport) {
+      firstRadixImport = importDeclaration
+    } else {
+      // All subsequent Radix imports will be removed
+      radixImportsToRemove.push(importDeclaration)
+    }
+
+    const componentName = match[1]
+    
+    // Handle namespace imports like "import * as DialogPrimitive from '@radix-ui/react-dialog'"
+    const namespaceImport = importDeclaration.getNamespaceImport()
+    if (namespaceImport) {
+      const aliasName = namespaceImport.getText()
+      
+      // Map the component name (e.g., "dialog" -> "Dialog", "dropdown-menu" -> "DropdownMenu")
+      const componentImportName = componentName
+        .split('-')
+        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+        .join('')
+      
+      radixImportsToAdd.push({ name: componentImportName, alias: aliasName })
+    }
+
+    // Handle named imports
+    const namedImports = importDeclaration.getNamedImports()
+    if (namedImports && namedImports.length > 0) {
+      for (const namedImport of namedImports) {
+        const importName = namedImport.getName()
+        const alias = namedImport.getAliasNode()?.getText()
+        
+        radixImportsToAdd.push({ name: importName, alias })
+      }
+    }
+  }
+
+  // Second pass: replace imports
+  if (radixImportsToAdd.length > 0 && firstRadixImport) {
+    // Remove duplicates
+    const uniqueImports = radixImportsToAdd.filter((imp, index, self) => 
+      index === self.findIndex(i => i.name === imp.name && i.alias === imp.alias)
+    )
+
+    // Replace the first Radix import with the unified import
+    const importText = `import { ${uniqueImports.map(imp => 
+      imp.alias ? `${imp.name} as ${imp.alias}` : imp.name
+    ).join(', ')} } from "radix-ui";`
+    
+    firstRadixImport.replaceWithText(importText)
+
+    // Remove all other Radix imports
+    for (const imp of radixImportsToRemove) {
+      imp.remove()
+    }
+  }
+
+  return sourceFile.getText()
+}

--- a/packages/shadcn/src/migrations/migrate-radix.ts
+++ b/packages/shadcn/src/migrations/migrate-radix.ts
@@ -2,14 +2,100 @@ import { promises as fs } from "fs"
 import path from "path"
 import { Config } from "@/src/utils/get-config"
 import { getPackageInfo } from "@/src/utils/get-package-info"
-import { getPackageManager } from "@/src/utils/get-package-manager"
 import { highlighter } from "@/src/utils/highlighter"
 import { logger } from "@/src/utils/logger"
 import { spinner } from "@/src/utils/spinner"
+import { updateDependencies } from "@/src/utils/updaters/update-dependencies"
 import fg from "fast-glob"
 import prompts from "prompts"
 
-export async function migrateRadix(config: Config) {
+function toPascalCase(str: string): string {
+  return str
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("")
+}
+
+function processNamedImports(
+  namedImports: string,
+  isTypeOnly: boolean,
+  imports: Array<{ name: string; alias?: string; isType?: boolean }>,
+  packageName: string
+) {
+  // Clean up multi-line imports by removing comments and extra whitespace
+  const cleanedImports = namedImports
+    .replace(/\/\/.*$/gm, "") // Remove single-line comments
+    .replace(/\/\*[\s\S]*?\*\//g, "") // Remove multi-line comments
+    .replace(/\s+/g, " ") // Normalize whitespace
+    .trim()
+
+  const namedImportList = cleanedImports
+    .split(",")
+    .map((imp) => imp.trim())
+    .filter(Boolean)
+
+  for (const imp of namedImportList) {
+    const inlineTypeMatch = imp.match(/^type\s+(\w+)(?:\s+as\s+(\w+))?$/)
+    const aliasMatch = imp.match(/^(\w+)\s+as\s+(\w+)$/)
+
+    if (inlineTypeMatch) {
+      // Inline type: "type DialogProps" or "type DialogProps as Props"
+      const name = inlineTypeMatch[1]
+      const alias = inlineTypeMatch[2]
+      
+      // Special handling for Slot: always alias it as SlotPrimitive
+      if (packageName === "slot" && name === "Slot" && !alias) {
+        imports.push({
+          name: "Slot",
+          alias: "SlotPrimitive",
+          isType: true,
+        })
+      } else {
+        imports.push({
+          name,
+          alias,
+          isType: true,
+        })
+      }
+    } else if (aliasMatch) {
+      // Regular import with alias: "Root as DialogRoot"
+      const name = aliasMatch[1]
+      const alias = aliasMatch[2]
+      
+      // Special handling for Slot: always alias it as SlotPrimitive
+      if (packageName === "slot" && name === "Slot" && alias === "Slot") {
+        imports.push({
+          name: "Slot",
+          alias: "SlotPrimitive",
+          isType: isTypeOnly,
+        })
+      } else {
+        imports.push({
+          name,
+          alias,
+          isType: isTypeOnly,
+        })
+      }
+    } else {
+      // Simple import: "Root"
+      // Special handling for Slot: always alias it as SlotPrimitive
+      if (packageName === "slot" && imp === "Slot") {
+        imports.push({
+          name: "Slot",
+          alias: "SlotPrimitive",
+          isType: isTypeOnly,
+        })
+      } else {
+        imports.push({
+          name: imp,
+          isType: isTypeOnly,
+        })
+      }
+    }
+  }
+}
+
+export async function migrateRadix(config: Config, options: { yes?: boolean } = {}) {
   if (!config.resolvedPaths.ui) {
     throw new Error(
       "We could not find a valid `ui` path in your `components.json` file. Please ensure you have a valid `ui` path in your `components.json` file."
@@ -21,20 +107,22 @@ export async function migrateRadix(config: Config) {
     cwd: uiPath,
   })
 
-  const { confirm } = await prompts({
-    type: "confirm",
-    name: "confirm",
-    initial: true,
-    message: `We will migrate ${highlighter.info(
-      files.length
-    )} files in ${highlighter.info(
-      `./${path.relative(config.resolvedPaths.cwd, uiPath)}`
-    )} from to ${highlighter.info("radix-ui")}. Continue?`,
-  })
+  if (!options.yes) {
+    const { confirm } = await prompts({
+      type: "confirm",
+      name: "confirm",
+      initial: true,
+      message: `We will migrate ${highlighter.info(
+        files.length
+      )} files in ${highlighter.info(
+        `./${path.relative(config.resolvedPaths.cwd, uiPath)}`
+      )} to ${highlighter.info("radix-ui")}. Continue?`,
+    })
 
-  if (!confirm) {
-    logger.info("Migration cancelled.")
-    process.exit(0)
+    if (!confirm) {
+      logger.info("Migration cancelled.")
+      process.exit(0)
+    }
   }
 
   const migrationSpinner = spinner(`Migrating imports...`)?.start()
@@ -72,26 +160,16 @@ export async function migrateRadix(config: Config) {
       return
     }
 
-    const removedPackages: string[] = []
     const foundPackagesArray = Array.from(foundPackages)
 
-    // Only remove packages that we actually found in source files
-    // Check dependencies
-    if (packageJson.dependencies) {
-      for (const pkg of foundPackagesArray) {
-        if (packageJson.dependencies[pkg]) {
-          removedPackages.push(pkg)
-          delete packageJson.dependencies[pkg]
-        }
-      }
-    }
-
-    // Check devDependencies
-    if (packageJson.devDependencies) {
-      for (const pkg of foundPackagesArray) {
-        if (packageJson.devDependencies[pkg]) {
-          removedPackages.push(pkg)
-          delete packageJson.devDependencies[pkg]
+    // Remove packages from both dependencies and devDependencies if found in source files
+    const dependencyTypes = ["dependencies", "devDependencies"] as const
+    for (const depType of dependencyTypes) {
+      if (packageJson[depType]) {
+        for (const pkg of foundPackagesArray) {
+          if (packageJson[depType]![pkg]) {
+            delete packageJson[depType]![pkg]
+          }
         }
       }
     }
@@ -114,40 +192,16 @@ export async function migrateRadix(config: Config) {
 
       packageSpinner.succeed(`Updated package.json.`)
 
-      // Detect package manager and show appropriate install command
-      const packageManager = await getPackageManager(config.resolvedPaths.cwd)
-      const installCommand = getInstallCommand(packageManager)
-
-      logger.break()
-      logger.info("  Run the following command to install the new dependency:")
-      logger.info(`    ${installCommand}`)
-      logger.break()
+      // Install radix-ui dependency
+      await updateDependencies(["radix-ui"], [], config, { silent: false })
     } else {
       packageSpinner.succeed("No packages found in source files.")
     }
   } catch (error) {
     packageSpinner.fail("Failed to update package.json")
     logger.warn(
-      "Could not update package.json. You may need to manually replace @radix-ui/react-* packages with radix-ui"
+      "You may need to manually replace @radix-ui/react-* packages with radix-ui"
     )
-  }
-}
-
-function getInstallCommand(
-  packageManager: "yarn" | "pnpm" | "bun" | "npm" | "deno"
-): string {
-  switch (packageManager) {
-    case "yarn":
-      return "yarn install"
-    case "pnpm":
-      return "pnpm install"
-    case "bun":
-      return "bun install"
-    case "deno":
-      return "deno install"
-    case "npm":
-    default:
-      return "npm install"
   }
 }
 
@@ -168,13 +222,20 @@ export async function migrateRadixFile(
 
   // Find all Radix imports
   while ((match = radixImportPattern.exec(content)) !== null) {
-    const [fullMatch, typeKeyword, namespaceAlias, namedImports, quote, packageName] = match
-    
+    const [
+      fullMatch,
+      typeKeyword,
+      namespaceAlias,
+      namedImports,
+      quote,
+      packageName,
+    ] = match
+
     // Skip react-icons package and any sub-paths (like react-icons/dist/types)
-    if (packageName === 'icons' || packageName.startsWith('icons/')) {
+    if (packageName === "icons" || packageName.startsWith("icons/")) {
       continue
     }
-    
+
     linesToRemove.push(fullMatch)
 
     // Use the quote style from the first import
@@ -189,52 +250,18 @@ export async function migrateRadixFile(
 
     if (namespaceAlias) {
       // Handle namespace imports: import * as DialogPrimitive from "@radix-ui/react-dialog"
-      // Note: type-only namespace imports are not common, but we'll handle them
-      const componentName = packageName
-        .split("-")
-        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-        .join("")
-
-      imports.push({ name: componentName, alias: namespaceAlias, isType: isTypeOnly })
+      const componentName = toPascalCase(packageName)
+      imports.push({
+        name: componentName,
+        alias: namespaceAlias,
+        isType: isTypeOnly,
+      })
     } else if (namedImports) {
       // Handle named imports: import { Root, Trigger } from "@radix-ui/react-dialog"
       // or import type { DialogProps } from "@radix-ui/react-dialog"
       // or import { type DialogProps, Root } from "@radix-ui/react-dialog"
-      
-      // Clean up multi-line imports by removing comments and extra whitespace
-      const cleanedImports = namedImports
-        .replace(/\/\/.*$/gm, '') // Remove single-line comments
-        .replace(/\/\*[\s\S]*?\*\//g, '') // Remove multi-line comments
-        .replace(/\s+/g, ' ') // Normalize whitespace
-        .trim()
-      
-      const namedImportList = cleanedImports.split(",").map((imp) => imp.trim()).filter(Boolean)
-      for (const imp of namedImportList) {
-        // Check for inline type keyword: "type DialogProps"
-        const inlineTypeMatch = imp.match(/^type\s+(\w+)(?:\s+as\s+(\w+))?$/)
-        if (inlineTypeMatch) {
-          imports.push({ 
-            name: inlineTypeMatch[1], 
-            alias: inlineTypeMatch[2], 
-            isType: true 
-          })
-        } else {
-          // Regular import with possible alias: "Root as DialogRoot"
-          const aliasMatch = imp.match(/^(\w+)\s+as\s+(\w+)$/)
-          if (aliasMatch) {
-            imports.push({ 
-              name: aliasMatch[1], 
-              alias: aliasMatch[2], 
-              isType: isTypeOnly 
-            })
-          } else {
-            imports.push({ 
-              name: imp, 
-              isType: isTypeOnly 
-            })
-          }
-        }
-      }
+
+      processNamedImports(namedImports, isTypeOnly, imports, packageName)
     }
   }
 
@@ -249,39 +276,107 @@ export async function migrateRadixFile(
   const uniqueImports = imports.filter(
     (imp, index, self) =>
       index ===
-      self.findIndex((i) => i.name === imp.name && i.alias === imp.alias && i.isType === imp.isType)
+      self.findIndex(
+        (i) =>
+          i.name === imp.name &&
+          i.alias === imp.alias &&
+          i.isType === imp.isType
+      )
   )
 
   // Create the unified import with preserved quote style and type annotations
   const importList = uniqueImports
     .map((imp) => {
       const typePrefix = imp.isType ? "type " : ""
-      if (imp.alias) {
-        return `${typePrefix}${imp.name} as ${imp.alias}`
-      } else {
-        return `${typePrefix}${imp.name}`
-      }
+      return imp.alias
+        ? `${typePrefix}${imp.name} as ${imp.alias}`
+        : `${typePrefix}${imp.name}`
     })
     .join(", ")
 
   const unifiedImport = `import { ${importList} } from ${quoteStyle}radix-ui${quoteStyle};`
 
-  // Remove all Radix imports and replace the first one with unified import
-  for (let i = 0; i < linesToRemove.length; i++) {
-    if (i === 0) {
-      // Replace first import with unified import
-      result = result.replace(linesToRemove[i], unifiedImport)
-    } else {
-      // Remove subsequent imports
-      result = result.replace(linesToRemove[i], "")
-    }
-  }
+  // Replace first import with unified import, remove the rest
+  result = linesToRemove.reduce((acc, line, index) => {
+    return acc.replace(line, index === 0 ? unifiedImport : "")
+  }, result)
 
   // Clean up extra blank lines
   result = result.replace(/\n\s*\n\s*\n/g, "\n\n")
 
+  // Handle special case for Slot usage transformation
+  // Now that we import { Slot as SlotPrimitive }, we need to:
+  // 1. Transform: const Comp = asChild ? Slot : [ANYTHING] -> const Comp = asChild ? SlotPrimitive.Slot : [ANYTHING]
+  // 2. Transform: React.ComponentProps<typeof Slot> -> React.ComponentProps<typeof SlotPrimitive.Slot>
+  const hasSlotImport = uniqueImports.some(imp => imp.name === "Slot" && imp.alias === "SlotPrimitive")
+  
+  if (hasSlotImport) {
+    // Find all lines that are NOT import lines to avoid transforming the import statement itself
+    const lines = result.split('\n')
+    const transformedLines = lines.map(line => {
+      // Skip import lines
+      if (line.trim().startsWith('import ')) {
+        return line
+      }
+      
+      let transformedLine = line
+      
+      // Handle all Slot references in one comprehensive pass
+      // Use placeholders to avoid double replacements
+      
+      // First, mark specific patterns with placeholders
+      transformedLine = transformedLine.replace(
+        /\b(asChild\s*\?\s*)Slot(\s*:)/g,
+        "$1__SLOT_PLACEHOLDER__$2"
+      )
+      
+      transformedLine = transformedLine.replace(
+        /\bReact\.ComponentProps<typeof\s+Slot>/g,
+        "React.ComponentProps<typeof __SLOT_PLACEHOLDER__>"
+      )
+      
+      transformedLine = transformedLine.replace(
+        /\bComponentProps<typeof\s+Slot>/g,
+        "ComponentProps<typeof __SLOT_PLACEHOLDER__>"
+      )
+      
+      transformedLine = transformedLine.replace(
+        /(<\/?)Slot(\s*\/?>)/g,
+        "$1__SLOT_PLACEHOLDER__$2"
+      )
+      
+      // Handle any other standalone Slot usage
+      transformedLine = transformedLine.replace(
+        /\bSlot\b/g,
+        (match, offset, string) => {
+          // Don't transform if it's inside quotes
+          const beforeMatch = string.substring(0, offset)
+          const openQuotes = (beforeMatch.match(/"/g) || []).length
+          const openSingleQuotes = (beforeMatch.match(/'/g) || []).length
+          
+          // If we're inside quotes, don't transform
+          if (openQuotes % 2 !== 0 || openSingleQuotes % 2 !== 0) {
+            return match
+          }
+          
+          return "__SLOT_PLACEHOLDER__"
+        }
+      )
+      
+      // Finally, replace all placeholders with SlotPrimitive.Slot
+      transformedLine = transformedLine.replace(
+        /__SLOT_PLACEHOLDER__/g,
+        "SlotPrimitive.Slot"
+      )
+      
+      return transformedLine
+    })
+    
+    result = transformedLines.join('\n')
+  }
+
   // Remove duplicate packages
-  const uniqueReplacedPackages = [...new Set(replacedPackages)]
+  const uniqueReplacedPackages = Array.from(new Set(replacedPackages))
 
   return {
     content: result,

--- a/packages/shadcn/src/migrations/migrate-radix.ts
+++ b/packages/shadcn/src/migrations/migrate-radix.ts
@@ -1,6 +1,4 @@
-import { randomBytes } from "crypto"
 import { promises as fs } from "fs"
-import { tmpdir } from "os"
 import path from "path"
 import { Config } from "@/src/utils/get-config"
 import { getPackageInfo } from "@/src/utils/get-package-info"
@@ -10,7 +8,6 @@ import { logger } from "@/src/utils/logger"
 import { spinner } from "@/src/utils/spinner"
 import fg from "fast-glob"
 import prompts from "prompts"
-import { Project, ScriptKind } from "ts-morph"
 
 export async function migrateRadix(config: Config) {
   if (!config.resolvedPaths.ui) {
@@ -32,9 +29,7 @@ export async function migrateRadix(config: Config) {
       files.length
     )} files in ${highlighter.info(
       `./${path.relative(config.resolvedPaths.cwd, uiPath)}`
-    )} from individual Radix UI packages to the unified ${highlighter.info(
-      "radix-ui"
-    )} package. Continue?`,
+    )} from to ${highlighter.info("radix-ui")}. Continue?`,
   })
 
   if (!confirm) {
@@ -42,7 +37,8 @@ export async function migrateRadix(config: Config) {
     process.exit(0)
   }
 
-  const migrationSpinner = spinner(`Migrating Radix UI imports...`)?.start()
+  const migrationSpinner = spinner(`Migrating imports...`)?.start()
+  const foundPackages = new Set<string>()
 
   await Promise.all(
     files.map(async (file) => {
@@ -51,33 +47,40 @@ export async function migrateRadix(config: Config) {
       const filePath = path.join(uiPath, file)
       const fileContent = await fs.readFile(filePath, "utf-8")
 
-      const content = await migrateRadixFile(fileContent)
+      const { content, replacedPackages } = await migrateRadixFile(fileContent)
+
+      // Track which packages we found
+      replacedPackages.forEach((pkg) => foundPackages.add(pkg))
 
       await fs.writeFile(filePath, content)
     })
   )
 
-  migrationSpinner.succeed("Source files migrated.")
+  migrationSpinner.succeed("Migrating imports.")
 
   // Update package.json dependencies
   const packageSpinner = spinner(`Updating package.json...`)?.start()
 
   try {
     const packageJson = getPackageInfo(config.resolvedPaths.cwd, false)
-    
+
     if (!packageJson) {
       packageSpinner.fail("Could not read package.json")
-      logger.warn("Could not update package.json. You may need to manually replace @radix-ui/react-* packages with radix-ui")
+      logger.warn(
+        "Could not update package.json. You may need to manually replace @radix-ui/react-* packages with radix-ui"
+      )
       return
     }
 
-    const radixPackages: string[] = []
+    const removedPackages: string[] = []
+    const foundPackagesArray = Array.from(foundPackages)
 
+    // Only remove packages that we actually found in source files
     // Check dependencies
     if (packageJson.dependencies) {
-      for (const [pkg, version] of Object.entries(packageJson.dependencies)) {
-        if (pkg.startsWith("@radix-ui/react-")) {
-          radixPackages.push(pkg)
+      for (const pkg of foundPackagesArray) {
+        if (packageJson.dependencies[pkg]) {
+          removedPackages.push(pkg)
           delete packageJson.dependencies[pkg]
         }
       }
@@ -85,45 +88,54 @@ export async function migrateRadix(config: Config) {
 
     // Check devDependencies
     if (packageJson.devDependencies) {
-      for (const [pkg, version] of Object.entries(packageJson.devDependencies)) {
-        if (pkg.startsWith("@radix-ui/react-")) {
-          radixPackages.push(pkg)
+      for (const pkg of foundPackagesArray) {
+        if (packageJson.devDependencies[pkg]) {
+          removedPackages.push(pkg)
           delete packageJson.devDependencies[pkg]
         }
       }
     }
 
     // Add radix-ui if we found any Radix packages
-    if (radixPackages.length > 0) {
+    if (foundPackagesArray.length > 0) {
       if (!packageJson.dependencies) {
         packageJson.dependencies = {}
       }
       packageJson.dependencies["radix-ui"] = "latest"
 
-      const packageJsonPath = path.join(config.resolvedPaths.cwd, "package.json")
-      await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2) + "\n")
-      
-      packageSpinner.succeed(`Updated package.json: removed ${radixPackages.length} Radix packages, added radix-ui`)
-      logger.info(`Removed packages: ${radixPackages.join(", ")}`)
-      
+      const packageJsonPath = path.join(
+        config.resolvedPaths.cwd,
+        "package.json"
+      )
+      await fs.writeFile(
+        packageJsonPath,
+        JSON.stringify(packageJson, null, 2) + "\n"
+      )
+
+      packageSpinner.succeed(`Updated package.json.`)
+
       // Detect package manager and show appropriate install command
       const packageManager = await getPackageManager(config.resolvedPaths.cwd)
       const installCommand = getInstallCommand(packageManager)
-      
-      logger.info("Run your package manager to install the new dependency:")
-      logger.info(`  ${installCommand}`)
+
+      logger.break()
+      logger.info("  Run the following command to install the new dependency:")
+      logger.info(`    ${installCommand}`)
+      logger.break()
     } else {
-      packageSpinner.succeed("No Radix UI packages found in package.json")
+      packageSpinner.succeed("No packages found in source files.")
     }
   } catch (error) {
     packageSpinner.fail("Failed to update package.json")
-    logger.warn("Could not update package.json. You may need to manually replace @radix-ui/react-* packages with radix-ui")
+    logger.warn(
+      "Could not update package.json. You may need to manually replace @radix-ui/react-* packages with radix-ui"
+    )
   }
-
-  logger.info("Migration complete!")
 }
 
-function getInstallCommand(packageManager: "yarn" | "pnpm" | "bun" | "npm" | "deno"): string {
+function getInstallCommand(
+  packageManager: "yarn" | "pnpm" | "bun" | "npm" | "deno"
+): string {
   switch (packageManager) {
     case "yarn":
       return "yarn install"
@@ -139,91 +151,140 @@ function getInstallCommand(packageManager: "yarn" | "pnpm" | "bun" | "npm" | "de
   }
 }
 
-export async function migrateRadixFile(content: string) {
-  const dir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-"))
-  const project = new Project({
-    compilerOptions: {},
-  })
+export async function migrateRadixFile(
+  content: string
+): Promise<{ content: string; replacedPackages: string[] }> {
+  // Enhanced regex to handle type-only imports, but exclude react-icons
+  const radixImportPattern =
+    /import\s+(?:(type)\s+)?(?:\*\s+as\s+(\w+)|{([^}]+)})\s+from\s+(["'])@radix-ui\/react-([^"']+)\4/g
 
-  const tempFile = path.join(
-    dir,
-    `shadcn-radix-${randomBytes(4).toString("hex")}.tsx`
-  )
-  const sourceFile = project.createSourceFile(tempFile, content, {
-    scriptKind: ScriptKind.TSX,
-  })
+  const imports: Array<{ name: string; alias?: string; isType?: boolean }> = []
+  const linesToRemove: string[] = []
+  const replacedPackages: string[] = []
+  let quoteStyle = '"' // Default to double quotes
 
-  const radixImportsToAdd: Array<{ name: string; alias?: string }> = []
-  const radixPackagePattern = /^@radix-ui\/react-(.+)$/
-  let firstRadixImport: any = undefined
-  const radixImportsToRemove: any[] = []
+  let result = content
+  let match
 
-  // First pass: collect all imports and find first Radix import
-  const importDeclarations = sourceFile.getImportDeclarations()
-  for (const importDeclaration of importDeclarations) {
-    const moduleSpecifier = importDeclaration.getModuleSpecifier()?.getText()
-    if (!moduleSpecifier) continue
-
-    const cleanModuleSpecifier = moduleSpecifier.slice(1, -1) // Remove quotes
-    const match = cleanModuleSpecifier.match(radixPackagePattern)
-
-    if (!match) continue
-
-    // Track the first Radix import node
-    if (!firstRadixImport) {
-      firstRadixImport = importDeclaration
-    } else {
-      // All subsequent Radix imports will be removed
-      radixImportsToRemove.push(importDeclaration)
-    }
-
-    const componentName = match[1]
+  // Find all Radix imports
+  while ((match = radixImportPattern.exec(content)) !== null) {
+    const [fullMatch, typeKeyword, namespaceAlias, namedImports, quote, packageName] = match
     
-    // Handle namespace imports like "import * as DialogPrimitive from '@radix-ui/react-dialog'"
-    const namespaceImport = importDeclaration.getNamespaceImport()
-    if (namespaceImport) {
-      const aliasName = namespaceImport.getText()
-      
-      // Map the component name (e.g., "dialog" -> "Dialog", "dropdown-menu" -> "DropdownMenu")
-      const componentImportName = componentName
-        .split('-')
-        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
-        .join('')
-      
-      radixImportsToAdd.push({ name: componentImportName, alias: aliasName })
+    // Skip react-icons package and any sub-paths (like react-icons/dist/types)
+    if (packageName === 'icons' || packageName.startsWith('icons/')) {
+      continue
+    }
+    
+    linesToRemove.push(fullMatch)
+
+    // Use the quote style from the first import
+    if (linesToRemove.length === 1) {
+      quoteStyle = quote
     }
 
-    // Handle named imports
-    const namedImports = importDeclaration.getNamedImports()
-    if (namedImports && namedImports.length > 0) {
-      for (const namedImport of namedImports) {
-        const importName = namedImport.getName()
-        const alias = namedImport.getAliasNode()?.getText()
-        
-        radixImportsToAdd.push({ name: importName, alias })
+    // Track which package we're replacing
+    replacedPackages.push(`@radix-ui/react-${packageName}`)
+
+    const isTypeOnly = Boolean(typeKeyword)
+
+    if (namespaceAlias) {
+      // Handle namespace imports: import * as DialogPrimitive from "@radix-ui/react-dialog"
+      // Note: type-only namespace imports are not common, but we'll handle them
+      const componentName = packageName
+        .split("-")
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join("")
+
+      imports.push({ name: componentName, alias: namespaceAlias, isType: isTypeOnly })
+    } else if (namedImports) {
+      // Handle named imports: import { Root, Trigger } from "@radix-ui/react-dialog"
+      // or import type { DialogProps } from "@radix-ui/react-dialog"
+      // or import { type DialogProps, Root } from "@radix-ui/react-dialog"
+      
+      // Clean up multi-line imports by removing comments and extra whitespace
+      const cleanedImports = namedImports
+        .replace(/\/\/.*$/gm, '') // Remove single-line comments
+        .replace(/\/\*[\s\S]*?\*\//g, '') // Remove multi-line comments
+        .replace(/\s+/g, ' ') // Normalize whitespace
+        .trim()
+      
+      const namedImportList = cleanedImports.split(",").map((imp) => imp.trim()).filter(Boolean)
+      for (const imp of namedImportList) {
+        // Check for inline type keyword: "type DialogProps"
+        const inlineTypeMatch = imp.match(/^type\s+(\w+)(?:\s+as\s+(\w+))?$/)
+        if (inlineTypeMatch) {
+          imports.push({ 
+            name: inlineTypeMatch[1], 
+            alias: inlineTypeMatch[2], 
+            isType: true 
+          })
+        } else {
+          // Regular import with possible alias: "Root as DialogRoot"
+          const aliasMatch = imp.match(/^(\w+)\s+as\s+(\w+)$/)
+          if (aliasMatch) {
+            imports.push({ 
+              name: aliasMatch[1], 
+              alias: aliasMatch[2], 
+              isType: isTypeOnly 
+            })
+          } else {
+            imports.push({ 
+              name: imp, 
+              isType: isTypeOnly 
+            })
+          }
+        }
       }
     }
   }
 
-  // Second pass: replace imports
-  if (radixImportsToAdd.length > 0 && firstRadixImport) {
-    // Remove duplicates
-    const uniqueImports = radixImportsToAdd.filter((imp, index, self) => 
-      index === self.findIndex(i => i.name === imp.name && i.alias === imp.alias)
-    )
-
-    // Replace the first Radix import with the unified import
-    const importText = `import { ${uniqueImports.map(imp => 
-      imp.alias ? `${imp.name} as ${imp.alias}` : imp.name
-    ).join(', ')} } from "radix-ui";`
-    
-    firstRadixImport.replaceWithText(importText)
-
-    // Remove all other Radix imports
-    for (const imp of radixImportsToRemove) {
-      imp.remove()
+  if (imports.length === 0) {
+    return {
+      content,
+      replacedPackages: [],
     }
   }
 
-  return sourceFile.getText()
+  // Remove duplicates (considering name, alias, and type status)
+  const uniqueImports = imports.filter(
+    (imp, index, self) =>
+      index ===
+      self.findIndex((i) => i.name === imp.name && i.alias === imp.alias && i.isType === imp.isType)
+  )
+
+  // Create the unified import with preserved quote style and type annotations
+  const importList = uniqueImports
+    .map((imp) => {
+      const typePrefix = imp.isType ? "type " : ""
+      if (imp.alias) {
+        return `${typePrefix}${imp.name} as ${imp.alias}`
+      } else {
+        return `${typePrefix}${imp.name}`
+      }
+    })
+    .join(", ")
+
+  const unifiedImport = `import { ${importList} } from ${quoteStyle}radix-ui${quoteStyle};`
+
+  // Remove all Radix imports and replace the first one with unified import
+  for (let i = 0; i < linesToRemove.length; i++) {
+    if (i === 0) {
+      // Replace first import with unified import
+      result = result.replace(linesToRemove[i], unifiedImport)
+    } else {
+      // Remove subsequent imports
+      result = result.replace(linesToRemove[i], "")
+    }
+  }
+
+  // Clean up extra blank lines
+  result = result.replace(/\n\s*\n\s*\n/g, "\n\n")
+
+  // Remove duplicate packages
+  const uniqueReplacedPackages = [...new Set(replacedPackages)]
+
+  return {
+    content: result,
+    replacedPackages: uniqueReplacedPackages,
+  }
 }


### PR DESCRIPTION
This adds a new `npx shadcn@latest migrate radix` command to migrate all `@radix-ui/react-*` imports and dependencies to `radix-ui`.