### PR TITLE
refactor(components): remove redundant style in progress component

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/progress.tsx
+++ b/apps/v4/registry/new-york-v4/ui/progress.tsx
@@ -21,7 +21,7 @@ function Progress({
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="bg-primary h-full w-full flex-1 transition-all"
+        className="bg-primary h-full w-full transition-all"
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/apps/www/registry/default/ui/progress.tsx
+++ b/apps/www/registry/default/ui/progress.tsx
@@ -18,7 +18,7 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className="h-full w-full bg-primary transition-all"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/apps/www/registry/new-york/ui/progress.tsx
+++ b/apps/www/registry/new-york/ui/progress.tsx
@@ -18,7 +18,7 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className="h-full w-full bg-primary transition-all"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>


### PR DESCRIPTION
Removed redundant `flex-1` style in Progress component
`flex-1` exists despite of it's parent is not a flex element.

before: `className="h-full w-full flex-1 bg-primary transition-all"`
after: `className="h-full w-full bg-primary transition-all"`

modified: 
`apps/v4/registry/new-york-v4/ui/progress.tsx`
`apps/www/registry/default/ui/progress.tsx`
`apps/www/registry/new-york/ui/progress.tsx`