### PR TITLE
Fix npx corresponding to yarn dlx in install docs

### DIFF
--- a/apps/v4/lib/highlight-code.ts
+++ b/apps/v4/lib/highlight-code.ts
@@ -39,7 +39,7 @@ export const transformers = [
         // npx.
         if (raw.startsWith("npx")) {
           node.properties["__npm__"] = raw
-          node.properties["__yarn__"] = raw.replace("npx", "yarn")
+          node.properties["__yarn__"] = raw.replace("npx", "yarn dlx")
           node.properties["__pnpm__"] = raw.replace("npx", "pnpm dlx")
           node.properties["__bun__"] = raw.replace("npx", "bunx --bun")
         }
@@ -47,7 +47,7 @@ export const transformers = [
         // npm run.
         if (raw.startsWith("npm run")) {
           node.properties["__npm__"] = raw
-          node.properties["__yarn__"] = raw.replace("npm run", "yarn")
+          node.properties["__yarn__"] = raw.replace("npm run", "yarn dlx")
           node.properties["__pnpm__"] = raw.replace("npm run", "pnpm")
           node.properties["__bun__"] = raw.replace("npm run", "bun")
         }


### PR DESCRIPTION
The docs have a minor documentation mismatch where it tries to replace `npx` with raw `yarn`, which works for some commands, but probably many cases it does not.

This pull request replaces the swap mechanism to be: `npx` -> `yarn dlx` and `npx run` -> `yarn dlx`

Found on this page: https://ui.shadcn.com/docs/installation/vite where for example `yarn shadcn@latest add button` is not a command string that yarn understands.

