### PR TITLE
fix(components): resolve typescript error in chart.tsx

### DIFF
--- a/apps/www/registry/default/ui/chart.tsx
+++ b/apps/www/registry/default/ui/chart.tsx
@@ -106,8 +106,10 @@ const ChartTooltipContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
     React.ComponentProps<"div"> & {
+      payload?: any[]
       hideLabel?: boolean
       hideIndicator?: boolean
+      label?: string
       indicator?: "line" | "dot" | "dashed"
       nameKey?: string
       labelKey?: string
@@ -261,7 +263,8 @@ const ChartLegend = RechartsPrimitive.Legend
 const ChartLegendContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div"> &
-    Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
+    Pick<RechartsPrimitive.LegendProps, "verticalAlign"> & {
+      payload?: any[]
       hideIcon?: boolean
       nameKey?: string
     }

--- a/apps/www/registry/new-york/ui/chart.tsx
+++ b/apps/www/registry/new-york/ui/chart.tsx
@@ -106,8 +106,10 @@ const ChartTooltipContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
     React.ComponentProps<"div"> & {
+      payload?: any[]
       hideLabel?: boolean
       hideIndicator?: boolean
+      label?: string
       indicator?: "line" | "dot" | "dashed"
       nameKey?: string
       labelKey?: string
@@ -261,7 +263,8 @@ const ChartLegend = RechartsPrimitive.Legend
 const ChartLegendContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div"> &
-    Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
+    Pick<RechartsPrimitive.LegendProps, "verticalAlign"> & {
+      payload?: any[]
       hideIcon?: boolean
       nameKey?: string
     }


### PR DESCRIPTION
1. there are two type `payload` in Recharts, the first type is an array and the item in it have a key named `payload`, so the first type `payload` should be the same as any[] in Recharts, the second type `payload` you defined is unknow I don't change.

2. `label` should define the type, and it should be string.

3. `RechartsPrimitive.LegendProps` has already omit the key named `payload` so we should add `payload` after it instead of picking `payload`. 