### PR TITLE
docs: remove `disableTransitionOnChange` from ThemeProvider example

### DIFF
--- a/apps/v4/content/docs/dark-mode/next.mdx
+++ b/apps/v4/content/docs/dark-mode/next.mdx
@@ -46,7 +46,6 @@ export default function RootLayout({ children }: RootLayoutProps) {
             attribute="class"
             defaultTheme="system"
             enableSystem
-            disableTransitionOnChange
           >
             {children}
           </ThemeProvider>


### PR DESCRIPTION
**PR Description:**
* The example previously included disableTransitionOnChange, which disables all CSS transitions during theme changes.
* As a result, the ModeToggle button's icon animations (e.g., rotation) were not visible.
This option has been removed so the example behaves as expected.
 
**Changes:**

* Removed `disableTransitionOnChange` from the ThemeProvider example
<img width="923" height="264" alt="example" src="https://github.com/user-attachments/assets/694b48dd-06b8-4762-92d2-8a5250bfa924" />
