### PR TITLE
fix(carousel): enable autoplay plugin options

### DIFF
--- a/apps/v4/registry/new-york-v4/examples/carousel-plugin.tsx
+++ b/apps/v4/registry/new-york-v4/examples/carousel-plugin.tsx
@@ -14,7 +14,7 @@ import {
 
 export default function CarouselPlugin() {
   const plugin = React.useRef(
-    Autoplay({ delay: 2000, stopOnInteraction: false })
+    Autoplay({ delay: 2000, stopOnInteraction: false, stopOnMouseEnter: true })
   )
 
   return (

--- a/deprecated/www/registry/default/examples/carousel-plugin.tsx
+++ b/deprecated/www/registry/default/examples/carousel-plugin.tsx
@@ -12,7 +12,7 @@ import {
 
 export default function CarouselPlugin() {
   const plugin = React.useRef(
-    Autoplay({ delay: 2000, stopOnInteraction: false, stopOnMouseEnter: true })
+    Autoplay({ delay: 2000, stopOnInteraction: true })
   )
 
   return (


### PR DESCRIPTION
## Description

Fixes #8390

This PR enables the carousel component to properly respect autoplay plugin options, particularly `stopOnInteraction`, which was ignored before.

## Issue

`stopOnInteraction: true` in the autoplay plugin options was not working. It's the default setting and should stop autoplay when the previous or next button is clicked, as per the Embla Carousel docs. If it is false, the autoplay delay should reset on interaction, which wasn't happening either. 

Additionally, the documentation examples were hardcoding `onMouseEnter` and `onMouseLeave` handlers to manually control the autoplay plugin, rather than leveraging the plugin's built-in options:

```tsx
onMouseEnter={plugin.current.stop}
onMouseLeave={plugin.current.reset}
```
      
The autoplay plugin has an option for `stopOnMouseEnter` so these aren't necessary. Also, calling `reset()` after autoplay has been stopped doesn't restart it, so this wasn't restarting the autoplay as intended. 

A third issue was that the autoplay timer wasn't being reset when the next or previous buttons were clicked, which is the default behaviour in Embla's examples.

These bugs prevented users from configuring the autoplay behavior according to their needs.

## Solution

### Carousel Component
Added an `onButtonClick` handler which takes the api as a parameter to check the plugin's options:
- If `stopOnInteraction` is `false`, call `reset()` to restart the autoplay timer
- Otherwise, call `stop()` to stop autoplay (default behavior)

This brings the implementation in line with how it's done in the [Embla Carousel documentation examples](https://www.embla-carousel.com/plugins/autoplay/). It will also play well with dots/progress when they are added. There are some PRs open for the dots feature that either don't address the timing issue or have manual calls to `reset()`, but calling reset indiscriminately won't respect the autoplay options. This handler can be added to any navigation function and will respect those options.

### Carousel Examples
Updated carousel plugin example to:
- Use `stopOnInteraction: false` for continuous autoplay
- Remove manual `onMouseEnter`/`onMouseLeave` handlers and replace with `stopOnMouseEnter: true`
- Let the plugin handle the behavior
