### PR TITLE
fix(combobox): ensure CommandInput autofocus works inside DropdownMenu

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/command.tsx
+++ b/apps/v4/registry/new-york-v4/ui/command.tsx
@@ -64,6 +64,16 @@ function CommandInput({
   className,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  const inputRef = React.useRef<HTMLInputElement>(null)
+
+  React.useEffect(() => {
+    if (props.autoFocus && inputRef.current) {
+      requestAnimationFrame(() => {
+        inputRef.current?.focus()
+      })
+    }
+  }, [props.autoFocus])
+
   return (
     <div
       data-slot="command-input-wrapper"
@@ -71,6 +81,7 @@ function CommandInput({
     >
       <SearchIcon className="size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
+        ref={inputRef}
         data-slot="command-input"
         className={cn(
           "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",


### PR DESCRIPTION
Fixes: https://github.com/shadcn-ui/ui/issues/8942

This PR fixes an issue where a Combobox rendered inside a DropdownMenu fails to autofocus its CommandInput.
The root cause is Radix's focus trapping behavior, which prevents the internal input from receiving focus during the opening transition.

## What’s fixed

When autoFocus is enabled, the CommandInput now reliably receives focus even when nested inside a DropdownMenu.

## How it works

Added a `requestAnimationFrame` wrapper around the focus call to delay it until after Radix has finished its focus-trap initialization.

Focus is applied only when autoFocus is truthy.

##  Change
```
const inputRef = React.useRef<HTMLInputElement>(null)

React.useEffect(() => {
  if (props.autoFocus && inputRef.current) {
    requestAnimationFrame(() => {
      inputRef.current?.focus()
    })
  }
}, [props.autoFocus])
```

## Actual behavior

CommandInput does not receive focus when Combobox is placed inside a DropdownMenu.

## Expected behavior

CommandInput should automatically receive focus when autoFocus is enabled, regardless of DropdownMenu context.

## Notes

- No breaking changes.

- Behavior outside DropdownMenu remains the same.