### PR TITLE
fix(docs): correct Empty component structure in documentation

### DIFF
--- a/apps/v4/content/docs/components/empty.mdx
+++ b/apps/v4/content/docs/components/empty.mdx
@@ -57,9 +57,9 @@ import {
     <EmptyMedia variant="icon">
       <Icon />
     </EmptyMedia>
+    <EmptyTitle>No data</EmptyTitle>
+    <EmptyDescription>No data found</EmptyDescription>
   </EmptyHeader>
-  <EmptyTitle>No data</EmptyTitle>
-  <EmptyDescription>No data found</EmptyDescription>
   <EmptyContent>
     <Button>Add data</Button>
   </EmptyContent>


### PR DESCRIPTION
##  Related Issue
Fixes #8367 — Incorrect structure in the **Empty** component documentation.

## Bug Description

The documentation for the **`Empty`** component had an incorrect structure.  
In the docs, the **Title** and **Description** were placed **outside** of the `<EmptyHeader>` component, which caused inconsistent spacing compared to the rendered example.

---

## Visual Comparison

The Title and Description are outside the Header, leading to extra spacing.
<br/>
<img width="1220" height="663" alt="Screenshot from 2025-10-07 19-46-42" src="https://github.com/user-attachments/assets/7bc3eaae-b922-4edb-b3e1-4de616f9bcc6" />

---

### After (Fixed Structure)
After restructuring the `apps/v4/content/docs/components/empty.mdx` file,  
the Title and Description are now properly nested inside the Header — fixing the layout.
<br/>
<img width="1920" height="1037" alt="Screenshot from 2025-10-07 19-50-35" src="https://github.com/user-attachments/assets/7884202a-89ef-4500-871a-04b06692f5ea" />

---