### PR TITLE
feat: add viewportRef to ScrollArea for virtualization support

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/scroll-area.tsx
+++ b/apps/v4/registry/new-york-v4/ui/scroll-area.tsx
@@ -8,8 +8,11 @@ import { cn } from "@/lib/utils"
 function ScrollArea({
   className,
   children,
+  viewportRef,
   ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root> & {
+  viewportRef?: React.RefObject<HTMLDivElement | null>
+}) {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
@@ -17,6 +20,7 @@ function ScrollArea({
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
+        ref={viewportRef}
         data-slot="scroll-area-viewport"
         className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
       >


### PR DESCRIPTION
### Summary

Adds an optional `viewportRef` prop to `ScrollArea` to allow direct access to the underlying Radix `Viewport` element. This enables seamless integration with list virtualization libraries (e.g. TanStack Virtual) that require a direct reference to the scroll container.

### Impact

- ✅ No breaking changes
- ✅ Improved compatibility with virtualization libraries
- ✅ Backwards compatible
