### PR TITLE
feat(components): added time picker

### DIFF
--- a/apps/v4/app/(internal)/sink/component-registry.ts
+++ b/apps/v4/app/(internal)/sink/component-registry.ts
@@ -55,6 +55,7 @@ import { SwitchDemo } from "./components/switch-demo"
 import { TableDemo } from "./components/table-demo"
 import { TabsDemo } from "./components/tabs-demo"
 import { TextareaDemo } from "./components/textarea-demo"
+import { TimePickerDemo } from "./components/time-picker-demo"
 import { ToggleDemo } from "./components/toggle-demo"
 import { ToggleGroupDemo } from "./components/toggle-group-demo"
 import { TooltipDemo } from "./components/tooltip-demo"
@@ -184,6 +185,13 @@ export const componentRegistry: Record<string, ComponentConfig> = {
     component: DatePickerDemo,
     type: "registry:ui",
     href: "/sink/date-picker",
+  },
+  "time-picker": {
+    name: "Time Picker",
+    component: TimePickerDemo,
+    type: "registry:ui",
+    href: "/sink/time-picker",
+    label: "New",
   },
   dialog: {
     name: "Dialog",

--- a/apps/v4/app/(internal)/sink/components/time-picker-demo.tsx
+++ b/apps/v4/app/(internal)/sink/components/time-picker-demo.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import * as React from "react"
+import { format } from "date-fns"
+import { Clock3Icon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/registry/new-york-v4/ui/button"
+import { TimePicker } from "@/registry/new-york-v4/ui/time-picker"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/registry/new-york-v4/ui/popover"
+
+export function TimePickerDemo() {
+  return (
+    <div className="flex w-full flex-col gap-8 md:flex-row">
+      <BasicTimePicker />
+      <TimePickerWithPresets />
+    </div>
+  )
+}
+
+function BasicTimePicker() {
+  const [value, setValue] = React.useState<Date | undefined>()
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          className={cn(
+            "min-w-[200px] justify-start px-2 font-normal",
+            !value && "text-muted-foreground"
+          )}
+        >
+          <Clock3Icon className="text-muted-foreground mr-2 size-4" />
+          {value ? format(value, "h:mm a") : <span>Pick a time</span>}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto" align="start">
+        <TimePicker value={value} onValueChange={setValue} />
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+const PRESETS = [
+  { label: "08:00", hour: 8, minute: 0 },
+  { label: "09:30", hour: 9, minute: 30 },
+  { label: "12:00", hour: 12, minute: 0 },
+  { label: "14:30", hour: 14, minute: 30 },
+]
+
+function TimePickerWithPresets() {
+  const [value, setValue] = React.useState<Date>(() => {
+    const now = new Date()
+    now.setHours(9, 30, 0, 0)
+    return now
+  })
+
+  const applyPreset = React.useCallback((preset: (typeof PRESETS)[number]) => {
+    setValue((previous) => {
+      const next = previous ? new Date(previous) : new Date()
+      next.setHours(preset.hour)
+      next.setMinutes(preset.minute)
+      next.setSeconds(0)
+      next.setMilliseconds(0)
+      return next
+    })
+  }, [])
+
+  return (
+    <div className="flex flex-col gap-4">
+      <TimePicker
+        value={value}
+        onValueChange={setValue}
+        hourCycle={24}
+        minuteStep={15}
+        hideLabels
+      />
+      <div className="flex flex-wrap gap-2">
+        {PRESETS.map((preset) => {
+          const isActive =
+            value.getHours() === preset.hour &&
+            value.getMinutes() === preset.minute
+
+          return (
+            <Button
+              key={preset.label}
+              size="sm"
+              variant={isActive ? "default" : "outline"}
+              onClick={() => applyPreset(preset)}
+              className="font-medium"
+            >
+              {preset.label}
+            </Button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/v4/content/docs/components/time-picker.mdx
+++ b/apps/v4/content/docs/components/time-picker.mdx
@@ -1,0 +1,73 @@
+---
+title: Time Picker
+description: A time picker component with support for custom steps and presets.
+component: true
+---
+
+<ComponentPreview
+  name="time-picker-demo"
+  title="Time Picker"
+  description="Pick a time from a popover."
+/>
+
+## Installation
+
+The Time Picker uses the `<Select />` and `<Label />` components under the hood.
+Install the component with the CLI:
+
+```bash
+npx shadcn@latest add time-picker popover button
+```
+
+<ComponentSource name="time-picker" title="components/ui/time-picker.tsx" />
+
+## Usage
+
+```tsx showLineNumbers title="components/example-time-picker.tsx"
+"use client"
+
+import * as React from "react"
+import { format } from "date-fns"
+import { Clock3Icon } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { TimePicker } from "@/components/ui/time-picker"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+
+export function ExampleTimePicker() {
+  const [value, setValue] = React.useState<Date | undefined>()
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          className="w-[220px] justify-start font-normal"
+          data-empty={!value}
+        >
+          <Clock3Icon className="mr-2 size-4 opacity-50" />
+          {value ? format(value, "h:mm a") : <span>Pick a time</span>}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto" align="start">
+        <TimePicker value={value} onValueChange={setValue} />
+      </PopoverContent>
+    </Popover>
+  )
+}
+```
+
+## Granularity and presets
+
+Control the hour cycle and minute steps with the `hourCycle`, `minuteStep`,
+and `granularity` props. You can combine the picker with any UI to offer quick selections.
+
+<ComponentPreview
+  name="time-picker-with-presets"
+  title="Time Picker with Presets"
+  description="Customize the hour cycle and add quick actions."
+/>

--- a/apps/v4/lib/docs.ts
+++ b/apps/v4/lib/docs.ts
@@ -7,6 +7,7 @@ export const PAGES_NEW = [
   "/docs/components/kbd",
   "/docs/components/spinner",
   "/docs/components/native-select",
+  "/docs/components/time-picker",
 ]
 
 export const PAGES_UPDATED = ["/docs/components/button"]

--- a/apps/v4/public/r/styles/new-york-v4/registry.json
+++ b/apps/v4/public/r/styles/new-york-v4/registry.json
@@ -735,6 +735,20 @@
       ]
     },
     {
+      "name": "time-picker",
+      "type": "registry:ui",
+      "registryDependencies": [
+        "select",
+        "label"
+      ],
+      "files": [
+        {
+          "path": "registry/new-york-v4/ui/time-picker.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "toggle",
       "type": "registry:ui",
       "dependencies": [
@@ -7204,6 +7218,38 @@
       "files": [
         {
           "path": "registry/new-york-v4/examples/textarea-with-text.tsx",
+          "type": "registry:example"
+        }
+      ]
+    },
+    {
+      "name": "time-picker-demo",
+      "type": "registry:example",
+      "dependencies": [
+        "date-fns"
+      ],
+      "registryDependencies": [
+        "button",
+        "time-picker",
+        "popover"
+      ],
+      "files": [
+        {
+          "path": "registry/new-york-v4/examples/time-picker-demo.tsx",
+          "type": "registry:example"
+        }
+      ]
+    },
+    {
+      "name": "time-picker-with-presets",
+      "type": "registry:example",
+      "registryDependencies": [
+        "button",
+        "time-picker"
+      ],
+      "files": [
+        {
+          "path": "registry/new-york-v4/examples/time-picker-with-presets.tsx",
           "type": "registry:example"
         }
       ]

--- a/apps/v4/public/r/styles/new-york-v4/time-picker-demo.json
+++ b/apps/v4/public/r/styles/new-york-v4/time-picker-demo.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "time-picker-demo",
+  "type": "registry:example",
+  "dependencies": [
+    "date-fns"
+  ],
+  "registryDependencies": [
+    "button",
+    "time-picker",
+    "popover"
+  ],
+  "files": [
+    {
+      "path": "registry/new-york-v4/examples/time-picker-demo.tsx",
+      "content": "\"use client\"\\n\\nimport * as React from \\\"react\\\"\\nimport { format } from \\\"date-fns\\\"\\nimport { Clock3Icon } from \\\"lucide-react\\\"\\n\\nimport { Button } from \\\"@/registry/new-york-v4/ui/button\\\"\\nimport { TimePicker } from \\\"@/registry/new-york-v4/ui/time-picker\\\"\\nimport {\\n  Popover,\\n  PopoverContent,\\n  PopoverTrigger,\\n} from \\\"@/registry/new-york-v4/ui/popover\\\"\\n\\nexport default function TimePickerDemo() {\\n  const [value, setValue] = React.useState<Date | undefined>()\\n\\n  return (\\n    <Popover>\\n      <PopoverTrigger asChild>\\n        <Button\\n          variant=\\\"outline\\\"\\n          className=\\\"w-[220px] justify-start font-normal\\\"\\n          data-empty={!value}\\n        >\\n          <Clock3Icon className=\\\"mr-2 size-4 opacity-50\\\" />\\n          {value ? format(value, \\\"h:mm a\\\") : <span>Pick a time</span>}\\n        </Button>\\n      </PopoverTrigger>\\n      <PopoverContent className=\\\"w-auto\\\" align=\\\"start\\\">\\n        <TimePicker value={value} onValueChange={setValue} />\\n      </PopoverContent>\\n    </Popover>\\n  )\\n}\\n",
+      "type": "registry:example"
+    }
+  ]
+}

--- a/apps/v4/public/r/styles/new-york-v4/time-picker-with-presets.json
+++ b/apps/v4/public/r/styles/new-york-v4/time-picker-with-presets.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "time-picker-with-presets",
+  "type": "registry:example",
+  "registryDependencies": [
+    "button",
+    "time-picker"
+  ],
+  "files": [
+    {
+      "path": "registry/new-york-v4/examples/time-picker-with-presets.tsx",
+      "content": "\"use client\"\\n\\nimport * as React from \\\"react\\\"\\n\\nimport { Button } from \\\"@/registry/new-york-v4/ui/button\\\"\\nimport { TimePicker } from \\\"@/registry/new-york-v4/ui/time-picker\\\"\\n\\nconst PRESETS = [\\n  { label: \\\"08:00\\\", hour: 8, minute: 0 },\\n  { label: \\\"09:30\\\", hour: 9, minute: 30 },\\n  { label: \\\"12:00\\\", hour: 12, minute: 0 },\\n  { label: \\\"14:30\\\", hour: 14, minute: 30 },\\n]\\n\\nexport default function TimePickerWithPresets() {\\n  const [value, setValue] = React.useState<Date>(() => {\\n    const base = new Date()\\n    base.setHours(9, 30, 0, 0)\\n    return base\\n  })\\n\\n  const applyPreset = React.useCallback((preset: (typeof PRESETS)[number]) => {\\n    setValue((previous) => {\\n      const next = previous ? new Date(previous) : new Date()\\n      next.setHours(preset.hour)\\n      next.setMinutes(preset.minute)\\n      next.setSeconds(0)\\n      next.setMilliseconds(0)\\n      return next\\n    })\\n  }, [])\\n\\n  return (\\n    <div className=\\\"flex flex-col gap-4\\\">\\n      <TimePicker\\n        value={value}\\n        onValueChange={setValue}\\n        hourCycle={24}\\n        minuteStep={15}\\n        hideLabels\\n      />\\n      <div className=\\\"flex flex-wrap gap-2\\\">\\n        {PRESETS.map((preset) => {\\n          const isActive =\\n            value.getHours() === preset.hour &&\\n            value.getMinutes() === preset.minute\\n\\n          return (\\n            <Button\\n              key={preset.label}\\n              size=\\\"sm\\\"\\n              variant={isActive ? \\\"default\\\" : \\\"outline\\\"}\\n              onClick={() => applyPreset(preset)}\\n              className=\\\"font-medium\\\"\\n            >\\n              {preset.label}\\n            </Button>\\n          )\\n        })}\\n      </div>\\n    </div>\\n  )\\n}\\n",
+      "type": "registry:example"
+    }
+  ]
+}

--- a/apps/v4/registry.json
+++ b/apps/v4/registry.json
@@ -735,6 +735,20 @@
       ]
     },
     {
+      "name": "time-picker",
+      "type": "registry:ui",
+      "registryDependencies": [
+        "select",
+        "label"
+      ],
+      "files": [
+        {
+          "path": "registry/new-york-v4/ui/time-picker.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "toggle",
       "type": "registry:ui",
       "dependencies": [
@@ -7204,6 +7218,38 @@
       "files": [
         {
           "path": "registry/new-york-v4/examples/textarea-with-text.tsx",
+          "type": "registry:example"
+        }
+      ]
+    },
+    {
+      "name": "time-picker-demo",
+      "type": "registry:example",
+      "dependencies": [
+        "date-fns"
+      ],
+      "registryDependencies": [
+        "button",
+        "time-picker",
+        "popover"
+      ],
+      "files": [
+        {
+          "path": "registry/new-york-v4/examples/time-picker-demo.tsx",
+          "type": "registry:example"
+        }
+      ]
+    },
+    {
+      "name": "time-picker-with-presets",
+      "type": "registry:example",
+      "registryDependencies": [
+        "button",
+        "time-picker"
+      ],
+      "files": [
+        {
+          "path": "registry/new-york-v4/examples/time-picker-with-presets.tsx",
           "type": "registry:example"
         }
       ]

--- a/apps/v4/registry/__index__.tsx
+++ b/apps/v4/registry/__index__.tsx
@@ -889,6 +889,24 @@ export const Index: Record<string, Record<string, any>> = {
       categories: undefined,
       meta: undefined,
     },
+    "time-picker": {
+      name: "time-picker",
+      description: "",
+      type: "registry:ui",
+      registryDependencies: ["select","label"],
+      files: [{
+        path: "registry/new-york-v4/ui/time-picker.tsx",
+        type: "registry:ui",
+        target: ""
+      }],
+      component: React.lazy(async () => {
+        const mod = await import("@/registry/new-york-v4/ui/time-picker.tsx")
+        const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+        return { default: mod.default || mod[exportName] }
+      }),
+      categories: undefined,
+      meta: undefined,
+    },
     "toggle": {
       name: "toggle",
       description: "",
@@ -7399,6 +7417,43 @@ export const Index: Record<string, Record<string, any>> = {
       }],
       component: React.lazy(async () => {
         const mod = await import("@/registry/new-york-v4/examples/textarea-with-text.tsx")
+        const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+        return { default: mod.default || mod[exportName] }
+      }),
+      categories: undefined,
+      meta: undefined,
+    },
+    "time-picker-demo": {
+      name: "time-picker-demo",
+      description: "",
+      type: "registry:example",
+      dependencies: ["date-fns"],
+      registryDependencies: ["button","time-picker","popover"],
+      files: [{
+        path: "registry/new-york-v4/examples/time-picker-demo.tsx",
+        type: "registry:example",
+        target: ""
+      }],
+      component: React.lazy(async () => {
+        const mod = await import("@/registry/new-york-v4/examples/time-picker-demo.tsx")
+        const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+        return { default: mod.default || mod[exportName] }
+      }),
+      categories: undefined,
+      meta: undefined,
+    },
+    "time-picker-with-presets": {
+      name: "time-picker-with-presets",
+      description: "",
+      type: "registry:example",
+      registryDependencies: ["button","time-picker"],
+      files: [{
+        path: "registry/new-york-v4/examples/time-picker-with-presets.tsx",
+        type: "registry:example",
+        target: ""
+      }],
+      component: React.lazy(async () => {
+        const mod = await import("@/registry/new-york-v4/examples/time-picker-with-presets.tsx")
         const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
         return { default: mod.default || mod[exportName] }
       }),

--- a/apps/v4/registry/new-york-v4/examples/time-picker-demo.tsx
+++ b/apps/v4/registry/new-york-v4/examples/time-picker-demo.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import * as React from "react"
+import { format } from "date-fns"
+import { Clock3Icon } from "lucide-react"
+
+import { Button } from "@/registry/new-york-v4/ui/button"
+import { TimePicker } from "@/registry/new-york-v4/ui/time-picker"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/registry/new-york-v4/ui/popover"
+
+export default function TimePickerDemo() {
+  const [value, setValue] = React.useState<Date | undefined>()
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          className="w-[220px] justify-start font-normal"
+          data-empty={!value}
+        >
+          <Clock3Icon className="mr-2 size-4 opacity-50" />
+          {value ? format(value, "h:mm a") : <span>Pick a time</span>}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto" align="start">
+        <TimePicker value={value} onValueChange={setValue} />
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/v4/registry/new-york-v4/examples/time-picker-with-presets.tsx
+++ b/apps/v4/registry/new-york-v4/examples/time-picker-with-presets.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import * as React from "react"
+
+import { Button } from "@/registry/new-york-v4/ui/button"
+import { TimePicker } from "@/registry/new-york-v4/ui/time-picker"
+
+const PRESETS = [
+  { label: "08:00", hour: 8, minute: 0 },
+  { label: "09:30", hour: 9, minute: 30 },
+  { label: "12:00", hour: 12, minute: 0 },
+  { label: "14:30", hour: 14, minute: 30 },
+]
+
+export default function TimePickerWithPresets() {
+  const [value, setValue] = React.useState<Date>(() => {
+    const base = new Date()
+    base.setHours(9, 30, 0, 0)
+    return base
+  })
+
+  const applyPreset = React.useCallback((preset: (typeof PRESETS)[number]) => {
+    setValue((previous) => {
+      const next = previous ? new Date(previous) : new Date()
+      next.setHours(preset.hour)
+      next.setMinutes(preset.minute)
+      next.setSeconds(0)
+      next.setMilliseconds(0)
+      return next
+    })
+  }, [])
+
+  return (
+    <div className="flex flex-col gap-4">
+      <TimePicker
+        value={value}
+        onValueChange={setValue}
+        hourCycle={24}
+        minuteStep={15}
+        hideLabels
+      />
+      <div className="flex flex-wrap gap-2">
+        {PRESETS.map((preset) => {
+          const isActive =
+            value.getHours() === preset.hour &&
+            value.getMinutes() === preset.minute
+
+          return (
+            <Button
+              key={preset.label}
+              size="sm"
+              variant={isActive ? "default" : "outline"}
+              onClick={() => applyPreset(preset)}
+              className="font-medium"
+            >
+              {preset.label}
+            </Button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/v4/registry/new-york-v4/ui/_registry.ts
+++ b/apps/v4/registry/new-york-v4/ui/_registry.ts
@@ -623,6 +623,17 @@ export const ui: Registry["items"] = [
     ],
   },
   {
+    name: "time-picker",
+    type: "registry:ui",
+    registryDependencies: ["select", "label"],
+    files: [
+      {
+        path: "ui/time-picker.tsx",
+        type: "registry:ui",
+      },
+    ],
+  },
+  {
     name: "toast",
     type: "registry:ui",
     dependencies: ["@radix-ui/react-toast"],

--- a/apps/v4/registry/new-york-v4/ui/time-picker.tsx
+++ b/apps/v4/registry/new-york-v4/ui/time-picker.tsx
@@ -1,0 +1,421 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/registry/new-york-v4/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/registry/new-york-v4/ui/select"
+
+type TimePickerGranularity = "hour" | "minute" | "second"
+
+type Period = "am" | "pm"
+
+type TimePickerProps = {
+  value?: Date
+  defaultValue?: Date
+  onValueChange?: (value: Date) => void
+  hourCycle?: 12 | 24
+  hourStep?: number
+  minuteStep?: number
+  secondStep?: number
+  granularity?: TimePickerGranularity
+  hideLabels?: boolean
+  disabled?: boolean
+} & Omit<React.ComponentProps<"div">, "onChange" | "defaultValue">
+
+function TimePicker({
+  className,
+  value,
+  defaultValue,
+  onValueChange,
+  hourCycle = 12,
+  hourStep = 1,
+  minuteStep = 5,
+  secondStep = 1,
+  granularity = "minute",
+  hideLabels = false,
+  disabled = false,
+  ...props
+}: TimePickerProps) {
+  const isControlled = value !== undefined
+  const [internalValue, setInternalValue] = React.useState<Date | undefined>(
+    defaultValue
+  )
+  const fallbackDate = React.useMemo(
+    () => (defaultValue ? new Date(defaultValue) : new Date()),
+    [defaultValue]
+  )
+  const resolvedValue = React.useMemo(
+    () => value ?? internalValue ?? fallbackDate,
+    [value, internalValue, fallbackDate]
+  )
+
+  const handleValueChange = React.useCallback(
+    (next: Date) => {
+      if (!isControlled) {
+        setInternalValue(next)
+      }
+      onValueChange?.(next)
+    },
+    [isControlled, onValueChange]
+  )
+
+  const period: Period = resolvedValue.getHours() >= 12 ? "pm" : "am"
+  const hour24 = resolvedValue.getHours()
+  const minute = resolvedValue.getMinutes()
+  const second = resolvedValue.getSeconds()
+
+  const displayHour =
+    hourCycle === 12
+      ? hour24 % 12 === 0
+        ? 12
+        : hour24 % 12
+      : hour24
+
+  const hourValue = displayHour.toString().padStart(2, "0")
+  const minuteValue = minute.toString().padStart(2, "0")
+  const secondValue = second.toString().padStart(2, "0")
+
+  const showMinutes = granularity === "minute" || granularity === "second"
+  const showSeconds = granularity === "second"
+
+  const hourOptions = React.useMemo(() => {
+    const hours: { value: string; label: string }[] = []
+
+    if (hourCycle === 12) {
+      for (let h = 1; h <= 12; h += Math.max(1, hourStep)) {
+        const value = h.toString().padStart(2, "0")
+        hours.push({ value, label: value })
+      }
+
+      if (!hours.some((option) => option.value === hourValue)) {
+        hours.push({ value: hourValue, label: hourValue })
+      }
+
+      return hours.sort((a, b) => Number(a.value) - Number(b.value))
+    }
+
+    for (let h = 0; h < 24; h += Math.max(1, hourStep)) {
+      const value = h.toString().padStart(2, "0")
+      hours.push({ value, label: value })
+    }
+
+    if (!hours.some((option) => option.value === hourValue)) {
+      hours.push({ value: hourValue, label: hourValue })
+    }
+
+    return hours.sort((a, b) => Number(a.value) - Number(b.value))
+  }, [hourCycle, hourStep, hourValue])
+
+  const minuteOptions = React.useMemo(() => {
+    const minutes: { value: string; label: string }[] = []
+
+    for (let m = 0; m < 60; m += Math.max(1, minuteStep)) {
+      const value = m.toString().padStart(2, "0")
+      minutes.push({ value, label: value })
+    }
+
+    if (!minutes.some((option) => option.value === minuteValue)) {
+      minutes.push({ value: minuteValue, label: minuteValue })
+    }
+
+    return minutes.sort((a, b) => Number(a.value) - Number(b.value))
+  }, [minuteStep, minuteValue])
+
+  const secondOptions = React.useMemo(() => {
+    const seconds: { value: string; label: string }[] = []
+
+    for (let s = 0; s < 60; s += Math.max(1, secondStep)) {
+      const value = s.toString().padStart(2, "0")
+      seconds.push({ value, label: value })
+    }
+
+    if (!seconds.some((option) => option.value === secondValue)) {
+      seconds.push({ value: secondValue, label: secondValue })
+    }
+
+    return seconds.sort((a, b) => Number(a.value) - Number(b.value))
+  }, [secondStep, secondValue])
+
+  const baseId = React.useId()
+  const hourId = `${baseId}-hour`
+  const minuteId = `${baseId}-minute`
+  const secondId = `${baseId}-second`
+  const periodId = `${baseId}-period`
+
+  const setHours = React.useCallback(
+    (nextHour: number) => {
+      const nextDate = new Date(resolvedValue)
+      nextDate.setHours(nextHour)
+      handleValueChange(nextDate)
+    },
+    [resolvedValue, handleValueChange]
+  )
+
+  const setMinutes = React.useCallback(
+    (nextMinute: number) => {
+      const nextDate = new Date(resolvedValue)
+      nextDate.setMinutes(nextMinute)
+      handleValueChange(nextDate)
+    },
+    [resolvedValue, handleValueChange]
+  )
+
+  const setSeconds = React.useCallback(
+    (nextSecond: number) => {
+      const nextDate = new Date(resolvedValue)
+      nextDate.setSeconds(nextSecond)
+      handleValueChange(nextDate)
+    },
+    [resolvedValue, handleValueChange]
+  )
+
+  const handleHourChange = React.useCallback(
+    (value: string) => {
+      const numericHour = Number.parseInt(value, 10)
+      if (Number.isNaN(numericHour)) return
+
+      if (hourCycle === 12) {
+        let nextHour = numericHour % 12
+        if (period === "pm" && nextHour !== 12) {
+          nextHour += 12
+        }
+
+        if (period === "am" && nextHour === 12) {
+          nextHour = 0
+        }
+
+        setHours(nextHour)
+        return
+      }
+
+      setHours(numericHour)
+    },
+    [hourCycle, period, setHours]
+  )
+
+  const handleMinuteChange = React.useCallback(
+    (value: string) => {
+      const numericMinute = Number.parseInt(value, 10)
+      if (Number.isNaN(numericMinute)) return
+      setMinutes(numericMinute)
+    },
+    [setMinutes]
+  )
+
+  const handleSecondChange = React.useCallback(
+    (value: string) => {
+      const numericSecond = Number.parseInt(value, 10)
+      if (Number.isNaN(numericSecond)) return
+      setSeconds(numericSecond)
+    },
+    [setSeconds]
+  )
+
+  const handlePeriodChange = React.useCallback(
+    (nextPeriod: Period) => {
+      let nextHour = hour24
+
+      if (nextPeriod === "am" && nextHour >= 12) {
+        nextHour -= 12
+      }
+
+      if (nextPeriod === "pm" && nextHour < 12) {
+        nextHour += 12
+      }
+
+      setHours(nextHour)
+    },
+    [hour24, setHours]
+  )
+
+  return (
+    <div
+      data-slot="time-picker"
+      className={cn("flex items-end gap-3", className)}
+      {...props}
+    >
+      <TimePickerSection
+        id={hourId}
+        label="Hour"
+        hideLabel={hideLabels}
+        className="w-20"
+      >
+        <Select
+          value={hourValue}
+          onValueChange={handleHourChange}
+          disabled={disabled}
+        >
+          <SelectTrigger
+            id={hourId}
+            size="sm"
+            className="justify-between"
+            aria-label="Select hour"
+          >
+            <SelectValue placeholder="--" />
+          </SelectTrigger>
+          <SelectContent align="start">
+            {hourOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </TimePickerSection>
+
+      {showMinutes ? (
+        <>
+          <TimeSeparator />
+          <TimePickerSection
+            id={minuteId}
+            label="Minute"
+            hideLabel={hideLabels}
+            className="w-20"
+          >
+            <Select
+              value={minuteValue}
+              onValueChange={handleMinuteChange}
+              disabled={disabled}
+            >
+              <SelectTrigger
+                id={minuteId}
+                size="sm"
+                className="justify-between"
+                aria-label="Select minute"
+              >
+                <SelectValue placeholder="--" />
+              </SelectTrigger>
+              <SelectContent align="start">
+                {minuteOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </TimePickerSection>
+        </>
+      ) : null}
+
+      {showSeconds ? (
+        <>
+          <TimeSeparator />
+          <TimePickerSection
+            id={secondId}
+            label="Second"
+            hideLabel={hideLabels}
+            className="w-20"
+          >
+            <Select
+              value={secondValue}
+              onValueChange={handleSecondChange}
+              disabled={disabled}
+            >
+              <SelectTrigger
+                id={secondId}
+                size="sm"
+                className="justify-between"
+                aria-label="Select second"
+              >
+                <SelectValue placeholder="--" />
+              </SelectTrigger>
+              <SelectContent align="start">
+                {secondOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </TimePickerSection>
+        </>
+      ) : null}
+
+      {hourCycle === 12 ? (
+        <>
+          <TimeSeparator aria-hidden />
+          <TimePickerSection
+            id={periodId}
+            label="Period"
+            hideLabel={hideLabels}
+            className="w-24"
+          >
+            <Select
+              value={period}
+              onValueChange={handlePeriodChange}
+              disabled={disabled}
+            >
+              <SelectTrigger
+                id={periodId}
+                size="sm"
+                className="justify-between"
+                aria-label="Select period"
+              >
+                <SelectValue placeholder="--" />
+              </SelectTrigger>
+              <SelectContent align="start">
+                <SelectItem value="am">AM</SelectItem>
+                <SelectItem value="pm">PM</SelectItem>
+              </SelectContent>
+            </Select>
+          </TimePickerSection>
+        </>
+      ) : null}
+    </div>
+  )
+}
+
+function TimePickerSection({
+  id,
+  label,
+  hideLabel,
+  className,
+  children,
+}: {
+  id: string
+  label: string
+  hideLabel?: boolean
+  className?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      data-slot="time-picker-section"
+      className={cn("flex flex-col gap-1", className)}
+    >
+      {hideLabel ? null : (
+        <Label
+          data-slot="time-picker-label"
+          htmlFor={id}
+          className="text-xs font-medium"
+        >
+          {label}
+        </Label>
+      )}
+      <div data-slot="time-picker-control">{children}</div>
+    </div>
+  )
+}
+
+function TimeSeparator(props: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="time-picker-separator"
+      aria-hidden="true"
+      className="text-muted-foreground pb-2 text-xl"
+      {...props}
+    >
+      :
+    </span>
+  )
+}
+
+export { TimePicker }
+export type { TimePickerGranularity, TimePickerProps }


### PR DESCRIPTION
this PR Closes: #7339
### Summary

We’ve been relying on shadcn/ui for years across accounting apps and personal projects.
A more advanced TimePicker is really needed, and I thought it would be awesome if shadcn/ui included one. (It already has a basic version, but it doesn’t meet our or our users’ needs.)

**Changes made:**
- add a reusable TimePicker component that supports 12/24 hour cycles, minute/second granularity, and preset-friendly state handling
- register the component and new demos in the shadcn registry (UI + examples + kitchen-sink entry)
- document installation/usage on /docs/components/time-picker, including granularity and preset guidance

you can find it under `docs/components/time-picker`

**Please tell me if any changes are required**


### Screenshots of TImePicker:

<img width="1830" height="876" alt="Screenshot From 2025-11-06 23-34-15" src="https://github.com/user-attachments/assets/08d5aa63-af77-476a-bea6-7c1d16c92807" />


<img width="1830" height="876" alt="Screenshot From 2025-11-06 23-34-35" src="https://github.com/user-attachments/assets/9108935c-7e3e-45c5-89f0-d2d55fb40544" />


<img width="1830" height="876" alt="Screenshot From 2025-11-06 23-45-55" src="https://github.com/user-attachments/assets/d9861242-2112-4112-bcf6-e0ece79fe25f" />


<img width="1830" height="876" alt="Screenshot From 2025-11-06 23-47-24" src="https://github.com/user-attachments/assets/ee3ed882-7206-4169-9591-1cb3014d0c74" />
