### PR TITLE
context menu repositioning on every right-click fixed.

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/context-menu.tsx
+++ b/apps/v4/registry/new-york-v4/ui/context-menu.tsx
@@ -9,7 +9,21 @@ import { cn } from "@/lib/utils"
 function ContextMenu({
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
-  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />
+  const [menuKey, setMenuKey] = React.useState(0);
+
+  return (
+    <ContextMenuPrimitive.Root 
+      key={menuKey}
+      data-slot="context-menu" 
+      onOpenChange={(open) => {
+        props.onOpenChange?.(open);
+        if (!open) {
+          setMenuKey(prev => prev + 1);
+        }
+      }}
+      {...props} 
+    />
+  );
 }
 
 function ContextMenuTrigger({


### PR DESCRIPTION
Add state management for menu key to reset context menu on close.

Before:

https://github.com/user-attachments/assets/652f0e00-cc35-4a5d-97c5-72a53469c2a1

After: 

https://github.com/user-attachments/assets/de383c15-c3fa-4687-b0c1-e0a9fe83fb30

