### PR TITLE
feat(shadcn): alias-agnostic registry imports, string-literal rewriting, custom alias support in components.json

### DIFF
--- a/apps/www/content/docs/components-json.mdx
+++ b/apps/www/content/docs/components-json.mdx
@@ -214,13 +214,13 @@ Import alias for `hooks` such as `use-media-query` or `use-toast`.
 
 ### Custom aliases
 
-You can define additional alias keys beyond the built-ins (components, utils, ui, lib, hooks). These map extra “buckets” you might reference from a registry or in your code.
+Add extra alias keys when you need to route files from third‑party registries (for example, `payload`, `editor`, `cms`). These work alongside the built‑ins (`components`, `utils`, `ui`, `lib`, `hooks`).
 
-- Default behavior: built‑in buckets work out of the box. If a registry bucket has no matching alias, it falls back to your `components` alias (e.g., `@/registry/new-york/payload/x` → `@/components/payload/x`).
-- Purpose: primarily enables third‑party registries to ship a greater variety of components (custom buckets like `payload`, `editor`, `cms`).
-- Control installation paths: route each third‑party library’s code to specific locations via custom alias keys.
-- Requirements: some libraries may require one or more aliases—check their docs. If not set, fallback to `components` may not match the library’s expectations.
-- Usage: add any key under `aliases` (for example, `"payload": "@/payload"`). The CLI rewrites both import specifiers that start with `@/` or `@/registry/(style?)/…` and alias‑like string literals in code.
+- Default: built‑ins work out of the box. Buckets without a matching alias fall back to your `components` alias (e.g., `@/registry/new-york/payload/x` → `@/components/payload/x`).
+- Why: lets third‑party registries ship more than just `ui/lib/hooks/components`.
+- Control: send each library’s files to a predictable place with a custom alias.
+- Requirements: some libraries expect aliases—check their docs.
+- How: add a key under `aliases` (e.g., `"payload": "@/payload"`). The CLI rewrites both `@/…` and `@/registry/(style?)/…` imports, and alias‑like string literals.
 
 ```json title="components.json"
 {
@@ -233,4 +233,4 @@ You can define additional alias keys beyond the built-ins (components, utils, ui
 }
 ```
 
-Tip: include any custom alias roots in your `tsconfig.json`/`jsconfig.json` path mappings.
+Tip: add path mappings for any custom alias roots in your `tsconfig.json`/`jsconfig.json`.

--- a/apps/www/content/docs/components-json.mdx
+++ b/apps/www/content/docs/components-json.mdx
@@ -211,3 +211,26 @@ Import alias for `hooks` such as `use-media-query` or `use-toast`.
   }
 }
 ```
+
+### Custom aliases
+
+You can define additional alias keys beyond the built-ins (components, utils, ui, lib, hooks). These map extra “buckets” you might reference from a registry or in your code.
+
+- Default behavior: built‑in buckets work out of the box. If a registry bucket has no matching alias, it falls back to your `components` alias (e.g., `@/registry/new-york/payload/x` → `@/components/payload/x`).
+- Purpose: primarily enables third‑party registries to ship a greater variety of components (custom buckets like `payload`, `editor`, `cms`).
+- Control installation paths: route each third‑party library’s code to specific locations via custom alias keys.
+- Requirements: some libraries may require one or more aliases—check their docs. If not set, fallback to `components` may not match the library’s expectations.
+- Usage: add any key under `aliases` (for example, `"payload": "@/payload"`). The CLI rewrites both import specifiers that start with `@/` or `@/registry/(style?)/…` and alias‑like string literals in code.
+
+```json title="components.json"
+{
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "payload": "@/payload",
+    "editor": "@/vendor/editor"
+  }
+}
+```
+
+Tip: include any custom alias roots in your `tsconfig.json`/`jsconfig.json` path mappings.

--- a/apps/www/content/docs/components-json.mdx
+++ b/apps/www/content/docs/components-json.mdx
@@ -214,7 +214,7 @@ Import alias for `hooks` such as `use-media-query` or `use-toast`.
 
 ### Custom aliases
 
-Add extra alias keys when you need to route files from third‑party registries (for example, `payload`, `editor`, `cms`). These work alongside the built‑ins (`components`, `utils`, `ui`, `lib`, `hooks`).
+Add extra alias keys when you need to route files from third‑party registries (for example, `payload`). These work alongside the built‑ins (`components`, `utils`, `ui`, `lib`, `hooks`).
 
 - Default: built‑ins work out of the box. Buckets without a matching alias fall back to your `components` alias (e.g., `@/registry/new-york/payload/x` → `@/components/payload/x`).
 - Why: lets third‑party registries ship more than just `ui/lib/hooks/components`.
@@ -227,8 +227,7 @@ Add extra alias keys when you need to route files from third‑party registries 
   "aliases": {
     "components": "@/components",
     "utils": "@/lib/utils",
-    "payload": "@/payload",
-    "editor": "@/vendor/editor"
+    "payload": "@/payload"
   }
 }
 ```

--- a/apps/www/content/docs/monorepo.mdx
+++ b/apps/www/content/docs/monorepo.mdx
@@ -111,7 +111,7 @@ turbo.json
 
 1. Every workspace must have a `components.json` file. A `package.json` file tells npm how to install the dependencies. A `components.json` file tells the CLI how and where to install components.
 
