### PR TITLE
fix: make spacing in update-css-vars.ts consistent

### DIFF
--- a/packages/shadcn/src/utils/updaters/update-css-vars.ts
+++ b/packages/shadcn/src/utils/updaters/update-css-vars.ts
@@ -558,6 +558,7 @@ function updateThemePlugin(cssVars: z.infer<typeof registryItemCssVarsSchema>) {
           isLocalHSLValue(value) || isColorValue(value)
             ? `--color-${variable.replace(/^--/, "")}`
             : `--${variable.replace(/^--/, "")}`
+            
         if (prop === "--color-sidebar-background") {
           prop = "--color-sidebar"
         }
@@ -576,6 +577,7 @@ function updateThemePlugin(cssVars: z.infer<typeof registryItemCssVarsSchema>) {
           (node): node is postcss.Declaration =>
             node.type === "decl" && node.prop === cssVarNode.prop
         )
+
         if (!existingDecl) {
           if (themeVarNodes?.length) {
             themeNode?.insertAfter(
@@ -839,6 +841,7 @@ function updateTailwindConfigAnimationPlugin(
       const parsedAnimationValue = z
         .record(z.string(), z.string())
         .safeParse(tailwindConfig.theme.extend.animation)
+        
       if (!parsedAnimationValue.success) {
         return
       }


### PR DESCRIPTION
PR Description:

This PR fixes the following issue: https://github.com/shadcn-ui/ui/issues/8809

I added blank lines after variable declarations before if statements to match the existing pattern in update-css-vars.ts