### PR TITLE
fix: correct link to Form documentation in form.mdx

### DIFF
--- a/apps/v4/content/docs/components/form.mdx
+++ b/apps/v4/content/docs/components/form.mdx
@@ -9,7 +9,7 @@ import { InfoIcon } from "lucide-react"
 
 <Callout icon={<InfoIcon />} title="We are not actively developing this component anymore.">
 
-The Form component is an abstraction over the `react-hook-form` library. Going forward, we recommend using the [`<Field />`](/docs/components/field) component to build forms. See the [Form](/docs/form) documentation for more information.
+The Form component is an abstraction over the `react-hook-form` library. Going forward, we recommend using the [`<Field />`](/docs/components/field) component to build forms. See the [Form](/docs/forms) documentation for more information.
 
 </Callout>
 


### PR DESCRIPTION
## Fix: Update broken link in Form component documentation

This pull request fixes a broken link in the Form component documentation.

### Problem
The Form component documentation contained a broken link that was pointing to `/docs/form`, which results in a 404 error when clicked.

### Solution
Updated the link to point to the correct path `/docs/forms` where the forms documentation actually exists.

### Changes
- 📝 Fixed broken link from `/docs/form` to `/docs/forms` in `apps/v4/content/docs/components/form.mdx`

### Before
```markdown
See the [Form](/docs/form) documentation for more information.