### PR TITLE
fix：Combobox input doesn't autofocus inside a dropdown menu #8942

### DIFF
--- a/apps/v4/registry/new-york-v4/examples/combobox-dropdown-menu.tsx
+++ b/apps/v4/registry/new-york-v4/examples/combobox-dropdown-menu.tsx
@@ -68,6 +68,9 @@ export default function ComboboxDropdownMenu() {
                     placeholder="Filter label..."
                     autoFocus={true}
                     className="h-9"
+                    ref={(input) => {
+                      if (input) setTimeout(() => input.focus(), 10)
+                    }}
                   />
                   <CommandList>
                     <CommandEmpty>No label found.</CommandEmpty>


### PR DESCRIPTION
Added a ref callback to the CommandInput and used a small setTimeout delay to call input.focus().

This ensures that the input is focused after the submenu fully opens, avoiding conflicts with Radix's focus management.

Preserves the official shadcn component structure and behavior.