### PR TITLE
feat: added some changes to ui component sonner

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/sonner.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sonner.tsx
@@ -1,25 +1,26 @@
 "use client"
 
 import { useTheme } from "next-themes"
-import { Toaster as Sonner, ToasterProps } from "sonner"
+import { Toaster as Sonner, toast } from "sonner";
 
-const Toaster = ({ ...props }: ToasterProps) => {
+const Toaster = ({
+  ...props
+}) => {
   const { theme = "system" } = useTheme()
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme={theme}
       className="toaster group"
       style={
         {
           "--normal-bg": "var(--popover)",
           "--normal-text": "var(--popover-foreground)",
-          "--normal-border": "var(--border)",
-        } as React.CSSProperties
+          "--normal-border": "var(--border)"
+        }
       }
-      {...props}
-    />
-  )
+      {...props} />
+  );
 }
 
-export { Toaster }
+export { Toaster, toast }

--- a/apps/www/registry/default/ui/sonner.tsx
+++ b/apps/www/registry/default/ui/sonner.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useTheme } from "next-themes"
-import { Toaster as Sonner } from "sonner"
+import { Toaster as Sonner, toast } from "sonner"
 
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
@@ -28,4 +28,4 @@ const Toaster = ({ ...props }: ToasterProps) => {
   )
 }
 
-export { Toaster }
+export { Toaster, toast }

--- a/apps/www/registry/new-york/ui/sonner.tsx
+++ b/apps/www/registry/new-york/ui/sonner.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useTheme } from "next-themes"
-import { Toaster as Sonner } from "sonner"
+import { Toaster as Sonner, toast } from "sonner"
 
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
@@ -28,4 +28,4 @@ const Toaster = ({ ...props }: ToasterProps) => {
   )
 }
 
-export { Toaster }
+export { Toaster, toast }


### PR DESCRIPTION
### **Explanation of Changes for Sonner Module**

I've addressed an **"Export toast doesn't exist in target module"** error encountered when attempting to use the `toast` function from `@/components/ui/sonner` in components outside of `layout.js`.

The `shadcn/ui` generated `sonner.tsx` module previously only re-exported `Toaster`. To resolve this, I've updated the module to explicitly re-export the `toast` function from the underlying `sonner` library.

Specifically, I changed the import and export lines in `components/ui/sonner.tsx`:

- **Import:** `import { Toaster as Sonner } from "sonner"; to import { Toaster as Sonner, toast } from "sonner";`
- **Export:** `export { Toaster } to export { Toaster, toast }`

This change ensures that both `Toaster` (for the root layout) and `toast` (for triggering notifications from any client component) are correctly available when imported from `@/components/ui/sonner`, allowing existing and future usages to work seamlessly.