### PR TITLE
feat(registry): Add Fancy Components to the registry index

### DIFF
--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -45,5 +45,6 @@
   "@zippystarter": "https://zippystarter.com/r/{name}.json",
   "@elevenlabs-ui": "https://ui.elevenlabs.io/r/{name}.json",
   "@intentui": "https://intentui.com/r/{name}",
-  "@shadcn-map": "http://shadcn-map.vercel.app/r/{name}.json"
+  "@shadcn-map": "http://shadcn-map.vercel.app/r/{name}.json",
+  "@fancy": "https://fancycomponents.dev/r/{name}.json"
 }


### PR DESCRIPTION
Running `pnpm validate:registries` passes validation.

Let me know if something is missing though!

Website:
https://fancycomponents.dev

Github repo:
https://github.com/danielpetho/fancy