### PR TITLE
fix(calendar-demo): preserve selected month when reopening calendar

### DIFF
--- a/apps/v4/registry/new-york-v4/examples/calendar-demo.tsx
+++ b/apps/v4/registry/new-york-v4/examples/calendar-demo.tsx
@@ -12,6 +12,7 @@ export default function CalendarDemo() {
       mode="single"
       selected={date}
       onSelect={setDate}
+      defaultMonth={date}
       className="rounded-md border shadow-sm"
       captionLayout="dropdown"
     />


### PR DESCRIPTION
This PR fixes the behavior of the Calendar component from the shadcn/ui library (https://ui.shadcn.com/docs/components/calendar), specifically based on the Date of Birth Picker example.

**Issue:**  
After selecting a date of birth, the selected date appeared correctly in the input field. However, when reopening the calendar to change the date, the calendar always opened on the current date instead of the previously selected date.

**Solution:**  
- Updated the calendar logic to retain and display the previously selected date when reopening the calendar.

```
   <Calendar
  mode="single"
  selected={date}
  onSelect={setDate}
  defaultMonth={date} // Added this line
  className="rounded-md border shadow-sm"
  captionLayout="dropdown"/>
```

- Ensured consistent behavior across different scenarios and input changes.
- Verified functionality in the Date of Birth Picker example.

Closes #8243.
