### PR TITLE
docs(CONTRIBUTING): update references from `shadcn-ui` to `shadcn`in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ packages
 | `apps/www/components` | The React components for the website.    |
 | `apps/www/content`    | The content for the website.             |
 | `apps/www/registry`   | The registry for the components.         |
-| `packages/cli`        | The `shadcn-ui` package.                 |
+| `packages/cli`        | The `shadcn` package.                    |
 
 ## Development
 
@@ -85,10 +85,10 @@ You can use the `pnpm --filter=[WORKSPACE]` command to start the development pro
 pnpm --filter=www dev
 ```
 
-2. To run the `shadcn-ui` package:
+2. To run the `shadcn` package:
 
 ```bash
-pnpm --filter=shadcn-ui dev
+pnpm --filter=shadcn dev
 ```
 
 ## Running the CLI Locally
@@ -196,7 +196,7 @@ If you have a request for a new component, please open a discussion on GitHub. W
 
 ## CLI
 
-The `shadcn-ui` package is a CLI for adding components to your project. You can find the documentation for the CLI [here](https://ui.shadcn.com/docs/cli).
+The `shadcn` package is a CLI for adding components to your project. You can find the documentation for the CLI [here](https://ui.shadcn.com/docs/cli).
 
 Any changes to the CLI should be made in the `packages/cli` directory. If you can, it would be great if you could add tests for your changes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ packages
 | `apps/www/components` | The React components for the website.    |
 | `apps/www/content`    | The content for the website.             |
 | `apps/www/registry`   | The registry for the components.         |
-| `packages/cli`        | The `shadcn` package.                    |
+| `packages/shadcn`     | The `shadcn` package.                    |
 
 ## Development
 
@@ -88,7 +88,7 @@ pnpm --filter=www dev
 2. To run the `shadcn` package:
 
 ```bash
-pnpm --filter=shadcn dev
+pnpm shadcn:dev
 ```
 
 ## Running the CLI Locally
@@ -198,7 +198,7 @@ If you have a request for a new component, please open a discussion on GitHub. W
 
 The `shadcn` package is a CLI for adding components to your project. You can find the documentation for the CLI [here](https://ui.shadcn.com/docs/cli).
 
-Any changes to the CLI should be made in the `packages/cli` directory. If you can, it would be great if you could add tests for your changes.
+Any changes to the CLI should be made in the `packages/shadcn` directory. If you can, it would be great if you could add tests for your changes.
 
 ## Testing
 


### PR DESCRIPTION
Hi! I was following the contribution guide, but I think some scripts aren't working properly maybe because the shadcn-ui package is missing from the packages folder.