### PR TITLE
fix(www): command menu shortcut reactivity after clearing search input

### DIFF
--- a/apps/v4/components/command-menu.tsx
+++ b/apps/v4/components/command-menu.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation"
 import { type DialogProps } from "@radix-ui/react-dialog"
 import { IconArrowRight } from "@tabler/icons-react"
 import { CornerDownLeftIcon, SquareDashedIcon } from "lucide-react"
+import { useCommandState } from "cmdk"
 
 import { type Color, type ColorPalette } from "@/lib/colors"
 import { showMcpDocs } from "@/lib/flags"
@@ -361,6 +362,8 @@ function CommandMenuItem({
   "aria-selected"?: string
 }) {
   const ref = React.useRef<HTMLDivElement>(null)
+
+  useCommandState((state) => state.search)
 
   useMutationObserver(ref, (mutations) => {
     mutations.forEach((mutation) => {


### PR DESCRIPTION
Hey there!

I've found a small issue that occurs when having a searching for something on the docs' cmd+k command menu and then clearing it.

## The issue

What currently happens is that the `CommandMenuItem` component isn't re-rendered and made aware of changes in the search after clearing a given search input, and the mutation observer won't trigger any events. This leads to the bottom section of the `CommandMenu` (the shortcut hints) being out of sync with the highlighted command menu item.

It's best visible in a screen recording (watch how the bottom shortcut hints don't match the highlighted item after clearing the input):

https://github.com/user-attachments/assets/b56dd24a-d3e8-46f9-89fa-6e1b3309112e

## My fix

I just added a call to `useCommandState` inside `CommandMenuItem` which makes it properly reactive. I hope this is the best solution for this.

After:

https://github.com/user-attachments/assets/dab94a87-5e92-4b97-8062-0967554c99cb


