### PR TITLE
fix: move key prop to li element in sidebar-16.tsx

### DIFF
--- a/apps/www/registry/new-york/v0/sidebar-16.tsx
+++ b/apps/www/registry/new-york/v0/sidebar-16.tsx
@@ -359,8 +359,8 @@ export default function Page() {
                   <NavigationMenuContent>
                     <ul className="grid w-[400px] gap-3 p-4 md:w-[500px] md:grid-cols-2 lg:w-[600px] ">
                       {components.map((component) => (
-                        <li>
-                          <NavigationMenuLink key={component.title} asChild>
+                        <li key={component.title}>
+                          <NavigationMenuLink asChild>
                             <a className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground">
                               <div className="text-sm font-medium leading-none">
                                 {component.title}


### PR DESCRIPTION
[Fixes #8204 - Move key prop from NavigationMenuLink to parent li element to resolve React/ESLint error 'Missing key prop for element in iterator'](fix: move key prop to li element in sidebar-16.tsx)