### PR TITLE
feat(button): add subtle active pressed state (scale + brightness)

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/button.tsx
+++ b/apps/v4/registry/new-york-v4/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive active:scale-[0.98] active:brightness-95 motion-reduce:active:scale-100",
   {
     variants: {
       variant: {


### PR DESCRIPTION
**Summary**  
Adds a subtle `:active` (pressed) state to the shared `Button` component to improve click/tap feedback. The effect is a slight scale down (`0.98`) plus a tiny brightness reduction. Reduced-motion users are respected.

**Why**  
Improves perceived responsiveness, especially on mobile/touch devices, and aligns the component with common UX patterns.

**Implementation**  
- Added `active:scale-[0.98] active:brightness-95 motion-reduce:active:scale-100` to the button base class in `Button` component.

**Testing checklist**
- [ ] Click a primary button on desktop: see slight scale-down + darker look while mouse is pressed.
- [ ] Tap a button on mobile: tactile visual feedback appears (scale + brightness).
- [ ] Verify hover styles remain unchanged.
- [ ] Verify disabled buttons show no active feedback.
- [ ] Turn on OS `Reduce Motion` and verify there is no scale animation.
- [ ] Keyboard focus via Tab still shows the correct focus-visible ring.
- [ ] Visual regression / Storybook checks if applicable.

**Notes**  
If maintainers prefer variant-specific styling instead of a global default, I can adjust in a follow-up.
