### PR TITLE
feat(docs) changed theme button in docs

### DIFF
--- a/apps/v4/components/mode-switcher.tsx
+++ b/apps/v4/components/mode-switcher.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import { MoonIcon, SunIcon } from "lucide-react"
 import { useTheme } from "next-themes"
 
 import { useMetaColor } from "@/hooks/use-meta-color"
@@ -26,25 +27,8 @@ export function ModeSwitcher() {
       onClick={toggleTheme}
       title="Toggle theme"
     >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="24"
-        height="24"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="size-4.5"
-      >
-        <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-        <path d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
-        <path d="M12 3l0 18" />
-        <path d="M12 9l4.65 -4.65" />
-        <path d="M12 14.3l7.37 -7.37" />
-        <path d="M12 19.6l8.85 -8.85" />
-      </svg>
+      <SunIcon className="hidden size-4.5 [html.dark_&]:block" />
+      <MoonIcon className="hidden size-4.5 [html.light_&]:block" />
       <span className="sr-only">Toggle theme</span>
     </Button>
   )


### PR DESCRIPTION
Changed docs theme (dark/light) button to use different svg in dark and light mode
the same svgs are used in the https://ui.shadcn.com/docs/dark-mode/next for changing the theme

Closes: #8239

video after change:

[theme.webm](https://github.com/user-attachments/assets/31301e69-a28f-48e8-9ebe-c43e019ace04)
