### PR TITLE
fix(sidebar): add missing --sidebar-width to prevent class name rewrite (#8897)

### DIFF
--- a/templates/monorepo-next/packages/ui/src/styles/globals.css
+++ b/templates/monorepo-next/packages/ui/src/styles/globals.css
@@ -41,6 +41,9 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+
+  /* ✅ FIX ADDED */
+  --sidebar-width: 240px;
 }
 
 .dark {


### PR DESCRIPTION
This PR fixes the issue described in #8897 where Tailwind rewrites 
`w-(--sidebar-width)` to `w-[--sidebar-width]` causing sidebar width 
styles to break.

Root cause:
- The CSS variable `--sidebar-width` was not defined in globals.css.
- Tailwind sanitizes undefined bracket notation and rewrites it incorrectly.

Fix:
- Added the missing CSS variable to templates/monorepo-next/packages/ui/src/styles/globals.css

```css
--sidebar-width: 240px;
