### PR TITLE
fix(sidebar): use CSS variables directly in outline shadow styles

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -480,7 +480,7 @@ const sidebarMenuButtonVariants = cva(
       variant: {
         default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
         outline:
-          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+          "bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]",
       },
       size: {
         default: "h-8 text-sm",


### PR DESCRIPTION
Replaces shadow colors from `hsl(var(--sidebar-…))` to `var(--sidebar-…)` 
for the `outline` variant in `sidebarMenuButtonVariants`.

This aligns the sidebar component with other components, removes 
unnecessary hsl() wrapping, and ensures consistency with the oklch 
color system introduced in v4.
