### PR TITLE
feat(cli): add format migration command to convert components between .jsx and .tsx

### DIFF
--- a/packages/shadcn/src/commands/migrate.ts
+++ b/packages/shadcn/src/commands/migrate.ts
@@ -1,4 +1,5 @@
 import path from "path"
+import { migrateFormat } from "@/src/migrations/migrate-format"
 import { migrateIcons } from "@/src/migrations/migrate-icons"
 import { migrateRadix } from "@/src/migrations/migrate-radix"
 import { preFlightMigrate } from "@/src/preflights/preflight-migrate"
@@ -16,6 +17,10 @@ export const migrations = [
   {
     name: "radix",
     description: "migrate to radix-ui.",
+  },
+  {
+    name: "format",
+    description: "migrate format of components. (.jsx to .tsx)",
   },
 ] as const
 
@@ -93,6 +98,10 @@ export const migrate = new Command()
 
       if (options.migration === "radix") {
         await migrateRadix(config, { yes: options.yes })
+      }
+
+      if (options.migration === "format") {
+        await migrateFormat(config)
       }
     } catch (error) {
       logger.break()

--- a/packages/shadcn/src/migrations/migrate-format.test.ts
+++ b/packages/shadcn/src/migrations/migrate-format.test.ts
@@ -1,0 +1,152 @@
+import * as fs from "fs"
+import * as add from "@/src/utils/add-components"
+import { Config } from "@/src/utils/get-config"
+import * as fg from "fast-glob"
+import prompts from "prompts"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { migrateFormat } from "./migrate-format"
+
+vi.mock("fs", () => ({
+  promises: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    unlink: vi.fn(),
+    mkdtemp: vi.fn(),
+  },
+}))
+
+vi.mock("fast-glob", () => ({
+  default: vi.fn(),
+}))
+
+vi.mock("prompts", () => ({
+  default: vi.fn(),
+}))
+
+vi.mock("@/src/utils/add-components", () => ({
+  addComponents: vi.fn(),
+}))
+
+vi.mock("@/src/utils/spinner", () => ({
+  spinner: () => ({
+    start: () => ({
+      text: "",
+      stop: vi.fn(),
+    }),
+  }),
+}))
+
+vi.mock("@/src/utils/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    break: vi.fn(),
+    log: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const mockedFg = fg.default as vi.Mock
+const mockedPrompts = prompts as unknown as vi.Mock
+const mockedUnlink = fs.promises.unlink as vi.Mock
+const mockedAddComponents = add.addComponents as vi.Mock
+
+const config: Config = {
+  resolvedPaths: {
+    cwd: "/project",
+    ui: "/project/src/components/ui",
+  },
+} as any
+
+describe("migrateFormat", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("migrates valid files and deletes them", async () => {
+    mockedFg.mockResolvedValue(["Button.jsx", "Input.jsx", "Other.tsx"])
+    mockedPrompts.mockResolvedValueOnce({ from: "jsx", to: "tsx" })
+    mockedPrompts.mockResolvedValueOnce({ confirm: true })
+
+    mockedAddComponents.mockResolvedValue(undefined)
+
+    await migrateFormat(config)
+
+    expect(mockedAddComponents).toHaveBeenCalledTimes(2)
+    expect(mockedAddComponents).toHaveBeenCalledWith(
+      ["Button"],
+      expect.anything(),
+      expect.objectContaining({ overwrite: true })
+    )
+    expect(mockedUnlink).toHaveBeenCalledWith(
+      "/project/src/components/ui/Button.jsx"
+    )
+    expect(mockedUnlink).toHaveBeenCalledWith(
+      "/project/src/components/ui/Input.jsx"
+    )
+    expect(mockedUnlink).not.toHaveBeenCalledWith(
+      "/project/src/components/ui/Other.tsx"
+    )
+  })
+
+  it("skips invalid files without throwing", async () => {
+    mockedFg.mockResolvedValue(["Fake.jsx", "Real.jsx"])
+    mockedPrompts.mockResolvedValueOnce({ from: "jsx", to: "tsx" })
+    mockedPrompts.mockResolvedValueOnce({ confirm: true })
+
+    mockedAddComponents
+      .mockImplementationOnce(() => {
+        throw { __intercepted: true }
+      })
+      .mockResolvedValueOnce(undefined)
+
+    await migrateFormat(config)
+
+    expect(mockedAddComponents).toHaveBeenCalledTimes(2)
+    expect(mockedUnlink).toHaveBeenCalledWith(
+      "/project/src/components/ui/Real.jsx"
+    )
+    expect(mockedUnlink).not.toHaveBeenCalledWith(
+      "/project/src/components/ui/Fake.jsx"
+    )
+  })
+
+  it("aborts migration if user cancels", async () => {
+    mockedFg.mockResolvedValue(["One.jsx"])
+    mockedPrompts.mockResolvedValueOnce({ from: "jsx", to: "tsx" })
+    mockedPrompts.mockResolvedValueOnce({ confirm: false })
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit")
+    })
+
+    try {
+      await migrateFormat(config)
+    } catch (e) {
+      // expected
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(0)
+    expect(mockedAddComponents).not.toHaveBeenCalled()
+    expect(mockedUnlink).not.toHaveBeenCalled()
+  })
+
+  it("throws if no files to migrate", async () => {
+    mockedFg.mockResolvedValue(["Other.tsx"])
+    mockedPrompts.mockResolvedValueOnce({ from: "jsx", to: "tsx" })
+
+    await expect(migrateFormat(config)).rejects.toThrow(
+      "No .jsx files found to migrate."
+    )
+  })
+
+  it("throws if from === to", async () => {
+    mockedFg.mockResolvedValue(["Input.tsx"])
+    mockedPrompts.mockResolvedValueOnce({ from: "tsx", to: "tsx" })
+
+    await expect(migrateFormat(config)).rejects.toThrow(
+      "You cannot migrate to the same format."
+    )
+  })
+})

