### PR TITLE
Fixes #8667

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/empty.tsx
+++ b/apps/v4/registry/new-york-v4/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/deprecated/www/registry/default/ui/empty.tsx
+++ b/deprecated/www/registry/default/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/deprecated/www/registry/new-york/ui/empty.tsx
+++ b/deprecated/www/registry/new-york/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"


### PR DESCRIPTION
Fixes #8667

The EmptyDescription component was typed to accept React.ComponentProps<"p"> but renders a <div> element. This type mismatch could lead to confusion and potential type errors if paragraph-specific props are passed.

Changed the type definition to React.ComponentProps<"div"> to match the actual rendered element.