### PR TITLE
docs(apps/www/content): Update navigation-menu.mdx missing <NavigationMenu>

### DIFF
--- a/apps/www/content/docs/components/navigation-menu.mdx
+++ b/apps/www/content/docs/components/navigation-menu.mdx
@@ -86,13 +86,15 @@ import { navigationMenuTriggerStyle } from "@/components/ui/navigation-menu"
 ```
 
 ```tsx {3-5}
-<NavigationMenuItem>
-  <Link href="/docs" legacyBehavior passHref>
-    <NavigationMenuLink className={navigationMenuTriggerStyle()}>
-      Documentation
-    </NavigationMenuLink>
-  </Link>
-</NavigationMenuItem>
+<NavigationMenu>
+  <NavigationMenuItem>
+    <Link href="/docs" legacyBehavior passHref>
+      <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+        Documentation
+      </NavigationMenuLink>
+    </Link>
+  </NavigationMenuItem>
+</NavigationMenu>
 ```
 
 See also the [Radix UI documentation](https://www.radix-ui.com/docs/primitives/components/navigation-menu#with-client-side-routing) for handling client side routing.


### PR DESCRIPTION
NavigationMenu was missing in the [example ](https://ui.shadcn.com/docs/components/navigation-menu), which was throwing an error while building in the Next.js app. It says NavigationMenuDemo, so I expected it to run directly when I pasted it in my code editor.