### PR TITLE
chore(registry): remove react-dialog dependency from drawer

### DIFF
--- a/apps/v4/public/r/styles/new-york-v4/drawer.json
+++ b/apps/v4/public/r/styles/new-york-v4/drawer.json
@@ -3,8 +3,7 @@
   "name": "drawer",
   "type": "registry:ui",
   "dependencies": [
-    "vaul",
-    "@radix-ui/react-dialog"
+    "vaul"
   ],
   "files": [
     {

--- a/apps/v4/public/r/styles/new-york-v4/registry.json
+++ b/apps/v4/public/r/styles/new-york-v4/registry.json
@@ -284,8 +284,7 @@
       "name": "drawer",
       "type": "registry:ui",
       "dependencies": [
-        "vaul",
-        "@radix-ui/react-dialog"
+        "vaul"
       ],
       "files": [
         {

--- a/apps/v4/registry/new-york-v4/ui/_registry.ts
+++ b/apps/v4/registry/new-york-v4/ui/_registry.ts
@@ -227,7 +227,7 @@ export const ui: Registry["items"] = [
   {
     name: "drawer",
     type: "registry:ui",
-    dependencies: ["vaul", "@radix-ui/react-dialog"],
+    dependencies: ["vaul"],
     files: [
       {
         path: "ui/drawer.tsx",


### PR DESCRIPTION
The Drawer component does not use the `@radix-ui/react-dialog package`, so it can be safely removed.