### PR TITLE
fix(v4): update rendering mechanism for charts

### DIFF
--- a/apps/v4/app/(app)/charts/[type]/page.tsx
+++ b/apps/v4/app/(app)/charts/[type]/page.tsx
@@ -48,9 +48,9 @@ export default async function ChartPage({ params }: ChartPageProps) {
         {type.charAt(0).toUpperCase() + type.slice(1)} Charts
       </h2>
       <div className="grid flex-1 scroll-mt-20 items-stretch gap-10 md:grid-cols-2 md:gap-6 lg:grid-cols-3 xl:gap-10">
-        {Array.from({ length: 12 }).map((_, index) => {
+        {Array.from({ length: chartList.length }).map((_, index) => {
           const chart = chartList[index]
-          return chart ? (
+          return (
             <ChartDisplay
               key={chart.id}
               name={chart.id}
@@ -58,11 +58,6 @@ export default async function ChartPage({ params }: ChartPageProps) {
             >
               <chart.component />
             </ChartDisplay>
-          ) : (
-            <div
-              key={`empty-${index}`}
-              className="hidden aspect-square w-full rounded-lg border border-dashed xl:block"
-            />
           )
         })}
       </div>


### PR DESCRIPTION

### Problem:  

Radar charts have [14 examples](https://github.com/shadcn-ui/ui/blob/main/apps/v4/app/(app)/charts/charts.tsx#L154-L172) and the current logic is not able to render the last two charts.

### current logic for rendering charts examples: 

create an Array of 12 elements and push the charts to that array for rendering. [below code](https://github.com/shadcn-ui/ui/blob/main/apps/v4/app/(app)/charts/%5Btype%5D/page.tsx#L51-L67)
```TS

       {Array.from({ length: 12 }).map((_, index) => {
          const chart = chartList[index]
          return chart ? (
            <ChartDisplay
              key={chart.id}
              name={chart.id}
              className={cn(chart.fullWidth && "md:col-span-2 lg:col-span-3")}
            >
              <chart.component />
            </ChartDisplay>
          ) : (
            <div
              key={`empty-${index}`}
              className="hidden aspect-square w-full rounded-lg border border-dashed xl:block"
            />
          )
        })}
```


## proposed fix:

create appropriate length array instead of 12. if we add any more examples to these charts in the future, they will also be rendered correctly.


|Before|After|
|--|--|
|<img width="1149" height="961" alt="image" src="https://github.com/user-attachments/assets/9ff0933f-7aac-4858-9fac-5bb0d83599f5" />|<img width="1207" height="972" alt="image" src="https://github.com/user-attachments/assets/ed8e69c5-8fd0-4ac8-aeb9-3a7ade27a6f3" />|