### PR TITLE
Update Contributing Guide with build and environment setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,14 @@ pnpm install
 pnpm build
 ```
 
+### Setup environment variables
+
+Create a `.env` file inside the `/apps/v4` directory based on `.env.example`:
+
+```bash
+cp apps/v4/.env.example apps/v4/.env
+```
+
 ### Run a workspace
 
 You can use the `pnpm --filter=[WORKSPACE]` command to start the development process for a workspace.


### PR DESCRIPTION
**Reason for change:**  

- Added a note about running `pnpm build` after `pnpm install` to prevent import errors (e.g., `Cannot find module 'shadcn/schema'`) when setting up the project locally. This ensures all internal packages are properly built and linked before development.

- Added instructions for creating the `.env` file inside the `/apps/v4` directory based on `.env.example`.

