### PR TITLE
docs: add testId usage example for Sonner component

### DIFF
--- a/apps/v4/content/docs/components/sonner.mdx
+++ b/apps/v4/content/docs/components/sonner.mdx
@@ -99,3 +99,16 @@ import { toast } from "sonner"
 ```tsx
 toast("Event has been created.")
 ```
+
+## Examples
+
+### With testId for testing
+
+```tsx
+<Toaster testId="toast-container" />
+```
+
+```tsx
+// In your tests
+const toastContainer = screen.getByTestId("toast-container")
+```

--- a/apps/www/content/docs/components/sonner.mdx
+++ b/apps/www/content/docs/components/sonner.mdx
@@ -99,3 +99,16 @@ import { toast } from "sonner"
 ```tsx
 toast("Event has been created.")
 ```
+
+## Examples
+
+### With testId for testing
+
+```tsx
+<Toaster testId="toast-container" />
+```
+
+```tsx
+// In your tests
+const toastContainer = screen.getByTestId("toast-container")
+```


### PR DESCRIPTION
## Description
Adds documentation for the testId prop in Sonner component for testing purposes

## Problem
The Sonner component supports the testId prop (passed through via {...props}) but this wasn't documented, making it unclear for users how to test toast components.

## Solution
- Added example showing testId usage with Toaster component
- Added testing example showing how to access the toast container in tests
- Updated both v4 and www documentation

## Changes
- Added "Examples" section with testId usage
- Shows proper testing pattern with screen.getByTestId()

## Related Issue
Fixes #8232

## Testing
- [x] testId prop is passed through via {...props} spread
- [x] Documentation follows existing patterns
- [x] Both documentation sites updated consistently
