### PR TITLE
Update default calendar to use default button and not new york

### DIFF
--- a/apps/www/registry/default/ui/calendar.tsx
+++ b/apps/www/registry/default/ui/calendar.tsx
@@ -9,7 +9,7 @@ import {
 import { DayButton, DayPicker, getDefaultClassNames } from "react-day-picker"
 
 import { cn } from "@/lib/utils"
-import { Button, buttonVariants } from "@/registry/new-york/ui/button"
+import { Button, buttonVariants } from "@/registry/default/ui/button"
 
 function Calendar({
   className,


### PR DESCRIPTION
looking at https://ui.shadcn.com/r/styles/default/calendar.json we can see that the default styled calendar use the new-york button instead of the default one