### PR TITLE
chore(vscode): configure Tailwind IntelliSense for monorepo UI

### DIFF
--- a/templates/monorepo-next/.vscode/settings.json
+++ b/templates/monorepo-next/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "tailwindCSS.experimental.configFile": "packages/ui/src/styles/globals.css"
+}


### PR DESCRIPTION
Fixes an issue where Tailwind CSS IntelliSense wouldn't work in app folders (`/apps/web`, etc.) when using the default `shadcn/turborepo` setup.

By default, the VS Code Tailwind extension only detects the config inside `packages/ui`, causing class suggestions to fail in other packages.
This PR adds a `.vscode/settings.json` file that explicitly points to the correct config file:

```json
{
  "tailwindCSS.experimental.configFile": "packages/ui/src/styles/globals.css"
}
```

### Context

I raised the issue here on Twitter:
🔗 [https://x.com/steellgold/status/1934295365760512388](https://x.com/steellgold/status/1934295365760512388)

It was solved thanks to this suggestion:
💡 [https://x.com/Mahmut\_Jomaa/status/1934316610719830421](https://x.com/Mahmut_Jomaa/status/1934316610719830421)