### PR TITLE
fix(shadcn): fix next.js link import

### DIFF
--- a/apps/v4/content/docs/components/badge.mdx
+++ b/apps/v4/content/docs/components/badge.mdx
@@ -57,7 +57,7 @@ import { Badge } from "@/components/ui/badge"
 You can use the `asChild` prop to make another component look like a badge. Here's an example of a link that looks like a badge.
 
 ```tsx showLineNumbers
-import { Link } from "next/link"
+import Link from "next/link"
 
 import { Badge } from "@/components/ui/badge"
 

--- a/apps/v4/content/docs/components/breadcrumb.mdx
+++ b/apps/v4/content/docs/components/breadcrumb.mdx
@@ -180,7 +180,7 @@ To use a custom link component from your routing library, you can use the `asChi
 />
 
 ```tsx showLineNumbers {1,8-10}
-import { Link } from "next/link"
+import Link from "next/link"
 
 ...
 

--- a/apps/v4/content/docs/components/button.mdx
+++ b/apps/v4/content/docs/components/button.mdx
@@ -60,7 +60,7 @@ import { Button } from "@/components/ui/button"
 You can use the `asChild` prop to make another component look like a button. Here's an example of a link that looks like a button.
 
 ```tsx showLineNumbers
-import { Link } from "next/link"
+import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
 

--- a/apps/v4/content/docs/components/navigation-menu.mdx
+++ b/apps/v4/content/docs/components/navigation-menu.mdx
@@ -83,7 +83,7 @@ import {
 You can use the `asChild` prop to make another component look like a navigation menu trigger. Here's an example of a link that looks like a navigation menu trigger.
 
 ```tsx showLineNumbers title="components/example-navigation-menu.tsx"
-import { Link } from "next/link"
+import Link from "next/link"
 
 export function NavigationMenuDemo() {
   return (

--- a/apps/www/content/docs/components/breadcrumb.mdx
+++ b/apps/www/content/docs/components/breadcrumb.mdx
@@ -181,7 +181,7 @@ To use a custom link component from your routing library, you can use the `asChi
 />
 
 ```tsx showLineNumbers {1,8-10}
-import { Link } from "next/link"
+import Link from "next/link"
 
 ...
 


### PR DESCRIPTION
According to Next.js [official document](https://nextjs.org/docs/pages/api-reference/components/link), `Link` should be imported as default export.