### PR TITLE
docs: sidebar persisted state

### DIFF
--- a/apps/v4/content/docs/components/sidebar.mdx
+++ b/apps/v4/content/docs/components/sidebar.mdx
@@ -402,7 +402,7 @@ import { AppSidebar } from "@/components/app-sidebar"
 
 export async function Layout({ children }: { children: React.ReactNode }) {
   const cookieStore = await cookies()
-  const defaultOpen = cookieStore.get("sidebar_state")?.value === "true"
+  const defaultOpen = cookieStore.get("sidebar_state")?.value !== "false"
 
   return (
     <SidebarProvider defaultOpen={defaultOpen}>

--- a/apps/www/content/docs/components/sidebar.mdx
+++ b/apps/www/content/docs/components/sidebar.mdx
@@ -420,7 +420,7 @@ import { AppSidebar } from "@/components/app-sidebar"
 
 export async function Layout({ children }: { children: React.ReactNode }) {
   const cookieStore = await cookies()
-  const defaultOpen = cookieStore.get("sidebar_state")?.value === "true"
+  const defaultOpen = cookieStore.get("sidebar_state")?.value !== "false"
 
   return (
     <SidebarProvider defaultOpen={defaultOpen}>


### PR DESCRIPTION
The current cookie check logic makes the sidebar collapse when no cookie is set on the first load.

Invert the logic so that the sidebar expands by default.