### PR TITLE
fix(input-group-textarea): prevent child elements from overflowing by…

### DIFF
--- a/apps/v4/registry/new-york-v4/blocks/new-components-01/components/ui/input-group.tsx
+++ b/apps/v4/registry/new-york-v4/blocks/new-components-01/components/ui/input-group.tsx
@@ -15,7 +15,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
       role="group"
       className={cn(
         "group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-md border shadow-xs transition-[color,box-shadow] outline-none",
-        "h-9 has-[>textarea]:h-auto",
+        "h-9 min-w-0 has-[>textarea]:h-auto",
 
         // Variants based on alignment.
         "has-[>[data-align=inline-start]]:[&>input]:pl-2",

--- a/apps/v4/registry/new-york-v4/ui/input-group.tsx
+++ b/apps/v4/registry/new-york-v4/ui/input-group.tsx
@@ -15,7 +15,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
       role="group"
       className={cn(
         "group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-md border shadow-xs transition-[color,box-shadow] outline-none",
-        "h-9 has-[>textarea]:h-auto",
+        "h-9 min-w-0 has-[>textarea]:h-auto",
 
         // Variants based on alignment.
         "has-[>[data-align=inline-start]]:[&>input]:pl-2",


### PR DESCRIPTION
### Problem
The Textarea container element was missing a min-w-0 style.
As a result, when typing long text, the layout could overflow its parent container.

### Solution
Add min-w-0 to the Textarea container to ensure it respects its parent width and prevents overflow.

### Changes
- Added min-w-0 to the Textarea container class.
- Ensured long text input no longer causes layout overflow.

### Modified: 
- apps/v4/registry/new-york-v4/ui/input-group.tsx
- apps/v4/registry/new-york-v4/blocks/new-components-01/components/ui/input-group.tsx


### Before
```tsx
function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
  return (
    <div
      data-slot="input-group"
      role="group"
      className={cn(
        "group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-md border shadow-xs transition-[color,box-shadow] outline-none",
        "h-9 has-[>textarea]:h-auto",
//...
```

### After
```tsx
function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
  return (
    <div
      data-slot="input-group"
      role="group"
      className={cn(
        "group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-md border shadow-xs transition-[color,box-shadow] outline-none",
        "h-9 min-w-0 has-[>textarea]:h-auto",
//...
```

Related Issue
#8335 

Screenshots (from test page)

### Before (Error)
![before](https://github.com/user-attachments/assets/ebc9c51d-e479-48c5-a2ea-641c5fced9cd)

### After
![after](https://github.com/user-attachments/assets/5e0e068b-0670-44d7-bbc1-500f8d77ae19)



