### PR TITLE
fix(cli): ensure sidebar-02 adds collapsible component dependency

### DIFF
--- a/apps/v4/registry.json
+++ b/apps/v4/registry.json
@@ -814,7 +814,8 @@
         "breadcrumb",
         "separator",
         "label",
-        "dropdown-menu"
+        "dropdown-menu",
+        "collapsible"
       ],
       "files": [
         {


### PR DESCRIPTION
When adding the `sidebar-02` component via the CLI, the `collapsible` component is required but not automatically included. This PR fixes that by ensuring `collapsible` is added when `sidebar` is selected.

Closes #7903
<img width="668" height="195" alt="image" src="https://github.com/user-attachments/assets/ec30f9c3-322f-48b3-828c-d7310a2c645a" />