-2. The `components.json` file must properly define aliases for the workspace. This tells the CLI how to import components, hooks, utilities, etc. You may also define additional alias keys to map custom buckets (e.g., `payload`), and the CLI will rewrite both imports and alias-like strings to those paths. This primarily supports third‑party registries and lets you control where each third‑party library’s code is installed. Some libraries may require one or more aliases—ensure each workspace’s path mappings (tsconfig/jsconfig) include them.
+2. The `components.json` file must define aliases for the workspace. You can also add custom alias keys to route files from third‑party registries (for example, `payload`). The CLI rewrites both imports and alias‑like strings to those paths. Buckets without a matching alias fall back to `components`. Make sure each workspace’s `tsconfig.json`/`jsconfig.json` includes path mappings for any custom aliases.
 
 <Tabs defaultValue="v4">
 

--- a/apps/www/content/docs/monorepo.mdx
+++ b/apps/www/content/docs/monorepo.mdx
@@ -111,7 +111,7 @@ turbo.json
 
 1. Every workspace must have a `components.json` file. A `package.json` file tells npm how to install the dependencies. A `components.json` file tells the CLI how and where to install components.
 
-2. The `components.json` file must properly define aliases for the workspace. This tells the CLI how to import components, hooks, utilities, etc.
+2. The `components.json` file must properly define aliases for the workspace. This tells the CLI how to import components, hooks, utilities, etc. You may also define additional alias keys to map custom buckets (e.g., `payload`), and the CLI will rewrite both imports and alias-like strings to those paths. This primarily supports third‑party registries and lets you control where each third‑party library’s code is installed. Some libraries may require one or more aliases—ensure each workspace’s path mappings (tsconfig/jsconfig) include them.
 
 <Tabs defaultValue="v4">
 

--- a/apps/www/content/docs/registry/getting-started.mdx
+++ b/apps/www/content/docs/registry/getting-started.mdx
@@ -189,11 +189,11 @@ Here are some guidelines to follow when building components for a registry.
 - The following properties are required for the block definition: `name`, `description`, `type` and `files`.
 - Make sure to list all registry dependencies in `registryDependencies`. A registry dependency is the name of the component in the registry eg. `input`, `button`, `card`, etc or a URL to a registry item eg. `http://localhost:3000/r/editor.json`.
 - Make sure to list all dependencies in `dependencies`. A dependency is the name of the package in the registry eg. `zod`, `sonner`, etc. To set a version, you can use the `name@version` format eg. `zod@^3.20.0`.
-- **Imports should always use the `@/registry` path.** e.g. `import { HelloWorld } from "@/registry/new-york/hello-world/hello-world"`. The `style` segment after `@/registry` is optional—`@/registry/hello-world/...` is also accepted and will be rewritten based on your configured style.
-- The CLI also rewrites alias-like string literals (e.g., configuration values such as `"@/registry/new-york/lib/fields/color"` or `"@/lib/fields/color"`).
-- Unknown registry buckets fall back to your `components` alias by default (e.g., `@/registry/new-york/payload/x` → `@/components/payload/x`). Define custom alias keys in `components.json` to route these to specific locations (e.g., `"payload": "@/payload"`).
-- This capability mainly enables third‑party registries to ship a greater variety of files (custom buckets). It also lets you control where each third‑party library’s code is installed. Some libraries may require one or more aliases—check their docs.
-- Ideally, place your files within a registry item in `components`, `hooks`, `lib` directories.
+- Use the `@/registry` path for imports. e.g. `import { HelloWorld } from "@/registry/new-york/hello-world/hello-world"`. The `style` segment is optional—`@/registry/hello-world/...` also works and will be rewritten based on your configured style.
+- The CLI also rewrites alias-like string literals (for example, `"@/registry/new-york/lib/fields/color"` or `"@/lib/fields/color"`).
+- Buckets without a matching alias fall back to your `components` alias (e.g., `@/registry/new-york/payload/x` → `@/components/payload/x`). Add custom alias keys in `components.json` to route these to specific locations (e.g., `"payload": "@/payload"`).
+- This helps third‑party registries ship more than just `ui/lib/hooks/components`, and lets you control where each library’s files are installed. Some libraries require aliases—check their docs.
+- Ideally, place files within `components`, `hooks`, `lib` inside each registry item.
 
 ## Install using the CLI
 

--- a/apps/www/content/docs/registry/getting-started.mdx
+++ b/apps/www/content/docs/registry/getting-started.mdx
@@ -189,7 +189,10 @@ Here are some guidelines to follow when building components for a registry.
 - The following properties are required for the block definition: `name`, `description`, `type` and `files`.
 - Make sure to list all registry dependencies in `registryDependencies`. A registry dependency is the name of the component in the registry eg. `input`, `button`, `card`, etc or a URL to a registry item eg. `http://localhost:3000/r/editor.json`.
 - Make sure to list all dependencies in `dependencies`. A dependency is the name of the package in the registry eg. `zod`, `sonner`, etc. To set a version, you can use the `name@version` format eg. `zod@^3.20.0`.
