### PR TITLE
feat: add  @lytenyte to registry index

### DIFF
--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -68,5 +68,6 @@
   "@fancy": "https://fancycomponents.dev/r/{name}.json",
   "@shadcndesign": "https://shadcndesign-free.vercel.app/r/{name}.json",
   "@ha-components": "https://hacomponents.keshuac.com/r/{name}.json",
-  "@shadix-ui": "https://shadix-ui.vercel.app/r/{name}.json"
+  "@shadix-ui": "https://shadix-ui.vercel.app/r/{name}.json",
+  "@lytenyte": "https://1771technologies.com/r/{name}.json"
 }


### PR DESCRIPTION
LyteNyte Grid is a high performance React Data Grid. We have a Core edition under Apache 2.0 and a commercial PRO edition.

We've recently made available our public shadcn registry. It will be a nice shortcut if our users can simply use [@lytenyte](https://www.1771technologies.com/r/registry.json).

Thanks for building a great CLI and toolchain.

Our homepage: https://www.1771technologies.com/
Our GitHub repo: https://github.com/1771-Technologies/lytenyte