### PR TITLE
fix(sidebar): correct state calculation in mobile view (#7808)

### DIFF
--- a/apps/www/content/docs/components/sidebar.mdx
+++ b/apps/www/content/docs/components/sidebar.mdx
@@ -1392,3 +1392,7 @@ Fixed typo in `useSidebar` hook.
 -  throw new Error("useSidebar must be used within a Sidebar.")
 +  throw new Error("useSidebar must be used within a SidebarProvider.")
 ```
+
+### 2025-07-22 Fixed mobile state bug
+
+- Fixed a bug where the `state` from the `useSidebar` hook did not update correctly in mobile view.

--- a/apps/www/registry/default/ui/sidebar.tsx
+++ b/apps/www/registry/default/ui/sidebar.tsx
@@ -120,7 +120,7 @@ const SidebarProvider = React.forwardRef<
 
     // We add a state so that we can do data-state="expanded" or "collapsed".
     // This makes it easier to style the sidebar with Tailwind classes.
-    const state = open ? "expanded" : "collapsed"
+    const state = (isMobile ? openMobile : open) ? "expanded" : "collapsed"
 
     const contextValue = React.useMemo<SidebarContextProps>(
       () => ({

--- a/apps/www/registry/new-york/ui/sidebar.tsx
+++ b/apps/www/registry/new-york/ui/sidebar.tsx
@@ -120,7 +120,7 @@ const SidebarProvider = React.forwardRef<
 
     // We add a state so that we can do data-state="expanded" or "collapsed".
     // This makes it easier to style the sidebar with Tailwind classes.
-    const state = open ? "expanded" : "collapsed"
+    const state = (isMobile ? openMobile : open) ? "expanded" : "collapsed"
 
     const contextValue = React.useMemo<SidebarContextProps>(
       () => ({


### PR DESCRIPTION
Description

Fix sidebar state calculation on mobile view by deriving state from openMobile when isMobile is true. Previously, state was only derived from desktop open, causing incorrect behavior on mobile.

Changes

* Updated the `state` derivation in `SidebarProvider` to use the `openMobile` state when `isMobile` is `true`.

Testing

- [x] Verified sidebar state updates correctly on both desktop and mobile by logging state changes; no errors found.

Fixes #7808