### PR TITLE
fix(styles): replace invalid CSS // comments with /* */ syntax

### DIFF
--- a/apps/www/content/docs/tailwind-v4.mdx
+++ b/apps/www/content/docs/tailwind-v4.mdx
@@ -195,17 +195,17 @@ Here's how you do it:
 
 ```css showLineNumbers
 :root {
-  --background: hsl(0 0% 100%); // <-- Wrap in hsl
+  --background: hsl(0 0% 100%); /* ← Wrap in hsl */
   --foreground: hsl(0 0% 3.9%);
 }
 
 .dark {
-  --background: hsl(0 0% 3.9%); // <-- Wrap in hsl
+  --background: hsl(0 0% 3.9%); /* ← Wrap in hsl */
   --foreground: hsl(0 0% 98%);
 }
 
 @theme inline {
-  --color-background: var(--background); // <-- Remove hsl
+  --color-background: var(--background); /* ← Remove hsl */
   --color-foreground: var(--foreground);
 }
 ```


### PR DESCRIPTION
This PR fixes incorrect comment syntax used in some CSS variable declarations.

CSS does not support `//` comments — only `/* ... */` is valid.  
The original code used:
:root {
  --background: hsl(0 0% 100%); // ← Wrap in hsl
  --foreground: hsl(0 0% 3.9%);
}

This has been corrected to:
:root {
  --background: hsl(0 0% 100%); /* ← Wrap in hsl */
  --foreground: hsl(0 0% 3.9%);
}

All similar instances (e.g., in .dark {} blocks) have also been updated accordingly.

This is a minor fix, but improves correctness and avoids unexpected behavior in browsers or tools that strictly parse CSS.