### PR TITLE
fix: dependencies for Bun in `monorepo-next`

### DIFF
--- a/templates/monorepo-next/apps/web/package.json
+++ b/templates/monorepo-next/apps/web/package.json
@@ -20,11 +20,13 @@
     "react-dom": "^19.1.1"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.11",
     "@types/node": "^20.19.9",
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
     "@workspace/eslint-config": "workspace:^",
     "@workspace/typescript-config": "workspace:*",
+    "eslint": "^9.32.0",
     "typescript": "^5.9.2"
   }
 }

--- a/templates/monorepo-next/packages/eslint-config/package.json
+++ b/templates/monorepo-next/packages/eslint-config/package.json
@@ -9,6 +9,7 @@
     "./react-internal": "./react-internal.js"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.1",
     "@next/eslint-plugin-next": "^15.4.5",
     "@typescript-eslint/eslint-plugin": "^8.39.0",
     "@typescript-eslint/parser": "^8.39.0",

--- a/templates/monorepo-next/packages/ui/package.json
+++ b/templates/monorepo-next/packages/ui/package.json
@@ -26,6 +26,7 @@
     "@types/react-dom": "^19.1.7",
     "@workspace/eslint-config": "workspace:*",
     "@workspace/typescript-config": "workspace:*",
+    "eslint": "^9.32.0",
     "tailwindcss": "^4.1.11",
     "typescript": "^5.9.2"
   },


### PR DESCRIPTION
https://github.com/vercel/turborepo/issues/11047 was opened in Turborepo, but this has to do with Bun's recent changes to dependency resolution. In short, Bun is more conservatively hoisting dependencies than other package managers, so we must be more explicit about declaring the dependencies for packages in the workspace.

This change will not negatively affect other package managers. Adding these dependencies is being more technically correct about which dependencies are getting used in which packages, so other package managers will continue working.