### PR TITLE
fix(components): fix application error when copying code from Scaled theme

### DIFF
--- a/apps/v4/components/theme-customizer.tsx
+++ b/apps/v4/components/theme-customizer.tsx
@@ -119,6 +119,7 @@ export function CopyCodeButton({
   ...props
 }: React.ComponentProps<typeof Button>) {
   let { activeTheme: activeThemeName = "neutral" } = useThemeConfig()
+  
   activeThemeName = activeThemeName === "default" ? "neutral" : activeThemeName
 
   return (
@@ -173,7 +174,7 @@ function CustomizerCode({ themeName }: { themeName: string }) {
   const activeThemeOKLCH = React.useMemo(
     () => baseColorsOKLCH[themeName as keyof typeof baseColorsOKLCH],
     [themeName]
-  )
+  )  
 
   React.useEffect(() => {
     if (hasCopied) {
@@ -240,7 +241,7 @@ function CustomizerCode({ themeName }: { themeName: string }) {
                 <span data-line className="line text-code-foreground">
                   &nbsp;&nbsp;&nbsp;--radius: 0.65rem;
                 </span>
-                {Object.entries(activeThemeOKLCH?.light).map(([key, value]) => (
+                {Object.entries(activeThemeOKLCH?.light ?? {}).map(([key, value]) => (
                   <span
                     data-line
                     className="line text-code-foreground"
@@ -258,7 +259,7 @@ function CustomizerCode({ themeName }: { themeName: string }) {
                 <span data-line className="line text-code-foreground">
                   &nbsp;.dark &#123;
                 </span>
-                {Object.entries(activeThemeOKLCH?.dark).map(([key, value]) => (
+                {Object.entries(activeThemeOKLCH?.dark ?? {}).map(([key, value]) => (
                   <span
                     data-line
                     className="line text-code-foreground"


### PR DESCRIPTION
Fixes #8357

This PR fixes the application error that occurs when clicking the "Copy Code" button
on the /themes page while the Scaled theme is selected.

## Changes:
- Updated `CustomizerCode` to correctly handle the Scaled theme
- Added null/undefined checks for theme variables to prevent runtime errors
- Tested locally using `pnpm v4:dev`

Now, the Copy Code button works as expected for all themes, including Scaled.

## Note:
Currently, some themes like Scaled and Amber do not have CSS code defined yet.
The modal will open correctly, but the code area will be empty until the theme is added.

This prevents runtime errors and improves stability while selecting unimplemented themes.