### PR TITLE
Fix: Automatically close sidebar on route navigation

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -509,7 +509,7 @@ function SidebarMenuButton({
   tooltip?: string | React.ComponentProps<typeof TooltipContent>
 } & VariantProps<typeof sidebarMenuButtonVariants>) {
   const Comp = asChild ? Slot : "button"
-  const { isMobile, state } = useSidebar()
+  const { isMobile, state, setOpenMobile } = useSidebar()
 
   const button = (
     <Comp
@@ -518,6 +518,7 @@ function SidebarMenuButton({
       data-size={size}
       data-active={isActive}
       className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      onClick={() => setOpenMobile(false)} // Closes the sidebar when a navigation link is pressed
       {...props}
     />
   )


### PR DESCRIPTION
Automatically close the mobile sidebar when a menu button is clicked.

Changes

Added `setOpenMobile` from `useSidebar()`

Added `onClick={() => setOpenMobile(false)}` to `SidebarMenuButton`