### PR TITLE
fix: correct improper JSON syntax

### DIFF
--- a/apps/v4/content/docs/registry/examples.mdx
+++ b/apps/v4/content/docs/registry/examples.mdx
@@ -580,7 +580,7 @@ You can also have a universal item that installs multiple files:
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "my-custom-start-template",
   "type": "registry:item",
-  dependencies: ["better-auth"]
+  "dependencies": ["better-auth"],
   "files": [
     {
       "path": "/path/to/file-01.json",


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![](https://github.com/user-attachments/assets/ddcba004-21da-4f17-8880-904d4201939e) | ![](https://github.com/user-attachments/assets/e12ec13a-5cc5-41d0-bdda-972caf6f5fa2) | 