### PR TITLE
fix(create-next-project): improve error messages when create-next-app fails during init

### DIFF
--- a/packages/shadcn/src/utils/create-project.ts
+++ b/packages/shadcn/src/utils/create-project.ts
@@ -189,9 +189,18 @@ async function createNextProject(
     )
   } catch (error) {
     logger.break()
-    logger.error(
-      `Something went wrong creating a new Next.js project. Please try again.`
-    )
+    logger.error(`Something went wrong creating a new Next.js project. Please try again.`)
+
+    if (error && typeof error === 'object' && 'stderr' in error) {
+      const execaError = error as any
+      const errorMessage = execaError.stderr || execaError.stdout || execaError.message
+      if (errorMessage) {
+        logger.error(errorMessage.trim())
+      }
+    } else if (error instanceof Error) {
+      logger.error(error.message)
+    }
+
     process.exit(1)
   }
 


### PR DESCRIPTION
## Description

Fixes #8370 

This PR improves error handling in the `shadcn init` command to show actual error messages from `create-next-app` instead of the generic "Something went wrong creating a new Next.js project. Please try again." message.

## Problem

Previously, when `create-next-app` failed (e.g., due to invalid project names with capital letters, special characters, or other npm naming restrictions), users only saw a generic error message without any indication of what actually went wrong. This made it difficult to diagnose and fix the issue.

## Solution

Enhanced the error handling in `create-project.ts` to extract and display the actual error messages from `create-next-app` by:
- Checking for `stderr`, `stdout`, and `message` properties from the execa error object
- Displaying the actual error message to help users understand what went wrong

## Changes Made

- Modified `createNextProject` function in `packages/shadcn/src/utils/create-project.ts`
- Added proper error extraction from execa errors (stderr, stdout, message)
- Improved error output to show actual error messages from `create-next-app`

## Testing

Tested locally with various error scenarios:
- ✅ Project names with capital letters
- ✅ Project names with special characters (@, !, etc.)
- ✅ Project names with spaces
- ✅ Reserved npm names
- ✅ Names starting with dots or underscores

<img width="643" height="262" alt="Screenshot 2025-10-07 at 5 42 34 PM" src="https://github.com/user-attachments/assets/b1079b65-7f31-42ce-bda9-8aaa5416273b" />


All error scenarios now display the actual error message from `create-next-app`, making it clear to users what needs to be fixed.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves existing functionality)
