### PR TITLE
fix(button): fix import statement for Link component in button component docs

### DIFF
--- a/apps/v4/content/docs/components/button.mdx
+++ b/apps/v4/content/docs/components/button.mdx
@@ -265,7 +265,7 @@ To create a button group, use the `ButtonGroup` component. See the [Button Group
 You can use the `asChild` prop to make another component look like a button. Here's an example of a link that looks like a button.
 
 ```tsx showLineNumbers
-import { Link } from "next/link"
+import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
 


### PR DESCRIPTION
## Fix: Correct Link import to use default export

This PR updates the import statement for the `Link` component in the Button documentation.

- Fixes #8425 

### What Changed

- The import statement now correctly imports `Link` as a default export instead of a named export.

### Why

- Previously, `Link` was imported as a named export, which is incorrect and causes import errors.
- The `Link` component should be imported as the default export to match its actual export structure.

### Impact

- Prevents import errors for users copying the example.
- Ensures documentation accurately reflects the correct usage of the `Link` component.

