### PR TITLE
feat(cli): add support for custom tsconfig path

### DIFF
--- a/packages/shadcn/src/commands/init.ts
+++ b/packages/shadcn/src/commands/init.ts
@@ -77,6 +77,7 @@ export const initOptionsSchema = z.object({
       }
     ),
   style: z.string(),
+  tsconfig: z.string().optional(),
 })
 
 export const init = new Command()
@@ -94,6 +95,10 @@ export const init = new Command()
     "-b, --base-color <base-color>",
     "the base color to use. (neutral, gray, zinc, stone, slate)",
     undefined
+  )
+  .option(
+    "--tsconfig <tsconfig>",
+    "the path to the tsconfig.json file to use."
   )
   .option("-y, --yes", "skip confirmation prompt.", true)
   .option("-d, --defaults,", "use default configuration.", false)
@@ -184,7 +189,7 @@ export async function runInit(
   const projectConfig = await getProjectConfig(options.cwd, projectInfo)
   const config = projectConfig
     ? await promptForMinimalConfig(projectConfig, options)
-    : await promptForConfig(await getConfig(options.cwd))
+    : await promptForConfig(await getConfig(options.cwd), options)
 
   if (!options.yes) {
     const { proceed } = await prompts({
@@ -237,7 +242,10 @@ export async function runInit(
   return fullConfig
 }
 
-async function promptForConfig(defaultConfig: Config | null = null) {
+async function promptForConfig(
+  defaultConfig: Config | null = null,
+  opts: Pick<z.infer<typeof initOptionsSchema>, "tsconfig"> = {}
+) {
   const [styles, baseColors] = await Promise.all([
     getRegistryStyles(),
     getRegistryBaseColors(),
@@ -350,6 +358,7 @@ async function promptForConfig(defaultConfig: Config | null = null) {
       lib: options.components.replace(/\/components$/, "lib"),
       hooks: options.components.replace(/\/components$/, "hooks"),
     },
+    tsconfig: opts.tsconfig,
   })
 }
 
@@ -410,5 +419,6 @@ async function promptForMinimalConfig(
     tsx: defaultConfig?.tsx,
     aliases: defaultConfig?.aliases,
     iconLibrary: defaultConfig?.iconLibrary,
+    tsconfig: opts.tsconfig,
   })
 }

--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -41,6 +41,7 @@ export const rawConfigSchema = z
       hooks: z.string().optional(),
     }),
     iconLibrary: z.string().optional(),
+    tsconfig: z.string().optional(),
   })
   .strict()
 
@@ -81,8 +82,12 @@ export async function getConfig(cwd: string) {
 }
 
 export async function resolveConfigPaths(cwd: string, config: RawConfig) {
+  const tsconfigPath = config.tsconfig
+    ? path.resolve(cwd, config.tsconfig)
+    : path.resolve(cwd, "tsconfig.json")
+
   // Read tsconfig.json.
-  const tsConfig = await loadConfig(cwd)
+  const tsConfig = await loadConfig(tsconfigPath)
 
   if (tsConfig.resultType === "failed") {
     throw new Error(


### PR DESCRIPTION
When having two or more `tsconfig.json` files, the `init` command can't recognize the path alias config.