### PR TITLE
fix(ui/calendar): missing background on range middle cells

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/calendar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/calendar.tsx
@@ -107,7 +107,7 @@ function Calendar({
           "rounded-l-md bg-accent",
           defaultClassNames.range_start
         ),
-        range_middle: cn("rounded-none", defaultClassNames.range_middle),
+        range_middle: cn("rounded-none bg-accent", defaultClassNames.range_middle),
         range_end: cn("rounded-r-md bg-accent", defaultClassNames.range_end),
         today: cn(
           "bg-accent text-accent-foreground rounded-md data-[selected=true]:rounded-none",


### PR DESCRIPTION
It fixes the missing background for range calendars

Before:

<img width="821" height="513" alt="image" src="https://github.com/user-attachments/assets/9066b786-9d33-4a96-b34b-ea5bfce2f266" />

After:

<img width="821" height="513" alt="image" src="https://github.com/user-attachments/assets/d1c628a6-98f8-4f3a-843d-b4455ef137cc" />
