### PR TITLE
Fix unused shadow class in ToggleGroup for default spacing

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/toggle-group.tsx
+++ b/apps/v4/registry/new-york-v4/ui/toggle-group.tsx
@@ -33,7 +33,7 @@ function ToggleGroup({
       data-slot="toggle-group"
       data-variant={variant}
       data-size={size}
-      data-spacing={spacing}
+      data-spacing={spacing || 'default'}
       style={{ "--gap": spacing } as React.CSSProperties}
       className={cn(
         "group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs",
@@ -63,7 +63,7 @@ function ToggleGroupItem({
       data-slot="toggle-group-item"
       data-variant={context.variant || variant}
       data-size={context.size || size}
-      data-spacing={context.spacing}
+      data-spacing={context.spacing || 'default'}
       className={cn(
         toggleVariants({
           variant: context.variant || variant,


### PR DESCRIPTION
#### Problem
The CSS class selector `data-[spacing=default]:data-[variant=outline]:shadow-xs` in the `ToggleGroup` component is effectively unused because it never matches. This occurs because:
- The `spacing` prop defaults to `0` (a number).
- The `data-spacing` attribute is set directly to `spacing`, resulting in `data-spacing="0"` (string representation).
- The selector expects `data-spacing="default"` (string), so the shadow effect for `variant="outline"` with default spacing is never applied.

This leads to inconsistent styling, as the shadow should appear for the default spacing (0) with the outline variant, per the component's design.

Closes #8580.

#### Solution
Update the `data-spacing` attribute assignment in `ui/apps/v4/registry/new-york-v4/ui/toggle-group.tsx` (around line 28) to treat `spacing=0` as the string `"default"`, allowing the selector to match.

**Before:**
```tsx
data-spacing={spacing}
```

**After:**
```tsx
data-spacing={spacing || 'default'}
```

#### Why This Works
- `spacing || 'default'` uses logical OR: When `spacing` is `0` (falsy), it defaults to `'default'`, matching the selector and applying the shadow for `variant="outline"` with default spacing.
- For other truthy values (e.g., `spacing={4}`), `data-spacing` remains the number (as a string), enabling custom spacing without triggering the shadow.
- This aligns with the intent: Shadow for explicit default (0), no impact when undefined (as noted in issue comments). Using `??` (nullish coalescing) wouldn't suffice since `0` is falsy but not nullish.
- No other changes are needed—the `style` prop with `--gap` handles numeric spacing correctly.

#### Testing
- Verified the shadow appears for `<ToggleGroup variant="outline" spacing={0}>` or `<ToggleGroup variant="outline">` (omitted spacing).
- Confirmed no shadow for other `spacing` values (e.g., `4`) or non-outline variants.
- Ran `npm run build` and `npm run lint` to ensure no regressions.
- Tested in a local demo to confirm styling consistency across themes.

This is a minimal, targeted fix that resolves the unused class without affecting other functionality. Open to feedback and iterations!