### PR TITLE
fix(button-group): add RTL support using logical properties

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/button-group.tsx
+++ b/apps/v4/registry/new-york-v4/ui/button-group.tsx
@@ -5,12 +5,12 @@ import { cn } from "@/lib/utils"
 import { Separator } from "@/registry/new-york-v4/ui/separator"
 
 const buttonGroupVariants = cva(
-  "flex w-fit items-stretch [&>*]:focus-visible:z-10 [&>*]:focus-visible:relative [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md has-[>[data-slot=button-group]]:gap-2",
+  "flex w-fit items-stretch [&>*]:focus-visible:z-10 [&>*]:focus-visible:relative [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-e-md has-[>[data-slot=button-group]]:gap-2",
   {
     variants: {
       orientation: {
         horizontal:
-          "[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none",
+          "[&>*:not(:first-child)]:rounded-s-none [&>*:not(:first-child)]:border-s-0 [&>*:not(:last-child)]:rounded-e-none",
         vertical:
           "flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none",
       },


### PR DESCRIPTION
### Description

Updated the `ButtonGroup` component to support RTL (right-to-left) text direction by replacing directional CSS utilities with logical properties.

#### Changes made:
- `rounded-l-none` → `rounded-s-none`
- `border-l-0` → `border-s-0`
- `rounded-r-none` → `rounded-e-none`
- `rounded-r-md` → `rounded-e-md`

These logical utilities automatically adapt to text direction:
- In LTR: `s` = left, `e` = right
- In RTL: `s` = right, `e` = left

This ensures correct rounding and borders in both LTR and RTL layouts.

#### Testing
- Verified visually in both LTR and RTL directions.
- No regressions in existing button group styles.
- Tested with Tailwind’s dir="rtl" and verified proper adaptation.

### Screenshots

**Before (LTR-only support):**
<img width="105" height="63" alt="Screenshot 2025-10-26 at 12 02 32 PM" src="https://github.com/user-attachments/assets/e74e1fc9-923f-4fb7-a52b-30c884e3b192" />


**After (RTL supported):**
<img width="105" height="63" alt="Screenshot 2025-10-26 at 12 02 05 PM" src="https://github.com/user-attachments/assets/63647bd5-2c0b-4906-b5bd-ced039425016" />
