### PR TITLE
 fix: correct TanStack Start title configuration in documentation

### DIFF
--- a/apps/v4/content/docs/installation/tanstack.mdx
+++ b/apps/v4/content/docs/installation/tanstack.mdx
@@ -58,10 +58,8 @@ export const Route = createRootRoute({
         name: "viewport",
         content: "width=device-width, initial-scale=1",
       },
-      {
-        title: "TanStack Start Starter",
-      },
     ],
+    title: "TanStack Start Starter",
     links: [
       {
         rel: "stylesheet",

--- a/apps/www/content/docs/installation/tanstack.mdx
+++ b/apps/www/content/docs/installation/tanstack.mdx
@@ -58,10 +58,8 @@ export const Route = createRootRoute({
         name: "viewport",
         content: "width=device-width, initial-scale=1",
       },
-      {
-        title: "TanStack Start Starter",
-      },
     ],
+    title: "TanStack Start Starter",
     links: [
       {
         rel: "stylesheet",

--- a/apps/www/registry/new-york/v0/sidebar-16.tsx
+++ b/apps/www/registry/new-york/v0/sidebar-16.tsx
@@ -359,8 +359,8 @@ export default function Page() {
                   <NavigationMenuContent>
                     <ul className="grid w-[400px] gap-3 p-4 md:w-[500px] md:grid-cols-2 lg:w-[600px] ">
                       {components.map((component) => (
-                        <li>
-                          <NavigationMenuLink key={component.title} asChild>
+                        <li key={component.title}>
+                          <NavigationMenuLink asChild>
                             <a className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground">
                               <div className="text-sm font-medium leading-none">
                                 {component.title}


### PR DESCRIPTION
## Description
Fixes incorrect TanStack Start root route configuration in documentation

## Problem
The `title` property was incorrectly placed inside the `meta` array in the TanStack Start documentation example, which causes configuration errors.

## Solution
- Moved `title` from `meta` array to be a separate property in the `head` function return object
- Updated both v4 and www documentation files

## Changes
```diff
head: () => ({
  meta: [
    { charSet: "utf-8" },
    { name: "viewport", content: "width=device-width, initial-scale=1" },
-   { title: "TanStack Start Starter" },
  ],
+ title: "TanStack Start Starter",
  links: [...]
})
