### PR TITLE
fix(mcp): await async npxShadcn to prevent [object Promise] output in…

### DIFF
--- a/packages/shadcn/src/mcp/index.ts
+++ b/packages/shadcn/src/mcp/index.ts
@@ -230,7 +230,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           content: [
             {
               type: "text",
-              text: formatSearchResultsWithPagination(results, {
+              text: await formatSearchResultsWithPagination(results, {
                 query: args.query,
                 registries: args.registries,
               }),
@@ -272,7 +272,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           content: [
             {
               type: "text",
-              text: formatSearchResultsWithPagination(results, {
+              text: await formatSearchResultsWithPagination(results, {
                 registries: args.registries,
               }),
             },

--- a/packages/shadcn/src/mcp/utils.ts
+++ b/packages/shadcn/src/mcp/utils.ts
@@ -20,7 +20,7 @@ export async function getMcpConfig(cwd = process.cwd()) {
   }
 }
 
-export function formatSearchResultsWithPagination(
+export async function formatSearchResultsWithPagination(
   results: z.infer<typeof searchResultsSchema>,
   options?: {
     query?: string
@@ -29,27 +29,31 @@ export function formatSearchResultsWithPagination(
 ) {
   const { query, registries } = options || {}
 
-  const formattedItems = results.items.map((item) => {
-    const parts: string[] = [`- ${item.name}`]
+  const formattedItems = await Promise.all(
+    results.items.map(async (item) => {
+      const parts: string[] = [`- ${item.name}`]
 
-    if (item.type) {
-      parts.push(`(${item.type})`)
-    }
+      if (item.type) {
+        parts.push(`(${item.type})`)
+      }
 
-    if (item.description) {
-      parts.push(`- ${item.description}`)
-    }
+      if (item.description) {
+        parts.push(`- ${item.description}`)
+      }
 
-    if (item.registry) {
-      parts.push(`[${item.registry}]`)
-    }
+      if (item.registry) {
+        parts.push(`[${item.registry}]`)
+      }
 
-    parts.push(
-      `\n  Add command: \`${npxShadcn(`add ${item.addCommandArgument}`)}\``
-    )
+      parts.push(
+        `\n  Add command: \`${await npxShadcn(
+          `add ${item.addCommandArgument}`
+        )}\``
+      )
 
-    return parts.join(" ")
-  })
+      return parts.join(" ")
+    })
+  )
 
   let header = `Found ${results.pagination.total} items`
   if (query) {


### PR DESCRIPTION
# fix(mcp): resolve [object Promise] issue in registry item listings

## Summary

This PR fixes an issue in the MCP tools where asynchronous calls to `npxShadcn`
inside `formatSearchResultsWithPagination` were not awaited.
This caused the output to display `[object Promise]` instead of the actual
command text when listing or searching items in registries.

## Affected Tools

* `list_items_in_registries`
* `search_items_in_registries`

## Changes

* Converted `formatSearchResultsWithPagination` into an **async** function.
* Used `Promise.all` to properly handle async mapping of items.
* Updated MCP request handlers to **await** calls to the formatting function.

## Before

Example output from `list_items_in_registries`:

```
Add command: [object Promise]
```

✅ No breaking changes introduced.
