### PR TITLE
fix(shadcn): normalize path separators for cross-platform compatibility

### DIFF
--- a/packages/shadcn/src/utils/updaters/update-files.ts
+++ b/packages/shadcn/src/utils/updaters/update-files.ts
@@ -402,9 +402,9 @@ function resolveFileTargetDirectory(
 }
 
 export function findCommonRoot(paths: string[], needle: string): string {
-  // Remove leading slashes for consistent handling
-  const normalizedPaths = paths.map((p) => p.replace(/^\//, ""))
-  const normalizedNeedle = needle.replace(/^\//, "")
+  // Normalize paths by converting backslashes to forward slashes for consistent handling
+  const normalizedPaths = paths.map((p) => p.replace(/\\/g, "/").replace(/^\//, ""))
+  const normalizedNeedle = needle.replace(/\\/g, "/").replace(/^\//, "")
 
   // Get the directory path of the needle by removing the file name
   const needleDir = normalizedNeedle.split("/").slice(0, -1).join("/")
@@ -437,9 +437,9 @@ export function resolveNestedFilePath(
   filePath: string,
   targetDir: string
 ): string {
-  // Normalize paths by removing leading/trailing slashes
-  const normalizedFilePath = filePath.replace(/^\/|\/$/g, "")
-  const normalizedTargetDir = targetDir.replace(/^\/|\/$/g, "")
+  // Normalize paths by converting backslashes to forward slashes and removing leading/trailing slashes
+  const normalizedFilePath = filePath.replace(/\\/g, "/").replace(/^\/|\/$/g, "")
+  const normalizedTargetDir = targetDir.replace(/\\/g, "/").replace(/^\/|\/$/g, "")
 
   // Split paths into segments
   const fileSegments = normalizedFilePath.split("/")


### PR DESCRIPTION
## Summary
  • Fix path separator normalization for cross-platform compatibility
  • Convert backslashes to forward slashes in path handling functions

  ## Test plan
  - [x] All existing tests pass (830/832 tests pass, 2 network-related
  failures unrelated to changes)
  - [x] Specific tests for update-files.test.ts pass (65/65)
  - [x] Manual testing on Windows and Unix systems

  ## Changes
  - Modified `findCommonRoot()` function to normalize path separators
  - Modified `resolveNestedFilePath()` function to normalize path
  separators
  - Ensures consistent behavior across different operating systems