### PR TITLE
Fix(sidebar): /issue 8975 sidebar lg collapse

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -485,7 +485,7 @@ const sidebarMenuButtonVariants = cva(
       size: {
         default: "h-8 text-sm",
         sm: "h-7 text-xs",
-        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:size-8!",
       },
     },
     defaultVariants: {
@@ -569,7 +569,7 @@ function SidebarMenuAction({
         "peer-data-[size=lg]/menu-button:top-2.5",
         "group-data-[collapsible=icon]:hidden",
         showOnHover &&
-          "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
+        "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
         className
       )}
       {...props}


### PR DESCRIPTION
## Description

Fixes #8975 

This PR fixes the issue where `SidebarMenuButton` with `size="lg"` doesn't properly collapse to icon-only mode when the sidebar is in `collapsible="icon"` state.

## Changes

- Added `group-data-[collapsible=icon]:size-8!` to the `lg` size variant in `sidebarMenuButtonVariants`
- Removed `group-data-[collapsible=icon]:p-0!`
- This ensures lg buttons collapse to 32x32px (matching default and sm sizes)

## Before

When sidebar was collapsed, `size="lg"` buttons retained their 48px height and text remained visible.

<img width="95" height="507" alt="image" src="https://github.com/user-attachments/assets/e8f74fb9-5280-43c3-b64f-58844ac6090d" />

## After

`size="lg"` buttons now properly collapse to 32x32px icon-only mode, with text hidden and tooltip displayed on hover.

<img width="67" height="327" alt="image" src="https://github.com/user-attachments/assets/b3699249-dceb-49f4-9b58-c26b9b414761" />

## Testing

- [x] Tested with `size="lg"` buttons in collapsed sidebar
- [x] Verified tooltip appears on hover when collapsed
- [x] Confirmed expand/collapse transitions work smoothly
- [x] Checked that default and sm sizes still work correctly