### PR TITLE
fix(chartCopyButton) : tooltip arrow visibility in dark mode for chart copy button

### DIFF
--- a/apps/v4/components/chart-copy-button.tsx
+++ b/apps/v4/components/chart-copy-button.tsx
@@ -57,7 +57,7 @@ export function ChartCopyButton({
           {hasCopied ? <IconCheck /> : <IconCopy />}
         </Button>
       </TooltipTrigger>
-      <TooltipContent className="bg-black text-white">Copy code</TooltipContent>
+      <TooltipContent>Copy code</TooltipContent>
     </Tooltip>
   )
 }


### PR DESCRIPTION
## Description

Fixes the tooltip arrow color mismatch in dark mode for the chart copy button.

## Problem

The `ChartCopyButton` component was using hardcoded colors (`bg-black text-white`) for the tooltip, which caused the tooltip arrow to not display correctly in dark mode. The arrow uses theme-aware colors (`bg-foreground`), but the content was hardcoded to black, creating a visual mismatch.

## Solution

Removed the hardcoded `className="bg-black text-white"` from `TooltipContent` to allow it to use the default theme-aware styling. Now both the tooltip content and arrow use consistent colors that adapt to the current theme.

### Before
- Light mode: Works (black tooltip + black arrow)
- Dark mode: Broken (black tooltip + white arrow - invisible/mismatched)
- 
<img width="535" height="385" alt="image" src="https://github.com/user-attachments/assets/cee5d575-069e-4461-a176-80ff7b4fd474" />

### After
- Light mode: Works (dark tooltip + dark arrow)
- Dark mode: Works (light tooltip + light arrow)

<img width="568" height="397" alt="image" src="https://github.com/user-attachments/assets/c6d86e24-91dd-4652-8515-85b7ac6cd104" />

## Related Issue

Closes #8988

## Checklist

- [x] I've made research efforts and searched the documentation
- [x] I've searched for existing issues
- [x] The code follows the project's style guidelines
- [x] I have tested this in both light and dark mode