### PR TITLE
Fix issue in which search palette would hijack the copy command in docs website

### DIFF
--- a/apps/v4/components/command-menu.tsx
+++ b/apps/v4/components/command-menu.tsx
@@ -158,7 +158,16 @@ export function CommandMenu({
         e.preventDefault()
         setOpen((open) => !open)
       }
+    }
 
+    document.addEventListener("keydown", down)
+    return () => document.removeEventListener("keydown", down)
+  }, [])
+
+  React.useEffect(() => {
+    if (!open) return
+
+    const down = (e: KeyboardEvent) => {
       if (e.key === "c" && (e.metaKey || e.ctrlKey)) {
         runCommand(() => {
           if (selectedType === "color") {
@@ -187,7 +196,7 @@ export function CommandMenu({
 
     document.addEventListener("keydown", down)
     return () => document.removeEventListener("keydown", down)
-  }, [copyPayload, runCommand, selectedType, packageManager])
+  }, [open, copyPayload, runCommand, selectedType, packageManager])
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
Fixes an issue in which if you open the command palette and search for a component, you can no longer copy from the page.

This is because the same event that opens and closes the cmdk palette, also hijacks the cmd+C shortcut to copy the install syntax for a package.

Fixes https://github.com/shadcn-ui/ui/issues/7512
Fixes https://github.com/shadcn-ui/ui/issues/8071 (possibly; didn't test but symptoms look similar).

### Steps to reproduce
1. Open cmd+k, search for a component, say Badge.
2. Go to that page or close the search via `esc`.
3. Try to select something in the page and copy via `cmd+k`
4. Notice that your clipboard `bun dlx shadcn@latest add badge` instead of what you copied`.

### Testing steps.
1. Run steps 1->3 above.
2. Notice that your clipboard contain what you selected.