### PR TITLE
fix(sidebar): prevent overflow in SidebarSeparator with horizontal orientation

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -362,7 +362,10 @@ function SidebarSeparator({
     <Separator
       data-slot="sidebar-separator"
       data-sidebar="separator"
-      className={cn("mx-2 w-auto bg-sidebar-border", className)}
+      className={cn(
+        "mx-2 bg-sidebar-border data-[orientation=horizontal]:w-auto",
+        className
+      )}
       {...props}
     />
   )


### PR DESCRIPTION
## Description

This PR fixes an overflow issue in the `SidebarSeparator` component by making the width override more specific to horizontal orientations.

Fixes #7257

## Changes

Updated the `SidebarSeparator` component in the v4 registry to use `data-[orientation=horizontal]:w-auto` instead of `w-auto`. This prevents overflow issues caused by the underlying `Separator` classes.

### Files Changed
- `apps/v4/registry/new-york-v4/ui/sidebar.tsx`

## Why

The previous implementation used `w-auto` which applied to all separator orientations. This could cause overflow issues when the `Separator` component's base classes conflicted with the sidebar styling. By using `data-[orientation=horizontal]:w-auto`, we ensure the override only applies when needed.

## Testing

- Registry has been rebuilt with `pnpm build:registry`
- All changes formatted with prettier
- Visual inspection of sidebar separators in both horizontal and vertical orientations