### PR TITLE
refactor(components): Consistency in import of types using 'type' keyword

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { cva, VariantProps } from "class-variance-authority"
+import { cva, type VariantProps } from "class-variance-authority"
 import { PanelLeftIcon } from "lucide-react"
 
 import { useIsMobile } from "@/registry/new-york-v4/hooks/use-mobile"

--- a/apps/v4/registry/new-york-v4/ui/sonner.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sonner.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useTheme } from "next-themes"
-import { Toaster as Sonner, ToasterProps } from "sonner"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()

--- a/apps/www/registry/default/ui/pagination.tsx
+++ b/apps/www/registry/default/ui/pagination.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { ButtonProps, buttonVariants } from "@/registry/default/ui/button"
+import { buttonVariants, type ButtonProps } from "@/registry/default/ui/button"
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav

--- a/apps/www/registry/default/ui/sidebar.tsx
+++ b/apps/www/registry/default/ui/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { VariantProps, cva } from "class-variance-authority"
+import { cva, type VariantProps } from "class-variance-authority"
 import { PanelLeft } from "lucide-react"
 
 import { useIsMobile } from "@/registry/default/hooks/use-mobile"

--- a/apps/www/registry/new-york/ui/pagination.tsx
+++ b/apps/www/registry/new-york/ui/pagination.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { ButtonProps, buttonVariants } from "@/registry/new-york/ui/button"
+import { buttonVariants, type ButtonProps } from "@/registry/new-york/ui/button"
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav

--- a/apps/www/registry/new-york/ui/sidebar.tsx
+++ b/apps/www/registry/new-york/ui/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { VariantProps, cva } from "class-variance-authority"
+import { cva, type VariantProps } from "class-variance-authority"
 import { PanelLeft } from "lucide-react"
 
 import { useIsMobile } from "@/registry/new-york/hooks/use-mobile"


### PR DESCRIPTION
In most of the components types are imported using `type` keyword but missing in Sidebar, Sonner and Pagination.
In this case Typescript compiler will throw an error if
```json
{
  "compilerOptions": {
    "verbatimModuleSyntax": true,
  }
}
```
is used. This PR attempts to fix this issue. Please let know if any additional information/work is needed.
Thank You!