### PR TITLE
feat(tooltip): add optional arrow prop support

### DIFF
--- a/apps/www/registry/default/ui/tooltip.tsx
+++ b/apps/www/registry/default/ui/tooltip.tsx
@@ -6,15 +6,15 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 import { cn } from "@/lib/utils"
 
 const TooltipProvider = TooltipPrimitive.Provider
-
 const Tooltip = TooltipPrimitive.Root
-
 const TooltipTrigger = TooltipPrimitive.Trigger
 
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> & {
+    arrow?: boolean
+  }
+>(({ className, sideOffset = 4, arrow = false, ...props }, ref) => (
   <TooltipPrimitive.Content
     ref={ref}
     sideOffset={sideOffset}
@@ -23,7 +23,10 @@ const TooltipContent = React.forwardRef<
       className
     )}
     {...props}
-  />
+  >
+    {props.children}
+    {arrow && <TooltipPrimitive.Arrow className="fill-popover" />}
+  </TooltipPrimitive.Content>
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 


### PR DESCRIPTION
### ✅ What I Did:
- Added support for optional `arrow` prop in the `TooltipContent` component.
- If `arrow={true}` is passed, it will render `<TooltipPrimitive.Arrow />` from Radix UI.
- This adds visual clarity to tooltips and matches what's shown in the demo.

### 🐛 Fixes:
Fixes shadcn-ui/ui#7792

### 🙋 Contribution Note:
Contributing as part of OSCI program 🌟  
Thanks for reviewing!
