### PR TITLE
docs (security) : add clickable link to security reporting section

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,4 +6,4 @@ We will investigate all legitimate reports and do our best to quickly fix the pr
 
 Our preference is that you make use of GitHub's private vulnerability reporting feature to disclose potential security vulnerabilities in our Open Source Software. 
 
-To do this, please visit the security tab of the repository and click the <a href="https://github.com/shadcn-ui/ui/security/advisories/new">Report a vulnerability</a> button.
+To do this, please visit the security tab of the repository and click the [Report a vulnerability](https://github.com/shadcn-ui/ui/security/advisories/new) button.


### PR DESCRIPTION
### Description
Changed the "Report a vulnerability" text into a clickable link that directly opens the GitHub security advisories page.

### Motivation
This improves usability by allowing contributors to access the reporting form with one click.

### Changes
- Edited SECURITY.md
- Added HTML anchor tag linking to https://github.com/shadcn-ui/ui/security/advisories/new

### Checklist
- [ ] Documentation updated
