### PR TITLE
docs(tanstack-form): replaced children prop with actual children

### DIFF
--- a/apps/v4/content/docs/forms/tanstack-form.mdx
+++ b/apps/v4/content/docs/forms/tanstack-form.mdx
@@ -40,7 +40,7 @@ This form leverages TanStack Form for powerful, headless form handling. We'll bu
 
 Here's a basic example of a form using TanStack Form with the `<Field />` component.
 
-```tsx showLineNumbers {15-31}
+```tsx showLineNumbers {13-29}
 <form
   onSubmit={(e) => {
     e.preventDefault()
@@ -48,9 +48,8 @@ Here's a basic example of a form using TanStack Form with the `<Field />` compon
   }}
 >
   <FieldGroup>
-    <form.Field
-      name="title"
-      children={(field) => {
+    <form.Field name="title">
+      {(field) => {
         const isInvalid =
           field.state.meta.isTouched && !field.state.meta.isValid
         return (
@@ -73,7 +72,7 @@ Here's a basic example of a form using TanStack Form with the `<Field />` compon
           </Field>
         )
       }}
-    />
+    </form.Field>
   </FieldGroup>
   <Button type="submit">Submit</Button>
 </form>
@@ -225,10 +224,9 @@ Display errors next to the field using `<FieldError />`. For styling and accessi
 - Add the `data-invalid` prop to the `<Field />` component.
 - Add the `aria-invalid` prop to the form control such as `<Input />`, `<SelectTrigger />`, `<Checkbox />`, etc.
 
-```tsx showLineNumbers title="form.tsx" {4,18}
-<form.Field
-  name="email"
-  children={(field) => {
+```tsx showLineNumbers title="form.tsx" {3,17}
+<form.Field name="email">
+  {(field) => {
     const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid
 
     return (
@@ -247,7 +245,7 @@ Display errors next to the field using `<FieldError />`. For styling and accessi
       </Field>
     )
   }}
-/>
+</form.Field>
 ```
 
 ## Working with Different Field Types
@@ -263,10 +261,9 @@ Display errors next to the field using `<FieldError />`. For styling and accessi
   chromeLessOnMobile
 />
 
-```tsx showLineNumbers title="form.tsx" {6,11-14,22}
-<form.Field
-  name="username"
-  children={(field) => {
+```tsx showLineNumbers title="form.tsx" {5,10-13,21}
+<form.Field name="username">
+  {(field) => {
     const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid
     return (
       <Field data-invalid={isInvalid}>
@@ -289,7 +286,7 @@ Display errors next to the field using `<FieldError />`. For styling and accessi
       </Field>
     )
   }}
-/>
+</form.Field>
 ```
 
 ### Textarea
@@ -303,10 +300,9 @@ Display errors next to the field using `<FieldError />`. For styling and accessi
   chromeLessOnMobile
 />
 
-```tsx showLineNumbers title="form.tsx" {6,13-16,24}
-<form.Field
-  name="about"
-  children={(field) => {
+```tsx showLineNumbers title="form.tsx" {5,12-15,23}
+<form.Field name="about">
+  {(field) => {
     const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid
     return (
       <Field data-invalid={isInvalid}>
@@ -331,7 +327,7 @@ Display errors next to the field using `<FieldError />`. For styling and accessi
       </Field>
     )
   }}
-/>
+</form.Field>
 ```
 
 ### Select
@@ -345,10 +341,9 @@ Display errors next to the field using `<FieldError />`. For styling and accessi
   chromeLessOnMobile
 />
 
-```tsx showLineNumbers title="form.tsx" {6,18-19,23}
-<form.Field
-  name="language"
-  children={(field) => {
+```tsx showLineNumbers title="form.tsx" {5,17-18,22}
+<form.Field name="language">
+  {(field) => {
     const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid
     return (
       <Field orientation="responsive" data-invalid={isInvalid}>
@@ -381,7 +376,7 @@ Display errors next to the field using `<FieldError />`. For styling and accessi
       </Field>
     )
   }}
-/>
+</form.Field>
 ```
 
 ### Checkbox
@@ -397,11 +392,9 @@ Display errors next to the field using `<FieldError />`. For styling and accessi
   chromeLessOnMobile
 />
 
-```tsx showLineNumbers title="form.tsx" {12,17,22-24,44}
-<form.Field
-  name="tasks"
-  mode="array"
-  children={(field) => {
+```tsx showLineNumbers title="form.tsx" {10,15,20-22,42}
+<form.Field name="tasks" mode="array">
+  {(field) => {
     const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid
     return (
       <FieldSet>
@@ -445,7 +438,7 @@ Display errors next to the field using `<FieldError />`. For styling and accessi
       </FieldSet>
     )
   }}
-/>
+</form.Field>
 ```
 
 ### Radio Group
@@ -459,10 +452,9 @@ Display errors next to the field using `<FieldError />`. For styling and accessi
   chromeLessOnMobile
 />
 
-```tsx showLineNumbers title="form.tsx" {21,29,35}
-<form.Field
-  name="plan"
-  children={(field) => {
+```tsx showLineNumbers title="form.tsx" {20,28,34}
+<form.Field name="plan">
+  {(field) => {
     const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid
     return (
       <FieldSet>
@@ -498,7 +490,7 @@ Display errors next to the field using `<FieldError />`. For styling and accessi
       </FieldSet>
     )
   }}
-/>
+</form.Field>
 ```
 
 ### Switch
@@ -512,10 +504,9 @@ Display errors next to the field using `<FieldError />`. For styling and accessi
   chromeLessOnMobile
 />
 
-```tsx showLineNumbers title="form.tsx" {6,14,19-21}
-<form.Field
-  name="twoFactor"
-  children={(field) => {
+```tsx showLineNumbers title="form.tsx" {5,13,18-20}
+<form.Field name="twoFactor">
+  {(field) => {
     const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid
     return (
       <Field orientation="horizontal" data-invalid={isInvalid}>
@@ -538,7 +529,7 @@ Display errors next to the field using `<FieldError />`. For styling and accessi
       </Field>
     )
   }}
-/>
+</form.Field>
 ```
 
 ### Complex Forms
@@ -580,8 +571,8 @@ Use `mode="array"` on the parent field to enable array field management.
 ```tsx showLineNumbers title="form.tsx" {3,12-14}
 <form.Field
   name="emails"
-  mode="array"
-  children={(field) => {
+  mode="array">
+  {(field) => {
     return (
       <FieldSet>
         <FieldLegend variant="label">Email Addresses</FieldLegend>
@@ -596,7 +587,7 @@ Use `mode="array"` on the parent field to enable array field management.
       </FieldSet>
     )
   }}
-/>
+</form.Field>
 ```
 
 ### Nested Fields
@@ -604,9 +595,8 @@ Use `mode="array"` on the parent field to enable array field management.
 Access individual array items using bracket notation: `fieldName[index].propertyName`. This example uses `InputGroup` to display the remove button inline with the input.
 
 ```tsx showLineNumbers title="form.tsx"
-<form.Field
-  name={`emails[${index}].address`}
-  children={(subField) => {
+<form.Field name={`emails[${index}].address`}>
+  {(subField) => {
     const isSubFieldInvalid =
       subField.state.meta.isTouched && !subField.state.meta.isValid
     return (
@@ -644,7 +634,7 @@ Access individual array items using bracket notation: `fieldName[index].property
       </Field>
     )
   }}
-/>
+</form.Field>
 ```
 
 ### Adding Items

--- a/apps/v4/registry/new-york-v4/examples/form-tanstack-array.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-tanstack-array.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-children-prop */
 "use client"
 
 import * as React from "react"
@@ -95,10 +94,8 @@ export default function FormTanstackArray() {
                   </FieldDescription>
                   <FieldGroup className="gap-4">
                     {field.state.value.map((_, index) => (
-                      <form.Field
-                        key={index}
-                        name={`emails[${index}].address`}
-                        children={(subField) => {
+                      <form.Field key={index} name={`emails[${index}].address`}>
+                        {(subField) => {
                           const isSubFieldInvalid =
                             subField.state.meta.isTouched &&
                             !subField.state.meta.isValid
@@ -145,7 +142,7 @@ export default function FormTanstackArray() {
                             </Field>
                           )
                         }}
-                      />
+                      </form.Field>
                     ))}
                     <Button
                       type="button"

--- a/apps/v4/registry/new-york-v4/examples/form-tanstack-checkbox.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-tanstack-checkbox.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-children-prop */
 "use client"
 
 import { useForm } from "@tanstack/react-form"
@@ -92,9 +91,8 @@ export default function FormTanstackCheckbox() {
           }}
         >
           <FieldGroup>
-            <form.Field
-              name="responses"
-              children={(field) => {
+            <form.Field name="responses">
+              {(field) => {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
@@ -129,12 +127,10 @@ export default function FormTanstackCheckbox() {
                   </FieldSet>
                 )
               }}
-            />
+            </form.Field>
             <FieldSeparator />
-            <form.Field
-              name="tasks"
-              mode="array"
-              children={(field) => {
+            <form.Field name="tasks" mode="array">
+              {(field) => {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
@@ -181,7 +177,7 @@ export default function FormTanstackCheckbox() {
                   </FieldSet>
                 )
               }}
-            />
+            </form.Field>
           </FieldGroup>
         </form>
       </CardContent>

--- a/apps/v4/registry/new-york-v4/examples/form-tanstack-complex.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-tanstack-complex.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-children-prop */
 "use client"
 
 import * as React from "react"
@@ -119,9 +118,8 @@ export default function FormTanstackComplex() {
           }}
         >
           <FieldGroup>
-            <form.Field
-              name="plan"
-              children={(field) => {
+            <form.Field name="plan">
+              {(field) => {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
@@ -178,11 +176,10 @@ export default function FormTanstackComplex() {
                   </FieldSet>
                 )
               }}
-            />
+            </form.Field>
             <FieldSeparator />
-            <form.Field
-              name="billingPeriod"
-              children={(field) => {
+            <form.Field name="billingPeriod">
+              {(field) => {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
@@ -211,12 +208,10 @@ export default function FormTanstackComplex() {
                   </Field>
                 )
               }}
-            />
+            </form.Field>
             <FieldSeparator />
-            <form.Field
-              name="addons"
-              mode="array"
-              children={(field) => {
+            <form.Field name="addons" mode="array">
+              {(field) => {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
@@ -267,11 +262,10 @@ export default function FormTanstackComplex() {
                   </FieldSet>
                 )
               }}
-            />
+            </form.Field>
             <FieldSeparator />
-            <form.Field
-              name="emailNotifications"
-              children={(field) => {
+            <form.Field name="emailNotifications">
+              {(field) => {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
@@ -297,7 +291,7 @@ export default function FormTanstackComplex() {
                   </Field>
                 )
               }}
-            />
+            </form.Field>
           </FieldGroup>
         </form>
       </CardContent>

--- a/apps/v4/registry/new-york-v4/examples/form-tanstack-demo.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-tanstack-demo.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-children-prop */
 "use client"
 
 import * as React from "react"
@@ -85,9 +84,8 @@ export default function BugReportForm() {
           }}
         >
           <FieldGroup>
-            <form.Field
-              name="title"
-              children={(field) => {
+            <form.Field name="title">
+              {(field) => {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
@@ -109,10 +107,9 @@ export default function BugReportForm() {
                   </Field>
                 )
               }}
-            />
-            <form.Field
-              name="description"
-              children={(field) => {
+            </form.Field>
+            <form.Field name="description">
+              {(field) => {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
@@ -146,7 +143,7 @@ export default function BugReportForm() {
                   </Field>
                 )
               }}
-            />
+            </form.Field>
           </FieldGroup>
         </form>
       </CardContent>

--- a/apps/v4/registry/new-york-v4/examples/form-tanstack-input.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-tanstack-input.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-children-prop */
 "use client"
 
 import { useForm } from "@tanstack/react-form"
@@ -77,9 +76,8 @@ export default function FormTanstackInput() {
           }}
         >
           <FieldGroup>
-            <form.Field
-              name="username"
-              children={(field) => {
+            <form.Field name="username">
+              {(field) => {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
@@ -108,7 +106,7 @@ export default function FormTanstackInput() {
                   </Field>
                 )
               }}
-            />
+            </form.Field>
           </FieldGroup>
         </form>
       </CardContent>

--- a/apps/v4/registry/new-york-v4/examples/form-tanstack-radiogroup.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-tanstack-radiogroup.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-children-prop */
 "use client"
 
 import { useForm } from "@tanstack/react-form"
@@ -95,9 +94,8 @@ export default function FormTanstackRadioGroup() {
           }}
         >
           <FieldGroup>
-            <form.Field
-              name="plan"
-              children={(field) => {
+            <form.Field name="plan">
+              {(field) => {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
@@ -141,7 +139,7 @@ export default function FormTanstackRadioGroup() {
                   </FieldSet>
                 )
               }}
-            />
+            </form.Field>
           </FieldGroup>
         </form>
       </CardContent>

--- a/apps/v4/registry/new-york-v4/examples/form-tanstack-select.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-tanstack-select.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-children-prop */
 "use client"
 
 import { useForm } from "@tanstack/react-form"
@@ -94,9 +93,8 @@ export default function FormTanstackSelect() {
           }}
         >
           <FieldGroup>
-            <form.Field
-              name="language"
-              children={(field) => {
+            <form.Field name="language">
+              {(field) => {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
@@ -140,7 +138,7 @@ export default function FormTanstackSelect() {
                   </Field>
                 )
               }}
-            />
+            </form.Field>
           </FieldGroup>
         </form>
       </CardContent>

--- a/apps/v4/registry/new-york-v4/examples/form-tanstack-switch.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-tanstack-switch.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-children-prop */
 "use client"
 
 import { useForm } from "@tanstack/react-form"
@@ -73,9 +72,8 @@ export default function FormTanstackSwitch() {
           }}
         >
           <FieldGroup>
-            <form.Field
-              name="twoFactor"
-              children={(field) => {
+            <form.Field name="twoFactor">
+              {(field) => {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
@@ -102,7 +100,7 @@ export default function FormTanstackSwitch() {
                   </Field>
                 )
               }}
-            />
+            </form.Field>
           </FieldGroup>
         </form>
       </CardContent>

--- a/apps/v4/registry/new-york-v4/examples/form-tanstack-textarea.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-tanstack-textarea.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-children-prop */
 "use client"
 
 import { useForm } from "@tanstack/react-form"
@@ -73,9 +72,8 @@ export default function FormTanstackTextarea() {
           }}
         >
           <FieldGroup>
-            <form.Field
-              name="about"
-              children={(field) => {
+            <form.Field name="about">
+              {(field) => {
                 const isInvalid =
                   field.state.meta.isTouched && !field.state.meta.isValid
                 return (
@@ -103,7 +101,7 @@ export default function FormTanstackTextarea() {
                   </Field>
                 )
               }}
-            />
+            </form.Field>
           </FieldGroup>
         </form>
       </CardContent>


### PR DESCRIPTION
I've updated both tutorial and it's components to use actual children, instead of children prop which results in eslint errors (also removed eslint ignore comments).

Usage of children prop might be intentional, I'm not sure about that so if that was the case this PR can be just rejected. But since it's resulting eslint errors I wanted to both update tutorial and components so copy pasted code doesn't include these errors too.