### PR TITLE
Update sidebar.tsx  fix: use type-only import for VariantProps to prevent runtime crash

### DIFF
--- a/apps/www/registry/default/ui/sidebar.tsx
+++ b/apps/www/registry/default/ui/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { VariantProps, cva } from "class-variance-authority"
+import { type VariantProps, cva } from "class-variance-authority"
 import { PanelLeft } from "lucide-react"
 
 import { useIsMobile } from "@/registry/default/hooks/use-mobile"


### PR DESCRIPTION
fix: use type-only import for VariantProps to prevent runtime crash

Vite was throwing an error because `VariantProps` was imported as a regular value import from `class-variance-authority`. Since `VariantProps` is purely a TypeScript type and does not exist at runtime, including it in a value import caused the build to fail.

By switching to `import type { VariantProps }`, we ensure that the import is erased at compile time and never included in the runtime bundle. This aligns with TypeScript best practices for type-only imports and prevents similar issues in the future.