### PR TITLE
feat: add RTL support to Switch component

### DIFF
--- a/apps/www/registry/default/ui/switch.tsx
+++ b/apps/www/registry/default/ui/switch.tsx
@@ -7,9 +7,12 @@ import { cn } from "@/lib/utils"
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & {
+    dir?: "ltr" | "rtl"
+  }
+>(({ className, dir = "ltr", ...props }, ref) => (
   <SwitchPrimitives.Root
+    dir={dir}
     className={cn(
       "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
       className
@@ -18,8 +21,12 @@ const Switch = React.forwardRef<
     ref={ref}
   >
     <SwitchPrimitives.Thumb
+      key={dir}
       className={cn(
-        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=unchecked]:translate-x-0",
+        dir === "rtl"
+          ? "data-[state=checked]:-translate-x-5"
+          : "data-[state=checked]:translate-x-5"
       )}
     />
   </SwitchPrimitives.Root>

--- a/apps/www/registry/new-york/ui/switch.tsx
+++ b/apps/www/registry/new-york/ui/switch.tsx
@@ -7,9 +7,12 @@ import { cn } from "@/lib/utils"
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & {
+    dir?: "ltr" | "rtl"
+  }
+>(({ className, dir = "ltr", ...props }, ref) => (
   <SwitchPrimitives.Root
+    dir={dir}
     className={cn(
       "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
       className
@@ -18,8 +21,12 @@ const Switch = React.forwardRef<
     ref={ref}
   >
     <SwitchPrimitives.Thumb
+      key={dir}
       className={cn(
-        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=unchecked]:translate-x-0",
+        dir === "rtl"
+          ? "data-[state=checked]:-translate-x-4"
+          : "data-[state=checked]:translate-x-4"
       )}
     />
   </SwitchPrimitives.Root>


### PR DESCRIPTION
## ✨ Feature
Adds RTL (Right-to-Left) support to Switch component for both default and new-york variants.

## 🔧 Changes
- Added `dir` prop with `"ltr" | "rtl"` type support
- Added conditional CSS classes for proper thumb movement
- Added `key={dir}` for proper re-rendering
- Updated both registry variants consistently

## 🧪 Testing
- ✅ LTR: thumb moves left → right  
- ✅ RTL: thumb moves right → left
- ✅ No CSS conflicts
- ✅ Proper accessibility support

## 📁 Files Changed
- `apps/www/registry/default/ui/switch.tsx`
- `apps/www/registry/new-york/ui/switch.tsx`
