### PR TITLE
refactor(registry/utils): move `determineFileType` to `determine-file-type.ts` | #1

### DIFF
--- a/packages/shadcn/src/registry/utils.ts
+++ b/packages/shadcn/src/registry/utils.ts
@@ -8,6 +8,7 @@ import {
 } from "@/src/schema"
 import { Config } from "@/src/utils/get-config"
 import { ProjectInfo, getProjectInfo } from "@/src/utils/get-project-info"
+import { determineFileType } from "@/src/utils/registry/determine-file-type"
 import { resolveImport } from "@/src/utils/resolve-import"
 import {
   findCommonRoot,
@@ -225,30 +226,6 @@ export async function recursivelyResolveFileImports(
 async function createTempSourceFile(filename: string) {
   const dir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-"))
   return path.join(dir, filename)
-}
-
-// This is a bit tricky to accurately determine.
-// For now we'll use the module specifier to determine the type.
-function determineFileType(
-  moduleSpecifier: string
-): z.infer<typeof registryItemSchema>["type"] {
-  if (moduleSpecifier.includes("/ui/")) {
-    return "registry:ui"
-  }
-
-  if (moduleSpecifier.includes("/lib/")) {
-    return "registry:lib"
-  }
-
-  if (moduleSpecifier.includes("/hooks/")) {
-    return "registry:hook"
-  }
-
-  if (moduleSpecifier.includes("/components/")) {
-    return "registry:component"
-  }
-
-  return "registry:component"
 }
 
 // Additional utility functions for local file support

--- a/packages/shadcn/src/utils/registry/determine-file-type.ts
+++ b/packages/shadcn/src/utils/registry/determine-file-type.ts
@@ -1,0 +1,25 @@
+import type { RegistryItem } from "@/src/registry/schema"
+
+// This is a bit tricky to accurately determine.
+// For now we'll use the module specifier to determine the type.
+const determineFileType = (moduleSpecifier: string): RegistryItem["type"] => {
+  if (moduleSpecifier.includes("/ui/")) {
+    return "registry:ui"
+  }
+
+  if (moduleSpecifier.includes("/lib/")) {
+    return "registry:lib"
+  }
+
+  if (moduleSpecifier.includes("/hooks/")) {
+    return "registry:hook"
+  }
+
+  if (moduleSpecifier.includes("/components/")) {
+    return "registry:component"
+  }
+
+  return "registry:component"
+}
+
+export { determineFileType }


### PR DESCRIPTION
# PR: Improve Registry Path Handling in Monorepo Environments

## 🛠️ Changes Summary

- Move `determineFileType` to a dedicated file `utils/registry/determine-file-type.ts` to avoid upcoming circular dependencies.

### Reason

- upcoming `createRegistryFile` function (which will be imported into `utils.ts`) uses `determineFileType`, which currently lives inside `utils.ts`.
- moving `determineFileType` out prevents circular imports between `utils.ts` and `createRegistryFile`.

---

PR roadmap introduces several refactors and new utility functions to improve how the `shadcn registry:build` CLI handles failed aliased import paths, especially in **monorepo setups** using path aliases (e.g. `@/components/...`).

### 🐛 Problem

In monorepos, adding a registry component like:

```json
{
  "files": [
    {
      "path": "@/components/rhf/rhf-text-field.tsx",
      "type": "registry:component"
    }
  ]
}
```

...and running:

```bash
pnpm shadcn registry:build
```

Would fail with:

```
ENOENT: no such file or directory, stat '/absolute/path/to/ui/apps/registry/@/components/ui/rhf/rhf-text-field.tsx'
```

<br />

`fs.stat()` is called before the alias is resolved by `tsconfig-paths`, causing the CLI to crash ungracefully.

---

## 💡 Why This Happens

In a monorepo, files from multiple workspaces may be referenced using aliases (`@`, `@ui`, etc.). If these aliases aren't fully resolved to disk paths, the CLI crashes when trying to access them directly via `fs.stat`.

The current logic fails here:

```ts
// packages/shadcn/src/registry/utils.ts
const stat = await fs.stat(resolvedFilePath);
if (!stat.isFile()) {
  // Optionally log or handle this case
  return { dependencies: [], files: [] };
}
```

When `fs.stat()` is called on an invalid or unresolved path, it throws an `ENOENT` error, causing the CLI to crash ungracefully.

---

## 🧭 Roadmap

part of a multi step effort to enable the registry CLI to handle path aliases gracefully in monorepo environments.

- [x] **Refactor:** – move `determineFileType()` to its own file (`utils/registry/determine-file-type.ts`) ✅ (this PR)
- [ ] **Refactor:** – add `createRegistryFile()` util for creating registry file shape
- [ ] **Refactor:** – add `getStatsOrNonFile()` to gracefully suppress ENOENT errors
- [ ] **Refactor:** – add ~~`re`~~`tryAlternativePath()`  to retry common alias misresolves
- [ ] **Feature:** – inject fallback logic into `!stat.isFile()` and handle returned suppressed files in registry build command's `resolveRegistryItems`
- [ ] Feature – add warning/logging system for invalid file paths (follow-up)

Each change is isolated for clean diffs.

---

## 🧱 Directory Structure (for Context)

my monorepo structure to understand the issue:

```bash
./
├── apps/registry/ # registry
│   ├── components.json, package.json, registry.json
│   ├── public/r/ → registry.json, rhf-text-field.json, theme.json
│   └── src/
│       ├── app/
│       │   ├── (registry)/
│       │   └── demo/[name]/ → components/rhf-text-field.tsx, ui/ # demo
│       ├── components/ → registry/, rhf-text-field.tsx # example
│       ├── content/, hooks/, layouts/
│       └── lib/ → highlight-code.ts, products.ts, registry.ts, utils.ts
│       ├── tsconfig.json, tsconfig.tsbuildinfo
├── package.json
├── packages/
│   ├── eslint-config/, hooks/, typescript-config/
│   ├── shadcn-ui/ # shadcn-ui repo
│   │   ├── components.json, package.json, tsconfig.json
│   │   └── src/
│   │       ├── components/ui/ → button.tsx, form.tsx, input.tsx, label.tsx
│   │       ├── hooks/, lib/utils.ts, styles/globals.css
│   ├── shadcn-ui-extended/ # extended component repo `rhf-text-field.tsx`
│   │   ├── package.json, tsconfig.json
│   │   └── src/
│   │       ├── components/ → rhf/rhf-text-field.tsx, ui/
│   │       └── data/, helpers/, hooks/, lib/, utils/
│   └── ui/turbo/generators/
└── pnpm-lock.yaml, pnpm-workspace.yaml, turbo.json
```

_tsconfig.json_

```json
    "paths": {
      // ...
      "@/components/ui/*": [
        "../../packages/shadcn-ui/src/components/ui/*", // primary: shadcn-ui package
        "src/components/ui/*" // fallback: local overrides
      ],

      "@/components/rhf/*": [
        "../../packages/shadcn-ui-extended/src/components/rhf/*", // shadcn-ui-extended
        "src/components/rhf/*" // local overrides
      ],
    }
```

---

## 📚 Notes

- `tsconfig-paths` is used, but current `fs.stat()` happens before alias resolution in some cases.
- roadmap feat provides resilience without adding external dependencies or needing a separate alias parser (yet).

---

## 🔗 Follow-Ups

- Log warnings for files that fail even after retry fallback