### PR TITLE
correct alignment in empty component demo

### DIFF
--- a/apps/v4/registry/new-york-v4/examples/empty-demo.tsx
+++ b/apps/v4/registry/new-york-v4/examples/empty-demo.tsx
@@ -26,7 +26,7 @@ export default function EmptyDemo() {
       </EmptyHeader>
       <EmptyContent>
         <div className="flex gap-2">
-          <Button size="sm">Create Project</Button>
+          <Button>Create Project</Button>
           <Button variant="outline">Import Project</Button>
         </div>
       </EmptyContent>


### PR DESCRIPTION
in the demo of empty component we got a misalignment between "Create Project" and "Import project" due to `size="sm"`.