### PR TITLE
fix(components): changed input component placeholder text color a little lighter

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/input.tsx
+++ b/apps/v4/registry/new-york-v4/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-neutral-400 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className


### PR DESCRIPTION
The PR Closes #7565 

the placeholder value of input component had too much contrast that showed the placeholder like actual text 
I changed the input class `placeholder:text-muted-foreground` to `placeholder:text-neutral-400` cause the value `text-muted-foreground` was used many places like places like Accordion Icon, Alert description, Input placeholder ... so I did not change the actual CSS variable value

if you have any idea to change the actual CSS variable value or make any change comment and I will make the changes

Screenshot for the new changes:

![Screenshot from 2025-06-20 23-26-17](https://github.com/user-attachments/assets/6798d4ee-1519-48ac-933d-f4fe09b68a71)

