### PR TITLE
docs: add additional examples to namespaced registries 

### DIFF
--- a/apps/v4/content/docs/registry/namespace.mdx
+++ b/apps/v4/content/docs/registry/namespace.mdx
@@ -877,6 +877,15 @@ Access forbidden for https://api.company.com/button.json
 Verify your API key has the necessary permissions.
 ```
 
+You may provide a custom error message with the `message` property in your response. This will be shown in the CLI output. This can be useful to direct users to a page where they can get access to your registry.
+
+```json
+{
+  "error": "Authentication failed",
+  "message": "This is a private registry. Please visit https://www.yourwebsite.com to create an account and generate an accesss token."
+}
+```
+
 ## Creating Your Own Registry
 
 To make your registry compatible with the namespace system, you can serve any type of resource - components, libraries, utilities, AI prompts, themes, configurations, or any other shareable code/content:

--- a/apps/v4/content/docs/registry/namespace.mdx
+++ b/apps/v4/content/docs/registry/namespace.mdx
@@ -227,6 +227,16 @@ With style set to `new-york`, installing `@themes/card` resolves to: `https://re
 
 The style placeholder is optional. Use this when you want to serve different versions of the same resource. For example, you can serve a different version of a component for each style.
 
+### Registry URLs Without .json Extensions
+
+There is no strict requirement for registry URL's to end with `.json` or be served as static `.json` files. They can be dynamic endpoints that return JSON, which is typical in the case of authenticated registries.
+
+```json
+{
+  "@private": "https://registry.example.com/{name}"
+}
+```
+
 ## Authentication & Security
 
 ### Environment Variables


### PR DESCRIPTION
- add example of custom error message responses to 401 and 403 requests
- add clarification that regsitry urls do not need to be .json files.