-- **Imports should always use the `@/registry` path.** eg. `import { HelloWorld } from "@/registry/new-york/hello-world/hello-world"`
+- **Imports should always use the `@/registry` path.** e.g. `import { HelloWorld } from "@/registry/new-york/hello-world/hello-world"`. The `style` segment after `@/registry` is optional—`@/registry/hello-world/...` is also accepted and will be rewritten based on your configured style.
+- The CLI also rewrites alias-like string literals (e.g., configuration values such as `"@/registry/new-york/lib/fields/color"` or `"@/lib/fields/color"`).
+- Unknown registry buckets fall back to your `components` alias by default (e.g., `@/registry/new-york/payload/x` → `@/components/payload/x`). Define custom alias keys in `components.json` to route these to specific locations (e.g., `"payload": "@/payload"`).
+- This capability mainly enables third‑party registries to ship a greater variety of files (custom buckets). It also lets you control where each third‑party library’s code is installed. Some libraries may require one or more aliases—check their docs.
 - Ideally, place your files within a registry item in `components`, `hooks`, `lib` directories.
 
 ## Install using the CLI

--- a/apps/www/content/docs/registry/getting-started.mdx
+++ b/apps/www/content/docs/registry/getting-started.mdx
@@ -189,8 +189,8 @@ Here are some guidelines to follow when building components for a registry.
 - The following properties are required for the block definition: `name`, `description`, `type` and `files`.
 - Make sure to list all registry dependencies in `registryDependencies`. A registry dependency is the name of the component in the registry eg. `input`, `button`, `card`, etc or a URL to a registry item eg. `http://localhost:3000/r/editor.json`.
 - Make sure to list all dependencies in `dependencies`. A dependency is the name of the package in the registry eg. `zod`, `sonner`, etc. To set a version, you can use the `name@version` format eg. `zod@^3.20.0`.
-- Use the `@/registry` path for imports. e.g. `import { HelloWorld } from "@/registry/new-york/hello-world/hello-world"`. The `style` segment is optional—`@/registry/hello-world/...` also works and will be rewritten based on your configured style.
-- The CLI also rewrites alias-like string literals (for example, `"@/registry/new-york/lib/fields/color"` or `"@/lib/fields/color"`).
+- Use the `@/registry` path for imports. e.g. `import { Button } from "@/registry/new-york/ui/button"`. The `style` segment is optional—`@/registry/ui/button` also works and will be rewritten based on your configured style.
+- The CLI also rewrites alias-like string literals (for example, `"@/registry/new-york/payload/fields/color"` or `"@/payload/fields/color"`).
 - Buckets without a matching alias fall back to your `components` alias (e.g., `@/registry/new-york/payload/x` → `@/components/payload/x`). Add custom alias keys in `components.json` to route these to specific locations (e.g., `"payload": "@/payload"`).
 - This helps third‑party registries ship more than just `ui/lib/hooks/components`, and lets you control where each library’s files are installed. Some libraries require aliases—check their docs.
 - Ideally, place files within `components`, `hooks`, `lib` inside each registry item.

--- a/packages/shadcn/src/registry/schema.extra-aliases.test.ts
+++ b/packages/shadcn/src/registry/schema.extra-aliases.test.ts
@@ -1,0 +1,24 @@
+import { rawConfigSchema } from "@/src/schema"
+import { describe, expect, it } from "vitest"
+
+describe("rawConfigSchema aliases supports extra keys", () => {
+  it("accepts additional alias keys beyond the known ones", () => {
+    const result = rawConfigSchema.safeParse({
+      style: "new-york",
+      tsx: true,
+      rsc: false,
+      tailwind: {
+        css: "tailwind.css",
+        baseColor: "slate",
+        cssVariables: true,
+        prefix: "",
+      },
+      aliases: {
+        components: "@/components",
+        utils: "@/lib/utils",
+        payload: "@acme/payload",
+      },
+    })
+    expect(result.success).toBe(true)
+  })
+})

--- a/packages/shadcn/src/registry/schema.ts
+++ b/packages/shadcn/src/registry/schema.ts
@@ -164,13 +164,15 @@ export const rawConfigSchema = z
       prefix: z.string().default("").optional(),
     }),
     iconLibrary: z.string().optional(),
-    aliases: z.object({
-      components: z.string(),
-      utils: z.string(),
-      ui: z.string().optional(),
-      lib: z.string().optional(),
-      hooks: z.string().optional(),
-    }),
+    aliases: z
+      .object({
+        components: z.string(),
+        utils: z.string(),
+        ui: z.string().optional(),
+        lib: z.string().optional(),
+        hooks: z.string().optional(),
+      })
+      .catchall(z.string()),
     registries: registryConfigSchema.optional(),
   })
   .strict()

--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -189,9 +189,9 @@ export async function findPackageRoot(cwd: string, resolvedPath: string) {
 function isAliasKey(
   key: string,
   config: Config
-): key is keyof Config["aliases"] {
+): key is keyof Config["resolvedPaths"] {
   return Object.keys(config.resolvedPaths)
-    .filter((key) => key !== "utils")
+    .filter((k) => k !== "utils")
     .includes(key)
 }
 
@@ -272,7 +272,13 @@ export function createConfig(partial?: DeepPartial<Config>): Config {
       },
       aliases: {
         ...defaultConfig.aliases,
-        ...(partial.aliases || {}),
+        ...((partial.aliases
+          ? Object.fromEntries(
+              Object.entries(partial.aliases as Record<string, unknown>).filter(
+                ([, v]) => typeof v === "string"
+              )
+            )
+          : {}) as Record<string, string>),
       },
     }
   }

