### PR TITLE
fix(breadcrumbs): aria-label BreadcrumbPage as "text" not "link" to avoid accessibility issue

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/breadcrumb.tsx
+++ b/apps/v4/registry/new-york-v4/ui/breadcrumb.tsx
@@ -53,7 +53,7 @@ function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
       data-slot="breadcrumb-page"
-      role="link"
+      role="text"
       aria-disabled="true"
       aria-current="page"
       className={cn("text-foreground font-normal", className)}

--- a/apps/www/registry/default/ui/breadcrumb.tsx
+++ b/apps/www/registry/default/ui/breadcrumb.tsx
@@ -63,7 +63,7 @@ const BreadcrumbPage = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <span
     ref={ref}
-    role="link"
+    role="text"
     aria-disabled="true"
     aria-current="page"
     className={cn("font-normal text-foreground", className)}

--- a/apps/www/registry/new-york/ui/breadcrumb.tsx
+++ b/apps/www/registry/new-york/ui/breadcrumb.tsx
@@ -63,7 +63,7 @@ const BreadcrumbPage = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <span
     ref={ref}
-    role="link"
+    role="text"
     aria-disabled="true"
     aria-current="page"
     className={cn("font-normal text-foreground", className)}


### PR DESCRIPTION
Fixes https://github.com/shadcn-ui/ui/issues/7639

This is flagged by biome's lint/a11y/useFocusableInteractive rule which is in
their on-by-default recommended set.

BreadcrumbPage is more of a span than a link. We have BreadcrumbLink for
breadrumbs that are links. So I think this is a good fix.
