### PR TITLE
docs(calendar): fix example/title mismatch - calendar

### DIFF
--- a/apps/v4/content/docs/components/calendar.mdx
+++ b/apps/v4/content/docs/components/calendar.mdx
@@ -138,13 +138,20 @@ export function CalendarWithTimezone() {
 
 ## Examples
 
-### Range Calendar
+### Multiple Months
 
 <ComponentPreview
   name="calendar-02"
+  title="Multiple Months"
+  description="A calendar showing multiple months."
+/>
+
+### Range Calendar
+
+<ComponentPreview
+  name="calendar-04"
   title="Range Calendar"
-  description="A calendar showing the current date and range selection."
-  className="**:[.preview]:h-auto lg:**:[.preview]:h-[450px]"
+  description="A calendar with range selection."
 />
 
 ### Month and Year Selector


### PR DESCRIPTION
The "Range Calendar" does not show the right block. It currently shows a "Multiple Month" block

Fix: 
- Add the "Range Calendar" block 
- Fix titles