--- a/packages/shadcn/src/utils/transformers/index.ts
+++ b/packages/shadcn/src/utils/transformers/index.ts
@@ -11,6 +11,7 @@ import { transformRsc } from "@/src/utils/transformers/transform-rsc"
 import { Project, ScriptKind, type SourceFile } from "ts-morph"
 import { z } from "zod"
 
+import { transformStringAliases } from "./transform-string-aliases"
 import { transformTwPrefixes } from "./transform-tw-prefix"
 
 export type TransformOpts = {
@@ -41,6 +42,7 @@ export async function transform(
   opts: TransformOpts,
   transformers: Transformer[] = [
     transformImport,
+    transformStringAliases,
     transformRsc,
     transformCssVars,
     transformTwPrefixes,

--- a/packages/shadcn/src/utils/transformers/transform-import.test.ts
+++ b/packages/shadcn/src/utils/transformers/transform-import.test.ts
@@ -1,7 +1,8 @@
 import { type Config } from "@/src/utils/get-config"
+import { describe, expect, test } from "vitest"
+
 import { transform } from "../transformers"
 import { transformImport } from "./transform-import"
-import { describe, expect, test } from "vitest"
 
 const baseConfig: Config = {
   style: "new-york",
@@ -33,10 +34,9 @@ const baseConfig: Config = {
 describe("transformImport", () => {
   test("rewrites registry ui (with style) to components/ui when ui alias missing", async () => {
     const raw = `import { Button } from "@/registry/new-york/ui/button"\n`
-    const out = await transform(
-      { filename: "a.ts", raw, config: baseConfig },
-      [transformImport]
-    )
+    const out = await transform({ filename: "a.ts", raw, config: baseConfig }, [
+      transformImport,
+    ])
     expect(out).toContain('from "@/components/ui/button"')
   })
 
@@ -46,10 +46,9 @@ describe("transformImport", () => {
       aliases: { ...baseConfig.aliases, components: "@acme/components" },
     }
     const raw = `import x from "@/registry/new-york/components/input"\n`
-    const out = await transform(
-      { filename: "a.ts", raw, config },
-      [transformImport]
-    )
+    const out = await transform({ filename: "a.ts", raw, config }, [
+      transformImport,
+    ])
     expect(out).toContain('from "@acme/components/input"')
   })
 
@@ -62,10 +61,9 @@ describe("transformImport", () => {
       },
     }
     const raw = `import { foo } from "@/lib/foo"\n`
-    const out = await transform(
-      { filename: "a.ts", raw, config },
-      [transformImport]
-    )
+    const out = await transform({ filename: "a.ts", raw, config }, [
+      transformImport,
+    ])
     expect(out).toContain('from "@acme/lib/foo"')
   })
 
@@ -79,10 +77,9 @@ describe("transformImport", () => {
       },
     }
     const raw = `import { cn } from "@/lib/utils"\n`
-    const out = await transform(
-      { filename: "a.ts", raw, config },
-      [transformImport]
-    )
+    const out = await transform({ filename: "a.ts", raw, config }, [
+      transformImport,
+    ])
     expect(out).toContain('from "@acme/utils"')
   })
 
@@ -101,19 +98,29 @@ describe("transformImport", () => {
       aliases: { ...baseConfig.aliases, components: "@acme/components" },
     }
     const raw = `import x from "@/registry/new-york/payload/field"\n`
-    const out = await transform(
-      { filename: "a.ts", raw, config },
-      [transformImport]
-    )
+    const out = await transform({ filename: "a.ts", raw, config }, [
+      transformImport,
+    ])
     expect(out).toContain('from "@acme/components/payload/field"')
   })
 
   test("style segment optional in registry path", async () => {
     const raw = `import { Button } from "@/registry/ui/button"\n`
-    const out = await transform(
-      { filename: "a.ts", raw, config: baseConfig },
-      [transformImport]
-    )
+    const out = await transform({ filename: "a.ts", raw, config: baseConfig }, [
+      transformImport,
+    ])
     expect(out).toContain('from "@/components/ui/button"')
+  })
+
+  test("rewrites registry custom alias bucket (payload)", async () => {
+    const config: Config = {
+      ...baseConfig,
+      aliases: { ...baseConfig.aliases, payload: "@acme/payload" } as any,
+    }
+    const raw = `import x from "@/registry/new-york/payload/field"\n`
+    const out = await transform({ filename: "a.ts", raw, config }, [
+      transformImport,
+    ])
+    expect(out).toContain('from "@acme/payload/field"')
   })
 })

