### PR TITLE
feat(docs): add keyboard navigation for prev/next pages using arrow keys

### DIFF
--- a/apps/v4/app/(app)/docs/[[...slug]]/page.tsx
+++ b/apps/v4/app/(app)/docs/[[...slug]]/page.tsx
@@ -13,6 +13,7 @@ import { absoluteUrl } from "@/lib/utils"
 import { DocsCopyPage } from "@/components/docs-copy-page"
 import { DocsTableOfContents } from "@/components/docs-toc"
 import { OpenInV0Cta } from "@/components/open-in-v0-cta"
+import { DocsKeyNav } from "@/components/docs-key-nav"
 import { Badge } from "@/registry/new-york-v4/ui/badge"
 import { Button } from "@/registry/new-york-v4/ui/button"
 
@@ -94,6 +95,11 @@ export default async function Page(props: {
       data-slot="docs"
       className="flex items-stretch text-[1.05rem] sm:text-[15px] xl:w-full"
     >
+      {/* Global left/right arrow key navigation for docs */}
+      <DocsKeyNav
+        prevHref={neighbours.previous?.url}
+        nextHref={neighbours.next?.url}
+      />
       <div className="flex min-w-0 flex-1 flex-col">
         <div className="h-(--top-spacing) shrink-0" />
         <div className="mx-auto flex w-full max-w-2xl min-w-0 flex-1 flex-col gap-8 px-4 py-6 text-neutral-800 md:px-0 lg:py-8 dark:text-neutral-300">

--- a/apps/v4/components/docs-key-nav.tsx
+++ b/apps/v4/components/docs-key-nav.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+
+interface DocsKeyNavProps {
+  prevHref?: string
+  nextHref?: string
+}
+
+export function DocsKeyNav({ prevHref, nextHref }: DocsKeyNavProps) {
+  const router = useRouter()
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "ArrowLeft" && prevHref) {
+        router.push(prevHref)
+      } else if (e.key === "ArrowRight" && nextHref) {
+        router.push(nextHref)
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [router, prevHref, nextHref])
+
+  return null
+}
+
+

--- a/apps/www/components/pager.tsx
+++ b/apps/www/components/pager.tsx
@@ -1,6 +1,4 @@
-import { useEffect } from "react"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
 import { Doc } from "contentlayer/generated"
 import { ChevronLeft, ChevronRight } from "lucide-react"
 import { NavItem, NavItemWithChildren } from "types/nav"
@@ -14,20 +12,6 @@ interface DocsPagerProps {
 
 export function DocsPager({ doc }: DocsPagerProps) {
   const pager = getPagerForDoc(doc)
-  const router = useRouter()
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "ArrowLeft" && pager?.prev?.href) {
-        router.push(pager.prev.href)
-      } else if (event.key === "ArrowRight" && pager?.next?.href) {
-        router.push(pager.next.href)
-      }
-    }
-
-    window.addEventListener("keydown", handleKeyDown)
-    return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [pager?.next?.href, pager?.prev?.href, router])
 
   if (!pager) {
     return null
@@ -68,7 +52,10 @@ export function getPagerForDoc(doc: Doc) {
     activeIndex !== flattenedLinks.length - 1
       ? flattenedLinks[activeIndex + 1]
       : null
-  return { prev, next }
+  return {
+    prev,
+    next,
+  }
 }
 
 export function flatten(links: NavItemWithChildren[]): NavItem[] {


### PR DESCRIPTION
> Note: The previous implementation in apps/www was reverted as that folder is deprecated.
> The fix has been migrated to apps/v4.

This PR introduces keyboard navigation support to the documentation pager component (pager.tsx), improving accessibility and navigation flow for users browsing the docs.

## Problem

Currently, users can only navigate between documentation pages using the on-screen “← / →” buttons.
This interrupts workflow for keyboard users and slows down power browsing.

## Solution

Added a global keydown listener inside the DocsPager component:

- Press Left Arrow (←) → navigates to the previous documentation page (if available).
- Press Right Arrow (→) → navigates to the next documentation page (if available).
- Uses router.push() from next/navigation for smooth client-side transitions (no full reloads).
- Includes proper cleanup via useEffect return function to prevent event listener leaks.

## Implementation
- Hook: useEffect with key event listener
- Dependencies: pager?.next?.href, pager?.prev?.href, and router

### Checklist

- [x] Added keyboard navigation support
- [x] 	Verified smooth navigation using router.push()
- [x] 	Tested across multiple pages
- [x] 	No breaking changes introduced

### Closes

Fixes #8403