### PR TITLE
Add @shadcn-editor registry URL to registries.json

### DIFF
--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -26,5 +26,6 @@
   "@smoothui": "https://smoothui.dev/r/{name}.json",
   "@formcn": "https://formcn.dev/r/{name}.json",
   "@limeplay": "https://limeplay.winoffrg.dev/r/{name}.json",
-  "@skiper-ui": "https://skiper-ui.com/registry/{name}.json"
+  "@skiper-ui": "https://skiper-ui.com/registry/{name}.json",
+  "@shadcn-editor": "https://shadcn-editor.vercel.app/r/{name}.json"
 }


### PR DESCRIPTION
- [x] The registry must be open source and publicly accessible.
- [x] The registry must be a valid JSON file that conforms to the [registry schema specification](https://ui.shadcn.com/docs/registry/registry-json).
- [x] The registry is expected to be a flat registry with no nested items i.e /registry.json and /component-name.json files are expected to be in the root of the registry.
- [x] The files array, if present, must NOT include a content property.