### PR TITLE
fix (issue #8475): preserve InputGroup focus ring when wrapped by FormControl

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/input-group.tsx
+++ b/apps/v4/registry/new-york-v4/ui/input-group.tsx
@@ -24,7 +24,10 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
         "has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3",
 
         // Focus state.
+        // "has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot=input-group-control]:focus-visible]:ring-[3px]",
+
         "has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot=input-group-control]:focus-visible]:ring-[3px]",
+        "has-[[data-slot=form-control]:focus-visible]:border-ring has-[[data-slot=form-control]:focus-visible]:ring-ring/50 has-[[data-slot=form-control]:focus-visible]:ring-[3px]",
 
         // Error state.
         "has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40",


### PR DESCRIPTION
Fixes issue #8475

**What?**
- Fixes a regression where InputGroup lost its focus ring when the input element was wrapped by FormControl.

**Why?**
- When FormControl wraps the actual input (via Radix’s Slot), it changes the data-slot from "input-group-control" to "form-control".
- The InputGroup container applies focus styles using has-[[data-slot=input-group-control]:focus-visible], so focus styles no longer triggered.

**How?**
- Updated InputGroup focus selectors to include both [data-slot=input-group-control] and [data-slot=form-control].
- This ensures consistent focus ring behavior whether or not FormControl is used.

**Before:** Focus ring disappeared when the input was wrapped by FormControl.

**After:** Focus ring now appears correctly in both configurations.

**Related context:** This addresses ARIA and focus behavior inconsistencies noted when combining FormControl and InputGroup.

**Test the updated bhavior**
- Once you update InputGroup to include both selectors:

```
"has-[[data-slot=input-group-control]:focus-visible]:border-ring ...",
"has-[[data-slot=form-control]:focus-visible]:border-ring ..."
```

- Re-run the Case B example (of issue #8475):

```
<InputGroup>
  <FormControl>
    <InputGroupInput {...field} type="password" />
  </FormControl>
  <InputGroupAddon align="inline-end">
    <InputGroupButton>Toggle</InputGroupButton>
  </InputGroupAddon>
</InputGroup>
```

**Expected result:**
- Label click focuses the input.
- ARIA attributes attach correctly.
- InputGroup now gets its expected border-ring and ring-ring/50 focus styles.
- Screen readers and keyboard navigation both work properly.