### PR TITLE
fix(input-group): use logical properties for RTL support

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/input-group.tsx
+++ b/apps/v4/registry/new-york-v4/ui/input-group.tsx
@@ -18,8 +18,8 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
         "h-9 min-w-0 has-[>textarea]:h-auto",
 
         // Variants based on alignment.
-        "has-[>[data-align=inline-start]]:[&>input]:pl-2",
-        "has-[>[data-align=inline-end]]:[&>input]:pr-2",
+        "has-[>[data-align=inline-start]]:[&>input]:ps-2",
+        "has-[>[data-align=inline-end]]:[&>input]:pe-2",
         "has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3",
         "has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3",
 
@@ -42,9 +42,9 @@ const inputGroupAddonVariants = cva(
     variants: {
       align: {
         "inline-start":
-          "order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]",
+          "order-first ps-3 has-[>button]:ms-[-0.45rem] has-[>kbd]:ms-[-0.35rem]",
         "inline-end":
-          "order-last pr-3 has-[>button]:mr-[-0.45rem] has-[>kbd]:mr-[-0.35rem]",
+          "order-last pe-3 has-[>button]:me-[-0.45rem] has-[>kbd]:me-[-0.35rem]",
         "block-start":
           "order-first w-full justify-start px-3 pt-3 [.border-b]:pb-3 group-has-[>input]/input-group:pt-2.5",
         "block-end":

--- a/apps/www/registry/default/ui/input-group.tsx
+++ b/apps/www/registry/default/ui/input-group.tsx
@@ -18,8 +18,8 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
         "h-9 has-[>textarea]:h-auto",
 
         // Variants based on alignment.
-        "has-[>[data-align=inline-start]]:[&>input]:pl-2",
-        "has-[>[data-align=inline-end]]:[&>input]:pr-2",
+        "has-[>[data-align=inline-start]]:[&>input]:ps-2",
+        "has-[>[data-align=inline-end]]:[&>input]:pe-2",
         "has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3",
         "has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3",
 
@@ -42,9 +42,9 @@ const inputGroupAddonVariants = cva(
     variants: {
       align: {
         "inline-start":
-          "order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]",
+          "order-first ps-3 has-[>button]:ms-[-0.45rem] has-[>kbd]:ms-[-0.35rem]",
         "inline-end":
-          "order-last pr-3 has-[>button]:mr-[-0.4rem] has-[>kbd]:mr-[-0.35rem]",
+          "order-last pe-3 has-[>button]:me-[-0.4rem] has-[>kbd]:me-[-0.35rem]",
         "block-start":
           "[.border-b]:pb-3 order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5",
         "block-end":

--- a/apps/www/registry/new-york/ui/input-group.tsx
+++ b/apps/www/registry/new-york/ui/input-group.tsx
@@ -18,8 +18,8 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
         "h-9 has-[>textarea]:h-auto",
 
         // Variants based on alignment.
-        "has-[>[data-align=inline-start]]:[&>input]:pl-2",
-        "has-[>[data-align=inline-end]]:[&>input]:pr-2",
+        "has-[>[data-align=inline-start]]:[&>input]:ps-2",
+        "has-[>[data-align=inline-end]]:[&>input]:pe-2",
         "has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3",
         "has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3",
 
@@ -42,9 +42,9 @@ const inputGroupAddonVariants = cva(
     variants: {
       align: {
         "inline-start":
-          "order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]",
+          "order-first ps-3 has-[>button]:ms-[-0.45rem] has-[>kbd]:ms-[-0.35rem]",
         "inline-end":
-          "order-last pr-3 has-[>button]:mr-[-0.4rem] has-[>kbd]:mr-[-0.35rem]",
+          "order-last pe-3 has-[>button]:me-[-0.4rem] has-[>kbd]:me-[-0.35rem]",
         "block-start":
           "[.border-b]:pb-3 order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5",
         "block-end":


### PR DESCRIPTION
## Description

The `input-group` component currently uses physical directional properties (`pl`, `pr`, `ml`, `mr`) which don't adapt to RTL layouts. This PR converts them to logical properties (`ps`, `pe`, `ms`, `me`) to properly support both LTR and RTL text directions.

---

## Visual Comparison

### Before (LTR works, RTL broken)
<img width="399" height="84" alt="image" src="https://github.com/user-attachments/assets/240b0f2e-9607-411f-9248-aaf7c2202697" />

---

### After (Both LTR and RTL work correctly)
<img width="402" height="102" alt="image" src="https://github.com/user-attachments/assets/d1a731fb-38ca-4a8e-b737-50f2019ef508" />

---

## Changes Made

Converted physical directional properties to logical properties across all input-group variants:

**Input padding:**
- `pl-2` → `ps-2` (padding-inline-start)
- `pr-2` → `pe-2` (padding-inline-end)

**Inline-start addon:**
- `pl-3` → `ps-3`
- `ml-[-0.45rem]` → `ms-[-0.45rem]`
- `ml-[-0.35rem]` → `ms-[-0.35rem]`

**Inline-end addon:**
- `pr-3` → `pe-3`
- `mr-[-0.45rem]` → `me-[-0.45rem]`
- `mr-[-0.35rem]` → `me-[-0.35rem]`

## Why This Matters

Using logical properties instead of physical directional properties (left/right) allows the component to automatically adapt its layout based on the document's text direction. This ensures proper spacing in both LTR and RTL layouts without requiring additional code or direction detection.