### PR TITLE
docs: change className to class in Astro example

### DIFF
--- a/apps/v4/content/docs/installation/astro.mdx
+++ b/apps/v4/content/docs/installation/astro.mdx
@@ -65,7 +65,7 @@ import { Button } from "@/components/ui/button"
 	</head>
 
 	<body>
-		<div className="grid place-items-center h-screen content-center">
+		<div class="grid place-items-center h-screen content-center">
 			<Button>Button</Button>
 		</div>
 	</body>


### PR DESCRIPTION
Fixes #8165

This PR fixes the Astro installation documentation where `className` was incorrectly used instead of `class` in the example `.astro` file.

**Changes:**
- Changed `className` to `class` in the Astro installation example
- This ensures the example code works correctly when copied into an `.astro` file