### PR TITLE
Update tanstack-start installation instructions to use tailwindcss vite plugin

### DIFF
--- a/apps/www/content/docs/installation/tanstack.mdx
+++ b/apps/www/content/docs/installation/tanstack.mdx
@@ -23,7 +23,7 @@ npm install tailwindcss @tailwindcss/vite
 
 Add the `@tailwindcss/vite` plugin to your `vite.config.ts` file.
 
-```ts title="vite.config.ts" showLineNumbers {3,9}
+```ts title="vite.config.ts" showLineNumbers
 import { defineConfig } from 'vite'
 import tailwindcss from '@tailwindcss/vite'
 import tsConfigPaths from 'vite-tsconfig-paths'


### PR DESCRIPTION
The tanstack-start since it moved to vite, no longer needs the postcss- https://tanstack.com/start/latest/docs/framework/react/build-from-scratch