### PR TITLE
fix(components): add hidden SheetTitle for screen reader accessibility

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/sheet.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sheet.tsx
@@ -71,6 +71,7 @@ function SheetContent({
         )}
         {...props}
       >
+        <SheetTitle className="sr-only">Sheet Title</SheetTitle>
         {children}
         <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
           <XIcon className="size-4" />

--- a/apps/www/registry/default/ui/sheet.tsx
+++ b/apps/www/registry/default/ui/sheet.tsx
@@ -64,6 +64,7 @@ const SheetContent = React.forwardRef<
       className={cn(sheetVariants({ side }), className)}
       {...props}
     >
+      <SheetTitle className="sr-only">Sheet Title</SheetTitle>
       {children}
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" />

--- a/apps/www/registry/new-york/ui/sheet.tsx
+++ b/apps/www/registry/new-york/ui/sheet.tsx
@@ -64,6 +64,7 @@ const SheetContent = React.forwardRef<
       className={cn(sheetVariants({ side }), className)}
       {...props}
     >
+      <SheetTitle className="sr-only">Sheet Title</SheetTitle>
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>


### PR DESCRIPTION
Fixes the DialogContent requires a DialogTitle accessibility warning that appears when using the Sheet component on mobile devices.

Added hidden SheetTitle with sr-only class to SheetContent component
Applied fix to all style variants (default, new-york, v4)
Maintains visual design while ensuring screen reader accessibility

How to Reproduce it
create a Sheet component in a Next.js app
open the app on mobile or use browser dev tools mobile view
trigger the Sheet to open
check browser console  you'll see the error

Fixes the accessibility issue mentioned in the Radix UI documentation: https://radix-ui.com/primitives/docs/components/dialog