### PR TITLE
docs: add Icons for React and Radix

### DIFF
--- a/apps/www/config/docs.ts
+++ b/apps/www/config/docs.ts
@@ -103,6 +103,11 @@ export const docsConfig: DocsConfig = {
           items: [],
         },
         {
+          title: "Icons",
+          href: "/docs/icons",
+          items: [],
+        },
+        {
           title: "Figma",
           href: "/docs/figma",
           items: [],

--- a/apps/www/content/docs/icons.mdx
+++ b/apps/www/content/docs/icons.mdx
@@ -1,0 +1,58 @@
+---
+title: Icons
+description: Add icons from Lucide, React, or ShadCN to your project
+---
+
+## Radix Icons
+
+### Installation
+
+Make sure `@radix-ui/react-icons` is installed, it should already be installed by default. If not it can be installed with:
+
+```bash
+npm install @radix-ui/react-icons
+```
+
+### Usage
+
+```tsx
+import { SunIcon } from "@radix-ui/react-icons"
+
+import { Button } from "@/components/ui/button"
+
+export function ButtonIcon() {
+  return (
+    <Button variant="secondary" size="icon" className="size-8">
+      <SunIcon />
+    </Button>
+  )
+}
+
+```
+
+## Lucide Icons
+
+### Installation
+
+Make sure `lucide-react` is installed, it should already be installed by default. If not it can be installed with:
+
+```bash
+npm install lucide-react
+```
+
+### Usage
+
+```tsx
+import { Moon } from 'lucide-react';
+
+import { Button } from "@/components/ui/button"
+
+export function ButtonIcon() {
+  return (
+    <Button variant="secondary" size="icon" className="size-8">
+      <Moon />
+    </Button>
+  )
+}
+
+```


### PR DESCRIPTION
Added a new 'Icons' documentation page with installation and usage instructions for Radix and Lucide icons. Updated the docs config to include 'Icons' in the sidebar navigation.

Solves #1006 partially, doesn't add documentation for the shadcn icons. I had it but removed it so if wanted I can add instructions. However they can only be installed manually and have no way to be imported with npm from what I see