### PR TITLE
feat: add magic ui pro registry

### DIFF
--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -10,6 +10,7 @@
   "@kibo-ui": "https://www.kibo-ui.com/r/{name}.json",
   "@kokonutui": "https://kokonutui.com/r/{name}.json",
   "@magicui": "https://magicui.design/r/{name}.json",
+  "@magicui-pro": "https://pro.magicui.design/registry/{name}",
   "@motion-primitives": "https://motion-primitives.com/c/{name}.json",
   "@originui": "https://originui.com/r/{name}.json",
   "@prompt-kit": "https://prompt-kit.com/c/{name}.json",


### PR DESCRIPTION
## Magic UI Pro Registry

This PR adds Magic UI Pro as a trusted registry.

The entire registry is available to view at https://pro.magicui.design/registry.json

The individual components are only available using the bearer token authentication scheme by sending token to the `https://pro.magicui.design/registry/{name}` API route. More details [here](https://pro.magicui.design/docs/installation) 

## Manual Installation

Add the following to your `components.json`
```
{
  "registries": {
    "@magicui-pro": {
      "url": "https://pro.magicui.design/registry/{name}",
      "headers": {
        "Authorization": "Bearer ${MAGICUI_PRO_REGISTRY_TOKEN}"
      }
    }
  }
}