### PR TITLE
fix: correct prop types for Spinner component

### DIFF
--- a/apps/v4/content/docs/components/spinner.mdx
+++ b/apps/v4/content/docs/components/spinner.mdx
@@ -59,7 +59,7 @@ import { LoaderIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({ className, ...props }: React.ComponentProps<typeof LoaderIcon>) {
   return (
     <LoaderIcon
       role="status"

--- a/apps/v4/registry/new-york-v4/blocks/new-components-01/components/ui/spinner.tsx
+++ b/apps/v4/registry/new-york-v4/blocks/new-components-01/components/ui/spinner.tsx
@@ -2,7 +2,7 @@ import { Loader2Icon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({ className, ...props }: React.ComponentProps<typeof Loader2Icon>) {
   return (
     <Loader2Icon
       role="status"

--- a/apps/v4/registry/new-york-v4/examples/spinner-custom.tsx
+++ b/apps/v4/registry/new-york-v4/examples/spinner-custom.tsx
@@ -2,7 +2,7 @@ import { LoaderIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({ className, ...props }: React.ComponentProps<typeof Loader2Icon>) {
   return (
     <LoaderIcon
       role="status"

--- a/apps/v4/registry/new-york-v4/ui/spinner.tsx
+++ b/apps/v4/registry/new-york-v4/ui/spinner.tsx
@@ -2,7 +2,7 @@ import { Loader2Icon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({ className, ...props }: React.ComponentProps<typeof Loader2Icon>) {
   return (
     <Loader2Icon
       role="status"


### PR DESCRIPTION
#### What does this PR do?

This PR fixes a typing error in the `Spinner` component. The prop types have been updated to correctly reflect the component being rendered internally (`LoaderIcon`), instead of a generic `<svg>` element.

#### Problem Context

The `Spinner` component was typed with `React.ComponentProps<"svg">`, which assumed it accepted the properties of a standard HTML SVG element. However, the component forwards all received props (`...props`) to the `LoaderIcon` component (likely from the `lucide-react` library).

This caused a type mismatch error because the props expected by `LoaderIcon` (`LucideProps`) are different from the props of a generic `<svg>`. TypeScript correctly reported the following error:

```typescript
Type '{ ... }' is not assignable to type 'Omit<LucideProps, "ref">'.
  Types of property 'children' are incompatible.
    Type 'React.ReactNode' is not assignable to type 'import(".../@types/react/index").ReactNode'.
```

#### Solution

The `Spinner` component's prop type was changed from:

```typescript
}: React.ComponentProps<"svg">)
```

To:

```typescript
}: React.ComponentProps<typeof LoaderIcon>)
```

This change allows TypeScript to automatically infer the props from `LoaderIcon`, ensuring that the `Spinner` only accepts and forwards valid properties. This resolves the typing error and improves type safety and the developer experience (DX) when using the component.