### PR TITLE
fix(shadcn): tailwind prefix on array classnames

### DIFF
--- a/packages/shadcn/src/utils/transformers/transform-tw-prefix.ts
+++ b/packages/shadcn/src/utils/transformers/transform-tw-prefix.ts
@@ -58,6 +58,24 @@ export const transformTwPrefixes: Transformer = async ({
                     )}"`
                   )
                 }
+
+                const arrayClassNames = node.getInitializerIfKind(
+                  SyntaxKind.ArrayLiteralExpression
+                )
+
+                if (arrayClassNames) {
+                  arrayClassNames
+                    .getDescendantsOfKind(SyntaxKind.StringLiteral)
+                    .forEach((classNames) => {
+                      classNames.replaceWithText(
+                        `"${applyPrefix(
+                          classNames.getText()?.replace(/"|'/g, ""),
+                          config.tailwind.prefix,
+                          tailwindVersion
+                        )}"`
+                      )
+                    })
+                }
               })
           })
       }


### PR DESCRIPTION
### Sumary
This PR resolves the current behavior on the file generation, applying the tailwind prefix correctly on array classnames when using the cva helper. Giving an example from `Field` component.

### Current behavior
```tsx
const fieldVariants = cva(
  "tw:group/field tw:flex tw:w-full tw:gap-3 tw:data-[invalid=true]:text-destructive",
  {
    variants: {
      orientation: {
        vertical: ["flex-col [&>*]:w-full [&>.sr-only]:w-auto"],
        horizontal: [
          "flex-row items-center",
          "[&>[data-slot=field-label]]:flex-auto",
          "has-[>[data-slot=field-content]]:items-start has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
        ],
        responsive: [
          "flex-col [&>*]:w-full [&>.sr-only]:w-auto @md/field-group:flex-row @md/field-group:items-center @md/field-group:[&>*]:w-auto",
          "@md/field-group:[&>[data-slot=field-label]]:flex-auto",
          "@md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
        ],
      },
    },
    defaultVariants: {
      orientation: "vertical",
    },
  }
);
```

### Fix
```tsx
const fieldVariants = cva(
  "",
  {
    variants: {
      orientation: {
        vertical: ["tw:flex-col tw:[&>*]:w-full tw:[&>.sr-only]:w-auto"],
        horizontal: [
          "tw:flex-row tw:items-center",
          "tw:[&>[data-slot=field-label]]:flex-auto",
          "tw:has-[>[data-slot=field-content]]:items-start tw:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
        ],
        responsive: [
          "tw:flex-col tw:[&>*]:w-full tw:[&>.sr-only]:w-auto tw:@md/field-group:flex-row tw:@md/field-group:items-center tw:@md/field-group:[&>*]:w-auto",
          "tw:@md/field-group:[&>[data-slot=field-label]]:flex-auto",
          "tw:@md/field-group:has-[>[data-slot=field-content]]:items-start tw:@md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
        ],
      },
    },
    defaultVariants: {
      orientation: "vertical",
    },
  }
);
```