### PR TITLE
fix: removed toggle group unused class

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/toggle-group.tsx
+++ b/apps/v4/registry/new-york-v4/ui/toggle-group.tsx
@@ -36,7 +36,7 @@ function ToggleGroup({
       data-spacing={spacing}
       style={{ "--gap": spacing } as React.CSSProperties}
       className={cn(
-        "group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs",
+        "group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))] rounded-md",
         className
       )}
       {...props}


### PR DESCRIPTION
Removed `data-[spacing=default]:data-[variant=outline]:shadow-xs` because the component always sets data-spacing to a numeric value (default 0), so the selector can never match. 
Keeping it meant shipping an unused outline shadow style, and the maintainers have indicated the outline variant shouldn’t add a shadow by default, so removing the dead utility keeps the ToggleGroup styles consistent with that intent.

Closes: #8580
