### PR TITLE
fix(ui): fix layout issue caused by block display instead of flex in examples theme selector layout

### DIFF
--- a/apps/v4/app/(app)/examples/layout.tsx
+++ b/apps/v4/app/(app)/examples/layout.tsx
@@ -69,7 +69,7 @@ export default function ExamplesLayout({
       </PageHeader>
       <PageNav id="examples">
         <ExamplesNav className="[&>a:first-child]:text-primary flex-1 overflow-hidden" />
-        <ThemeSelector className="mr-4 hidden md:block" />
+        <ThemeSelector className="mr-4 hidden md:flex" />
       </PageNav>
       <div className="container-wrapper section-soft flex flex-1 flex-col pb-6">
         <div className="theme-container container flex flex-1 scroll-mt-20 flex-col">


### PR DESCRIPTION
### Pull Request: Fix layout shift if theme selector in examples pages(examples/layout.tsx)

**Summary**

This PR addresses issue of theme selector buttons layout shift in examples layout(examples/layout.tsx).

**Changed `ThemeSelector` component in `examples/layout.tsx` to use `flex` container instead of `block`.**

**Why?**

- Ensures same PageNav layout on examples pages and root page
- It seemed that using display: block caused minor alignment differences on example pages. If this behavior was intentional, please feel free to disregard or clarify.

**Validation**

Ran pnpm test, successfully.

**Issue screenshot:**
<img width="1334" height="134" alt="image" src="https://github.com/user-attachments/assets/09419ebb-210e-4c8d-adaf-abaa99379096" />