### PR TITLE
feat: add @react-market to trusted registries

### DIFF
--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -37,5 +37,6 @@
   "@rigidui": "https://rigidui.com/r/{name}.json",
   "@retroui": "https://retroui.dev/r/{name}.json",
   "@wds": "https://wds-shadcn-registry.netlify.app/r/{name}.json",
+  "@react-market": "https://www.react-market.com/get/{name}",
   "@97cn": "https://97cn.itzik.co/r/{name}.json"
 }


### PR DESCRIPTION
This PR adds [React Market](https://react-market.com/) to the trusted registries.