### PR TITLE
Fix syntax for CSS variable in sidebar component

### DIFF
--- a/apps/v4/content/docs/components/sidebar.mdx
+++ b/apps/v4/content/docs/components/sidebar.mdx
@@ -565,7 +565,7 @@ The following example adds a `<DropdownMenu>` to the `SidebarHeader`.
               <ChevronDown className="ml-auto" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-[--radix-popper-anchor-width]">
+          <DropdownMenuContent className="w-(--radix-popper-anchor-width)">
             <DropdownMenuItem>
               <span>Acme Inc</span>
             </DropdownMenuItem>
@@ -618,7 +618,7 @@ export function AppSidebar() {
                 </DropdownMenuTrigger>
                 <DropdownMenuContent
                   side="top"
-                  className="w-[--radix-popper-anchor-width]"
+                  className="w-(--radix-popper-anchor-width)"
                 >
                   <DropdownMenuItem>
                     <span>Account</span>


### PR DESCRIPTION
the correct usage should be `-(--variable-name)` instead of `-[--variable-name]`.


w-(<custom-property>) | width: var(<custom-property>);
-- | --


https://tailwindcss.com/docs/width