### PR TITLE
no explicitly type any 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,12 +7,13 @@
     "prettier",
     "plugin:tailwindcss/recommended"
   ],
-  "plugins": ["tailwindcss"],
+  "plugins": ["tailwindcss", "@typescript-eslint"],
   "ignorePatterns": ["**/fixtures/**"],
   "rules": {
     "@next/next/no-html-link-for-pages": "off",
     "tailwindcss/no-custom-classname": "off",
-    "tailwindcss/classnames-order": "error"
+    "tailwindcss/classnames-order": "error",
+    "@typescript-eslint/no-explicit-any": "error"
   },
   "settings": {
     "tailwindcss": {


### PR DESCRIPTION
**ESLint Configuration Update**

**Change Summary:**
Added a rule to disallow explicit use of the any type in TypeScript files to improve type safety across the codebase.

**Details:**

**Added Rule:** _@typescript-eslint/no-explicit-any_

Enforced at error level to prevent use of any in TypeScript.


**Updated Plugins:** Included @typescript-eslint to support TypeScript-specific linting.

**Rationale:** Encourages stronger typing practices, reduces runtime errors, and ensures more maintainable code.


**File Updated:**
eslintrc.json

next add the package

```bash
pnpm add -D @typescript-eslint/eslint-plugin