### PR TITLE
fix: prevent subscription card chart overflow in CardsStats component

### DIFF
--- a/apps/v4/components/cards/stats.tsx
+++ b/apps/v4/components/cards/stats.tsx
@@ -92,7 +92,7 @@ export function CardsStats() {
           </ChartContainer>
         </CardContent>
       </Card>
-      <Card className="pb-0 lg:hidden xl:flex">
+      <Card className="overflow-x-auto pb-0 lg:hidden xl:flex">
         <CardHeader>
           <CardDescription>Subscriptions</CardDescription>
           <CardTitle className="text-3xl">+2,350</CardTitle>


### PR DESCRIPTION
## Changes
Added `overflow-x-auto` to the subscriptions card of the `CardsStats` component to ensure the chart content does not overflow beyond the card's boundaries.

## Screenshots
**Before:**
<img width="405" height="285" alt="before" src="https://github.com/user-attachments/assets/ec8e7722-bbb5-4f72-9ab9-a439ffe20dea" />

**After:**
<img width="405" height="285" alt="after" src="https://github.com/user-attachments/assets/075a7961-9b43-4602-b707-a99e32f25c62" />