### PR TITLE
fix: correct range calendar example in docs

### DIFF
--- a/apps/v4/content/docs/components/calendar.mdx
+++ b/apps/v4/content/docs/components/calendar.mdx
@@ -113,7 +113,7 @@ To use the Persian calendar, edit `components/ui/calendar.tsx` and replace `reac
 ### Range Calendar
 
 <ComponentPreview
-  name="calendar-02"
+  name="calendar-05"
   title="Range Calendar"
   description="A calendar showing the current date and range selection."
   className="**:[.preview]:h-auto lg:**:[.preview]:h-[450px]"


### PR DESCRIPTION
This PR resolves an issue in the current documentation where the [Range Calendar example](https://ui.shadcn.com/docs/components/calendar#range-calendar) is incorrect. The `calendar-02` example (Multiple months with single selection) is displayed instead of the `calendar-05` example (Multiple months with range selection).