### PR TITLE
fix: Range Calendar preview was missing mode="range"

### DIFF
--- a/apps/v4/registry/new-york-v4/blocks/calendar-02.tsx
+++ b/apps/v4/registry/new-york-v4/blocks/calendar-02.tsx
@@ -11,7 +11,7 @@ export default function Calendar02() {
 
   return (
     <Calendar
-      mode="single"
+      mode="range"
       defaultMonth={date}
       numberOfMonths={2}
       selected={date}

--- a/apps/v4/registry/new-york-v4/blocks/calendar-02.tsx
+++ b/apps/v4/registry/new-york-v4/blocks/calendar-02.tsx
@@ -3,19 +3,21 @@
 import * as React from "react"
 
 import { Calendar } from "@/registry/new-york-v4/ui/calendar"
+import type { DateRange } from "react-day-picker"
 
 export default function Calendar02() {
-  const [date, setDate] = React.useState<Date | undefined>(
-    new Date(2025, 5, 12)
-  )
+  const [range, setRange] = React.useState<DateRange | undefined>({
+    from: new Date(2025, 5, 12),
+    to: new Date(2025, 5, 18),
+  })
 
   return (
     <Calendar
       mode="range"
-      defaultMonth={date}
+      defaultMonth={range?.from}
       numberOfMonths={2}
-      selected={date}
-      onSelect={setDate}
+      selected={range}
+      onSelect={setRange}
       className="rounded-lg border shadow-sm"
     />
   )


### PR DESCRIPTION
Fixed the component preview block "Range Calendar" to use "range" and not "single"

Fixes: #7885