### PR TITLE
fix(button): add aria-invalid border for all variants

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/button.tsx
+++ b/apps/v4/registry/new-york-v4/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/templates/monorepo-next/packages/ui/src/components/button.tsx
+++ b/templates/monorepo-next/packages/ui/src/components/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@workspace/ui/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border aria-invalid:border-destructive",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- Add `aria-invalid:border` to Button component base styles
- Enables visible aria-invalid feedback for all button variants

Fixes #8920

## Description
The Button component had `aria-invalid:border-destructive` in its base classes, but this only worked for the `outline` variant which already has a `border` class. Other variants (default, secondary, ghost, destructive, link) showed no visual feedback when `aria-invalid` was set.

**Before:** Only outline variant showed red border on aria-invalid
**After:** All variants show red border on aria-invalid

## Changes
Added `aria-invalid:border` before `aria-invalid:border-destructive` in:
- `apps/v4/registry/new-york-v4/ui/button.tsx`
- `templates/monorepo-next/packages/ui/src/components/button.tsx`

## Testing
Tested all button variants with `aria-invalid` attribute:
- ✅ default - now shows red border
- ✅ secondary - now shows red border  
- ✅ ghost - now shows red border
- ✅ destructive - now shows red border
- ✅ outline - still works as before
- ✅ link - now shows red border