### PR TITLE
Fix sidebar shift when dropdown menu opens

### DIFF
--- a/apps/www/registry/default/ui/sidebar.tsx
+++ b/apps/www/registry/default/ui/sidebar.tsx
@@ -246,8 +246,8 @@ const Sidebar = React.forwardRef<
           className={cn(
             "fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] duration-200 ease-linear md:flex",
             side === "left"
-              ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
-              : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+              ? "group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
+              : "group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
             // Adjust the padding for floating and inset variants.
             variant === "floating" || variant === "inset"
               ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]"


### PR DESCRIPTION
When DropdownMenu is used within the sidebar with side="right", the react-remove-scroll library automatically adds a margin to compensate for the removed scrollbar. This margin conflicts with the right-0 and left-0 absolute positioning classes on the sidebar container, causing an unwanted visual shift.