### PR TITLE
Add new registry entry for @chisom-ui

### DIFF
--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -16,6 +16,7 @@
   "@bucharitesh": "https://bucharitesh.in/r/{name}.json",
   "@clerk": "https://clerk.com/r/{name}.json",
   "@coss": "https://coss.com/ui/r/{name}.json",
+  "@chisom-ui": "https://chisom-ui.netlify.app/r/{name}.json",
   "@cult-ui": "https://cult-ui.com/r/{name}.json",
   "@efferd": "https://efferd.com/r/{name}.json",
   "@eldoraui": "https://eldoraui.site/r/{name}.json",


### PR DESCRIPTION
Would like to add [Chisom UI](https://github.com/chisomuma/chisom-ui), a small collection of useful input components for React projects built on shadcn and other libraries to the shadcn registry.
Website: https://chisom-ui.netlify.app/
Repo: https://github.com/chisomuma/chisom-ui