--- a/packages/shadcn/src/utils/transformers/transform-import.test.ts
+++ b/packages/shadcn/src/utils/transformers/transform-import.test.ts
@@ -1,0 +1,119 @@
+import { type Config } from "@/src/utils/get-config"
+import { transform } from "../transformers"
+import { transformImport } from "./transform-import"
+import { describe, expect, test } from "vitest"
+
+const baseConfig: Config = {
+  style: "new-york",
+  tsx: true,
+  rsc: true,
+  tailwind: {
+    baseColor: "neutral",
+    cssVariables: true,
+    config: "tailwind.config.ts",
+    css: "tailwind.css",
+  },
+  aliases: {
+    components: "@/components",
+    utils: "@/lib/utils",
+    // ui/lib/hooks left undefined by default
+  },
+  resolvedPaths: {
+    cwd: "/",
+    components: "/components",
+    utils: "/lib/utils",
+    ui: "/ui",
+    lib: "/lib",
+    hooks: "/hooks",
+    tailwindConfig: "tailwind.config.ts",
+    tailwindCss: "tailwind.css",
+  },
+}
+
+describe("transformImport", () => {
+  test("rewrites registry ui (with style) to components/ui when ui alias missing", async () => {
+    const raw = `import { Button } from "@/registry/new-york/ui/button"\n`
+    const out = await transform(
+      { filename: "a.ts", raw, config: baseConfig },
+      [transformImport]
+    )
+    expect(out).toContain('from "@/components/ui/button"')
+  })
+
+  test("rewrites registry components to custom components alias", async () => {
+    const config: Config = {
+      ...baseConfig,
+      aliases: { ...baseConfig.aliases, components: "@acme/components" },
+    }
+    const raw = `import x from "@/registry/new-york/components/input"\n`
+    const out = await transform(
+      { filename: "a.ts", raw, config },
+      [transformImport]
+    )
+    expect(out).toContain('from "@acme/components/input"')
+  })
+
+  test("rewrites bare lib alias to custom lib alias", async () => {
+    const config: Config = {
+      ...baseConfig,
+      aliases: {
+        ...baseConfig.aliases,
+        lib: "@acme/lib",
+      },
+    }
+    const raw = `import { foo } from "@/lib/foo"\n`
+    const out = await transform(
+      { filename: "a.ts", raw, config },
+      [transformImport]
+    )
+    expect(out).toContain('from "@acme/lib/foo"')
+  })
+
+  test("cn special-case rewrites lib/utils to utils alias when importing cn", async () => {
+    const config: Config = {
+      ...baseConfig,
+      aliases: {
+        ...baseConfig.aliases,
+        lib: "@acme/lib",
+        utils: "@acme/utils",
+      },
+    }
+    const raw = `import { cn } from "@/lib/utils"\n`
+    const out = await transform(
+      { filename: "a.ts", raw, config },
+      [transformImport]
+    )
+    expect(out).toContain('from "@acme/utils"')
+  })
+
+  test("handles isRemote by prefixing registry style and rewriting", async () => {
+    const raw = `import { Button } from "@/ui/button"\n`
+    const out = await transform(
+      { filename: "a.ts", raw, config: baseConfig, isRemote: true },
+      [transformImport]
+    )
+    expect(out).toContain('from "@/components/ui/button"')
+  })
+
+  test("unknown registry bucket falls back to components alias", async () => {
+    const config: Config = {
+      ...baseConfig,
+      aliases: { ...baseConfig.aliases, components: "@acme/components" },
+    }
+    const raw = `import x from "@/registry/new-york/payload/field"\n`
+    const out = await transform(
+      { filename: "a.ts", raw, config },
+      [transformImport]
+    )
+    expect(out).toContain('from "@acme/components/payload/field"')
+  })
+
+  test("style segment optional in registry path", async () => {
+    const raw = `import { Button } from "@/registry/ui/button"\n`
+    const out = await transform(
+      { filename: "a.ts", raw, config: baseConfig },
+      [transformImport]
+    )
+    expect(out).toContain('from "@/components/ui/button"')
+  })
+})

--- a/packages/shadcn/src/utils/transformers/transform-import.test.ts
+++ b/packages/shadcn/src/utils/transformers/transform-import.test.ts
@@ -123,4 +123,16 @@ describe("transformImport", () => {
     ])
     expect(out).toContain('from "@acme/payload/field"')
   })
+
+  test("rewrites registry custom alias bucket without style (payload)", async () => {
+    const config: Config = {
+      ...baseConfig,
+      aliases: { ...baseConfig.aliases, payload: "@acme/payload" } as any,
+    }
+    const raw = `import x from "@/registry/payload/field"\n`
+    const out = await transform({ filename: "a.ts", raw, config }, [
+      transformImport,
+    ])
+    expect(out).toContain('from "@acme/payload/field"')
+  })
 })

