### PR TITLE
Fix(new-york:components/progress): Enable `max` to handle custom maximum value

### DIFF
--- a/apps/www/registry/new-york/ui/progress.tsx
+++ b/apps/www/registry/new-york/ui/progress.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils"
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+>(({ className, value, max, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
@@ -19,7 +19,7 @@ const Progress = React.forwardRef<
   >
     <ProgressPrimitive.Indicator
       className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      style={{ transform: `translateX(-${max || 100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>
 ))


### PR DESCRIPTION
This pull request makes adjustments to the `Progress` component in `apps/www/registry/default/ui/progress.tsx`, introducing a new `max` prop to enhance flexibility in calculating progress values.

Enhancements to the `Progress` component:

* Updated the `Progress` component's props to include a new `max` property, enabling dynamic customization of the maximum progress value. (`apps/www/registry/default/ui/progress.tsx`, [apps/www/registry/default/ui/progress.tsxL11-R11](diffhunk://#diff-a1845ba206ff3d9908ca7bba833e80c949d75502257b5e6b64e6cb7681a58cb1L11-R11))
* Modified the `style` attribute of `ProgressPrimitive.Indicator` to use the `max` property for calculating the progress transform, ensuring accurate progress representation when `max` is customized. (`apps/www/registry/default/ui/progress.tsx`, [apps/www/registry/default/ui/progress.tsxL22-R22](diffhunk://#diff-a1845ba206ff3d9908ca7bba833e80c949d75502257b5e6b64e6cb7681a58cb1L22-R22))