### PR TITLE
Add moveinready-casa/shadcn-native to registries.json

### DIFF
--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -44,5 +44,6 @@
   "@better-upload": "https://better-upload.com/r/{name}.json",
   "@zippystarter": "https://zippystarter.com/r/{name}.json",
   "@elevenlabs-ui": "https://ui.elevenlabs.io/r/{name}.json",
-  "@intentui": "https://intentui.com/r/{name}"
+  "@intentui": "https://intentui.com/r/{name}",
+  "@shadcn-native": "https://shadcn-native.moveinready.casa/registry/{name}"
 }


### PR DESCRIPTION
This adds [shadcn-native](https://shadcn-native.moveinready.casa/) for react native to the list!