### PR TITLE
Fix: Make size prop optional in PaginationLink to match default value behavior (#7984)

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/pagination.tsx
+++ b/apps/v4/registry/new-york-v4/ui/pagination.tsx
@@ -39,8 +39,8 @@ function PaginationItem({ ...props }: React.ComponentProps<"li">) {
 
 type PaginationLinkProps = {
   isActive?: boolean
-} & Pick<React.ComponentProps<typeof Button>, "size"> &
-  React.ComponentProps<"a">
+  size?: React.ComponentProps<typeof Button>["size"] // 👈 Mark as optional here
+} & React.ComponentProps<"a">
 
 function PaginationLink({
   className,


### PR DESCRIPTION
This PR fixes a TypeScript typing issue where the size prop in PaginationLink was inherited as a required prop from Button, causing type errors when it was omitted, even though the component defined a default value ("icon").

Changes made:

Updated PaginationLinkProps to mark size as optional (size?: ...) instead of required.

Ensured size still uses the same type as Button’s size prop for type safety.

Preserved default value ("icon") in the component implementation.

Before:

Omitting size in PaginationLink caused a TypeScript error.

After:

size is now optional, and no error occurs when omitted.

Linked issue: #7984