### PR TITLE
Change aria level of card title

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/card.tsx
+++ b/apps/v4/registry/new-york-v4/ui/card.tsx
@@ -32,6 +32,8 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
+      aria-level={2}
+      role="heading"
       className={cn("leading-none font-semibold", className)}
       {...props}
     />


### PR DESCRIPTION
This update enhances the accessibility and semantics of the CardTitle component. Currently, the title is rendered as a simple div, which lacks a defined heading role. This change introduces a heading role and an appropriate ARIA level, ensuring that screen readers and assistive technologies can correctly interpret the component as a section heading.

Added role="heading" and aria-level attributes to the CardTitle component.
Ensures semantic meaning without altering the visual structure or converting the element to an actual subheading tag.
Improves accessibility for users relying on screen readers.