### PR TITLE
fix(docs): calendar hijri doc fixed to show correct months in dropdown layout

### DIFF
--- a/apps/v4/content/docs/components/calendar.mdx
+++ b/apps/v4/content/docs/components/calendar.mdx
@@ -97,6 +97,9 @@ You can use the `<Calendar>` component to build a date picker. See the [Date Pic
 
 To use the Persian calendar, edit `components/ui/calendar.tsx` and replace `react-day-picker` with `react-day-picker/persian`.
 
+Then, to ensure the months dropdown displays correctly when `captionLayout='dropdown'`, pass a custom `formatMonthDropdown`
+function to your Calendar instance.
+
 ```diff
 - import { DayPicker } from "react-day-picker"
 + import { DayPicker } from "react-day-picker/persian"

--- a/apps/v4/registry/new-york-v4/examples/calendar-hijri.tsx
+++ b/apps/v4/registry/new-york-v4/examples/calendar-hijri.tsx
@@ -23,7 +23,17 @@ export default function CalendarHijri() {
       defaultMonth={date}
       selected={date}
       onSelect={setDate}
-      className="rounded-lg border shadow-sm"
+      className="rounded-lg border shadow-sm",
+      captionLayout='dropdown'
+      /**
+       * You can handle months in two ways:
+       * 1. Apply this solution for a specific Calendar instance.
+       * 2. Override the default `formatMonthDropdown` function
+       *    directly in the Calendar component code, as explained below.
+       */
+      formatters={{
+        formatMonthDropdown: date => date.toLocaleString('fa-IR', { month: 'short' }),
+      }}
     />
   )
 }
@@ -56,9 +66,14 @@ function Calendar({
         className
       )}
       captionLayout={captionLayout}
+      /**
+       * To override the month display when `captionLayout='dropdown'`
+       * provide a custom `formatMonthDropdown` here
+       * You can set your preferred locale or pass a prop as needed
+       */
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString("default", { month: "short" }),
+          date.toLocaleString("fa-IR", { month: "short" }), // customize the locale as needed
         ...formatters,
       }}
       classNames={{


### PR DESCRIPTION
## Fix Persian / Jalali Calendar Month Dropdown Display

This PR addresses the issue where the month dropdown in the Persian / Jalali calendar `captionLayout='dropdown'` was still displaying Gregorian months.

Fixes/Closes #8305 

Changes include:

Updated the documentation/example to show how to pass the `formatMonthDropdown` function when instantiating the Calendar component:

```jsx
<Calendar
  mode="single"
  selected={date}
  onSelect={handleDateSelect}
  autoFocus
  captionLayout="dropdown"
  formatters={{
    formatMonthDropdown: (date) =>
      date.toLocaleString("fa-IR", { month: "short" }),
  }}
/>;
```

### Result:

- Month dropdown now correctly displays Persian / Jalali month names.
- Provides both instance-level and global ways to configure month formatting.