### PR TITLE
Default of sidebar-primary-foreground in dark mode is not logical

### DIFF
--- a/apps/v4/styles/globals.css
+++ b/apps/v4/styles/globals.css
@@ -126,8 +126,8 @@
   --chart-5: var(--color-blue-800);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.985 0 0);
+  --sidebar-primary-foreground: oklch(0.205 0 0);
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);


### PR DESCRIPTION
This PR Closes #7523

All the UI is great but the blue color in sidebar component (at the background of SVG) in dark mode but in light it is as expected please check in sidebar at https://ui.shadcn.com/docs/components/sidebar
for more info please read the issue at https://github.com/shadcn-ui/ui/issues/7523

screenshot before changes:
![image](https://github.com/user-attachments/assets/23876379-3c81-4465-abac-7be2951d4b3f)


screenshot after changes:
![image](https://github.com/user-attachments/assets/9027f77c-859e-4fe1-8a38-c26b038249c0)
