### PR TITLE
docs(badge) fix typo in markdown

### DIFF
--- a/apps/v4/content/docs/components/badge.mdx
+++ b/apps/v4/content/docs/components/badge.mdx
@@ -49,7 +49,7 @@ import { Badge } from "@/components/ui/badge"
 ```
 
 ```tsx
-<Badge variant="default |outline | secondary | destructive">Badge</Badge>
+<Badge variant="default | outline | secondary | destructive">Badge</Badge>
 ```
 
 ### Link


### PR DESCRIPTION
Simple fix to correct a typo error in the markdown of the badge component