### PR TITLE
fix(card): add "id" field to form and "form" field to button to improve from handling

### DIFF
--- a/apps/v4/app/(internal)/sink/components/card-demo.tsx
+++ b/apps/v4/app/(internal)/sink/components/card-demo.tsx
@@ -30,7 +30,7 @@ export function CardDemo() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <form>
+          <form id="form-card-demo">
             <div className="flex flex-col gap-6">
               <div className="grid gap-2">
                 <Label htmlFor="email">Email</Label>
@@ -57,7 +57,7 @@ export function CardDemo() {
           </form>
         </CardContent>
         <CardFooter className="flex-col gap-2">
-          <Button type="submit" className="w-full">
+          <Button type="submit" form="form-card-demo" className="w-full">
             Login
           </Button>
           <Button variant="outline" className="w-full">

--- a/apps/v4/registry/new-york-v4/examples/card-demo.tsx
+++ b/apps/v4/registry/new-york-v4/examples/card-demo.tsx
@@ -24,7 +24,7 @@ export default function CardDemo() {
         </CardAction>
       </CardHeader>
       <CardContent>
-        <form>
+        <form id="form-card-demo">
           <div className="flex flex-col gap-6">
             <div className="grid gap-2">
               <Label htmlFor="email">Email</Label>
@@ -51,7 +51,7 @@ export default function CardDemo() {
         </form>
       </CardContent>
       <CardFooter className="flex-col gap-2">
-        <Button type="submit" className="w-full">
+        <Button type="submit" form="form-card-demo" className="w-full">
           Login
         </Button>
         <Button variant="outline" className="w-full">


### PR DESCRIPTION
# PR: fix(card): add form id and button form prop

## Issue
- In one of the examples for the Card component used a button placed outside the `<form/>` without a `form` prop, which is incorrect and can break form submission behaviour.

## Fixes: 
- Adds an `id` prop to `Form` and a `form` prop to `Button` so buttons outside forms can target them natively.

## Why
- Enables declarative form targeting for buttons that are not nested in a form (better accessibility, simpler
markup).

## Usage

```tsx
<Form id="signup-form">...</Form>

// Button outside the form
<Button form="signup-form" type="submit">Sign up</Button>