### PR TITLE
docs: fix typo 'mcpServers' to 'servers' in mcp server setup document…

### DIFF
--- a/apps/v4/content/docs/(root)/mcp.mdx
+++ b/apps/v4/content/docs/(root)/mcp.mdx
@@ -182,7 +182,7 @@ To configure MCP in VS Code with GitHub Copilot, add the shadcn server to your p
 
 ```json title=".vscode/mcp.json" showLineNumbers
 {
-  "mcpServers": {
+  "servers": {
     "shadcn": {
       "command": "npx",
       "args": ["shadcn@latest", "mcp"]


### PR DESCRIPTION
This pull request updates the MCP configuration instructions for VS Code by renaming the `mcpServers` property to `servers` in the example `.vscode/mcp.json` file. This change ensures the documentation matches the latest configuration format.

- **Documentation Update:**
  * Updated the JSON configuration example in `mcp.mdx` to use the `servers` property instead of `mcpServers` for MCP server definitions.
  
  VS Code MCP Server Configuration Link :- [VS Code MCP Server Setup](https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_add-an-mcp-server)