### PR TITLE
feat: rename @efferd-ui -> @efferd

### DIFF
--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -17,7 +17,7 @@
   "@clerk": "https://clerk.com/r/{name}.json",
   "@coss": "https://coss.com/ui/r/{name}.json",
   "@cult-ui": "https://cult-ui.com/r/{name}.json",
-  "@efferd-ui": "https://ui.efferd.com/r/{name}.json",
+  "@efferd": "https://efferd.com/r/{name}.json",
   "@eldoraui": "https://eldoraui.site/r/{name}.json",
   "@elements": "https://tryelements.dev/r/{name}.json",
   "@elevenlabs-ui": "https://ui.elevenlabs.io/r/{name}.json",


### PR DESCRIPTION
This PR renames the @efferd-ui to [@efferd](https://efferd.com/) in trusted registries 🚀... decided to go with only efferd.com instead to ui.efferd.com