### PR TITLE
Update vite.mdx to fix dark mode toggle code

### DIFF
--- a/apps/www/content/docs/dark-mode/vite.mdx
+++ b/apps/www/content/docs/dark-mode/vite.mdx
@@ -54,10 +54,12 @@ export function ThemeProvider({
         : "light"
 
       root.classList.add(systemTheme)
+      root.style.colorScheme = systemTheme
       return
     }
 
     root.classList.add(theme)
+    root.style.colorScheme = theme
   }, [theme])
 
   const value = {


### PR DESCRIPTION
The dark mode toggle code snippet for vite isn't working due to missing document style update.