### PR TITLE
fix: correct typos in docs/components/chart

### DIFF
--- a/apps/v4/content/docs/components/chart.mdx
+++ b/apps/v4/content/docs/components/chart.mdx
@@ -31,7 +31,7 @@ We designed the `chart` component with composition in mind. **You build your cha
 ```tsx showLineNumbers /ChartContainer/ /ChartTooltipContent/
 import { Bar, BarChart } from "recharts"
 
-import { ChartContainer, ChartTooltipContent } from "@/components/ui/charts"
+import { ChartContainer, ChartTooltipContent } from "@/components/ui/chart"
 
 export function MyChart() {
   return (


### PR DESCRIPTION
Fixed a filename typo in one of the code examples: https://ui.shadcn.com/docs/components/chart

`"@/components/ui/charts"` -> `"@/components/ui/chart"`