### PR TITLE
fix: sidebar skeleton hydration mismatch

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -607,8 +607,10 @@ function SidebarMenuSkeleton({
   showIcon?: boolean
 }) {
   // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`
+  const [width, setWidth] = React.useState("50%")
+
+  React.useEffect(() => {
+    setWidth(`${Math.floor(Math.random() * 40) + 50}%`)
   }, [])
 
   return (


### PR DESCRIPTION
## Description
This PR fixes a hydration mismatch error caused by using `Math.random()` inside `useMemo` (or `useState` initializers) in the `SidebarMenuSkeleton` component.

## Supersedes #8510
This PR supersedes #8510. 
While the approach in #8510 resolves the linter error, it uses `useState` with a random initializer. In Next.js (SSR), this causes a **Hydration Mismatch** because the server generates one random number and the client generates a different one during the initial render.

## The Solution
I implemented a two-pass approach to ensure hydration safety:
1. **Server/Initial Render:** The width initializes to a deterministic value (`"50%"`) so the Server HTML and Client HTML are identical.
2. **Effect Phase:** A `useEffect` hook randomizes the width immediately after mount.

This prevents the "Text content does not match server-rendered HTML" warning and ensures the component is theoretically pure during the render phase.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have verified that the skeleton renders correctly without hydration errors