### PR TITLE
docs: rename 'mcpServers' to 'servers' in mcp.json

### DIFF
--- a/apps/v4/content/docs/(root)/mcp.mdx
+++ b/apps/v4/content/docs/(root)/mcp.mdx
@@ -116,7 +116,7 @@ To use the shadcn MCP server with Claude Code, add the following configuration t
 
 ```json title=".mcp.json" showLineNumbers
 {
-  "mcpServers": {
+  "servers": {
     "shadcn": {
       "command": "npx",
       "args": ["shadcn@latest", "mcp"]


### PR DESCRIPTION
mcp.json in vscode uses 'servers' to define mcp servers in workspace