--- a/packages/shadcn/src/migrations/migrate-format.ts
+++ b/packages/shadcn/src/migrations/migrate-format.ts
@@ -1,0 +1,160 @@
+import { promises as fs } from "fs"
+import path from "path"
+import { addComponents } from "@/src/utils/add-components"
+import { Config } from "@/src/utils/get-config"
+import { highlighter } from "@/src/utils/highlighter"
+import { logger } from "@/src/utils/logger"
+import { spinner } from "@/src/utils/spinner"
+import fg from "fast-glob"
+import prompts from "prompts"
+
+export async function migrateFormat(config: Config) {
+  if (!config.resolvedPaths.ui) {
+    throw new Error(
+      "We could not find a valid `ui` path in your `components.json` file. Please ensure you have a valid `ui` path in your `components.json` file."
+    )
+  }
+
+  const uiPath = config.resolvedPaths.ui
+  const files = await fg("**/*.{js,ts,jsx,tsx}", { cwd: uiPath })
+
+  if (files.length === 0) {
+    throw new Error("No files found in the `ui` directory to migrate format.")
+  }
+
+  const formatChoices = [
+    { title: "JSX", value: "jsx" },
+    { title: "TSX", value: "tsx" },
+  ]
+
+  const migrateOptions = await prompts([
+    {
+      type: "select",
+      name: "from",
+      message: `Which format would you like to ${highlighter.info(
+        "migrate from"
+      )}?`,
+      choices: formatChoices,
+    },
+    {
+      type: "select",
+      name: "to",
+      message: `Which format would you like to ${highlighter.info(
+        "migrate to"
+      )}?`,
+      choices: formatChoices,
+    },
+  ])
+
+  if (migrateOptions.from === migrateOptions.to) {
+    throw new Error("You cannot migrate to the same format.")
+  }
+
+  const sourceFiles = files.filter((file) =>
+    file.endsWith(`.${migrateOptions.from}`)
+  )
+  if (sourceFiles.length === 0) {
+    throw new Error(`No .${migrateOptions.from} files found to migrate.`)
+  }
+
+  const { confirm } = await prompts({
+    type: "confirm",
+    name: "confirm",
+    initial: true,
+    message: `We will migrate ${highlighter.info(
+      sourceFiles.length
+    )} files in ${highlighter.info(
+      `./${path.relative(config.resolvedPaths.cwd, uiPath)}`
+    )} from ${highlighter.info(migrateOptions.from)} to ${highlighter.info(
+      migrateOptions.to
+    )}. Continue?`,
+  })
+
+  if (!confirm) {
+    logger.info("Migration cancelled.")
+    process.exit(0)
+  }
+
+  const migrationSpinner = spinner("Migrating format...")?.start()
+
+  const componentNames = sourceFiles.map((file) =>
+    file.replace(/\.[^/.]+$/, "")
+  )
+  const failedComponents: string[] = []
+  const successfulComponents: string[] = []
+
+  // Intercept process.exit
+  const originalExit = process.exit
+  process.exit = ((code: number) => {
+    throw { __intercepted: true, code }
+  }) as any
+  const originalConsoleError = console.error
+  const originalConsoleLog = console.log
+  console.error = () => {}
+  console.log = () => {}
+
+  // Migrate components
+  for (const componentName of componentNames) {
+    migrationSpinner.text = `Migrating ${componentName}...`
+    try {
+      await addComponents(
+        [componentName],
+        { ...config, tsx: migrateOptions.to === "tsx" },
+        { overwrite: true, silent: true }
+      )
+      successfulComponents.push(componentName)
+    } catch (err) {
+      failedComponents.push(componentName)
+    }
+  }
+
+  process.exit = originalExit
+  console.error = originalConsoleError
+  console.log = originalConsoleLog
+
+  // Delete old files
+  await Promise.all(
+    sourceFiles.map(async (file) => {
+      const component = file.replace(/\.[^/.]+$/, "")
+      migrationSpinner.text = `Deleting ${component}...`
+      if (successfulComponents.includes(component)) {
+        await fs.unlink(path.join(uiPath, file))
+      }
+    })
+  )
+
+  // Update components.json
+  const { resolvedPaths, ...rest } = config
+  const updatedConfig = {
+    ...rest,
+    tsx: migrateOptions.to === "tsx",
+  }
+  await fs.writeFile(
+    path.join(resolvedPaths.cwd, "components.json"),
+    JSON.stringify(updatedConfig, null, 2)
+  )
+
+  migrationSpinner?.stop()
+
+  logger.info("")
+  if (successfulComponents.length > 0) {
+    logger.log(
+      `Migrated ${successfulComponents.length} ${
+        successfulComponents.length === 1 ? "file" : "files"
+      }:`
+    )
+    for (const file of successfulComponents) {
+      logger.log(`  - ${file}.${migrateOptions.to}`)
+    }
+  }
+  if (failedComponents.length > 0) {
+    logger.warn(
+      `Skipped ${failedComponents.length} ${
+        failedComponents.length === 1 ? "file" : "files"
+      } (invalid or not found in registry):`
+    )
+    for (const file of failedComponents) {
+      logger.warn(`  - ${file}.${migrateOptions.from}`)
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a new `shadcn migrate format` command that allows users to convert installed UI components between `.jsx` and `.tsx` formats.

While migrating my own project from `.jsx` to `.tsx`, I noticed that the existing `shadcn add` command correctly installs components in the desired format, but manually cleaning up the old files (like deleting the `.jsx` after adding the `.tsx`) felt repetitive.

Since there’s already a `migrate` command namespace (`migrate icons`, `migrate radix`, etc.), this felt like a natural place to introduce a new subcommand: `migrate format`.

### How it Works

- Scans the `ui` directory for component files in the selected format
- Prompts the user to choose source and target formats (e.g., JSX → TSX)
- Re-adds each component in the target format using `addComponents`
- Gracefully skips invalid or non-registry components without breaking the process
- Deletes the original files only if migration succeeds

> Hope this feature feels helpful and worthy of being merged. Would love to improve it further if needed!