### PR TITLE
feat: add progress bar that triggers on every page load (#7713)

### DIFF
--- a/apps/v4/app/layout.tsx
+++ b/apps/v4/app/layout.tsx
@@ -9,6 +9,7 @@ import { Analytics } from "@/components/analytics"
 import { TailwindIndicator } from "@/components/tailwind-indicator"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/registry/new-york-v4/ui/sonner"
+import NProgressBar from "@/components/nprogress-bar"
 
 import "@/styles/globals.css"
 
@@ -91,6 +92,7 @@ export default function RootLayout({
         <ThemeProvider>
           <LayoutProvider>
             <ActiveThemeProvider>
+              <NProgressBar color="#6366f1" />
               {children}
               <TailwindIndicator />
               <Toaster position="top-center" />

--- a/apps/v4/components/nprogress-bar.tsx
+++ b/apps/v4/components/nprogress-bar.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { usePathname } from "next/navigation"
+import NProgress from "nprogress"
+import "nprogress/nprogress.css"
+
+interface NProgressBarProps {
+  color?: string
+  height?: number
+  delay?: number // ms
+}
+
+export default function NProgressBar({
+  color = "#6366f1",
+  height = 2,
+  delay = 100,
+}: NProgressBarProps) {
+  const pathname = usePathname()
+  const router = useRef<NodeJS.Timeout | null>(null)
+
+  useEffect(() => {
+    NProgress.configure({ showSpinner: false })
+    // Inject custom style for color/height
+    let style = document.getElementById("nprogress-custom-style") as HTMLStyleElement | null
+    if (!style) {
+      style = document.createElement("style")
+      style.id = "nprogress-custom-style"
+      document.head.appendChild(style)
+    }
+    style.innerHTML = `
+      #nprogress {
+        pointer-events: none;
+      }
+      #nprogress .bar {
+        background: ${color} !important;
+        position: fixed;
+        z-index: 1031;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: ${height}px !important;
+        transition: all 0.2s ease;
+      }
+      #nprogress .peg {
+        display: block;
+        position: absolute;
+        right: 0px;
+        width: 100px;
+        height: 100%;
+        box-shadow: 0 0 10px ${color}, 0 0 5px ${color};
+        opacity: 1.0;
+        transform: rotate(3deg) translate(0px, -4px);
+      }
+      #nprogress .spinner {
+        display: none !important;
+      }
+    `
+    // Only remove style on unmount, not on every color/height change
+    return () => {
+      // Only remove if component is unmounting (not just color/height change)
+      if (document.getElementById("nprogress-custom-style")) {
+        document.getElementById("nprogress-custom-style")?.remove()
+      }
+    }
+  }, [color, height])
+
+  useEffect(() => {
+    // Start progress bar with delay
+    if (router.current) clearTimeout(router.current)
+    router.current = setTimeout(() => {
+      NProgress.start()
+    }, delay)
+    return () => {
+      if (router.current) clearTimeout(router.current)
+      NProgress.done()
+    }
+  }, [pathname, delay])
+
+  return null
+} 


### PR DESCRIPTION
Implemented a global, customizable NProgress bar that appears at the top of the screen during every page/route load.
Progress bar starts on navigation and completes when the page is fully loaded.
Includes a slight delay to prevent flicker on fast loads.
Applied globally via the root layout; no manual inclusion needed on individual pages.
fixes #7713