### PR TITLE
Add @shadcn-studio registry URL to registries.json

### DIFF
--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -31,6 +31,7 @@
   "@limeplay": "https://limeplay.winoffrg.dev/r/{name}.json",
   "@skiper-ui": "https://skiper-ui.com/registry/{name}.json",
   "@shadcn-editor": "https://shadcn-editor.vercel.app/r/{name}.json",
+  "@shadcn-studio": "https://shadcnstudio.com/r/{name}.json",
   "@rigidui": "https://rigidui.com/r/{name}.json",
   "@retroui": "https://retroui.dev/r/{name}.json",
   "@wds": "https://wds-shadcn-registry.netlify.app/r/{name}.json",


### PR DESCRIPTION
Here is the site: [shadcnstudio.com](https://shadcnstudio.com)

Added opensource [components](https://shadcnstudio.com/components), [blocks](https://shadcnstudio.com/blocks), and [themes](https://shadcnstudio.com/theme-generator) registry.

- [x] The registry must be open source and publicly accessible.
- [x] The registry must be a valid JSON file that conforms to the [registry schema specification](https://ui.shadcn.com/docs/registry/registry-json).
- [x] The registry is expected to be a flat registry with no nested items i.e /registry.json and /component-name.json files are expected to be in the root of the registry.
- [x] The files array, if present, must NOT include a content property.