### PR TITLE
feat(registry): add viewportRef prop to allow forwarding ref to Viewport

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/scroll-area.tsx
+++ b/apps/v4/registry/new-york-v4/ui/scroll-area.tsx
@@ -5,11 +5,11 @@ import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 
 import { cn } from "@/lib/utils"
 
-function ScrollArea({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+type Props = React.ComponentProps<typeof ScrollAreaPrimitive.Root> & {
+  viewportRef?: React.Ref<HTMLDivElement>
+}
+
+function ScrollArea({ className, children, viewportRef, ...props }: Props) {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
@@ -17,6 +17,7 @@ function ScrollArea({
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
+        ref={viewportRef}
         data-slot="scroll-area-viewport"
         className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
       >


### PR DESCRIPTION
## Problem

Currently, the `ScrollArea` component does not provide a way to access a `ref` to the inner `ScrollAreaPrimitive.Viewport` element. This makes it difficult to integrate with libraries that require a reference to the actual scrolling container, such as virtualization libraries like `@tanstack/react-virtual`.

When trying to implement a virtualized list inside `ScrollArea`, the virtualizer cannot detect scroll events because the `ref` can only be attached to the `ScrollAreaPrimitive.Root` element, which is not the scrolling element.

## Solution

I propose adding an optional `viewportRef` prop to the `ScrollArea` component. This prop will be forwarded directly to the underlying `ScrollAreaPrimitive.Viewport`.

This provides a clean escape hatch for developers who need direct access to the viewport DOM node, without changing the existing API.

## Example Code Change in `scroll-area.tsx`

```tsx
type Props = React.ComponentProps<typeof ScrollAreaPrimitive.Root> & {
  viewportRef?: React.Ref<HTMLDivElement>;
};

function ScrollArea({ className, children, viewportRef, ...props }: Props) {
  return (
    <ScrollAreaPrimitive.Root {...props}>
      <ScrollAreaPrimitive.Viewport ref={viewportRef}>
        {children}
      </ScrollAreaPrimitive.Viewport>

      <ScrollAreaPrimitive.Corner />
    </ScrollAreaPrimitive.Root>
  );
}
```

## Example Usage

```tsx
const parentRef = React.useRef<HTMLDivElement>(null);

const rowVirtualizer = useVirtualizer({
  getScrollElement: () => parentRef.current,
  // ...
});

return (
  <ScrollArea
    viewportRef={parentRef}
  >
    <div style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
    // ...
   {/* Virtualized content... */}
  )
);
```

## Benefits

- Greatly enhances interoperability with third-party libraries.
- Directly enables high-performance virtualized lists within `ScrollArea`.
- The new prop is optional and does not affect existing users.

This would be a valuable addition for building complex and high-performance UIs. I'm happy to open a PR for this change.