### PR TITLE
fix(shadcn): Restore two-finger navigation on macOS by adjusting overscroll behavior

### DIFF
--- a/apps/v4/styles/globals.css
+++ b/apps/v4/styles/globals.css
@@ -150,7 +150,7 @@
     @apply bg-selection text-selection-foreground;
   }
   html {
-    @apply overscroll-y-none;
+    @apply overscroll-y-none scroll-smooth;
   }
   body {
     font-synthesis-weight: none;


### PR DESCRIPTION
### Summary 
This PR resolves Two-finger navigation broken on macOS.
On macOS, the global CSS rule `@apply overscroll-none scroll-smooth;
` prevents native two-finger swipe gestures (back/forward navigation) in Safari and Chromium-based browsers.

To fix this, the overscroll behavior is now restricted to the Y-axis only:

```
- @apply overscroll-none scroll-smooth;
+ @apply overscroll-y-none;
```
### Why ?
Using overscroll-behavior: none; disables horizontal overscroll as well, which breaks browser navigation gestures.
Switching to `overscroll-y: none;` ensures:

✅ Vertical bounce is still prevented
✅ Horizontal navigation gestures work again on macOS

closes #8705 