--- a/packages/shadcn/src/utils/transformers/transform-import.ts
+++ b/packages/shadcn/src/utils/transformers/transform-import.ts
@@ -1,4 +1,5 @@
-import { Config } from "@/src/utils/get-config"
+import { FALLBACK_STYLE } from "@/src/registry/constants"
+import { Config, DEFAULT_STYLE } from "@/src/utils/get-config"
 import { Transformer } from "@/src/utils/transformers"
 
 export const transformImport: Transformer = async ({
@@ -57,7 +58,7 @@ export function updateImportAliases(
     moduleSpecifier.startsWith("@/") &&
     !moduleSpecifier.startsWith("@/registry/")
   ) {
-    const style = config.style || "new-york"
+    const style = config.style || FALLBACK_STYLE
     moduleSpecifier = moduleSpecifier.replace(/^@\//, `@/registry/${style}/`)
   }
 
@@ -92,13 +93,15 @@ export function updateImportAliases(
     const parts = withoutPrefix.split("/")
 
     // Determine bucket with or without style
+    const resolvedPathKeys = config.resolvedPaths
+      ? Object.keys(config.resolvedPaths).filter(
+          (k) => !["cwd", "tailwindConfig", "tailwindCss"].includes(k)
+        )
+      : ["components", "utils", "ui", "lib", "hooks"]
+
     const aliasKeys = new Set([
-      ...Object.keys(config.aliases),
-      "components",
-      "ui",
-      "lib",
-      "hooks",
-      "utils",
+      ...Object.keys(config.aliases ?? {}),
+      ...resolvedPathKeys,
     ])
 
     let bucket = ""
@@ -107,8 +110,8 @@ export function updateImportAliases(
     const styleCandidates = new Set([
       config.style,
       "new-york",
-      "new-york-v4",
-      "default",
+      FALLBACK_STYLE,
+      DEFAULT_STYLE,
     ]) as Set<string>
     const hasStyle =
       parts.length >= 2 &&

--- a/packages/shadcn/src/utils/transformers/transform-string-aliases.test.ts
+++ b/packages/shadcn/src/utils/transformers/transform-string-aliases.test.ts
@@ -1,0 +1,93 @@
+import { type Config } from "@/src/utils/get-config"
+import { describe, expect, test } from "vitest"
+import { transform } from "../transformers"
+import { transformStringAliases } from "./transform-string-aliases"
+
+const baseConfig: Config = {
+  style: "new-york",
+  tsx: true,
+  rsc: true,
+  tailwind: {
+    baseColor: "neutral",
+    cssVariables: true,
+    config: "tailwind.config.ts",
+    css: "tailwind.css",
+  },
+  aliases: {
+    components: "@/components",
+    utils: "@/lib/utils",
+  },
+  resolvedPaths: {
+    cwd: "/",
+    components: "/components",
+    utils: "/lib/utils",
+    ui: "/ui",
+    lib: "/lib",
+    hooks: "/hooks",
+    tailwindConfig: "tailwind.config.ts",
+    tailwindCss: "tailwind.css",
+  },
+}
+
+describe("transformStringAliases", () => {
+  test("rewrites registry string literal to alias", async () => {
+    const config: Config = {
+      ...baseConfig,
+      aliases: { ...baseConfig.aliases, lib: "@acme/lib" },
+    }
+    const raw = `export const admin = { field: "@/registry/new-york/lib/fields/color" }\n`
+    const out = await transform(
+      { filename: "a.ts", raw, config },
+      [transformStringAliases]
+    )
+    expect(out).toContain('"@acme/lib/fields/color"')
+  })
+
+  test("supports optional style in registry path", async () => {
+    const config: Config = {
+      ...baseConfig,
+      aliases: { ...baseConfig.aliases, lib: "@acme/lib" },
+    }
+    const raw = `const s = "@/registry/lib/fields/color"\n`
+    const out = await transform(
+      { filename: "a.ts", raw, config },
+      [transformStringAliases]
+    )
+    expect(out).toContain('"@acme/lib/fields/color"')
+  })
+
+  test("rewrites bare alias string", async () => {
+    const config: Config = {
+      ...baseConfig,
+      aliases: { ...baseConfig.aliases, hooks: "@acme/hooks" },
+    }
+    const raw = `const x = "@/hooks/use-thing"\n`
+    const out = await transform(
+      { filename: "a.ts", raw, config },
+      [transformStringAliases]
+    )
+    expect(out).toContain('"@acme/hooks/use-thing"')
+  })
+
+  test("unknown bucket falls back to components alias", async () => {
+    const config: Config = {
+      ...baseConfig,
+      aliases: { ...baseConfig.aliases, components: "@acme/components" },
+    }
+    const raw = `const x = "@/registry/new-york/payload/my-field"\n`
+    const out = await transform(
+      { filename: "a.ts", raw, config },
+      [transformStringAliases]
+    )
+    expect(out).toContain('"@acme/components/payload/my-field"')
+  })
+
+  test("non-alias strings are unchanged", async () => {
+    const raw = `const t = "hello world"\n`
+    const out = await transform(
+      { filename: "a.ts", raw, config: baseConfig },
+      [transformStringAliases]
+    )
+    expect(out).toContain('"hello world"')
+  })
+})

--- a/packages/shadcn/src/utils/transformers/transform-string-aliases.test.ts
+++ b/packages/shadcn/src/utils/transformers/transform-string-aliases.test.ts
@@ -1,5 +1,6 @@
 import { type Config } from "@/src/utils/get-config"
 import { describe, expect, test } from "vitest"
+
 import { transform } from "../transformers"
 import { transformStringAliases } from "./transform-string-aliases"
 
@@ -36,10 +37,9 @@ describe("transformStringAliases", () => {
       aliases: { ...baseConfig.aliases, lib: "@acme/lib" },
     }
     const raw = `export const admin = { field: "@/registry/new-york/lib/fields/color" }\n`
-    const out = await transform(
-      { filename: "a.ts", raw, config },
-      [transformStringAliases]
-    )
+    const out = await transform({ filename: "a.ts", raw, config }, [
+      transformStringAliases,
+    ])
     expect(out).toContain('"@acme/lib/fields/color"')
   })
 
@@ -49,10 +49,9 @@ describe("transformStringAliases", () => {
       aliases: { ...baseConfig.aliases, lib: "@acme/lib" },
     }
     const raw = `const s = "@/registry/lib/fields/color"\n`
-    const out = await transform(
-      { filename: "a.ts", raw, config },
-      [transformStringAliases]
-    )
+    const out = await transform({ filename: "a.ts", raw, config }, [
+      transformStringAliases,
+    ])
     expect(out).toContain('"@acme/lib/fields/color"')
   })
 
@@ -62,10 +61,9 @@ describe("transformStringAliases", () => {
       aliases: { ...baseConfig.aliases, hooks: "@acme/hooks" },
     }
     const raw = `const x = "@/hooks/use-thing"\n`
-    const out = await transform(
-      { filename: "a.ts", raw, config },
-      [transformStringAliases]
-    )
+    const out = await transform({ filename: "a.ts", raw, config }, [
+      transformStringAliases,
+    ])
     expect(out).toContain('"@acme/hooks/use-thing"')
   })
 
@@ -75,19 +73,29 @@ describe("transformStringAliases", () => {
       aliases: { ...baseConfig.aliases, components: "@acme/components" },
     }
     const raw = `const x = "@/registry/new-york/payload/my-field"\n`
-    const out = await transform(
-      { filename: "a.ts", raw, config },
-      [transformStringAliases]
-    )
+    const out = await transform({ filename: "a.ts", raw, config }, [
+      transformStringAliases,
+    ])
     expect(out).toContain('"@acme/components/payload/my-field"')
   })
 
   test("non-alias strings are unchanged", async () => {
     const raw = `const t = "hello world"\n`
-    const out = await transform(
-      { filename: "a.ts", raw, config: baseConfig },
-      [transformStringAliases]
-    )
+    const out = await transform({ filename: "a.ts", raw, config: baseConfig }, [
+      transformStringAliases,
+    ])
     expect(out).toContain('"hello world"')
+  })
+
+  test("rewrites string with custom alias bucket (payload)", async () => {
+    const config: Config = {
+      ...baseConfig,
+      aliases: { ...baseConfig.aliases, payload: "@acme/payload" } as any,
+    }
+    const raw = `const x = "@/registry/new-york/payload/my-field"\n`
+    const out = await transform({ filename: "a.ts", raw, config }, [
+      transformStringAliases,
+    ])
+    expect(out).toContain('"@acme/payload/my-field"')
   })
 })

