### PR TITLE
Fix border style for last child in TableBody

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/table.tsx
+++ b/apps/v4/registry/new-york-v4/ui/table.tsx
@@ -33,7 +33,7 @@ function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
   return (
     <tbody
       data-slot="table-body"
-      className={cn("[&_tr:last-child]:border-0", className)}
+      className={cn("[&_tr:last-child]:border-b-0", className)}
       {...props}
     />
   )


### PR DESCRIPTION
I believe the intention here is not to have the bottom border clash with the `TableFooter` border. And in that case it's only the bottom border that has to be removed, i.e. `border-b-0`, and not `border-0`. The latter removes all borders from the table row.