### PR TITLE
fix: add consistent spacing in update-css-vars.ts

### DIFF
--- a/packages/shadcn/src/utils/updaters/update-css-vars.ts
+++ b/packages/shadcn/src/utils/updaters/update-css-vars.ts
@@ -558,11 +558,13 @@ function updateThemePlugin(cssVars: z.infer<typeof registryItemCssVarsSchema>) {
           isLocalHSLValue(value) || isColorValue(value)
             ? `--color-${variable.replace(/^--/, "")}`
             : `--${variable.replace(/^--/, "")}`
+
         if (prop === "--color-sidebar-background") {
           prop = "--color-sidebar"
         }
 
         let propValue = `var(--${variable})`
+
         if (prop === "--color-sidebar") {
           propValue = "var(--sidebar)"
         }


### PR DESCRIPTION
**PR Description:**

fix: #8809

- Fixes inconsistent spacing in `update-css-vars.ts`. Adds blank lines after variable declarations before `if` statements to match the existing pattern.

**Changes:**
- Added a blank line after `prop` declaration (line 561)
- Added a blank line after `propValue` declaration (line 567)