### PR TITLE
fix(perf): css performance issues with rotating chevrons (rtl) in calendar.tsx

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/calendar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/calendar.tsx
@@ -30,8 +30,6 @@ function Calendar({
       showOutsideDays={showOutsideDays}
       className={cn(
         "bg-background group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
-        String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
-        String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
         className
       )}
       captionLayout={captionLayout}
@@ -54,11 +52,13 @@ function Calendar({
         button_previous: cn(
           buttonVariants({ variant: buttonVariant }),
           "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none",
+          "[dir="rtl"]_&_svg:rotate-180",
           defaultClassNames.button_previous
         ),
         button_next: cn(
           buttonVariants({ variant: buttonVariant }),
           "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none",
+          "[dir="rtl"]_&_svg:rotate-180",
           defaultClassNames.button_next
         ),
         month_caption: cn(


### PR DESCRIPTION
The recalculate style step where the browser iterates through all selectors and dom nodes to see which match becomes slow (if the dom is sufficiently large) due to these classes.

Tailwind generates the following from the two now deleted classes: `:is(& *)` (right most selector of a longer one, but selector matching works right to left) which apparently causes the browser a lot of work.

You can try this change by executing `document.documentElement.setAttribute('dir', 'rtl');` in the browser console and then opening the date picker. The two chevrons should still be rotated.

Regardless of the performance gain the suggested change seems to make more sense semantically (class on the thing I want to style), so could be considered based on that alone.