### PR TITLE
fix: correct destructive-foreground OKLCH values for proper contrast

### DIFF
--- a/apps/v4/content/docs/installation/manual.mdx
+++ b/apps/v4/content/docs/installation/manual.mdx
@@ -64,7 +64,7 @@ Add the following to your styles/globals.css file. You can learn more about usin
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
@@ -100,7 +100,7 @@ Add the following to your styles/globals.css file. You can learn more about usin
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.269 0 0);
   --input: oklch(0.269 0 0);
   --ring: oklch(0.439 0 0);

--- a/deprecated/www/content/docs/installation/manual.mdx
+++ b/deprecated/www/content/docs/installation/manual.mdx
@@ -62,7 +62,7 @@ Add the following to your styles/globals.css file. You can learn more about usin
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
@@ -98,7 +98,7 @@ Add the following to your styles/globals.css file. You can learn more about usin
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.269 0 0);
   --input: oklch(0.269 0 0);
   --ring: oklch(0.439 0 0);

--- a/packages/shadcn/test/fixtures/vite-with-tailwind/src/index.css
+++ b/packages/shadcn/test/fixtures/vite-with-tailwind/src/index.css
@@ -20,7 +20,7 @@
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.87 0 0);
@@ -56,7 +56,7 @@
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.269 0 0);
   --input: oklch(0.269 0 0);
   --ring: oklch(0.439 0 0);

--- a/templates/monorepo-next/packages/ui/src/styles/globals.css
+++ b/templates/monorepo-next/packages/ui/src/styles/globals.css
@@ -23,7 +23,7 @@
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
@@ -59,7 +59,7 @@
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.269 0 0);
   --input: oklch(0.269 0 0);
   --ring: oklch(0.556 0 0);


### PR DESCRIPTION
This PR corrects the `--destructive-foreground` OKLCH color values in templates and documentation to ensure proper text contrast on destructive/error backgrounds.

## The Problem

Currently, the OKLCH templates set `--destructive-foreground` to red values, creating red-on-red or red-on-darker-red combinations that fail accessibility contrast requirements:

**Light mode:**
```css
--destructive: oklch(0.577 0.245 27.325);
--destructive-foreground: oklch(0.577 0.245 27.325); /* Same red - poor contrast */
```

**Dark mode:**
```css
--destructive: oklch(0.396 0.141 25.723);
--destructive-foreground: oklch(0.637 0.237 25.331); /* Different red shade - still poor contrast */
```

This affects destructive buttons and alerts where text becomes difficult or impossible to read.

This PR changes `--destructive-foreground` to white (`oklch(0.985 0 0)`) in both light and dark modes, matching:

1. **The pattern used for other foreground colors:** All other color pairs like `--primary`/`--primary-foreground` and `--accent`/`--accent-foreground` use high contrast combinations
2. **The existing HSL templates:** The HSL color format templates already correctly use white (`0 0% 98%`) for `--destructive-foreground`

Comparison with HSL templates:
```css
/* HSL templates (correct) */
--destructive-foreground: 0 0% 98%; /* White */

/* OKLCH templates (before this PR - incorrect) */
--destructive-foreground: oklch(0.577 0.245 27.325); /* Red */
```

This suggests the OKLCH values may have been a conversion error rather than an intentional design choice.

## Question for Maintainers

**Was the red-on-red destructive-foreground color intentional, or should it match the HSL templates with proper white text on red backgrounds?**

If red-on-red was intentional, I'd be interested to understand the design rationale. Otherwise, this PR provides the fix.