### PR TITLE
Improve Skeleton with *:invisible Inheritance

### DIFF
--- a/apps/www/registry/default/ui/skeleton.tsx
+++ b/apps/www/registry/default/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-muted", className)}
+      className={cn("animate-pulse rounded-md bg-muted *:invisible", className)}
       {...props}
     />
   )

--- a/apps/www/registry/new-york/ui/skeleton.tsx
+++ b/apps/www/registry/new-york/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      className={cn("animate-pulse rounded-md bg-primary/10 *:invisible", className)}
       {...props}
     />
   )


### PR DESCRIPTION
Adds *:invisible to the Skeleton component to make child elements invisible, allowing it to inherit their dimensions for simpler loading states.

_**Current Problem:**_
Manually setting Skeleton dimensions is tedious, often leading to content layout shift when dimensions don’t match the content being replaced.

**_Changes:_**  
Added *:invisible to base classes in Skeleton component

**_Example:_**  
```ts
"use client"

import { Label } from "@/components/ui/label"
import { Skeleton } from "@/components/ui/skeleton"
import { useState, useEffect } from "react"

export default function Home() {
  const [isLoaded, setIsLoaded] = useState(false)

  useEffect(() => {
    // Simulate a loading delay
    // In a real application, this could be an API call or some other async operation
    // Here we use a timeout to simulate loading
    const timer = setTimeout(() => setIsLoaded(true), 2000)
    return () => clearTimeout(timer)
  }, [])

  return (
    <div className="flex justify-center items-center h-screen flex-col gap-2">
      {isLoaded ? (
        <Label>Hello World!</Label>
      ) : (
        <Skeleton>
          <Label>Hello World!</Label>
        </Skeleton>
      )}
    </div>
  )
}
```