### PR TITLE
Fix "Page 1 of 0" when table has no rows

### DIFF
--- a/apps/v4/app/(app)/examples/tasks/components/data-table-pagination.tsx
+++ b/apps/v4/app/(app)/examples/tasks/components/data-table-pagination.tsx
@@ -51,7 +51,7 @@ export function DataTablePagination<TData>({
         </div>
         <div className="flex w-[100px] items-center justify-center text-sm font-medium">
           Page {table.getState().pagination.pageIndex + 1} of{" "}
-          {table.getPageCount()}
+          {table.getPageCount() || 1}
         </div>
         <div className="flex items-center space-x-2">
           <Button


### PR DESCRIPTION
Pretty small thing, but I was experimenting with the tasks example's data table implementation as it is more comprehensive than the docs/data-table page, and I noticed this issue. 

With this change it will show "Page 1 of 1" when there are no rows instead of "Page 1 of 0".