### PR TITLE
fix(v4): Fix link to Form documentation in form.mdx

### DIFF
--- a/apps/v4/content/docs/components/form.mdx
+++ b/apps/v4/content/docs/components/form.mdx
@@ -9,7 +9,7 @@ import { InfoIcon } from "lucide-react"
 
 <Callout icon={<InfoIcon />} title="We are not actively developing this component anymore.">
 
-The Form component is an abstraction over the `react-hook-form` library. Going forward, we recommend using the [`<Field />`](/docs/components/field) component to build forms. See the [Form](/docs/form) documentation for more information.
+The Form component is an abstraction over the `react-hook-form` library. Going forward, we recommend using the [`<Field />`](/docs/components/field) component to build forms. See the [Form](/docs/forms) documentation for more information.
 
 </Callout>
 


### PR DESCRIPTION
Description
This PR fixes a broken link in the documentation. The form page was pointing to /form, which resulted in a 404. Updated it to the correct path /forms.

Change Summary

Updated link from /form → /forms in the docs