### PR TITLE
fix(blocks): refactor calendar-20 layout to fix visual discrepancies

### DIFF
--- a/apps/v4/registry/new-york-v4/blocks/calendar-20.tsx
+++ b/apps/v4/registry/new-york-v4/blocks/calendar-20.tsx
@@ -25,41 +25,43 @@ export default function Calendar20() {
 
   return (
     <Card className="gap-0 p-0">
-      <CardContent className="relative p-0 md:pr-48">
-        <div className="p-6">
-          <Calendar
-            mode="single"
-            selected={date}
-            onSelect={setDate}
-            defaultMonth={date}
-            disabled={bookedDates}
-            showOutsideDays={false}
-            modifiers={{
-              booked: bookedDates,
-            }}
-            modifiersClassNames={{
-              booked: "[&>button]:line-through opacity-100",
-            }}
-            className="bg-transparent p-0 [--cell-size:--spacing(10)] md:[--cell-size:--spacing(12)]"
-            formatters={{
-              formatWeekdayName: (date) => {
-                return date.toLocaleString("en-US", { weekday: "short" })
-              },
-            }}
-          />
-        </div>
-        <div className="no-scrollbar inset-y-0 right-0 flex max-h-72 w-full scroll-pb-6 flex-col gap-4 overflow-y-auto border-t p-6 md:absolute md:max-h-none md:w-48 md:border-t-0 md:border-l">
-          <div className="grid gap-2">
-            {timeSlots.map((time) => (
-              <Button
-                key={time}
-                variant={selectedTime === time ? "default" : "outline"}
-                onClick={() => setSelectedTime(time)}
-                className="w-full shadow-none"
-              >
-                {time}
-              </Button>
-            ))}
+      <CardContent className="p-0">
+        <div className="md:flex">
+          <div className="p-6">
+            <Calendar
+              mode="single"
+              selected={date}
+              onSelect={setDate}
+              defaultMonth={date}
+              disabled={bookedDates}
+              showOutsideDays={false}
+              modifiers={{
+                booked: bookedDates,
+              }}
+              modifiersClassNames={{
+                booked: "[&>button]:line-through opacity-100",
+              }}
+              className="bg-transparent p-0 [--cell-size:--spacing(10)] md:[--cell-size:--spacing(12)]"
+              formatters={{
+                formatWeekdayName: (date) => {
+                  return date.toLocaleString("en-US", { weekday: "short" })
+                },
+              }}
+            />
+          </div>
+          <div className="no-scrollbar flex h-72 w-full flex-col gap-4 overflow-y-auto border-t p-6 md:h-auto md:w-48 md:border-l">
+            <div className="grid gap-2">
+              {timeSlots.map((time) => (
+                <Button
+                  key={time}
+                  variant={selectedTime === time ? "default" : "outline"}
+                  onClick={() => setSelectedTime(time)}
+                  className="w-full shadow-none"
+                >
+                  {time}
+                </Button>
+              ))}
+            </div>
           </div>
         </div>
       </CardContent>


### PR DESCRIPTION
 fix(blocks): refactor calendar-20 layout to fix visual discrepancies

Fixes #8854

**Description:**

This pull request fixes a bug in the `Calendar-20` block where the layout does not match the demonstration on the shadcn/ui website. The following issues have been addressed:

- **Excessive spacing:** The large gap between the calendar and the timeslots has been removed.
- **Unexpected scrollbar:** The scrollbar that appeared on the timeslots container is now hidden.
- **Missing border-radius:** The right-top border-radius of the container is now visible.
- **Responsiveness:** The overall responsiveness of the component has been improved.

**Changes:**

The main change in this pull request is the refactoring of the layout for the `Calendar-20` component. The previous implementation used absolute positioning, which caused the visual discrepancies. The new implementation uses a flexbox-based layout, which is more robust and easier to maintain.

**How to test:**

1.  Add the `Calendar-20` block to a project: `npx shadcn@latest add calendar-20`
2.  Observe the rendered component and verify that the layout issues are resolved.

**Note:**

The project's dependencies could not be installed, so the changes have not been tested. The build, test, and lint commands are all failing due to an `esbuild` version mismatch.