--- a/packages/shadcn/src/utils/transformers/transform-string-aliases.ts
+++ b/packages/shadcn/src/utils/transformers/transform-string-aliases.ts
@@ -1,0 +1,50 @@
+import { Config } from "@/src/utils/get-config"
+import { Transformer } from "@/src/utils/transformers"
+import { updateImportAliases } from "@/src/utils/transformers/transform-import"
+import { Node, SyntaxKind } from "ts-morph"
+
+function isInImportOrExport(node: Node) {
+  const parent = node.getParent()
+  if (!parent) return false
+  const kind = parent.getKind()
+  return (
+    kind === SyntaxKind.ImportDeclaration ||
+    kind === SyntaxKind.ExportDeclaration
+  )
+}
+
+export const transformStringAliases: Transformer = async ({
+  sourceFile,
+  config,
+  isRemote,
+}) => {
+  // Process normal string literals
+  sourceFile.getDescendantsOfKind(SyntaxKind.StringLiteral).forEach((lit) => {
+    if (isInImportOrExport(lit)) return
+    const raw = lit.getText() // includes quotes
+    const value = raw.replace(/^['"`]|['"`]$/g, "")
+    if (!value.startsWith("@/")) return
+
+    const next = updateImportAliases(value, config as Config, isRemote)
+    if (next !== value) {
+      lit.replaceWithText(`"${next}"`)
+    }
+  })
+
+  // Process template literals without substitutions
+  sourceFile
+    .getDescendantsOfKind(SyntaxKind.NoSubstitutionTemplateLiteral)
+    .forEach((lit) => {
+      if (isInImportOrExport(lit)) return
+      const raw = lit.getText() // includes backticks
+      const value = raw.slice(1, -1)
+      if (!value.startsWith("@/")) return
+
+      const next = updateImportAliases(value, config as Config, isRemote)
+      if (next !== value) {
+        lit.replaceWithText("`" + next + "`")
+      }
+    })
+
+  return sourceFile
+}

--- a/packages/shadcn/src/utils/updaters/update-files.ts
+++ b/packages/shadcn/src/utils/updaters/update-files.ts
@@ -22,6 +22,7 @@ import { transformCssVars } from "@/src/utils/transformers/transform-css-vars"
 import { transformIcons } from "@/src/utils/transformers/transform-icons"
 import { transformImport } from "@/src/utils/transformers/transform-import"
 import { transformRsc } from "@/src/utils/transformers/transform-rsc"
+import { transformStringAliases } from "@/src/utils/transformers/transform-string-aliases"
 import { transformTwPrefixes } from "@/src/utils/transformers/transform-tw-prefix"
 import prompts from "prompts"
 import { Project, ScriptKind } from "ts-morph"
@@ -123,6 +124,7 @@ export async function updateFiles(
           },
           [
             transformImport,
+            transformStringAliases,
             transformRsc,
             transformCssVars,
             transformTwPrefixes,


### PR DESCRIPTION
Notice: I leaned on GPT 5 heavily to write this since I started it as a POC. I gave it very strict guidance and reviewed everything written, afterwards I tested it locally to ensure everything worked as I intended. There wasn't as much code to add as I thought, to be fair. If you are curious, you can read through my conversation history [here](https://opencode.ai/s/VthNrf3U) as I was building. I also had it explain in this pr and why I'm pushing it back here. I imagine other registry authors might find use of this functionality in one form or another. I'm building a registry of components that includes payload cms blocks, this feature would help me keep all of my registry code in better order, since most of my code for this project will be written directly in my registry folder & I would like to have it organized in its own manner. Registry docs are very nice, btw. Made it very simple to get started w my own component registry.

## Summary

• Allow custom alias buckets in components.json (e.g., payload) and rewrite:
 • Imports: “@/registry/(style?)//…” and “@//…”
 • String literals (non-imports) that start with “@/…” or “@/registry/(style?)/…”
• Optional style segment for @/registry paths (both “@/registry/new-york/…” and “@/registry/…”
accepted)
• Unknown import aliases fall back to components alias by default
• Installer now rewrites alias-like string literals during file install
• Docs updated to explain behavior and usage with third-party registries

## Why

• Third-party registries often include files beyond ui/lib/hooks/components (e.g., CMS/admin
buckets like payload). This enables authors to:
 • Define custom alias keys to control install paths
 • Reference files uniformly via @/registry across registries
 • Rewrite alias-like config strings (not just imports)
• Defaults remain sane: when no custom alias is defined, unknown buckets fall back to components.

## What changed

### Examples

1. components.json

```json
{
  "style": "new-york",
  "aliases": {
    "components": "~/components",
    "utils": "~/lib/utils",
    "payload": "~/payload"
  }
}
```

2. Registry import usage (UI example)
// in a registry file

`import { Button } from "@/registry/new-york/ui/button"`
// transforms to:
`import { Button } from "~/components/ui/button"`

3. Registry string literal usage (Payload color field)

Input (registry payload file):

```ts
import type { TextField } from "@/registry/payload/fields"

export default function colorField(props?: Partial<TextField>) {
  return {
    admin: {
      components: {
        Field: "@/registry/payload/fields/color"
      }
    },
    ...props
  } as TextField
}
```

Output in a project WITH alias "payload": "~/payload" in components.json

```ts
import type { TextField } from "~/payload/fields"

export default function colorField(props?: Partial<TextField>) {
  return {
    admin: {
      components: {
        Field: "~/payload/fields/color"
      }
    },
    ...props
  } as TextField
}
```

Output in a project WITHOUT alias "payload" defined in components.json

```ts
import type { TextField } from "~/components/payload/fields"

export default function colorField(props?: Partial<TextField>) {
  return {
    admin: {
      components: {
        Field: "~/components/payload/fields/color"
      }
    },
    ...props
  } as TextField
}
```

### Notes on imports

• Optional style: “@/registry/ui/button” is accepted and rewritten based on config.style.
• isRemote normalization: if a file is processed as remote, “@/…” is treated as “@/registry//…”.
• cn import preserved: importing cn from “@/lib/utils” rewrites to the configured utils alias.

### Docs

• apps/www/content/docs/components-json.mdx
• apps/www/content/docs/registry/getting-started.mdx
• apps/www/content/docs/monorepo.mdx

### Tests

• All shadcn tests: 767 passing locally
• New tests:
 • src/utils/transformers/transform-import.test.ts (9 total)
 • src/utils/transformers/transform-string-aliases.test.ts (6 total)
 • src/registry/schema.extra-aliases.test.ts


## Backwards compatibility

• All changes are additive. If you don’t define new alias keys, behavior matches current CLI
behavior.
• Built-in buckets (ui, components, lib, hooks) continue to work as before.
• Unknown buckets default to components when no custom alias exists.
• The @/registry style segment is optional; explicit style paths remain fully supported.

## Current workaround (pre-feature)

• I’m routing my Payload files through the built-in lib bucket:
 • components.json:
 ```json
{
   "style": "new-york",
   "aliases": {
     "components": "~/components",
     "utils": "~/lib/utils",
     "lib": "~/payload"
   }
 }
```

 • In my registry, Payload files import via the lib bucket:
 // Registry file
 `import type { TextField } from "@/registry/new-york/lib/fields"`
 // Installed output
 `import type { TextField } from "~/payload/fields"`

• This works but overloads the meaning of lib and makes it hard to differentiate true library
utilities from CMS/admin code. The proposed feature lets me use a dedicated payload alias and
write clearer imports like:
 • Registry: `"@/registry/new-york/payload/fields/…"`
 • Installed (with alias): `"~/payload/fields/…"`
• The change keeps current behavior while allowing better separation and future-proofing
third-party registry buckets.

## Open to changes

• Happy to make edits per review.
• Will add a changeset if required; proposed as a minor release (new functionality, backward
compatible).

Additional context

• Enables “in-registry” import style like “@/registry/uifoundry/payload/…” across complex
third-party registries while letting consumers route installation paths per library via aliases.

Thanks for the review