### PR TITLE
docs(components): add code of use-media-query hook for responsive combobox component

### DIFF
--- a/apps/v4/content/docs/components/combobox.mdx
+++ b/apps/v4/content/docs/components/combobox.mdx
@@ -143,3 +143,25 @@ export function ExampleCombobox() {
 You can create a responsive combobox by using the `<Popover />` on desktop and the `<Drawer />` components on mobile.
 
 <ComponentPreview name="combobox-responsive" />
+
+```tsx showLineNumbers title="use-media-query.tsx"
+import * as React from "react"
+
+export function useMediaQuery(query: string) {
+  const [value, setValue] = React.useState(false)
+
+  React.useEffect(() => {
+    function onChange(event: MediaQueryListEvent) {
+      setValue(event.matches)
+    }
+
+    const result = matchMedia(query)
+    result.addEventListener("change", onChange)
+    setValue(result.matches)
+
+    return () => result.removeEventListener("change", onChange)
+  }, [query])
+
+  return value
+}
+```


### PR DESCRIPTION
add the useMediaQuery hook's code to the docs which has been taken from '@/hooks/use-media-query.tsx' in the codebase 

Issue: The hook was being imported in the responsive combobox component's code but the hook's code is not available in the docs