### PR TITLE
fix(components): SidebarGroupAction isn't visually disabled

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -426,7 +426,7 @@ function SidebarGroupAction({
       data-slot="sidebar-group-action"
       data-sidebar="group-action"
       className={cn(
-        "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "disabled:hover:text-sidebar-foreground text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 disabled:hover:bg-transparent [&>svg]:size-4 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 md:after:hidden",
         "group-data-[collapsible=icon]:hidden",


### PR DESCRIPTION
This PR Closes #7350 
When disable the SidebarGroupAction in sidebar it still has the hover bg color and also 
the changes I made is as disabled other components: 
`disabled:hover:text-sidebar-foreground disabled:pointer-events-none disabled:opacity-50 disabled:hover:bg-transparent` 

before changes when disabled:
<img width="676" height="484" alt="image" src="https://github.com/user-attachments/assets/88262487-9393-445c-9f92-b90b6014e8ad" />


after changes when disabled:
<img width="657" height="438" alt="image" src="https://github.com/user-attachments/assets/6a59e35a-b2c4-4196-8386-1a37dc2f4f41" />
