### PR TITLE
fix(sidebar): pass className prop to SheetContent for mobile CSS variable inheritance

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -187,7 +187,10 @@ function Sidebar({
           data-sidebar="sidebar"
           data-slot="sidebar"
           data-mobile="true"
-          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+          className={cn(
+            "bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden",
+            className
+          )}
           style={
             {
               "--sidebar-width": SIDEBAR_WIDTH_MOBILE,


### PR DESCRIPTION
### Problem
On mobile and tablet screens, the Sidebar's Sheet component renders outside the DOM tree via Portal, causing it to not inherit CSS variables (like `--sidebar` and `--sidebar-foreground`) from the `SidebarProvider`. This results in incorrect colors on mobile devices.

### Solution
- Pass the `className` prop from `Sidebar` to `SheetContent` using the `cn()` utility
- This allows CSS variables to be properly applied to the mobile sidebar

### Changes
- **Modified**: `apps/v4/registry/new-york-v4/ui/sidebar.tsx`

### Before
```tsx
<SheetContent
  className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
  // className prop not passed
>
```

### After
```tsx
<SheetContent
  className={cn(
    "w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden",
    className // <= className prop now passed
  )}
>
```

### Related Issue
#8058

### Screenshots (from test page)

#### Before (Error)
![녹화_2025_09_10_20_43_20_984](https://github.com/user-attachments/assets/48f84fbc-a54c-4f44-93d3-70a3e94e4ff5)

#### After (Fixed)
![녹화_2025_09_11_17_06_44_998](https://github.com/user-attachments/assets/79434d8d-f633-4666-a9bd-a5fc3eb4d4e8)


This is my first PR, so it took some time to thoroughly test and reproduce the issue. I created a dedicated test page to verify the fix works correctly. I welcome all feedback and suggestions for improvement!
