### PR TITLE
fix: add correct rendering for 0 in chart tooltip

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/chart.tsx
+++ b/apps/v4/registry/new-york-v4/ui/chart.tsx
@@ -234,7 +234,7 @@ function ChartTooltipContent({
                           {itemConfig?.label || item.name}
                         </span>
                       </div>
-                      {item.value && (
+                      {item.value !== undefined && item.value !== null && (
                         <span className="text-foreground font-mono font-medium tabular-nums">
                           {item.value.toLocaleString()}
                         </span>


### PR DESCRIPTION
## Description
This PR fixes incorrect 0 value rendering in chart tooltip

## Before patch
<img width="2788" height="1012" alt="image" src="https://github.com/user-attachments/assets/c9488528-44d2-438f-86cc-7bed467bf11b" />

## After patch
<img width="785" height="686" alt="image" src="https://github.com/user-attachments/assets/2b4918a4-5a46-4ef8-b209-20ecf4236888" />
