### PR TITLE
feat(componets): Add a display formatting option for chart values

### DIFF
--- a/apps/www/registry/default/ui/chart.tsx
+++ b/apps/www/registry/default/ui/chart.tsx
@@ -111,6 +111,7 @@ const ChartTooltipContent = React.forwardRef<
       indicator?: "line" | "dot" | "dashed"
       nameKey?: string
       labelKey?: string
+      valueFormatter?: (value: string) => string
     }
 >(
   (
@@ -128,6 +129,7 @@ const ChartTooltipContent = React.forwardRef<
       color,
       nameKey,
       labelKey,
+      valueFormatter,
     },
     ref
   ) => {
@@ -240,7 +242,9 @@ const ChartTooltipContent = React.forwardRef<
                       </div>
                       {item.value && (
                         <span className="font-mono font-medium tabular-nums text-foreground">
-                          {item.value.toLocaleString()}
+                          {valueFormatter
+                            ? valueFormatter(item.value.toString())
+                            : item.value.toLocaleString()}
                         </span>
                       )}
                     </div>

--- a/apps/www/registry/new-york/ui/chart.tsx
+++ b/apps/www/registry/new-york/ui/chart.tsx
@@ -111,6 +111,7 @@ const ChartTooltipContent = React.forwardRef<
       indicator?: "line" | "dot" | "dashed"
       nameKey?: string
       labelKey?: string
+      valueFormatter?: (value: string) => string
     }
 >(
   (
@@ -128,6 +129,7 @@ const ChartTooltipContent = React.forwardRef<
       color,
       nameKey,
       labelKey,
+      valueFormatter,
     },
     ref
   ) => {
@@ -240,7 +242,9 @@ const ChartTooltipContent = React.forwardRef<
                       </div>
                       {item.value && (
                         <span className="font-mono font-medium tabular-nums text-foreground">
-                          {item.value.toLocaleString()}
+                          {valueFormatter
+                            ? valueFormatter(item.value.toString())
+                            : item.value.toLocaleString()}
                         </span>
                       )}
                     </div>


### PR DESCRIPTION
I want to display custom formated value in the chart, but I see there no option aviable for that in the original components. So why not litle helper to able format the value without change the original data source.

### feat(charts): Add custom value formatter

This pull request introduces a `valueFormatter` prop to the chart components, allowing for flexible and powerful customization of how data is presented.

#### The Problem

Currently, there is no built-in way to format the values displayed within charts (e.g., in tooltips or as labels) without altering the original data source. For example, to display a raw number like `5000` as a currency string `$5,000`, the data itself would need to be modified before being passed to the component. This mixes data with presentation logic and is not ideal.

#### The Solution

This PR adds a `valueFormatter` prop that accepts a function with the signature `(value: string) => string`. This function is then used by the chart to format any value it displays.

This approach provides a clean separation between data and view logic, enabling developers to easily format numbers into currency, percentages, or any other custom format without mutating the source data.

#### Example Usage

Here's how you could format values as USD:

```tsx
<BarChart
  data={data}
  index="month"
  categories={["Sales"]}
  valueFormatter={(value) => `$${new Intl.NumberFormat('en-US').format(value).toString()}`}
/>
```

This enhancement significantly improves the flexibility of the chart components and the overall developer experience when working with data visualization.