### PR TITLE
fix(build-registry): use literal component name as export fallback

### DIFF
--- a/apps/v4/scripts/build-registry.mts
+++ b/apps/v4/scripts/build-registry.mts
@@ -48,7 +48,7 @@ export const Index: Record<string, any> = {`
       componentPath
         ? `React.lazy(async () => {
       const mod = await import("${componentPath}")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || "${item.name}"
       return { default: mod.default || mod[exportName] }
     })`
         : "null"


### PR DESCRIPTION
When generating `src/registry/__index__.tsx`, the template was emitting the literal string `item.name` instead of the component's real name.