### PR TITLE
Refactor Switch component to use CSS variables for improved sizing flexibility

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/switch.tsx
+++ b/apps/v4/registry/new-york-v4/ui/switch.tsx
@@ -11,9 +11,20 @@ function Switch({
 }: React.ComponentProps<typeof SwitchPrimitive.Root>) {
   return (
     <SwitchPrimitive.Root
+      style={
+				{
+					"--switch-width": "2rem",
+					"--switch-height": "calc(var(--switch-width) * (23 / 40))",
+					"--switch-padding": "1px", // always set as a whole number to prevent visual bugs
+					"--switch-thumb-size":
+						"calc(var(--switch-height) - 2 * var(--switch-padding))",
+					"--switch-thumb-travel":
+						"calc(var(--switch-width) - 2 * var(--switch-padding) - var(--switch-thumb-size))",
+				} as React.CSSProperties
+			}
       data-slot="switch"
       className={cn(
-        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex w-(--switch-width) h-(--switch-height) shrink-0 items-center rounded-full border-(length:--switch-padding) border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}
@@ -21,7 +32,7 @@ function Switch({
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-(--switch-thumb-size) rounded-full ring-0 transition-transform data-[state=unchecked]:translate-x-0 data-[state=checked]:translate-x-(--switch-thumb-travel) rtl:data-[state=checked]:-translate-x-(--switch-thumb-travel)"
         )}
       />
     </SwitchPrimitive.Root>


### PR DESCRIPTION
This PR refactors the Switch component from shadcn/ui to leverage CSS variables for all critical sizing and spacing logic. Key improvements include:
- Dynamic sizing: Introduced --switch-width, --switch-height, --switch-padding, and --switch-thumb-size to allow flexible scaling of the switch component without breaking layout.
- Improved thumb translation logic: Replaced static values with --switch-thumb-travel for accurate movement based on component dimensions.
- RTL support: Added logic to handle RTL layouts via conditional translation.
- Code cleanliness: Reduced repeated hardcoded numbers and improved readability through standardized variable names and consistent usage.

This update improves the scalability and maintainability of the Switch component, especially for design systems needing adaptable UI components.
