### PR TITLE
fix: Sidebar: [vite] The requested module 'class-variance-authority' does not provide an export named 'VariantProps'

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { cva, VariantProps } from "class-variance-authority"
+import { cva, type VariantProps } from "class-variance-authority"
 import { PanelLeftIcon } from "lucide-react"
 
 import { useIsMobile } from "@/registry/new-york-v4/hooks/use-mobile"


### PR DESCRIPTION
## Expected Behaviour

The sidebar component should build correctly on Vite 7

## Current Behaviour

* Currently, vite 7 after auto installing the `sidebar` component renders the following build error:

```
[vite] The requested module 'class-variance-authority' does not provide an export named 'VariantProps'
```

This change correctly exports `VariantProps` as a type, resolving the error.