### PR TITLE
fix: prevent calendar popover jumping by setting consistent height

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/calendar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/calendar.tsx
@@ -46,7 +46,7 @@ function Calendar({
           "flex gap-4 flex-col md:flex-row relative",
           defaultClassNames.months
         ),
-        month: cn("flex flex-col w-full gap-4", defaultClassNames.month),
+        month: cn("flex flex-col w-full gap-4 min-h-[calc(7*var(--cell-size))]", defaultClassNames.month),
         nav: cn(
           "flex items-center gap-1 w-full absolute top-0 inset-x-0 justify-between",
           defaultClassNames.nav


### PR DESCRIPTION
### Fix Calendar Popover Jumping

fix: #8802

**Problem:** Calendar popover jumps when navigating between months because the height changes based on number of weeks, causing navigation buttons to move and accidental backdrop clicks.

**Solution:** Added minimum height constraint `min-h-[calc(7*var(--cell-size))]` to calendar month container to maintain consistent height across all months.

**Changes:** Modified `apps/v4/registry/new-york-v4/ui/calendar.tsx` to prevent height fluctuations during month navigation.