### PR TITLE
fix: import VariantProps as a type-only import

### DIFF
--- a/apps/www/registry/default/ui/sidebar.tsx
+++ b/apps/www/registry/default/ui/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { VariantProps, cva } from "class-variance-authority"
+import { type VariantProps, cva } from "class-variance-authority"
 import { PanelLeft } from "lucide-react"
 
 import { useIsMobile } from "@/registry/default/hooks/use-mobile"


### PR DESCRIPTION
Currently, VariantProps is imported as a value:

  import { cva, VariantProps } from "class-variance-authority"

This causes a TypeScript error when `verbatimModuleSyntax` is enabled:

  'VariantProps' is a type and must be imported using a type-only import

Since VariantProps is a type, it should be imported with `import type`:

  import { cva, type VariantProps } from "class-variance-authority"

This fixes the type error in projects using TS 5.x strict module settings.