### PR TITLE
fix(theme-selector): add missing colors to theme selector on charts page

### DIFF
--- a/apps/v4/components/theme-selector.tsx
+++ b/apps/v4/components/theme-selector.tsx
@@ -58,6 +58,18 @@ const COLOR_THEMES = [
     name: "Teal",
     value: "teal",
   },
+  {
+    name: "Yellow",
+    value: "yellow",
+  },
+  {
+    name: "Violet",
+    value: "violet",
+  },
+  {
+    name: "Red",
+    value: "red",
+  },
 ]
 
 export function ThemeSelector({ className }: React.ComponentProps<"div">) {


### PR DESCRIPTION
### Reproduction:

https://github.com/user-attachments/assets/28b71f19-fcf7-408b-b31d-7718114e6f10

