### PR TITLE
feat(components): add FormError component to trigger custom error

### DIFF
--- a/apps/www/registry/default/ui/form.tsx
+++ b/apps/www/registry/default/ui/form.tsx
@@ -166,6 +166,35 @@ const FormMessage = React.forwardRef<
 })
 FormMessage.displayName = "FormMessage"
 
+const FormError = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({
+  name = "root",
+  className,
+  ...props
+}, ref) => {
+  const { errors } = useFormContext().formState;
+  const error = errors?.[name];
+  const message = error ? String(error?.message ?? "") : null;
+
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={`${name}-form-item-message`}
+      className={cn("text-destructive text-sm font-medium", className)}
+      {...props}
+    >
+      {message}
+    </p>
+  );
+})
+FormError.displayName = "FormError"
+
 export {
   useFormField,
   Form,
@@ -175,4 +204,5 @@ export {
   FormDescription,
   FormMessage,
   FormField,
+  FormError
 }

--- a/apps/www/registry/new-york/ui/form.tsx
+++ b/apps/www/registry/new-york/ui/form.tsx
@@ -166,6 +166,35 @@ const FormMessage = React.forwardRef<
 })
 FormMessage.displayName = "FormMessage"
 
+const FormError = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({
+  name = "root",
+  className,
+  ...props
+}, ref) => {
+  const { errors } = useFormContext().formState;
+  const error = errors?.[name];
+  const message = error ? String(error?.message ?? "") : null;
+
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={`${name}-form-item-message`}
+      className={cn("text-destructive text-sm font-medium", className)}
+      {...props}
+    >
+      {message}
+    </p>
+  );
+})
+FormError.displayName = "FormError"
+
 export {
   useFormField,
   Form,
@@ -175,4 +204,5 @@ export {
   FormDescription,
   FormMessage,
   FormField,
+  FormError
 }


### PR DESCRIPTION
This pull request introduces a new `FormError` component to enhance form error handling in two different registry UI modules. The `FormError` component dynamically displays error messages associated with form fields using the `useFormContext` hook.

### Addition of the `FormError` Component:

* **`apps/www/registry/default/ui/form.tsx`:** Added the `FormError` component, which renders custom form error messages based on the `name` prop. It uses `useFormContext` to access the form's error state and conditionally displays the error message. The component is exported alongside other form-related components. [[1]](diffhunk://#diff-ef4f0b4ac56fbc390473430e4ff26c6a1de392df3d330e4304614fa5ba63bf49R169-R197) [[2]](diffhunk://#diff-ef4f0b4ac56fbc390473430e4ff26c6a1de392df3d330e4304614fa5ba63bf49R207)

* **`apps/www/registry/new-york/ui/form.tsx`:** Added the same `FormError` component for the New York registry UI module, following the same implementation pattern as in the default registry. It is also exported for use in the module. [[1]](diffhunk://#diff-66b50bf276a5af6da026d97d3eca15e9f8b7ae44ce36f472e7342fbf14358f10R169-R197) [[2]](diffhunk://#diff-66b50bf276a5af6da026d97d3eca15e9f8b7ae44ce36f472e7342fbf14358f10R207)