### PR TITLE
Fix day cell layout issue on last month when endMonth is set

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/calendar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/calendar.tsx
@@ -90,7 +90,7 @@ function Calendar({
           "text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem] select-none",
           defaultClassNames.weekday
         ),
-        week: cn("flex w-fit mt-2", defaultClassNames.week),
+        week: cn("flex first:w-full w-fit mt-2", defaultClassNames.week),
         week_number_header: cn(
           "select-none w-(--cell-size)",
           defaultClassNames.week_number_header
@@ -100,7 +100,7 @@ function Calendar({
           defaultClassNames.week_number
         ),
         day: cn(
-          "relative w-fit h-full p-0 text-center [&:last-child[data-selected=true]_button]:rounded-r-md group/day aspect-square select-none",
+          "relative first:w-full w-fit h-full p-0 text-center [&:last-child[data-selected=true]_button]:rounded-r-md group/day aspect-square select-none",
           props.showWeekNumber
             ? "[&:nth-child(2)[data-selected=true]_button]:rounded-l-md"
             : "[&:first-child[data-selected=true]_button]:rounded-l-md",


### PR DESCRIPTION
### Description

This PR addresses [issue #8724](https://github.com/shadcn-ui/ui/issues/8724).

The issue occurred because the `<DayPicker />` component used `w-full` for both the **week** and **day** elements, causing layout overflow when some days or labels had longer content.  
To fix this, both class names were updated from `w-full` to `w-fit`, ensuring the layout adapts naturally to the content width without stretching.

The **first** `w-full` was intentionally kept to ensure the first day of the month remains in the correct position.

The bug can be viewed at [Calendar-11](https://ui.shadcn.com/blocks/calendar#calendar-11).

---

### Changes

```diff
- week: cn("flex w-full mt-2", defaultClassNames.week),
+ week: cn("flex first:w-full w-fit mt-2", defaultClassNames.week),

- day: cn("relative w-full ..."),
+ day: cn("relative first:w-full w-fit ..."),
```

### Notes

The command `pnpm registry:build` **was not executed** because it consistently failed due to the internal `prettier` process invoked in the build script.  
When running locally on Windows, `execFile('prettier', ...)` throws an `ENOENT` error, meaning the script cannot locate the `prettier` binary inside the monorepo environment.  
Because of this, the registry build could not be completed during testing, but the UI fix was applied and verified manually.

### Why the `first:w-full`?

![fixed one and created another](https://github.com/user-attachments/assets/9fe510af-e2f0-46ca-94c1-d176178431bf)

---

### Before and After

![default calendar](https://github.com/user-attachments/assets/fd218e71-5520-482a-ba5f-7f8dc2e617a5)
![calendar range](https://github.com/user-attachments/assets/64037dea-dd55-4d4b-af8a-65669c0775df)
![calendar in a drawer](https://github.com/user-attachments/assets/cd5a3bbe-e9eb-47e0-8953-608726cff6bf)
![calendar with presets](https://github.com/user-attachments/assets/b0d07d7f-6e38-4740-8037-53705099d676)
![calendar with custom days](https://github.com/user-attachments/assets/c2b91d53-b6d0-4ddc-9cb9-92fcf895af30)
![calendar with both extremes cutted](https://github.com/user-attachments/assets/4e8a48f7-f192-46c1-b42c-9ad31e0bb3f7)

