### PR TITLE
fix(ui): VariantProps is a type and must be imported using a type-only import

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { cva, VariantProps } from "class-variance-authority"
+import { cva, type VariantProps } from "class-variance-authority";
 import { PanelLeftIcon } from "lucide-react"
 
 import { useIsMobile } from "@/registry/new-york-v4/hooks/use-mobile"


### PR DESCRIPTION
Fix: Use type-only import for VariantProps to prevent runtime crash

Previously, VariantProps was imported as a regular value instead of a type-only import. This caused the React app to crash when the block sidebar was used. The fix ensures VariantProps is imported using a type-only import to avoid runtime issues.