### PR TITLE
fix: update animation classes in MenubarContent for consistency

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/menubar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/menubar.tsx
@@ -79,7 +79,7 @@ function MenubarContent({
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[12rem] origin-(--radix-menubar-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-md",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary

### Menubar: Add exit animations
- Added exit animation classes (`data-[state=closed]:animate-out`) to `MenubarContent` and `MenubarSubContent` components
- This ensures smooth closing transitions instead of abrupt disappearances

### Select: Exit animations limitation
- The `SelectContent` component already has the correct exit animation classes (`data-[state=closed]:animate-out`, `fade-out-0`, `zoom-out-95`)
- However, **exit animations do not work** due to a known Radix UI limitation
- Unlike other Radix components (Popover, Dialog, DropdownMenu), the Select primitive is missing the `forceMount` prop on its Portal, causing the component to unmount immediately before the CSS animation can play
- This is tracked in:
  - [radix-ui/primitives#1893](https://github.com/radix-ui/primitives/issues/1893) - "Add animation support when position='popper'"
  - [radix-ui/primitives#3236](https://github.com/radix-ui/primitives/issues/3236) - "The select is missing the forceMount prop"

### Before:

https://github.com/user-attachments/assets/cf91df6d-054d-41ae-81d5-619cf30b9408

### After:

https://github.com/user-attachments/assets/55950b0f-f5f2-4594-b849-a7691400d4a3

Linked to: https://github.com/shadcn-ui/ui/issues/8526