### PR TITLE
feat: add InlineEdit component for inline editing functionality (#8020)

### DIFF
--- a/apps/v4/content/docs/components/inline-edit.mdx
+++ b/apps/v4/content/docs/components/inline-edit.mdx
@@ -1,0 +1,227 @@
+---
+title: Inline Edit
+description: Displays a text field that can be edited in place.
+component: true
+---
+
+<ComponentPreview
+  name="inline-edit-demo"
+  description="A text field that can be edited in place."
+/>
+
+## Installation
+
+<CodeTabs>
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add inline-edit
+```
+
+</TabsContent>
+
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<ComponentSource name="inline-edit" title="components/ui/inline-edit.tsx" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</CodeTabs>
+
+## Usage
+
+```tsx
+import { InlineEdit } from "@/components/ui/inline-edit"
+```
+
+```tsx
+<InlineEdit />
+```
+
+## Examples
+
+### Default
+
+<ComponentPreview
+  name="inline-edit-demo"
+  description="A text field that can be edited in place."
+/>
+
+## Props
+
+The `InlineEdit` component accepts the following props:
+
+### variant
+
+Controls the visual style of the component.
+
+- `default` (default) - Subtle background on hover with rounded corners
+- `ghost` - Transparent background on hover
+- `outline` - Border with accent colors on hover
+
+```tsx
+<InlineEdit variant="default" />
+<InlineEdit variant="ghost" />
+<InlineEdit variant="outline" />
+```
+
+### size
+
+Controls the size and spacing of the component.
+
+- `default` (default) - Standard size with min-height of 36px
+- `sm` - Small size with min-height of 32px
+- `lg` - Large size with min-height of 40px
+
+```tsx
+<InlineEdit size="sm" />
+<InlineEdit size="default" />
+<InlineEdit size="lg" />
+```
+
+### inputType
+
+Controls the input type for the edit field.
+
+- `text` (default) - Standard text input
+- `email` - Email input with validation
+- `password` - Password input (masked)
+- `number` - Numeric input
+- `url` - URL input with validation
+- `tel` - Telephone number input
+
+```tsx
+<InlineEdit inputType="email" placeholder="Enter email" />
+<InlineEdit inputType="number" placeholder="Enter number" />
+<InlineEdit inputType="url" placeholder="Enter URL" />
+<InlineEdit inputType="tel" placeholder="Enter phone number" />
+```
+
+### State Control
+
+#### isEditing
+
+Controls whether the component is in edit mode (for controlled usage).
+
+```tsx
+<InlineEdit isEditing={true} />
+```
+
+#### disabled
+
+Disables the component, preventing editing.
+
+```tsx
+<InlineEdit disabled />
+```
+
+#### required
+
+Makes the field required, preventing empty submissions.
+
+```tsx
+<InlineEdit required />
+```
+
+#### isLoading
+
+Shows loading state with spinner.
+
+```tsx
+<InlineEdit isLoading />
+```
+
+#### error
+
+Displays an error message below the input.
+
+```tsx
+<InlineEdit error="This field is required" />
+```
+
+### Behavior Options
+
+#### showEditIcon
+
+Controls whether to show the edit icon on hover (default: `true`).
+
+```tsx
+<InlineEdit showEditIcon={false} />
+```
+
+#### showActionButtons
+
+Shows save/cancel buttons when editing (default: `false`).
+
+```tsx
+<InlineEdit showActionButtons />
+```
+
+#### saveOnEnter
+
+Save changes when Enter key is pressed (default: `true`).
+
+```tsx
+<InlineEdit saveOnEnter={false} />
+```
+
+#### cancelOnEscape
+
+Cancel editing when Escape key is pressed (default: `true`).
+
+```tsx
+<InlineEdit cancelOnEscape={false} />
+```
+
+#### saveOnBlur
+
+Save changes when input loses focus (default: `true`).
+
+```tsx
+<InlineEdit saveOnBlur={false} />
+```
+
+### Validation
+
+#### maxLength
+
+Maximum number of characters allowed.
+
+```tsx
+<InlineEdit maxLength={50} />
+```
+
+#### minLength
+
+Minimum number of characters required.
+
+```tsx
+<InlineEdit minLength={3} />
+```
+
+### Example with Props
+
+```tsx
+<InlineEdit
+  variant="outline"
+  size="lg"
+  inputType="email"
+  required
+  maxLength={100}
+  showActionButtons
+  defaultValue="Click to edit this text"
+/>
+```

--- a/apps/v4/registry.json
+++ b/apps/v4/registry.json
@@ -338,6 +338,16 @@
       ]
     },
     {
+      "name": "inline-edit",
+      "type": "registry:ui",
+      "files": [
+        {
+          "path": "registry/new-york-v4/ui/inline-edit.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "input-otp",
       "type": "registry:ui",
       "dependencies": [
@@ -4638,6 +4648,19 @@
       "files": [
         {
           "path": "registry/new-york-v4/examples/input-demo.tsx",
+          "type": "registry:example"
+        }
+      ]
+    },
+    {
+      "name": "inline-edit-demo",
+      "type": "registry:example",
+      "registryDependencies": [
+        "inline-edit"
+      ],
+      "files": [
+        {
+          "path": "registry/new-york-v4/examples/inline-edit-demo.tsx",
           "type": "registry:example"
         }
       ]

--- a/apps/v4/registry/__index__.tsx
+++ b/apps/v4/registry/__index__.tsx
@@ -6,7 +6,7 @@
 import * as React from "react"
 
 export const Index: Record<string, any> = {
-  "index": {
+  index: {
     name: "index",
     description: "",
     type: "registry:style",
@@ -16,7 +16,7 @@ export const Index: Record<string, any> = {
     categories: undefined,
     meta: undefined,
   },
-  "style": {
+  style: {
     name: "style",
     description: "",
     type: "registry:style",
@@ -26,37 +26,49 @@ export const Index: Record<string, any> = {
     categories: undefined,
     meta: undefined,
   },
-  "accordion": {
+  accordion: {
     name: "accordion",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/accordion.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/accordion.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/accordion.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "alert": {
+  alert: {
     name: "alert",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/alert.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/alert.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/alert.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -67,14 +79,20 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:ui",
     registryDependencies: ["button"],
-    files: [{
-      path: "registry/new-york-v4/ui/alert-dialog.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/alert-dialog.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/alert-dialog.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -85,212 +103,284 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/aspect-ratio.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/aspect-ratio.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/aspect-ratio.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "avatar": {
+  avatar: {
     name: "avatar",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/avatar.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/avatar.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/avatar.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "badge": {
+  badge: {
     name: "badge",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/badge.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/badge.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/badge.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "breadcrumb": {
+  breadcrumb: {
     name: "breadcrumb",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/breadcrumb.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/breadcrumb.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/breadcrumb.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "button": {
+  button: {
     name: "button",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/button.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/button.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/button.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "calendar": {
+  calendar: {
     name: "calendar",
     description: "",
     type: "registry:ui",
     registryDependencies: ["button"],
-    files: [{
-      path: "registry/new-york-v4/ui/calendar.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/calendar.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/calendar.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "card": {
+  card: {
     name: "card",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/card.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/card.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/card.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "carousel": {
+  carousel: {
     name: "carousel",
     description: "",
     type: "registry:ui",
     registryDependencies: ["button"],
-    files: [{
-      path: "registry/new-york-v4/ui/carousel.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/carousel.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/carousel.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "chart": {
+  chart: {
     name: "chart",
     description: "",
     type: "registry:ui",
     registryDependencies: ["card"],
-    files: [{
-      path: "registry/new-york-v4/ui/chart.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/chart.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/chart.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "checkbox": {
+  checkbox: {
     name: "checkbox",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/checkbox.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/checkbox.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/checkbox.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "collapsible": {
+  collapsible: {
     name: "collapsible",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/collapsible.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/collapsible.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/collapsible.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "command": {
+  command: {
     name: "command",
     description: "",
     type: "registry:ui",
     registryDependencies: ["dialog"],
-    files: [{
-      path: "registry/new-york-v4/ui/command.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/command.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/command.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -301,50 +391,68 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/context-menu.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/context-menu.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/context-menu.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "dialog": {
+  dialog: {
     name: "dialog",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/dialog.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/dialog.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/dialog.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "drawer": {
+  drawer: {
     name: "drawer",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/drawer.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/drawer.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/drawer.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -355,32 +463,44 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/dropdown-menu.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/dropdown-menu.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/dropdown-menu.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "form": {
+  form: {
     name: "form",
     description: "",
     type: "registry:ui",
-    registryDependencies: ["button","label"],
-    files: [{
-      path: "registry/new-york-v4/ui/form.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    registryDependencies: ["button", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/form.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/form.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -391,32 +511,44 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/hover-card.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/hover-card.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/hover-card.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "input": {
+  input: {
     name: "input",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/input.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/input.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/input.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -427,50 +559,68 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/input-otp.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/input-otp.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/input-otp.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "label": {
+  label: {
     name: "label",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/label.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/label.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/label.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "menubar": {
+  menubar: {
     name: "menubar",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/menubar.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/menubar.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/menubar.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -481,68 +631,92 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/navigation-menu.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/navigation-menu.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/navigation-menu.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "pagination": {
+  pagination: {
     name: "pagination",
     description: "",
     type: "registry:ui",
     registryDependencies: ["button"],
-    files: [{
-      path: "registry/new-york-v4/ui/pagination.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/pagination.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/pagination.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "popover": {
+  popover: {
     name: "popover",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/popover.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/popover.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/popover.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "progress": {
+  progress: {
     name: "progress",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/progress.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/progress.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/progress.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -553,32 +727,44 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/radio-group.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/radio-group.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/radio-group.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "resizable": {
+  resizable: {
     name: "resizable",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/resizable.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/resizable.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/resizable.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -589,230 +775,316 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/scroll-area.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/scroll-area.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/scroll-area.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "select": {
+  select: {
     name: "select",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/select.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/select.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/select.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "separator": {
+  separator: {
     name: "separator",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/separator.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/separator.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/separator.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "sheet": {
+  sheet: {
     name: "sheet",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/sheet.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/sheet.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/sheet.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "sidebar": {
+  sidebar: {
     name: "sidebar",
     description: "",
     type: "registry:ui",
-    registryDependencies: ["button","separator","sheet","tooltip","input","use-mobile","skeleton"],
-    files: [{
-      path: "registry/new-york-v4/ui/sidebar.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    registryDependencies: [
+      "button",
+      "separator",
+      "sheet",
+      "tooltip",
+      "input",
+      "use-mobile",
+      "skeleton",
+    ],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/sidebar.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/sidebar.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "skeleton": {
+  skeleton: {
     name: "skeleton",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/skeleton.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/skeleton.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/skeleton.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "slider": {
+  slider: {
     name: "slider",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/slider.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/slider.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/slider.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "sonner": {
+  sonner: {
     name: "sonner",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/sonner.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/sonner.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/sonner.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "switch": {
+  switch: {
     name: "switch",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/switch.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/switch.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/switch.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "table": {
+  table: {
     name: "table",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/table.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/table.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/table.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "tabs": {
+  tabs: {
     name: "tabs",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/tabs.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/tabs.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/tabs.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "textarea": {
+  textarea: {
     name: "textarea",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/textarea.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/textarea.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/textarea.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "toggle": {
+  toggle: {
     name: "toggle",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/toggle.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/toggle.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/toggle.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -823,32 +1095,44 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:ui",
     registryDependencies: ["toggle"],
-    files: [{
-      path: "registry/new-york-v4/ui/toggle-group.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/toggle-group.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/toggle-group.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  "tooltip": {
+  tooltip: {
     name: "tooltip",
     description: "",
     type: "registry:ui",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/ui/tooltip.tsx",
-      type: "registry:ui",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/tooltip.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/ui/tooltip.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -858,680 +1142,1027 @@ export const Index: Record<string, any> = {
     name: "dashboard-01",
     description: "A dashboard with sidebar, charts and data table.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb","separator","label","chart","card","select","tabs","table","toggle-group","badge","button","checkbox","dropdown-menu","drawer","input","avatar","sheet","sonner"],
-    files: [{
-      path: "registry/new-york-v4/blocks/dashboard-01/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/dashboard-01/data.json",
-      type: "registry:file",
-      target: "app/dashboard/data.json"
-    },{
-      path: "registry/new-york-v4/blocks/dashboard-01/components/app-sidebar.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/dashboard-01/components/chart-area-interactive.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/dashboard-01/components/data-table.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/dashboard-01/components/nav-documents.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/dashboard-01/components/nav-main.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/dashboard-01/components/nav-secondary.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/dashboard-01/components/nav-user.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/dashboard-01/components/section-cards.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/dashboard-01/components/site-header.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: [
+      "sidebar",
+      "breadcrumb",
+      "separator",
+      "label",
+      "chart",
+      "card",
+      "select",
+      "tabs",
+      "table",
+      "toggle-group",
+      "badge",
+      "button",
+      "checkbox",
+      "dropdown-menu",
+      "drawer",
+      "input",
+      "avatar",
+      "sheet",
+      "sonner",
+    ],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/dashboard-01/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/dashboard-01/data.json",
+        type: "registry:file",
+        target: "app/dashboard/data.json",
+      },
+      {
+        path: "registry/new-york-v4/blocks/dashboard-01/components/app-sidebar.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/dashboard-01/components/chart-area-interactive.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/dashboard-01/components/data-table.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/dashboard-01/components/nav-documents.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/dashboard-01/components/nav-main.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/dashboard-01/components/nav-secondary.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/dashboard-01/components/nav-user.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/dashboard-01/components/section-cards.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/dashboard-01/components/site-header.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/dashboard-01/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/dashboard-01/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: ["dashboard"],
-    meta: {"iframeHeight":"1000px"},
+    meta: { iframeHeight: "1000px" },
   },
   "sidebar-01": {
     name: "sidebar-01",
     description: "A simple sidebar with navigation grouped by section.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb","separator","label","dropdown-menu"],
-    files: [{
-      path: "registry/new-york-v4/blocks/sidebar-01/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-01/components/app-sidebar.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-01/components/search-form.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-01/components/version-switcher.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: [
+      "sidebar",
+      "breadcrumb",
+      "separator",
+      "label",
+      "dropdown-menu",
+    ],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/sidebar-01/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-01/components/app-sidebar.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-01/components/search-form.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-01/components/version-switcher.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/sidebar-01/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/sidebar-01/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["sidebar","dashboard"],
+    categories: ["sidebar", "dashboard"],
     meta: undefined,
   },
   "sidebar-02": {
     name: "sidebar-02",
     description: "A sidebar with collapsible sections.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb","separator","label","dropdown-menu"],
-    files: [{
-      path: "registry/new-york-v4/blocks/sidebar-02/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-02/components/app-sidebar.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-02/components/search-form.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-02/components/version-switcher.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: [
+      "sidebar",
+      "breadcrumb",
+      "separator",
+      "label",
+      "dropdown-menu",
+    ],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/sidebar-02/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-02/components/app-sidebar.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-02/components/search-form.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-02/components/version-switcher.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/sidebar-02/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/sidebar-02/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["sidebar","dashboard"],
+    categories: ["sidebar", "dashboard"],
     meta: undefined,
   },
   "sidebar-03": {
     name: "sidebar-03",
     description: "A sidebar with submenus.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb"],
-    files: [{
-      path: "registry/new-york-v4/blocks/sidebar-03/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-03/components/app-sidebar.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["sidebar", "breadcrumb"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/sidebar-03/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-03/components/app-sidebar.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/sidebar-03/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/sidebar-03/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["sidebar","dashboard"],
+    categories: ["sidebar", "dashboard"],
     meta: undefined,
   },
   "sidebar-04": {
     name: "sidebar-04",
     description: "A floating sidebar with submenus.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb","separator"],
-    files: [{
-      path: "registry/new-york-v4/blocks/sidebar-04/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-04/components/app-sidebar.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["sidebar", "breadcrumb", "separator"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/sidebar-04/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-04/components/app-sidebar.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/sidebar-04/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/sidebar-04/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["sidebar","dashboard"],
+    categories: ["sidebar", "dashboard"],
     meta: undefined,
   },
   "sidebar-05": {
     name: "sidebar-05",
     description: "A sidebar with collapsible submenus.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb","separator","label","collapsible"],
-    files: [{
-      path: "registry/new-york-v4/blocks/sidebar-05/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-05/components/app-sidebar.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-05/components/search-form.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: [
+      "sidebar",
+      "breadcrumb",
+      "separator",
+      "label",
+      "collapsible",
+    ],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/sidebar-05/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-05/components/app-sidebar.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-05/components/search-form.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/sidebar-05/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/sidebar-05/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["sidebar","dashboard"],
+    categories: ["sidebar", "dashboard"],
     meta: undefined,
   },
   "sidebar-06": {
     name: "sidebar-06",
     description: "A sidebar with submenus as dropdowns.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb","separator","card","dropdown-menu"],
-    files: [{
-      path: "registry/new-york-v4/blocks/sidebar-06/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-06/components/app-sidebar.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-06/components/nav-main.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-06/components/sidebar-opt-in-form.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: [
+      "sidebar",
+      "breadcrumb",
+      "separator",
+      "card",
+      "dropdown-menu",
+    ],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/sidebar-06/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-06/components/app-sidebar.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-06/components/nav-main.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-06/components/sidebar-opt-in-form.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/sidebar-06/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/sidebar-06/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["sidebar","dashboard"],
+    categories: ["sidebar", "dashboard"],
     meta: undefined,
   },
   "sidebar-07": {
     name: "sidebar-07",
     description: "A sidebar that collapses to icons.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb","separator","collapsible","dropdown-menu","avatar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/sidebar-07/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-07/components/app-sidebar.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-07/components/nav-main.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-07/components/nav-projects.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-07/components/nav-user.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-07/components/team-switcher.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: [
+      "sidebar",
+      "breadcrumb",
+      "separator",
+      "collapsible",
+      "dropdown-menu",
+      "avatar",
+    ],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/sidebar-07/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-07/components/app-sidebar.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-07/components/nav-main.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-07/components/nav-projects.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-07/components/nav-user.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-07/components/team-switcher.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/sidebar-07/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/sidebar-07/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["sidebar","dashboard"],
+    categories: ["sidebar", "dashboard"],
     meta: undefined,
   },
   "sidebar-08": {
     name: "sidebar-08",
     description: "An inset sidebar with secondary navigation.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb","separator","collapsible","dropdown-menu","avatar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/sidebar-08/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-08/components/app-sidebar.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-08/components/nav-main.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-08/components/nav-projects.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-08/components/nav-secondary.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-08/components/nav-user.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: [
+      "sidebar",
+      "breadcrumb",
+      "separator",
+      "collapsible",
+      "dropdown-menu",
+      "avatar",
+    ],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/sidebar-08/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-08/components/app-sidebar.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-08/components/nav-main.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-08/components/nav-projects.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-08/components/nav-secondary.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-08/components/nav-user.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/sidebar-08/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/sidebar-08/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["sidebar","dashboard"],
+    categories: ["sidebar", "dashboard"],
     meta: undefined,
   },
   "sidebar-09": {
     name: "sidebar-09",
     description: "Collapsible nested sidebars.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb","separator","collapsible","dropdown-menu","avatar","switch","label"],
-    files: [{
-      path: "registry/new-york-v4/blocks/sidebar-09/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-09/components/app-sidebar.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-09/components/nav-user.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: [
+      "sidebar",
+      "breadcrumb",
+      "separator",
+      "collapsible",
+      "dropdown-menu",
+      "avatar",
+      "switch",
+      "label",
+    ],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/sidebar-09/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-09/components/app-sidebar.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-09/components/nav-user.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/sidebar-09/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/sidebar-09/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["sidebar","dashboard"],
+    categories: ["sidebar", "dashboard"],
     meta: undefined,
   },
   "sidebar-10": {
     name: "sidebar-10",
     description: "A sidebar in a popover.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb","separator","popover","collapsible","dropdown-menu"],
-    files: [{
-      path: "registry/new-york-v4/blocks/sidebar-10/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-10/components/app-sidebar.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-10/components/nav-actions.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-10/components/nav-favorites.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-10/components/nav-main.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-10/components/nav-secondary.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-10/components/nav-workspaces.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-10/components/team-switcher.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: [
+      "sidebar",
+      "breadcrumb",
+      "separator",
+      "popover",
+      "collapsible",
+      "dropdown-menu",
+    ],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/sidebar-10/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-10/components/app-sidebar.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-10/components/nav-actions.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-10/components/nav-favorites.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-10/components/nav-main.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-10/components/nav-secondary.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-10/components/nav-workspaces.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-10/components/team-switcher.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/sidebar-10/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/sidebar-10/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["sidebar","dashboard"],
+    categories: ["sidebar", "dashboard"],
     meta: undefined,
   },
   "sidebar-11": {
     name: "sidebar-11",
     description: "A sidebar with a collapsible file tree.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb","separator","collapsible"],
-    files: [{
-      path: "registry/new-york-v4/blocks/sidebar-11/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-11/components/app-sidebar.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["sidebar", "breadcrumb", "separator", "collapsible"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/sidebar-11/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-11/components/app-sidebar.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/sidebar-11/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/sidebar-11/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["sidebar","dashboard"],
+    categories: ["sidebar", "dashboard"],
     meta: undefined,
   },
   "sidebar-12": {
     name: "sidebar-12",
     description: "A sidebar with a calendar.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb","separator","collapsible","calendar","dropdown-menu","avatar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/sidebar-12/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-12/components/app-sidebar.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-12/components/calendars.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-12/components/date-picker.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-12/components/nav-user.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: [
+      "sidebar",
+      "breadcrumb",
+      "separator",
+      "collapsible",
+      "calendar",
+      "dropdown-menu",
+      "avatar",
+    ],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/sidebar-12/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-12/components/app-sidebar.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-12/components/calendars.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-12/components/date-picker.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-12/components/nav-user.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/sidebar-12/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/sidebar-12/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["sidebar","dashboard"],
+    categories: ["sidebar", "dashboard"],
     meta: undefined,
   },
   "sidebar-13": {
     name: "sidebar-13",
     description: "A sidebar in a dialog.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb","button","dialog"],
-    files: [{
-      path: "registry/new-york-v4/blocks/sidebar-13/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-13/components/settings-dialog.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["sidebar", "breadcrumb", "button", "dialog"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/sidebar-13/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-13/components/settings-dialog.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/sidebar-13/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/sidebar-13/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["sidebar","dashboard"],
+    categories: ["sidebar", "dashboard"],
     meta: undefined,
   },
   "sidebar-14": {
     name: "sidebar-14",
     description: "A sidebar on the right.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb"],
-    files: [{
-      path: "registry/new-york-v4/blocks/sidebar-14/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-14/components/app-sidebar.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["sidebar", "breadcrumb"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/sidebar-14/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-14/components/app-sidebar.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/sidebar-14/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/sidebar-14/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["sidebar","dashboard"],
+    categories: ["sidebar", "dashboard"],
     meta: undefined,
   },
   "sidebar-15": {
     name: "sidebar-15",
     description: "A left and right sidebar.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb","separator","popover","collapsible","dropdown-menu","calendar","avatar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/sidebar-15/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-15/components/calendars.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-15/components/date-picker.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-15/components/nav-favorites.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-15/components/nav-main.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-15/components/nav-secondary.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-15/components/nav-user.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-15/components/nav-workspaces.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-15/components/sidebar-left.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-15/components/sidebar-right.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-15/components/team-switcher.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: [
+      "sidebar",
+      "breadcrumb",
+      "separator",
+      "popover",
+      "collapsible",
+      "dropdown-menu",
+      "calendar",
+      "avatar",
+    ],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/sidebar-15/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-15/components/calendars.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-15/components/date-picker.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-15/components/nav-favorites.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-15/components/nav-main.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-15/components/nav-secondary.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-15/components/nav-user.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-15/components/nav-workspaces.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-15/components/sidebar-left.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-15/components/sidebar-right.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-15/components/team-switcher.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/sidebar-15/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/sidebar-15/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["sidebar","dashboard"],
+    categories: ["sidebar", "dashboard"],
     meta: undefined,
   },
   "sidebar-16": {
     name: "sidebar-16",
     description: "A sidebar with a sticky site header.",
     type: "registry:block",
-    registryDependencies: ["sidebar","breadcrumb","separator","collapsible","dropdown-menu","avatar","button","label"],
-    files: [{
-      path: "registry/new-york-v4/blocks/sidebar-16/page.tsx",
-      type: "registry:page",
-      target: "app/dashboard/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-16/components/app-sidebar.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-16/components/nav-main.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-16/components/nav-projects.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-16/components/nav-secondary.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-16/components/nav-user.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-16/components/search-form.tsx",
-      type: "registry:component",
-      target: ""
-    },{
-      path: "registry/new-york-v4/blocks/sidebar-16/components/site-header.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: [
+      "sidebar",
+      "breadcrumb",
+      "separator",
+      "collapsible",
+      "dropdown-menu",
+      "avatar",
+      "button",
+      "label",
+    ],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/sidebar-16/page.tsx",
+        type: "registry:page",
+        target: "app/dashboard/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-16/components/app-sidebar.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-16/components/nav-main.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-16/components/nav-projects.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-16/components/nav-secondary.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-16/components/nav-user.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-16/components/search-form.tsx",
+        type: "registry:component",
+        target: "",
+      },
+      {
+        path: "registry/new-york-v4/blocks/sidebar-16/components/site-header.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/sidebar-16/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/sidebar-16/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["sidebar","dashboard"],
+    categories: ["sidebar", "dashboard"],
     meta: undefined,
   },
   "login-01": {
     name: "login-01",
     description: "A simple login form.",
     type: "registry:block",
-    registryDependencies: ["button","card","input","label"],
-    files: [{
-      path: "registry/new-york-v4/blocks/login-01/page.tsx",
-      type: "registry:page",
-      target: "app/login/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/login-01/components/login-form.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["button", "card", "input", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/login-01/page.tsx",
+        type: "registry:page",
+        target: "app/login/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/login-01/components/login-form.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/login-01/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/login-01/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["authentication","login"],
+    categories: ["authentication", "login"],
     meta: undefined,
   },
   "login-02": {
     name: "login-02",
     description: "A two column login page with a cover image.",
     type: "registry:block",
-    registryDependencies: ["button","card","input","label"],
-    files: [{
-      path: "registry/new-york-v4/blocks/login-02/page.tsx",
-      type: "registry:page",
-      target: "app/login/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/login-02/components/login-form.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["button", "card", "input", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/login-02/page.tsx",
+        type: "registry:page",
+        target: "app/login/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/login-02/components/login-form.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/login-02/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/login-02/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["authentication","login"],
+    categories: ["authentication", "login"],
     meta: undefined,
   },
   "login-03": {
     name: "login-03",
     description: "A login page with a muted background color.",
     type: "registry:block",
-    registryDependencies: ["button","card","input","label"],
-    files: [{
-      path: "registry/new-york-v4/blocks/login-03/page.tsx",
-      type: "registry:page",
-      target: "app/login/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/login-03/components/login-form.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["button", "card", "input", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/login-03/page.tsx",
+        type: "registry:page",
+        target: "app/login/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/login-03/components/login-form.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/login-03/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/login-03/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["authentication","login"],
+    categories: ["authentication", "login"],
     meta: undefined,
   },
   "login-04": {
     name: "login-04",
     description: "A login page with form and image.",
     type: "registry:block",
-    registryDependencies: ["button","card","input","label"],
-    files: [{
-      path: "registry/new-york-v4/blocks/login-04/page.tsx",
-      type: "registry:page",
-      target: "app/login/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/login-04/components/login-form.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["button", "card", "input", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/login-04/page.tsx",
+        type: "registry:page",
+        target: "app/login/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/login-04/components/login-form.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/login-04/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/login-04/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["authentication","login"],
+    categories: ["authentication", "login"],
     meta: undefined,
   },
   "login-05": {
     name: "login-05",
     description: "A simple email-only login page.",
     type: "registry:block",
-    registryDependencies: ["button","card","input","label"],
-    files: [{
-      path: "registry/new-york-v4/blocks/login-05/page.tsx",
-      type: "registry:page",
-      target: "app/login/page.tsx"
-    },{
-      path: "registry/new-york-v4/blocks/login-05/components/login-form.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["button", "card", "input", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/login-05/page.tsx",
+        type: "registry:page",
+        target: "app/login/page.tsx",
+      },
+      {
+        path: "registry/new-york-v4/blocks/login-05/components/login-form.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/blocks/login-05/page.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/blocks/login-05/page.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["authentication","login"],
+    categories: ["authentication", "login"],
     meta: undefined,
   },
   "calendar-01": {
@@ -1539,1850 +2170,2768 @@ export const Index: Record<string, any> = {
     description: "A simple calendar.",
     type: "registry:block",
     registryDependencies: ["calendar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-01.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-01.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-01.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-4 py-12 items-start md:py-20 justify-center min-w-0","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-4 py-12 items-start md:py-20 justify-center min-w-0",
+      mobile: "component",
+    },
   },
   "calendar-02": {
     name: "calendar-02",
     description: "Multiple months with single selection.",
     type: "registry:block",
     registryDependencies: ["calendar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-02.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-02.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-02.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-4 py-12 items-start md:py-20 justify-center min-w-0","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-4 py-12 items-start md:py-20 justify-center min-w-0",
+      mobile: "component",
+    },
   },
   "calendar-03": {
     name: "calendar-03",
     description: "Multiple months with multiple selection.",
     type: "registry:block",
     registryDependencies: ["calendar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-03.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-03.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-03.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-4 py-12 items-start md:py-20 justify-center min-w-0","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-4 py-12 items-start md:py-20 justify-center min-w-0",
+      mobile: "component",
+    },
   },
   "calendar-04": {
     name: "calendar-04",
     description: "Single month with range selection",
     type: "registry:block",
     registryDependencies: ["calendar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-04.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-04.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-04.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-4 py-12 items-start md:py-20 justify-center min-w-0 xl:pt-28","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-4 py-12 items-start md:py-20 justify-center min-w-0 xl:pt-28",
+      mobile: "component",
+    },
   },
   "calendar-05": {
     name: "calendar-05",
     description: "Multiple months with range selection",
     type: "registry:block",
     registryDependencies: ["calendar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-05.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-05.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-05.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-06": {
     name: "calendar-06",
     description: "Range selection with minimum days",
     type: "registry:block",
     registryDependencies: ["calendar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-06.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-06.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-06.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-07": {
     name: "calendar-07",
     description: "Range selection with minimum and maximum days",
     type: "registry:block",
     registryDependencies: ["calendar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-07.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-07.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-07.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-08": {
     name: "calendar-08",
     description: "Calendar with disabled days",
     type: "registry:block",
     registryDependencies: ["calendar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-08.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-08.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-08.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-09": {
     name: "calendar-09",
     description: "Calendar with disabled weekends",
     type: "registry:block",
     registryDependencies: ["calendar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-09.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-09.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-09.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-10": {
     name: "calendar-10",
     description: "Today button",
     type: "registry:block",
-    registryDependencies: ["calendar","card","button"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-10.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "card", "button"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-10.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-10.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-11": {
     name: "calendar-11",
     description: "Start and end of month",
     type: "registry:block",
     registryDependencies: ["calendar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-11.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-11.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-11.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-12": {
     name: "calendar-12",
     description: "Localized calendar",
     type: "registry:block",
-    registryDependencies: ["calendar","card","select"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-12.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "card", "select"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-12.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-12.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-13": {
     name: "calendar-13",
     description: "With Month and Year Dropdown",
     type: "registry:block",
-    registryDependencies: ["calendar","label","select"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-13.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "label", "select"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-13.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-13.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-14": {
     name: "calendar-14",
     description: "With Booked/Unavailable Days",
     type: "registry:block",
     registryDependencies: ["calendar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-14.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-14.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-14.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-15": {
     name: "calendar-15",
     description: "With Week Numbers",
     type: "registry:block",
     registryDependencies: ["calendar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-15.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-15.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-15.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-16": {
     name: "calendar-16",
     description: "With time picker",
     type: "registry:block",
-    registryDependencies: ["calendar","card","input","label"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-16.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "card", "input", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-16.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-16.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start justify-center min-w-0","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start justify-center min-w-0",
+      mobile: "component",
+    },
   },
   "calendar-17": {
     name: "calendar-17",
     description: "With time picker inline",
     type: "registry:block",
-    registryDependencies: ["calendar","card","input","label"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-17.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "card", "input", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-17.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-17.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-18": {
     name: "calendar-18",
     description: "Variable size",
     type: "registry:block",
     registryDependencies: ["calendar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-18.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-18.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-18.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-19": {
     name: "calendar-19",
     description: "With presets",
     type: "registry:block",
-    registryDependencies: ["calendar","card","input","label"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-19.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "card", "input", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-19.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-19.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start justify-center min-w-0","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start justify-center min-w-0",
+      mobile: "component",
+    },
   },
   "calendar-20": {
     name: "calendar-20",
     description: "With time presets",
     type: "registry:block",
-    registryDependencies: ["calendar","card","button"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-20.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "card", "button"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-20.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-20.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start justify-center min-w-0","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start justify-center min-w-0",
+      mobile: "component",
+    },
   },
   "calendar-21": {
     name: "calendar-21",
     description: "Custom days and formatters",
     type: "registry:block",
     registryDependencies: ["calendar"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-21.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-21.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-21.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start justify-center min-w-0","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start justify-center min-w-0",
+      mobile: "component",
+    },
   },
   "calendar-22": {
     name: "calendar-22",
     description: "Date picker",
     type: "registry:block",
-    registryDependencies: ["calendar","popover","button","label"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-22.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "popover", "button", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-22.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-22.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-23": {
     name: "calendar-23",
     description: "Date range picker",
     type: "registry:block",
-    registryDependencies: ["calendar","popover","button","label"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-23.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "popover", "button", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-23.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-23.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-24": {
     name: "calendar-24",
     description: "Date and Time picker",
     type: "registry:block",
-    registryDependencies: ["calendar","popover","button","label"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-24.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "popover", "button", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-24.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-24.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-25": {
     name: "calendar-25",
     description: "Date and Time range picker",
     type: "registry:block",
-    registryDependencies: ["calendar","popover","button","label"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-25.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "popover", "button", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-25.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-25.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-26": {
     name: "calendar-26",
     description: "Date range picker with time",
     type: "registry:block",
-    registryDependencies: ["calendar","popover","button","input","label"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-26.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "popover", "button", "input", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-26.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-26.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-27": {
     name: "calendar-27",
     description: "Chart filter",
     type: "registry:block",
-    registryDependencies: ["calendar","chart","card","popover","button"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-27.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "chart", "card", "popover", "button"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-27.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-27.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start justify-center min-w-0","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start justify-center min-w-0",
+      mobile: "component",
+    },
   },
   "calendar-28": {
     name: "calendar-28",
     description: "Input with date picker",
     type: "registry:block",
-    registryDependencies: ["calendar","input","label","popover","button"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-28.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "input", "label", "popover", "button"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-28.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-28.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-29": {
     name: "calendar-29",
     description: "Natural language date picker",
     type: "registry:block",
-    registryDependencies: ["calendar","input","label","popover","button"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-29.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "input", "label", "popover", "button"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-29.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-29.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-30": {
     name: "calendar-30",
     description: "With little-date",
     type: "registry:block",
-    registryDependencies: ["calendar","input","label","popover","button"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-30.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "input", "label", "popover", "button"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-30.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-30.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "calendar-31": {
     name: "calendar-31",
     description: "With event slots",
     type: "registry:block",
-    registryDependencies: ["calendar","card","button"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-31.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "card", "button"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-31.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-31.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"700px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "700px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0",
+      mobile: "component",
+    },
   },
   "calendar-32": {
     name: "calendar-32",
     description: "Date picker in a drawer",
     type: "registry:block",
-    registryDependencies: ["calendar","button","drawer"],
-    files: [{
-      path: "registry/new-york-v4/blocks/calendar-32.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "button", "drawer"],
+    files: [
+      {
+        path: "registry/new-york-v4/blocks/calendar-32.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/blocks/calendar-32.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-6 py-12 items-start md:pt-20 justify-center min-w-0 xl:py-24",
+      mobile: "component",
+    },
   },
   "chart-area-axes": {
     name: "chart-area-axes",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-area-axes.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-area-axes.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-area-axes.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-area-axes.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-area"],
+    categories: ["charts", "charts-area"],
     meta: undefined,
   },
   "chart-area-default": {
     name: "chart-area-default",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-area-default.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-area-default.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-area-default.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-area-default.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-area"],
+    categories: ["charts", "charts-area"],
     meta: undefined,
   },
   "chart-area-gradient": {
     name: "chart-area-gradient",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-area-gradient.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-area-gradient.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-area-gradient.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-area-gradient.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-area"],
+    categories: ["charts", "charts-area"],
     meta: undefined,
   },
   "chart-area-icons": {
     name: "chart-area-icons",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-area-icons.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-area-icons.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-area-icons.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-area-icons.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-area"],
+    categories: ["charts", "charts-area"],
     meta: undefined,
   },
   "chart-area-interactive": {
     name: "chart-area-interactive",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart","select"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-area-interactive.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart", "select"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-area-interactive.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-area-interactive.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-area-interactive.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-area"],
+    categories: ["charts", "charts-area"],
     meta: undefined,
   },
   "chart-area-legend": {
     name: "chart-area-legend",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-area-legend.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-area-legend.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-area-legend.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-area-legend.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-area"],
+    categories: ["charts", "charts-area"],
     meta: undefined,
   },
   "chart-area-linear": {
     name: "chart-area-linear",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-area-linear.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-area-linear.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-area-linear.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-area-linear.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-area"],
+    categories: ["charts", "charts-area"],
     meta: undefined,
   },
   "chart-area-stacked-expand": {
     name: "chart-area-stacked-expand",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-area-stacked-expand.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-area-stacked-expand.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-area-stacked-expand.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-area-stacked-expand.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-area"],
+    categories: ["charts", "charts-area"],
     meta: undefined,
   },
   "chart-area-stacked": {
     name: "chart-area-stacked",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-area-stacked.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-area-stacked.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-area-stacked.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-area-stacked.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-area"],
+    categories: ["charts", "charts-area"],
     meta: undefined,
   },
   "chart-area-step": {
     name: "chart-area-step",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-area-step.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-area-step.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-area-step.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-area-step.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-area"],
+    categories: ["charts", "charts-area"],
     meta: undefined,
   },
   "chart-bar-active": {
     name: "chart-bar-active",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-bar-active.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-bar-active.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-bar-active.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-bar-active.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-bar"],
+    categories: ["charts", "charts-bar"],
     meta: undefined,
   },
   "chart-bar-default": {
     name: "chart-bar-default",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-bar-default.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-bar-default.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-bar-default.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-bar-default.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-bar"],
+    categories: ["charts", "charts-bar"],
     meta: undefined,
   },
   "chart-bar-horizontal": {
     name: "chart-bar-horizontal",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-bar-horizontal.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-bar-horizontal.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-bar-horizontal.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-bar-horizontal.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-bar"],
+    categories: ["charts", "charts-bar"],
     meta: undefined,
   },
   "chart-bar-interactive": {
     name: "chart-bar-interactive",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-bar-interactive.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-bar-interactive.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-bar-interactive.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-bar-interactive.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-bar"],
+    categories: ["charts", "charts-bar"],
     meta: undefined,
   },
   "chart-bar-label-custom": {
     name: "chart-bar-label-custom",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-bar-label-custom.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-bar-label-custom.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-bar-label-custom.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-bar-label-custom.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-bar"],
+    categories: ["charts", "charts-bar"],
     meta: undefined,
   },
   "chart-bar-label": {
     name: "chart-bar-label",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-bar-label.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-bar-label.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-bar-label.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-bar-label.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-bar"],
+    categories: ["charts", "charts-bar"],
     meta: undefined,
   },
   "chart-bar-mixed": {
     name: "chart-bar-mixed",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-bar-mixed.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-bar-mixed.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-bar-mixed.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-bar-mixed.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-bar"],
+    categories: ["charts", "charts-bar"],
     meta: undefined,
   },
   "chart-bar-multiple": {
     name: "chart-bar-multiple",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-bar-multiple.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-bar-multiple.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-bar-multiple.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-bar-multiple.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-bar"],
+    categories: ["charts", "charts-bar"],
     meta: undefined,
   },
   "chart-bar-negative": {
     name: "chart-bar-negative",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-bar-negative.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-bar-negative.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-bar-negative.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-bar-negative.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-bar"],
+    categories: ["charts", "charts-bar"],
     meta: undefined,
   },
   "chart-bar-stacked": {
     name: "chart-bar-stacked",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-bar-stacked.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-bar-stacked.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-bar-stacked.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-bar-stacked.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-bar"],
+    categories: ["charts", "charts-bar"],
     meta: undefined,
   },
   "chart-line-default": {
     name: "chart-line-default",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-line-default.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-line-default.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-line-default.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-line-default.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-line"],
+    categories: ["charts", "charts-line"],
     meta: undefined,
   },
   "chart-line-dots-colors": {
     name: "chart-line-dots-colors",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-line-dots-colors.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-line-dots-colors.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-line-dots-colors.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-line-dots-colors.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-line"],
+    categories: ["charts", "charts-line"],
     meta: undefined,
   },
   "chart-line-dots-custom": {
     name: "chart-line-dots-custom",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-line-dots-custom.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-line-dots-custom.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-line-dots-custom.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-line-dots-custom.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-line"],
+    categories: ["charts", "charts-line"],
     meta: undefined,
   },
   "chart-line-dots": {
     name: "chart-line-dots",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-line-dots.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-line-dots.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-line-dots.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-line-dots.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-line"],
+    categories: ["charts", "charts-line"],
     meta: undefined,
   },
   "chart-line-interactive": {
     name: "chart-line-interactive",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-line-interactive.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-line-interactive.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-line-interactive.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-line-interactive.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-line"],
+    categories: ["charts", "charts-line"],
     meta: undefined,
   },
   "chart-line-label-custom": {
     name: "chart-line-label-custom",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-line-label-custom.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-line-label-custom.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-line-label-custom.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-line-label-custom.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-line"],
+    categories: ["charts", "charts-line"],
     meta: undefined,
   },
   "chart-line-label": {
     name: "chart-line-label",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-line-label.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-line-label.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-line-label.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-line-label.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-line"],
+    categories: ["charts", "charts-line"],
     meta: undefined,
   },
   "chart-line-linear": {
     name: "chart-line-linear",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-line-linear.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-line-linear.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-line-linear.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-line-linear.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-line"],
+    categories: ["charts", "charts-line"],
     meta: undefined,
   },
   "chart-line-multiple": {
     name: "chart-line-multiple",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-line-multiple.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-line-multiple.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-line-multiple.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-line-multiple.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-line"],
+    categories: ["charts", "charts-line"],
     meta: undefined,
   },
   "chart-line-step": {
     name: "chart-line-step",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-line-step.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-line-step.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-line-step.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-line-step.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-line"],
+    categories: ["charts", "charts-line"],
     meta: undefined,
   },
   "chart-pie-donut-active": {
     name: "chart-pie-donut-active",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-pie-donut-active.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-pie-donut-active.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-pie-donut-active.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-pie-donut-active.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-pie"],
+    categories: ["charts", "charts-pie"],
     meta: undefined,
   },
   "chart-pie-donut-text": {
     name: "chart-pie-donut-text",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-pie-donut-text.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-pie-donut-text.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-pie-donut-text.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-pie-donut-text.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-pie"],
+    categories: ["charts", "charts-pie"],
     meta: undefined,
   },
   "chart-pie-donut": {
     name: "chart-pie-donut",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-pie-donut.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-pie-donut.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-pie-donut.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-pie-donut.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-pie"],
+    categories: ["charts", "charts-pie"],
     meta: undefined,
   },
   "chart-pie-interactive": {
     name: "chart-pie-interactive",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-pie-interactive.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-pie-interactive.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-pie-interactive.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-pie-interactive.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-pie"],
+    categories: ["charts", "charts-pie"],
     meta: undefined,
   },
   "chart-pie-label-custom": {
     name: "chart-pie-label-custom",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-pie-label-custom.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-pie-label-custom.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-pie-label-custom.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-pie-label-custom.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-pie"],
+    categories: ["charts", "charts-pie"],
     meta: undefined,
   },
   "chart-pie-label-list": {
     name: "chart-pie-label-list",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-pie-label-list.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-pie-label-list.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-pie-label-list.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-pie-label-list.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-pie"],
+    categories: ["charts", "charts-pie"],
     meta: undefined,
   },
   "chart-pie-label": {
     name: "chart-pie-label",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-pie-label.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-pie-label.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-pie-label.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-pie-label.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-pie"],
+    categories: ["charts", "charts-pie"],
     meta: undefined,
   },
   "chart-pie-legend": {
     name: "chart-pie-legend",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-pie-legend.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-pie-legend.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-pie-legend.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-pie-legend.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-pie"],
+    categories: ["charts", "charts-pie"],
     meta: undefined,
   },
   "chart-pie-separator-none": {
     name: "chart-pie-separator-none",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-pie-separator-none.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-pie-separator-none.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-pie-separator-none.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-pie-separator-none.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-pie"],
+    categories: ["charts", "charts-pie"],
     meta: undefined,
   },
   "chart-pie-simple": {
     name: "chart-pie-simple",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-pie-simple.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-pie-simple.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-pie-simple.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-pie-simple.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-pie"],
+    categories: ["charts", "charts-pie"],
     meta: undefined,
   },
   "chart-pie-stacked": {
     name: "chart-pie-stacked",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-pie-stacked.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-pie-stacked.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-pie-stacked.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-pie-stacked.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-pie"],
+    categories: ["charts", "charts-pie"],
     meta: undefined,
   },
   "chart-radar-default": {
     name: "chart-radar-default",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radar-default.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radar-default.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radar-default.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radar-default.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radar"],
+    categories: ["charts", "charts-radar"],
     meta: undefined,
   },
   "chart-radar-dots": {
     name: "chart-radar-dots",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radar-dots.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radar-dots.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radar-dots.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radar-dots.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radar"],
+    categories: ["charts", "charts-radar"],
     meta: undefined,
   },
   "chart-radar-grid-circle-fill": {
     name: "chart-radar-grid-circle-fill",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radar-grid-circle-fill.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radar-grid-circle-fill.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radar-grid-circle-fill.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radar-grid-circle-fill.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radar"],
+    categories: ["charts", "charts-radar"],
     meta: undefined,
   },
   "chart-radar-grid-circle-no-lines": {
     name: "chart-radar-grid-circle-no-lines",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radar-grid-circle-no-lines.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radar-grid-circle-no-lines.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radar-grid-circle-no-lines.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radar-grid-circle-no-lines.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radar"],
+    categories: ["charts", "charts-radar"],
     meta: undefined,
   },
   "chart-radar-grid-circle": {
     name: "chart-radar-grid-circle",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radar-grid-circle.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radar-grid-circle.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radar-grid-circle.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radar-grid-circle.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radar"],
+    categories: ["charts", "charts-radar"],
     meta: undefined,
   },
   "chart-radar-grid-custom": {
     name: "chart-radar-grid-custom",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radar-grid-custom.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radar-grid-custom.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radar-grid-custom.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radar-grid-custom.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radar"],
+    categories: ["charts", "charts-radar"],
     meta: undefined,
   },
   "chart-radar-grid-fill": {
     name: "chart-radar-grid-fill",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radar-grid-fill.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radar-grid-fill.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radar-grid-fill.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radar-grid-fill.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radar"],
+    categories: ["charts", "charts-radar"],
     meta: undefined,
   },
   "chart-radar-grid-none": {
     name: "chart-radar-grid-none",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radar-grid-none.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radar-grid-none.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radar-grid-none.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radar-grid-none.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radar"],
+    categories: ["charts", "charts-radar"],
     meta: undefined,
   },
   "chart-radar-icons": {
     name: "chart-radar-icons",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radar-icons.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radar-icons.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radar-icons.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radar-icons.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radar"],
+    categories: ["charts", "charts-radar"],
     meta: undefined,
   },
   "chart-radar-label-custom": {
     name: "chart-radar-label-custom",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radar-label-custom.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radar-label-custom.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radar-label-custom.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radar-label-custom.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radar"],
+    categories: ["charts", "charts-radar"],
     meta: undefined,
   },
   "chart-radar-legend": {
     name: "chart-radar-legend",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radar-legend.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radar-legend.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radar-legend.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radar-legend.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radar"],
+    categories: ["charts", "charts-radar"],
     meta: undefined,
   },
   "chart-radar-lines-only": {
     name: "chart-radar-lines-only",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radar-lines-only.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radar-lines-only.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radar-lines-only.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radar-lines-only.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radar"],
+    categories: ["charts", "charts-radar"],
     meta: undefined,
   },
   "chart-radar-multiple": {
     name: "chart-radar-multiple",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radar-multiple.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radar-multiple.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radar-multiple.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radar-multiple.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radar"],
+    categories: ["charts", "charts-radar"],
     meta: undefined,
   },
   "chart-radar-radius": {
     name: "chart-radar-radius",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radar-radius.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radar-radius.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radar-radius.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radar-radius.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radar"],
+    categories: ["charts", "charts-radar"],
     meta: undefined,
   },
   "chart-radial-grid": {
     name: "chart-radial-grid",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radial-grid.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radial-grid.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radial-grid.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radial-grid.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radial"],
+    categories: ["charts", "charts-radial"],
     meta: undefined,
   },
   "chart-radial-label": {
     name: "chart-radial-label",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radial-label.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radial-label.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radial-label.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radial-label.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radial"],
+    categories: ["charts", "charts-radial"],
     meta: undefined,
   },
   "chart-radial-shape": {
     name: "chart-radial-shape",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radial-shape.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radial-shape.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radial-shape.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radial-shape.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radial"],
+    categories: ["charts", "charts-radial"],
     meta: undefined,
   },
   "chart-radial-simple": {
     name: "chart-radial-simple",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radial-simple.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radial-simple.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radial-simple.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radial-simple.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radial"],
+    categories: ["charts", "charts-radial"],
     meta: undefined,
   },
   "chart-radial-stacked": {
     name: "chart-radial-stacked",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radial-stacked.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radial-stacked.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radial-stacked.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radial-stacked.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radial"],
+    categories: ["charts", "charts-radial"],
     meta: undefined,
   },
   "chart-radial-text": {
     name: "chart-radial-text",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-radial-text.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-radial-text.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-radial-text.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-radial-text.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-radial"],
+    categories: ["charts", "charts-radial"],
     meta: undefined,
   },
   "chart-tooltip-default": {
     name: "chart-tooltip-default",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-tooltip-default.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-tooltip-default.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-tooltip-default.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-tooltip-default.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-tooltip"],
+    categories: ["charts", "charts-tooltip"],
     meta: undefined,
   },
   "chart-tooltip-indicator-line": {
     name: "chart-tooltip-indicator-line",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-tooltip-indicator-line.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-tooltip-indicator-line.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-tooltip-indicator-line.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-tooltip-indicator-line.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-tooltip"],
+    categories: ["charts", "charts-tooltip"],
     meta: undefined,
   },
   "chart-tooltip-indicator-none": {
     name: "chart-tooltip-indicator-none",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-tooltip-indicator-none.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-tooltip-indicator-none.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-tooltip-indicator-none.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-tooltip-indicator-none.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-tooltip"],
+    categories: ["charts", "charts-tooltip"],
     meta: undefined,
   },
   "chart-tooltip-label-none": {
     name: "chart-tooltip-label-none",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-tooltip-label-none.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-tooltip-label-none.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-tooltip-label-none.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-tooltip-label-none.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-tooltip"],
+    categories: ["charts", "charts-tooltip"],
     meta: undefined,
   },
   "chart-tooltip-label-custom": {
     name: "chart-tooltip-label-custom",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-tooltip-label-custom.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-tooltip-label-custom.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-tooltip-label-custom.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-tooltip-label-custom.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-tooltip"],
+    categories: ["charts", "charts-tooltip"],
     meta: undefined,
   },
   "chart-tooltip-label-formatter": {
     name: "chart-tooltip-label-formatter",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-tooltip-label-formatter.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-tooltip-label-formatter.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-tooltip-label-formatter.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-tooltip-label-formatter.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-tooltip"],
+    categories: ["charts", "charts-tooltip"],
     meta: undefined,
   },
   "chart-tooltip-formatter": {
     name: "chart-tooltip-formatter",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-tooltip-formatter.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-tooltip-formatter.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-tooltip-formatter.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-tooltip-formatter.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-tooltip"],
+    categories: ["charts", "charts-tooltip"],
     meta: undefined,
   },
   "chart-tooltip-icons": {
     name: "chart-tooltip-icons",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-tooltip-icons.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-tooltip-icons.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-tooltip-icons.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-tooltip-icons.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-tooltip"],
+    categories: ["charts", "charts-tooltip"],
     meta: undefined,
   },
   "chart-tooltip-advanced": {
     name: "chart-tooltip-advanced",
     description: "",
     type: "registry:block",
-    registryDependencies: ["card","chart"],
-    files: [{
-      path: "registry/new-york-v4/charts/chart-tooltip-advanced.tsx",
-      type: "registry:block",
-      target: ""
-    }],
+    registryDependencies: ["card", "chart"],
+    files: [
+      {
+        path: "registry/new-york-v4/charts/chart-tooltip-advanced.tsx",
+        type: "registry:block",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/charts/chart-tooltip-advanced.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/charts/chart-tooltip-advanced.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["charts","charts-tooltip"],
+    categories: ["charts", "charts-tooltip"],
     meta: undefined,
   },
-  "utils": {
+  utils: {
     name: "utils",
     description: "",
     type: "registry:lib",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/lib/utils.ts",
-      type: "registry:lib",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/lib/utils.ts",
+        type: "registry:lib",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/lib/utils.ts")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3393,14 +4942,20 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:hook",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/hooks/use-mobile.ts",
-      type: "registry:hook",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/hooks/use-mobile.ts",
+        type: "registry:hook",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/hooks/use-mobile.ts")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3411,14 +4966,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["accordion"],
-    files: [{
-      path: "registry/new-york-v4/examples/accordion-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/accordion-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/accordion-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/accordion-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3429,14 +4992,20 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["alert"],
-    files: [{
-      path: "registry/new-york-v4/examples/alert-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/alert-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/examples/alert-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3447,14 +5016,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["alert"],
-    files: [{
-      path: "registry/new-york-v4/examples/alert-destructive.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/alert-destructive.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/alert-destructive.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/alert-destructive.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3464,15 +5041,23 @@ export const Index: Record<string, any> = {
     name: "alert-dialog-demo",
     description: "",
     type: "registry:example",
-    registryDependencies: ["alert-dialog","button"],
-    files: [{
-      path: "registry/new-york-v4/examples/alert-dialog-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["alert-dialog", "button"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/alert-dialog-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/alert-dialog-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/alert-dialog-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3483,14 +5068,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["aspect-ratio"],
-    files: [{
-      path: "registry/new-york-v4/examples/aspect-ratio-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/aspect-ratio-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/aspect-ratio-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/aspect-ratio-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3501,14 +5094,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["avatar"],
-    files: [{
-      path: "registry/new-york-v4/examples/avatar-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/avatar-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/avatar-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/avatar-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3519,14 +5120,20 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["badge"],
-    files: [{
-      path: "registry/new-york-v4/examples/badge-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/badge-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/examples/badge-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3537,14 +5144,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["badge"],
-    files: [{
-      path: "registry/new-york-v4/examples/badge-destructive.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/badge-destructive.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/badge-destructive.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/badge-destructive.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3555,14 +5170,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["badge"],
-    files: [{
-      path: "registry/new-york-v4/examples/badge-outline.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/badge-outline.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/badge-outline.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/badge-outline.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3573,14 +5196,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["badge"],
-    files: [{
-      path: "registry/new-york-v4/examples/badge-secondary.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/badge-secondary.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/badge-secondary.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/badge-secondary.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3591,14 +5222,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["breadcrumb"],
-    files: [{
-      path: "registry/new-york-v4/examples/breadcrumb-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/breadcrumb-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/breadcrumb-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/breadcrumb-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3609,14 +5248,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["breadcrumb"],
-    files: [{
-      path: "registry/new-york-v4/examples/breadcrumb-separator.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/breadcrumb-separator.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/breadcrumb-separator.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/breadcrumb-separator.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3627,14 +5274,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["breadcrumb"],
-    files: [{
-      path: "registry/new-york-v4/examples/breadcrumb-dropdown.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/breadcrumb-dropdown.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/breadcrumb-dropdown.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/breadcrumb-dropdown.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3645,14 +5300,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["breadcrumb"],
-    files: [{
-      path: "registry/new-york-v4/examples/breadcrumb-ellipsis.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/breadcrumb-ellipsis.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/breadcrumb-ellipsis.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/breadcrumb-ellipsis.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3663,14 +5326,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["breadcrumb"],
-    files: [{
-      path: "registry/new-york-v4/examples/breadcrumb-link.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/breadcrumb-link.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/breadcrumb-link.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/breadcrumb-link.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3681,14 +5352,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["breadcrumb"],
-    files: [{
-      path: "registry/new-york-v4/examples/breadcrumb-responsive.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/breadcrumb-responsive.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/breadcrumb-responsive.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/breadcrumb-responsive.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3699,14 +5378,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["button"],
-    files: [{
-      path: "registry/new-york-v4/examples/button-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/button-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/button-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/button-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3717,14 +5404,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["button"],
-    files: [{
-      path: "registry/new-york-v4/examples/button-secondary.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/button-secondary.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/button-secondary.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/button-secondary.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3735,14 +5430,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["button"],
-    files: [{
-      path: "registry/new-york-v4/examples/button-destructive.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/button-destructive.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/button-destructive.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/button-destructive.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3753,14 +5456,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["button"],
-    files: [{
-      path: "registry/new-york-v4/examples/button-outline.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/button-outline.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/button-outline.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/button-outline.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3771,14 +5482,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["button"],
-    files: [{
-      path: "registry/new-york-v4/examples/button-ghost.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/button-ghost.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/button-ghost.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/button-ghost.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3789,14 +5508,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["button"],
-    files: [{
-      path: "registry/new-york-v4/examples/button-link.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/button-link.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/button-link.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/button-link.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3807,14 +5534,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["button"],
-    files: [{
-      path: "registry/new-york-v4/examples/button-with-icon.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/button-with-icon.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/button-with-icon.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/button-with-icon.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3825,14 +5560,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["button"],
-    files: [{
-      path: "registry/new-york-v4/examples/button-loading.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/button-loading.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/button-loading.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/button-loading.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3843,14 +5586,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["button"],
-    files: [{
-      path: "registry/new-york-v4/examples/button-icon.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/button-icon.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/button-icon.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/button-icon.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3861,14 +5612,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["button"],
-    files: [{
-      path: "registry/new-york-v4/examples/button-as-child.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/button-as-child.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/button-as-child.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/button-as-child.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3879,14 +5638,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["calendar"],
-    files: [{
-      path: "registry/new-york-v4/examples/calendar-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/calendar-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/calendar-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/calendar-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3896,15 +5663,23 @@ export const Index: Record<string, any> = {
     name: "calendar-form",
     description: "",
     type: "registry:example",
-    registryDependencies: ["calendar","form","popover"],
-    files: [{
-      path: "registry/new-york-v4/examples/calendar-form.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["calendar", "form", "popover"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/calendar-form.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/calendar-form.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/calendar-form.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3914,15 +5689,21 @@ export const Index: Record<string, any> = {
     name: "card-demo",
     description: "",
     type: "registry:example",
-    registryDependencies: ["card","button","switch"],
-    files: [{
-      path: "registry/new-york-v4/examples/card-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["card", "button", "switch"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/card-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/examples/card-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3932,15 +5713,23 @@ export const Index: Record<string, any> = {
     name: "card-with-form",
     description: "",
     type: "registry:example",
-    registryDependencies: ["button","card","input","label","select"],
-    files: [{
-      path: "registry/new-york-v4/examples/card-with-form.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["button", "card", "input", "label", "select"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/card-with-form.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/card-with-form.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/card-with-form.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3951,14 +5740,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["carousel"],
-    files: [{
-      path: "registry/new-york-v4/examples/carousel-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/carousel-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/carousel-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/carousel-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3969,14 +5766,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["carousel"],
-    files: [{
-      path: "registry/new-york-v4/examples/carousel-size.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/carousel-size.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/carousel-size.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/carousel-size.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -3987,14 +5792,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["carousel"],
-    files: [{
-      path: "registry/new-york-v4/examples/carousel-spacing.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/carousel-spacing.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/carousel-spacing.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/carousel-spacing.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4005,14 +5818,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["carousel"],
-    files: [{
-      path: "registry/new-york-v4/examples/carousel-orientation.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/carousel-orientation.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/carousel-orientation.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/carousel-orientation.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4023,14 +5844,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["carousel"],
-    files: [{
-      path: "registry/new-york-v4/examples/carousel-api.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/carousel-api.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/carousel-api.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/carousel-api.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4041,14 +5870,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["carousel"],
-    files: [{
-      path: "registry/new-york-v4/examples/carousel-plugin.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/carousel-plugin.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/carousel-plugin.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/carousel-plugin.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4059,14 +5896,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["checkbox"],
-    files: [{
-      path: "registry/new-york-v4/examples/checkbox-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/checkbox-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/checkbox-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/checkbox-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4077,14 +5922,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["checkbox"],
-    files: [{
-      path: "registry/new-york-v4/examples/checkbox-disabled.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/checkbox-disabled.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/checkbox-disabled.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/checkbox-disabled.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4094,15 +5947,23 @@ export const Index: Record<string, any> = {
     name: "checkbox-form-multiple",
     description: "",
     type: "registry:example",
-    registryDependencies: ["checkbox","form"],
-    files: [{
-      path: "registry/new-york-v4/examples/checkbox-form-multiple.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["checkbox", "form"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/checkbox-form-multiple.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/checkbox-form-multiple.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/checkbox-form-multiple.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4112,15 +5973,23 @@ export const Index: Record<string, any> = {
     name: "checkbox-form-single",
     description: "",
     type: "registry:example",
-    registryDependencies: ["checkbox","form"],
-    files: [{
-      path: "registry/new-york-v4/examples/checkbox-form-single.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["checkbox", "form"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/checkbox-form-single.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/checkbox-form-single.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/checkbox-form-single.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4131,14 +6000,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["checkbox"],
-    files: [{
-      path: "registry/new-york-v4/examples/checkbox-with-text.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/checkbox-with-text.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/checkbox-with-text.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/checkbox-with-text.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4149,14 +6026,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["collapsible"],
-    files: [{
-      path: "registry/new-york-v4/examples/collapsible-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/collapsible-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/collapsible-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/collapsible-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4167,14 +6052,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["command"],
-    files: [{
-      path: "registry/new-york-v4/examples/combobox-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/combobox-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/combobox-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/combobox-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4184,15 +6077,23 @@ export const Index: Record<string, any> = {
     name: "combobox-dropdown-menu",
     description: "",
     type: "registry:example",
-    registryDependencies: ["command","dropdown-menu","button"],
-    files: [{
-      path: "registry/new-york-v4/examples/combobox-dropdown-menu.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["command", "dropdown-menu", "button"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/combobox-dropdown-menu.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/combobox-dropdown-menu.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/combobox-dropdown-menu.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4202,15 +6103,23 @@ export const Index: Record<string, any> = {
     name: "combobox-form",
     description: "",
     type: "registry:example",
-    registryDependencies: ["command","form"],
-    files: [{
-      path: "registry/new-york-v4/examples/combobox-form.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["command", "form"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/combobox-form.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/combobox-form.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/combobox-form.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4220,15 +6129,23 @@ export const Index: Record<string, any> = {
     name: "combobox-popover",
     description: "",
     type: "registry:example",
-    registryDependencies: ["combobox","popover"],
-    files: [{
-      path: "registry/new-york-v4/examples/combobox-popover.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["combobox", "popover"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/combobox-popover.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/combobox-popover.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/combobox-popover.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4238,15 +6155,23 @@ export const Index: Record<string, any> = {
     name: "combobox-responsive",
     description: "",
     type: "registry:example",
-    registryDependencies: ["combobox","popover","drawer"],
-    files: [{
-      path: "registry/new-york-v4/examples/combobox-responsive.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["combobox", "popover", "drawer"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/combobox-responsive.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/combobox-responsive.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/combobox-responsive.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4257,14 +6182,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["command"],
-    files: [{
-      path: "registry/new-york-v4/examples/command-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/command-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/command-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/command-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4274,15 +6207,23 @@ export const Index: Record<string, any> = {
     name: "command-dialog",
     description: "",
     type: "registry:example",
-    registryDependencies: ["command","dialog"],
-    files: [{
-      path: "registry/new-york-v4/examples/command-dialog.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["command", "dialog"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/command-dialog.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/command-dialog.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/command-dialog.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4293,14 +6234,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["context-menu"],
-    files: [{
-      path: "registry/new-york-v4/examples/context-menu-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/context-menu-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/context-menu-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/context-menu-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4311,14 +6260,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["data-table"],
-    files: [{
-      path: "registry/new-york-v4/examples/data-table-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/data-table-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/data-table-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/data-table-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4328,15 +6285,23 @@ export const Index: Record<string, any> = {
     name: "date-picker-demo",
     description: "",
     type: "registry:example",
-    registryDependencies: ["button","calendar","popover"],
-    files: [{
-      path: "registry/new-york-v4/examples/date-picker-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["button", "calendar", "popover"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/date-picker-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/date-picker-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/date-picker-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4346,15 +6311,23 @@ export const Index: Record<string, any> = {
     name: "date-picker-form",
     description: "",
     type: "registry:example",
-    registryDependencies: ["button","calendar","form","popover"],
-    files: [{
-      path: "registry/new-york-v4/examples/date-picker-form.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["button", "calendar", "form", "popover"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/date-picker-form.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/date-picker-form.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/date-picker-form.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4364,15 +6337,23 @@ export const Index: Record<string, any> = {
     name: "date-picker-with-presets",
     description: "",
     type: "registry:example",
-    registryDependencies: ["button","calendar","popover","select"],
-    files: [{
-      path: "registry/new-york-v4/examples/date-picker-with-presets.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["button", "calendar", "popover", "select"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/date-picker-with-presets.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/date-picker-with-presets.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/date-picker-with-presets.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4382,15 +6363,23 @@ export const Index: Record<string, any> = {
     name: "date-picker-with-range",
     description: "",
     type: "registry:example",
-    registryDependencies: ["button","calendar","popover"],
-    files: [{
-      path: "registry/new-york-v4/examples/date-picker-with-range.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["button", "calendar", "popover"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/date-picker-with-range.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/date-picker-with-range.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/date-picker-with-range.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4401,14 +6390,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["dialog"],
-    files: [{
-      path: "registry/new-york-v4/examples/dialog-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/dialog-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/dialog-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/dialog-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4418,15 +6415,23 @@ export const Index: Record<string, any> = {
     name: "dialog-close-button",
     description: "",
     type: "registry:example",
-    registryDependencies: ["dialog","button"],
-    files: [{
-      path: "registry/new-york-v4/examples/dialog-close-button.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["dialog", "button"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/dialog-close-button.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/dialog-close-button.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/dialog-close-button.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4437,14 +6442,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["drawer"],
-    files: [{
-      path: "registry/new-york-v4/examples/drawer-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/drawer-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/drawer-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/drawer-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4454,15 +6467,23 @@ export const Index: Record<string, any> = {
     name: "drawer-dialog",
     description: "",
     type: "registry:example",
-    registryDependencies: ["drawer","dialog"],
-    files: [{
-      path: "registry/new-york-v4/examples/drawer-dialog.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["drawer", "dialog"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/drawer-dialog.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/drawer-dialog.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/drawer-dialog.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4473,14 +6494,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["dropdown-menu"],
-    files: [{
-      path: "registry/new-york-v4/examples/dropdown-menu-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/dropdown-menu-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/dropdown-menu-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/dropdown-menu-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4490,15 +6519,23 @@ export const Index: Record<string, any> = {
     name: "dropdown-menu-checkboxes",
     description: "",
     type: "registry:example",
-    registryDependencies: ["dropdown-menu","checkbox"],
-    files: [{
-      path: "registry/new-york-v4/examples/dropdown-menu-checkboxes.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["dropdown-menu", "checkbox"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/dropdown-menu-checkboxes.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/dropdown-menu-checkboxes.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/dropdown-menu-checkboxes.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4508,15 +6545,23 @@ export const Index: Record<string, any> = {
     name: "dropdown-menu-radio-group",
     description: "",
     type: "registry:example",
-    registryDependencies: ["dropdown-menu","radio-group"],
-    files: [{
-      path: "registry/new-york-v4/examples/dropdown-menu-radio-group.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["dropdown-menu", "radio-group"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/dropdown-menu-radio-group.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/dropdown-menu-radio-group.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/dropdown-menu-radio-group.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4527,14 +6572,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["hover-card"],
-    files: [{
-      path: "registry/new-york-v4/examples/hover-card-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/hover-card-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/hover-card-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/hover-card-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4545,14 +6598,20 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["input"],
-    files: [{
-      path: "registry/new-york-v4/examples/input-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/input-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/examples/input-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4563,14 +6622,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["input"],
-    files: [{
-      path: "registry/new-york-v4/examples/input-disabled.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/input-disabled.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/input-disabled.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/input-disabled.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4581,14 +6648,20 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["input"],
-    files: [{
-      path: "registry/new-york-v4/examples/input-file.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/input-file.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/examples/input-file.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4598,15 +6671,21 @@ export const Index: Record<string, any> = {
     name: "input-form",
     description: "",
     type: "registry:example",
-    registryDependencies: ["input","button","form"],
-    files: [{
-      path: "registry/new-york-v4/examples/input-form.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["input", "button", "form"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/input-form.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/examples/input-form.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4616,15 +6695,23 @@ export const Index: Record<string, any> = {
     name: "input-with-button",
     description: "",
     type: "registry:example",
-    registryDependencies: ["input","button"],
-    files: [{
-      path: "registry/new-york-v4/examples/input-with-button.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["input", "button"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/input-with-button.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/input-with-button.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/input-with-button.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4634,15 +6721,23 @@ export const Index: Record<string, any> = {
     name: "input-with-label",
     description: "",
     type: "registry:example",
-    registryDependencies: ["input","button","label"],
-    files: [{
-      path: "registry/new-york-v4/examples/input-with-label.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["input", "button", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/input-with-label.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/input-with-label.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/input-with-label.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4652,15 +6747,23 @@ export const Index: Record<string, any> = {
     name: "input-with-text",
     description: "",
     type: "registry:example",
-    registryDependencies: ["input","button","label"],
-    files: [{
-      path: "registry/new-york-v4/examples/input-with-text.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["input", "button", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/input-with-text.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/input-with-text.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/input-with-text.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4671,14 +6774,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["input-otp"],
-    files: [{
-      path: "registry/new-york-v4/examples/input-otp-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/input-otp-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/input-otp-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/input-otp-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4689,14 +6800,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["input-otp"],
-    files: [{
-      path: "registry/new-york-v4/examples/input-otp-pattern.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/input-otp-pattern.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/input-otp-pattern.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/input-otp-pattern.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4707,14 +6826,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["input-otp"],
-    files: [{
-      path: "registry/new-york-v4/examples/input-otp-separator.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/input-otp-separator.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/input-otp-separator.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/input-otp-separator.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4725,14 +6852,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["input-otp"],
-    files: [{
-      path: "registry/new-york-v4/examples/input-otp-controlled.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/input-otp-controlled.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/input-otp-controlled.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/input-otp-controlled.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4742,15 +6877,23 @@ export const Index: Record<string, any> = {
     name: "input-otp-form",
     description: "",
     type: "registry:example",
-    registryDependencies: ["input-otp","form"],
-    files: [{
-      path: "registry/new-york-v4/examples/input-otp-form.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["input-otp", "form"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/input-otp-form.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/input-otp-form.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/input-otp-form.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4761,14 +6904,20 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["label"],
-    files: [{
-      path: "registry/new-york-v4/examples/label-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/label-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/examples/label-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4779,14 +6928,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["menubar"],
-    files: [{
-      path: "registry/new-york-v4/examples/menubar-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/menubar-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/menubar-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/menubar-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4797,14 +6954,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["navigation-menu"],
-    files: [{
-      path: "registry/new-york-v4/examples/navigation-menu-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/navigation-menu-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/navigation-menu-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/navigation-menu-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4815,14 +6980,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["pagination"],
-    files: [{
-      path: "registry/new-york-v4/examples/pagination-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/pagination-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/pagination-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/pagination-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4833,14 +7006,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["popover"],
-    files: [{
-      path: "registry/new-york-v4/examples/popover-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/popover-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/popover-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/popover-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4851,14 +7032,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["progress"],
-    files: [{
-      path: "registry/new-york-v4/examples/progress-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/progress-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/progress-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/progress-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4869,14 +7058,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["radio-group"],
-    files: [{
-      path: "registry/new-york-v4/examples/radio-group-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/radio-group-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/radio-group-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/radio-group-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4886,15 +7083,23 @@ export const Index: Record<string, any> = {
     name: "radio-group-form",
     description: "",
     type: "registry:example",
-    registryDependencies: ["radio-group","form"],
-    files: [{
-      path: "registry/new-york-v4/examples/radio-group-form.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["radio-group", "form"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/radio-group-form.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/radio-group-form.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/radio-group-form.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4905,14 +7110,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["resizable"],
-    files: [{
-      path: "registry/new-york-v4/examples/resizable-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/resizable-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/resizable-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/resizable-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4923,14 +7136,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["resizable"],
-    files: [{
-      path: "registry/new-york-v4/examples/resizable-demo-with-handle.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/resizable-demo-with-handle.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/resizable-demo-with-handle.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/resizable-demo-with-handle.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4941,14 +7162,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["resizable"],
-    files: [{
-      path: "registry/new-york-v4/examples/resizable-vertical.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/resizable-vertical.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/resizable-vertical.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/resizable-vertical.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4959,14 +7188,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["resizable"],
-    files: [{
-      path: "registry/new-york-v4/examples/resizable-handle.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/resizable-handle.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/resizable-handle.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/resizable-handle.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4977,14 +7214,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["scroll-area"],
-    files: [{
-      path: "registry/new-york-v4/examples/scroll-area-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/scroll-area-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/scroll-area-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/scroll-area-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -4995,14 +7240,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["scroll-area"],
-    files: [{
-      path: "registry/new-york-v4/examples/scroll-area-horizontal-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/scroll-area-horizontal-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/scroll-area-horizontal-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/scroll-area-horizontal-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5013,14 +7266,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["select"],
-    files: [{
-      path: "registry/new-york-v4/examples/select-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/select-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/select-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/select-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5031,14 +7292,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["select"],
-    files: [{
-      path: "registry/new-york-v4/examples/select-scrollable.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/select-scrollable.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/select-scrollable.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/select-scrollable.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5049,14 +7318,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["select"],
-    files: [{
-      path: "registry/new-york-v4/examples/select-form.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/select-form.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/select-form.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/select-form.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5067,14 +7344,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["separator"],
-    files: [{
-      path: "registry/new-york-v4/examples/separator-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/separator-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/separator-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/separator-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5085,14 +7370,20 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["sheet"],
-    files: [{
-      path: "registry/new-york-v4/examples/sheet-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/sheet-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/examples/sheet-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5103,14 +7394,20 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["sheet"],
-    files: [{
-      path: "registry/new-york-v4/examples/sheet-side.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/sheet-side.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/examples/sheet-side.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5121,14 +7418,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["skeleton"],
-    files: [{
-      path: "registry/new-york-v4/examples/skeleton-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/skeleton-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/skeleton-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/skeleton-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5139,14 +7444,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["skeleton"],
-    files: [{
-      path: "registry/new-york-v4/examples/skeleton-card.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/skeleton-card.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/skeleton-card.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/skeleton-card.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5157,14 +7470,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["slider"],
-    files: [{
-      path: "registry/new-york-v4/examples/slider-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/slider-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/slider-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/slider-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5175,14 +7496,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["sonner"],
-    files: [{
-      path: "registry/new-york-v4/examples/sonner-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/sonner-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/sonner-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/sonner-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5193,14 +7522,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["switch"],
-    files: [{
-      path: "registry/new-york-v4/examples/switch-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/switch-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/switch-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/switch-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5210,15 +7547,23 @@ export const Index: Record<string, any> = {
     name: "switch-form",
     description: "",
     type: "registry:example",
-    registryDependencies: ["switch","form"],
-    files: [{
-      path: "registry/new-york-v4/examples/switch-form.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["switch", "form"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/switch-form.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/switch-form.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/switch-form.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5229,14 +7574,20 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["table"],
-    files: [{
-      path: "registry/new-york-v4/examples/table-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/table-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/examples/table-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5247,14 +7598,20 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["tabs"],
-    files: [{
-      path: "registry/new-york-v4/examples/tabs-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/tabs-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/examples/tabs-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5265,14 +7622,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["textarea"],
-    files: [{
-      path: "registry/new-york-v4/examples/textarea-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/textarea-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/textarea-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/textarea-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5283,14 +7648,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["textarea"],
-    files: [{
-      path: "registry/new-york-v4/examples/textarea-disabled.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/textarea-disabled.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/textarea-disabled.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/textarea-disabled.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5300,15 +7673,23 @@ export const Index: Record<string, any> = {
     name: "textarea-form",
     description: "",
     type: "registry:example",
-    registryDependencies: ["textarea","form"],
-    files: [{
-      path: "registry/new-york-v4/examples/textarea-form.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["textarea", "form"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/textarea-form.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/textarea-form.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/textarea-form.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5318,15 +7699,23 @@ export const Index: Record<string, any> = {
     name: "textarea-with-button",
     description: "",
     type: "registry:example",
-    registryDependencies: ["textarea","button"],
-    files: [{
-      path: "registry/new-york-v4/examples/textarea-with-button.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["textarea", "button"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/textarea-with-button.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/textarea-with-button.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/textarea-with-button.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5336,15 +7725,23 @@ export const Index: Record<string, any> = {
     name: "textarea-with-label",
     description: "",
     type: "registry:example",
-    registryDependencies: ["textarea","label"],
-    files: [{
-      path: "registry/new-york-v4/examples/textarea-with-label.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["textarea", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/textarea-with-label.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/textarea-with-label.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/textarea-with-label.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5354,15 +7751,23 @@ export const Index: Record<string, any> = {
     name: "textarea-with-text",
     description: "",
     type: "registry:example",
-    registryDependencies: ["textarea","label"],
-    files: [{
-      path: "registry/new-york-v4/examples/textarea-with-text.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    registryDependencies: ["textarea", "label"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/textarea-with-text.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/textarea-with-text.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/textarea-with-text.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5373,14 +7778,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["toggle-group"],
-    files: [{
-      path: "registry/new-york-v4/examples/toggle-group-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/toggle-group-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/toggle-group-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/toggle-group-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5391,14 +7804,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["toggle-group"],
-    files: [{
-      path: "registry/new-york-v4/examples/toggle-group-disabled.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/toggle-group-disabled.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/toggle-group-disabled.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/toggle-group-disabled.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5409,14 +7830,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["toggle-group"],
-    files: [{
-      path: "registry/new-york-v4/examples/toggle-group-lg.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/toggle-group-lg.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/toggle-group-lg.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/toggle-group-lg.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5427,14 +7856,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["toggle-group"],
-    files: [{
-      path: "registry/new-york-v4/examples/toggle-group-outline.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/toggle-group-outline.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/toggle-group-outline.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/toggle-group-outline.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5445,14 +7882,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["toggle-group"],
-    files: [{
-      path: "registry/new-york-v4/examples/toggle-group-sm.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/toggle-group-sm.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/toggle-group-sm.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/toggle-group-sm.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5463,14 +7908,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["toggle-group"],
-    files: [{
-      path: "registry/new-york-v4/examples/toggle-group-single.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/toggle-group-single.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/toggle-group-single.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/toggle-group-single.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5481,14 +7934,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["toggle"],
-    files: [{
-      path: "registry/new-york-v4/examples/toggle-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/toggle-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/toggle-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/toggle-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5499,14 +7960,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["toggle"],
-    files: [{
-      path: "registry/new-york-v4/examples/toggle-disabled.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/toggle-disabled.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/toggle-disabled.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/toggle-disabled.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5517,14 +7986,20 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["toggle"],
-    files: [{
-      path: "registry/new-york-v4/examples/toggle-lg.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/toggle-lg.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/examples/toggle-lg.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5535,14 +8010,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["toggle"],
-    files: [{
-      path: "registry/new-york-v4/examples/toggle-outline.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/toggle-outline.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/toggle-outline.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/toggle-outline.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5553,14 +8036,20 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["toggle"],
-    files: [{
-      path: "registry/new-york-v4/examples/toggle-sm.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/toggle-sm.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/new-york-v4/examples/toggle-sm.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5571,14 +8060,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["toggle"],
-    files: [{
-      path: "registry/new-york-v4/examples/toggle-with-text.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/toggle-with-text.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/toggle-with-text.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/toggle-with-text.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5589,14 +8086,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: ["tooltip"],
-    files: [{
-      path: "registry/new-york-v4/examples/tooltip-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/tooltip-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/tooltip-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/tooltip-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5607,14 +8112,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/typography-blockquote.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/typography-blockquote.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/typography-blockquote.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/typography-blockquote.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5625,14 +8138,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/typography-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/typography-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/typography-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/typography-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5643,14 +8164,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/typography-h1.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/typography-h1.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/typography-h1.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/typography-h1.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5661,14 +8190,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/typography-h2.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/typography-h2.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/typography-h2.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/typography-h2.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5679,14 +8216,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/typography-h3.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/typography-h3.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/typography-h3.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/typography-h3.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5697,14 +8242,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/typography-h4.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/typography-h4.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/typography-h4.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/typography-h4.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5715,14 +8268,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/typography-inline-code.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/typography-inline-code.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/typography-inline-code.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/typography-inline-code.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5733,14 +8294,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/typography-large.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/typography-large.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/typography-large.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/typography-large.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5751,14 +8320,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/typography-lead.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/typography-lead.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/typography-lead.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/typography-lead.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5769,14 +8346,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/typography-list.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/typography-list.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/typography-list.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/typography-list.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5787,14 +8372,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/typography-muted.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/typography-muted.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/typography-muted.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/typography-muted.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5805,14 +8398,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/typography-p.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/typography-p.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/typography-p.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/typography-p.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5823,14 +8424,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/typography-small.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/typography-small.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/typography-small.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/typography-small.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5841,14 +8450,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/typography-table.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/typography-table.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/typography-table.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/typography-table.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5859,14 +8476,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/mode-toggle.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/mode-toggle.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/mode-toggle.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/mode-toggle.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5877,14 +8502,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/chart-bar-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/chart-bar-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/chart-bar-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/chart-bar-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5895,14 +8528,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/chart-bar-demo-grid.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/chart-bar-demo-grid.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/chart-bar-demo-grid.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/chart-bar-demo-grid.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5913,14 +8554,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/chart-bar-demo-axis.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/chart-bar-demo-axis.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/chart-bar-demo-axis.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/chart-bar-demo-axis.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5931,14 +8580,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/chart-bar-demo-tooltip.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/chart-bar-demo-tooltip.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/chart-bar-demo-tooltip.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/chart-bar-demo-tooltip.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5949,14 +8606,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/chart-bar-demo-legend.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/chart-bar-demo-legend.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/chart-bar-demo-legend.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/chart-bar-demo-legend.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5967,14 +8632,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:example",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/examples/chart-tooltip-demo.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/chart-tooltip-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/chart-tooltip-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/chart-tooltip-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -5985,32 +8658,53 @@ export const Index: Record<string, any> = {
     description: "A Persian calendar.",
     type: "registry:example",
     registryDependencies: ["calendar"],
-    files: [{
-      path: "registry/new-york-v4/examples/calendar-hijri.tsx",
-      type: "registry:example",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/calendar-hijri.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/examples/calendar-hijri.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/examples/calendar-hijri.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
-    categories: ["calendar","date"],
-    meta: {"iframeHeight":"600px","container":"w-full bg-surface min-h-svh flex px-4 py-12 items-start md:py-20 justify-center min-w-0","mobile":"component"},
+    categories: ["calendar", "date"],
+    meta: {
+      iframeHeight: "600px",
+      container:
+        "w-full bg-surface min-h-svh flex px-4 py-12 items-start md:py-20 justify-center min-w-0",
+      mobile: "component",
+    },
   },
   "sidebar-demo": {
     name: "sidebar-demo",
     description: "",
     type: "registry:internal",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/internal/sidebar-demo.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/internal/sidebar-demo.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/internal/sidebar-demo.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/internal/sidebar-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -6021,14 +8715,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:internal",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/internal/sidebar-header.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/internal/sidebar-header.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/internal/sidebar-header.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/internal/sidebar-header.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -6039,14 +8741,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:internal",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/internal/sidebar-footer.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/internal/sidebar-footer.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/internal/sidebar-footer.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/internal/sidebar-footer.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -6057,14 +8767,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:internal",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/internal/sidebar-group.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/internal/sidebar-group.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/internal/sidebar-group.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/internal/sidebar-group.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -6075,14 +8793,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:internal",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/internal/sidebar-group-collapsible.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/internal/sidebar-group-collapsible.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/internal/sidebar-group-collapsible.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/internal/sidebar-group-collapsible.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -6093,14 +8819,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:internal",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/internal/sidebar-group-action.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/internal/sidebar-group-action.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/internal/sidebar-group-action.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/internal/sidebar-group-action.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -6111,14 +8845,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:internal",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/internal/sidebar-menu.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/internal/sidebar-menu.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/internal/sidebar-menu.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/internal/sidebar-menu.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -6129,14 +8871,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:internal",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/internal/sidebar-menu-action.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/internal/sidebar-menu-action.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/internal/sidebar-menu-action.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/internal/sidebar-menu-action.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -6147,14 +8897,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:internal",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/internal/sidebar-menu-sub.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/internal/sidebar-menu-sub.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/internal/sidebar-menu-sub.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/internal/sidebar-menu-sub.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -6165,14 +8923,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:internal",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/internal/sidebar-menu-collapsible.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/internal/sidebar-menu-collapsible.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/internal/sidebar-menu-collapsible.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/internal/sidebar-menu-collapsible.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -6183,14 +8949,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:internal",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/internal/sidebar-menu-badge.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/internal/sidebar-menu-badge.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/internal/sidebar-menu-badge.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/internal/sidebar-menu-badge.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -6201,14 +8975,22 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:internal",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/internal/sidebar-rsc.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/internal/sidebar-rsc.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/internal/sidebar-rsc.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/internal/sidebar-rsc.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
@@ -6219,17 +9001,75 @@ export const Index: Record<string, any> = {
     description: "",
     type: "registry:internal",
     registryDependencies: undefined,
-    files: [{
-      path: "registry/new-york-v4/internal/sidebar-controlled.tsx",
-      type: "registry:component",
-      target: ""
-    }],
+    files: [
+      {
+        path: "registry/new-york-v4/internal/sidebar-controlled.tsx",
+        type: "registry:component",
+        target: "",
+      },
+    ],
     component: React.lazy(async () => {
-      const mod = await import("@/registry/new-york-v4/internal/sidebar-controlled.tsx")
-      const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+      const mod = await import(
+        "@/registry/new-york-v4/internal/sidebar-controlled.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
       return { default: mod.default || mod[exportName] }
     }),
     categories: undefined,
     meta: undefined,
   },
-  }
+  "inline-edit": {
+    name: "Inline Edit",
+    description: "",
+    type: "registry:ui",
+    registryDependencies: ["cn"],
+    files: [
+      {
+        path: "registry/new-york-v4/ui/inline-edit.tsx",
+        type: "registry:ui",
+        target: "",
+      },
+    ],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/new-york-v4/ui/inline-edit.tsx")
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
+  "inline-edit-demo": {
+    name: "inline-edit-demo",
+    description: "",
+    type: "registry:example",
+    registryDependencies: ["inline-edit"],
+    files: [
+      {
+        path: "registry/new-york-v4/examples/inline-edit-demo.tsx",
+        type: "registry:example",
+        target: "",
+      },
+    ],
+    component: React.lazy(async () => {
+      const mod = await import(
+        "@/registry/new-york-v4/examples/inline-edit-demo.tsx"
+      )
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object"
+        ) || item.name
+      return { default: mod.default || mod[exportName] }
+    }),
+    categories: undefined,
+    meta: undefined,
+  },
+}

--- a/apps/v4/registry/new-york-v4/examples/inline-edit-demo.tsx
+++ b/apps/v4/registry/new-york-v4/examples/inline-edit-demo.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { InlineEdit } from "@/registry/new-york-v4/ui/inline-edit"
+
+export default function InlineEditDemo() {
+  return <InlineEdit placeholder="Click to edit" className="w-64" />
+}

--- a/apps/v4/registry/new-york-v4/ui/inline-edit.tsx
+++ b/apps/v4/registry/new-york-v4/ui/inline-edit.tsx
@@ -1,0 +1,452 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Check, Edit3, Loader2, X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const inlineEditVariants = cva(
+  "relative inline-flex items-center gap-2 transition-colors focus-within:outline-none",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-muted/50 rounded-md",
+        ghost: "hover:bg-transparent",
+        outline:
+          "border border-input hover:bg-accent hover:text-accent-foreground rounded-md",
+      },
+      size: {
+        default: "min-h-9 px-3 py-1 text-sm",
+        sm: "min-h-8 px-2 py-1 text-xs",
+        lg: "min-h-10 px-4 py-2 text-base",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface InlineEditProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "onChange" | "onSave">,
+    VariantProps<typeof inlineEditVariants> {
+  /** Current value of the input */
+  value?: string
+  /** Default value for uncontrolled mode */
+  defaultValue?: string
+  /** Placeholder text when no value is present */
+  placeholder?: string
+  /** Input type for the edit field */
+  inputType?: "text" | "email" | "password" | "number" | "url" | "tel"
+  /** Whether the component is in edit mode */
+  isEditing?: boolean
+  /** Whether the component is disabled */
+  disabled?: boolean
+  /** Whether the component is required */
+  required?: boolean
+  /** Whether to show edit icon on hover */
+  showEditIcon?: boolean
+  /** Whether to show action buttons (save/cancel) */
+  showActionButtons?: boolean
+  /** Whether to save on Enter key press */
+  saveOnEnter?: boolean
+  /** Whether to cancel on Escape key press */
+  cancelOnEscape?: boolean
+  /** Whether to save on blur */
+  saveOnBlur?: boolean
+  /** Loading state */
+  isLoading?: boolean
+  /** Error message */
+  error?: string
+  /** Maximum length of input */
+  maxLength?: number
+  /** Minimum length of input */
+  minLength?: number
+  /** Validation function */
+  validate?: (value: string) => string | null
+  /** Format function for display value */
+  formatValue?: (value: string) => string
+  /** Parse function for input value */
+  parseValue?: (value: string) => string
+  /** Custom input component */
+  inputComponent?: React.ComponentType<
+    React.InputHTMLAttributes<HTMLInputElement>
+  >
+  /** Custom display component */
+  displayComponent?: React.ComponentType<{ children: React.ReactNode }>
+  /** Callback fired when value changes */
+  onChange?: (value: string) => void
+  /** Callback fired when edit mode starts */
+  onEditStart?: () => void
+  /** Callback fired when edit mode ends */
+  onEditEnd?: () => void
+  /** Callback fired when value is saved */
+  onSave?: (value: string) => Promise<void> | void
+  /** Callback fired when edit is cancelled */
+  onCancel?: () => void
+  /** Callback fired on validation error */
+  onValidationError?: (error: string) => void
+}
+
+const InlineEdit = React.forwardRef<HTMLDivElement, InlineEditProps>(
+  (
+    {
+      className,
+      variant,
+      size,
+      value: controlledValue,
+      defaultValue = "",
+      placeholder,
+      inputType = "text",
+      isEditing: controlledIsEditing,
+      disabled = false,
+      required = false,
+      showEditIcon = true,
+      showActionButtons = false,
+      saveOnEnter = true,
+      cancelOnEscape = true,
+      saveOnBlur = true,
+      isLoading = false,
+      error,
+      maxLength,
+      minLength,
+      validate,
+      formatValue,
+      parseValue,
+      inputComponent: InputComponent,
+      displayComponent: DisplayComponent,
+      onChange,
+      onEditStart,
+      onEditEnd,
+      onSave,
+      onCancel,
+      onValidationError,
+      ...props
+    },
+    ref
+  ) => {
+    // Internal state management
+    const [internalValue, setInternalValue] = React.useState(defaultValue)
+    const [internalIsEditing, setInternalIsEditing] = React.useState(false)
+    const [internalError, setInternalError] = React.useState<string | null>(
+      null
+    )
+    const [isSaving, setIsSaving] = React.useState(false)
+
+    // Determine controlled vs uncontrolled mode
+    const isValueControlled = controlledValue !== undefined
+    const isEditingControlled = controlledIsEditing !== undefined
+
+    const value = isValueControlled ? controlledValue : internalValue
+    const isEditing = isEditingControlled
+      ? controlledIsEditing
+      : internalIsEditing
+    const currentError = error || internalError
+
+    // Refs
+    const inputRef = React.useRef<HTMLInputElement>(null)
+    const originalValueRef = React.useRef<string>(value)
+
+    // Update internal value when controlled value changes
+    React.useEffect(() => {
+      if (isValueControlled) {
+        setInternalValue(controlledValue)
+      }
+    }, [controlledValue, isValueControlled])
+
+    // Focus input when entering edit mode
+    React.useEffect(() => {
+      if (isEditing && inputRef.current) {
+        inputRef.current.focus()
+        inputRef.current.select()
+      }
+    }, [isEditing])
+
+    // Validation
+    const validateValue = React.useCallback(
+      (val: string): string | null => {
+        if (required && !val.trim()) {
+          return "This field is required"
+        }
+        if (minLength && val.length < minLength) {
+          return `Minimum length is ${minLength}`
+        }
+        if (maxLength && val.length > maxLength) {
+          return `Maximum length is ${maxLength}`
+        }
+        if (validate) {
+          return validate(val)
+        }
+        return null
+      },
+      [required, minLength, maxLength, validate]
+    )
+
+    // Handle value change
+    const handleValueChange = React.useCallback(
+      (newValue: string) => {
+        const parsedValue = parseValue ? parseValue(newValue) : newValue
+
+        if (!isValueControlled) {
+          setInternalValue(parsedValue)
+        }
+
+        onChange?.(parsedValue)
+
+        // Clear error when value changes
+        if (currentError) {
+          setInternalError(null)
+        }
+      },
+      [isValueControlled, onChange, parseValue, currentError]
+    )
+
+    // Start editing
+    const startEditing = React.useCallback(() => {
+      if (disabled || isEditing) return
+
+      originalValueRef.current = value
+
+      if (!isEditingControlled) {
+        setInternalIsEditing(true)
+      }
+
+      onEditStart?.()
+    }, [disabled, isEditing, isEditingControlled, value, onEditStart])
+
+    // End editing
+    const endEditing = React.useCallback(() => {
+      if (!isEditingControlled) {
+        setInternalIsEditing(false)
+      }
+
+      setInternalError(null)
+      onEditEnd?.()
+    }, [isEditingControlled, onEditEnd])
+
+    // Save changes
+    const saveChanges = React.useCallback(
+      async (newValue: string = value) => {
+        const validationError = validateValue(newValue)
+
+        if (validationError) {
+          setInternalError(validationError)
+          onValidationError?.(validationError)
+          return false
+        }
+
+        try {
+          setIsSaving(true)
+          await onSave?.(newValue)
+          endEditing()
+          return true
+        } catch (err) {
+          const errorMessage =
+            err instanceof Error ? err.message : "Save failed"
+          setInternalError(errorMessage)
+          onValidationError?.(errorMessage)
+          return false
+        } finally {
+          setIsSaving(false)
+        }
+      },
+      [value, validateValue, onSave, onValidationError, endEditing]
+    )
+
+    // Cancel editing
+    const cancelEditing = React.useCallback(() => {
+      if (!isValueControlled) {
+        setInternalValue(originalValueRef.current)
+      }
+
+      handleValueChange(originalValueRef.current)
+      onCancel?.()
+      endEditing()
+    }, [isValueControlled, handleValueChange, onCancel, endEditing])
+
+    // Keyboard handlers
+    const handleKeyDown = React.useCallback(
+      (event: React.KeyboardEvent) => {
+        if (event.key === "Enter" && saveOnEnter) {
+          event.preventDefault()
+          saveChanges()
+        } else if (event.key === "Escape" && cancelOnEscape) {
+          event.preventDefault()
+          cancelEditing()
+        }
+      },
+      [saveOnEnter, cancelOnEscape, saveChanges, cancelEditing]
+    )
+
+    // Input handlers
+    const handleInputChange = React.useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => {
+        handleValueChange(event.target.value)
+      },
+      [handleValueChange]
+    )
+
+    const handleInputBlur = React.useCallback(() => {
+      if (saveOnBlur && !showActionButtons) {
+        saveChanges()
+      } else if (!showActionButtons) {
+        endEditing()
+      }
+    }, [saveOnBlur, showActionButtons, saveChanges, endEditing])
+
+    // Display value
+    const displayValue = React.useMemo(() => {
+      if (!value) return placeholder
+      return formatValue ? formatValue(value) : value
+    }, [value, placeholder, formatValue])
+
+    // Render input
+    const renderInput = () => {
+      const inputProps = {
+        ref: inputRef,
+        type: inputType,
+        value: value,
+        onChange: handleInputChange,
+        onBlur: handleInputBlur,
+        onKeyDown: handleKeyDown,
+        className: cn(
+          "flex h-full w-full bg-transparent px-0 py-0 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+          currentError && "text-destructive"
+        ),
+        disabled: disabled || isSaving,
+        maxLength,
+        minLength,
+        required,
+        "aria-invalid": !!currentError,
+        "aria-describedby": currentError ? "inline-edit-error" : undefined,
+      }
+
+      if (InputComponent) {
+        return <InputComponent {...inputProps} />
+      }
+
+      return <input {...inputProps} />
+    }
+
+    // Render display
+    const renderDisplay = () => {
+      const content = (
+        <>
+          <span
+            className={cn("flex-1 truncate", !value && "text-muted-foreground")}
+          >
+            {displayValue}
+          </span>
+          {showEditIcon && (
+            <Edit3
+              className={cn(
+                "h-3 w-3 opacity-0 transition-opacity group-hover:opacity-100",
+                disabled && "hidden"
+              )}
+            />
+          )}
+        </>
+      )
+
+      if (DisplayComponent) {
+        return <DisplayComponent>{content}</DisplayComponent>
+      }
+
+      return content
+    }
+
+    // Render action buttons
+    const renderActionButtons = () => {
+      if (!showActionButtons || !isEditing) return null
+
+      return (
+        <div className="ml-2 flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => saveChanges()}
+            disabled={isSaving || !!currentError}
+            className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-6 w-6 items-center justify-center rounded-sm disabled:opacity-50"
+            aria-label="Save changes"
+          >
+            {isSaving ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <Check className="h-3 w-3" />
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={cancelEditing}
+            disabled={isSaving}
+            className="bg-muted text-muted-foreground hover:bg-muted/80 inline-flex h-6 w-6 items-center justify-center rounded-sm disabled:opacity-50"
+            aria-label="Cancel editing"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
+      )
+    }
+
+    if (isEditing) {
+      return (
+        <div
+          ref={ref}
+          className={cn(inlineEditVariants({ variant, size }), className)}
+          {...props}
+        >
+          <div className="min-w-0 flex-1">
+            {renderInput()}
+            {currentError && (
+              <div
+                id="inline-edit-error"
+                className="text-destructive mt-1 text-xs"
+                role="alert"
+              >
+                {currentError}
+              </div>
+            )}
+          </div>
+          {renderActionButtons()}
+        </div>
+      )
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          inlineEditVariants({ variant, size }),
+          "group cursor-pointer",
+          disabled && "cursor-default opacity-50",
+          className
+        )}
+        onClick={disabled ? undefined : startEditing}
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault()
+            startEditing()
+          }
+        }}
+        aria-label={`Edit ${displayValue}. Press Enter or Space to start editing.`}
+        {...props}
+      >
+        {isLoading ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span className="text-muted-foreground">Loading...</span>
+          </>
+        ) : (
+          renderDisplay()
+        )}
+      </div>
+    )
+  }
+)
+
+InlineEdit.displayName = "InlineEdit"
+
+export { InlineEdit, inlineEditVariants }

--- a/apps/v4/registry/registry-ui.ts
+++ b/apps/v4/registry/registry-ui.ts
@@ -610,4 +610,15 @@ export const ui: Registry["items"] = [
       },
     ],
   },
+  {
+    name: "inline-edit",
+    type: "registry:ui",
+    dependencies: ["cn"],
+    files: [
+      {
+        path: "ui/inline-edit.tsx",
+        type: "registry:ui",
+      },
+    ],
+  },
 ]


### PR DESCRIPTION
- Introduced InlineEdit component with customizable props for editing text inline.
- Added support for validation, error handling, and various input types.
- Implemented action buttons for saving and canceling edits.
- Created InlineEditDemo example to showcase usage.
- Updated registry to include InlineEdit component.