### PR TITLE
docs: update sidebar.mdx to fix extraneous asChild

### DIFF
--- a/apps/www/content/docs/components/sidebar.mdx
+++ b/apps/www/content/docs/components/sidebar.mdx
@@ -766,7 +766,7 @@ Use the `SidebarGroupAction` component to add an action button to the `SidebarGr
 export function AppSidebar() {
   return (
     <SidebarGroup>
-      <SidebarGroupLabel asChild>Projects</SidebarGroupLabel>
+      <SidebarGroupLabel>Projects</SidebarGroupLabel>
       <SidebarGroupAction title="Add Project">
         <Plus /> <span className="sr-only">Add Project</span>
       </SidebarGroupAction>


### PR DESCRIPTION
One line fix to remove an extraneous asChild on an SidebarGroupLabel since the contents is just text and there is no inner element.