### PR TITLE
fix: upgrade Next.js to 15.4.8 (CVE-2025-55182)

### DIFF
--- a/templates/monorepo-next/apps/web/package.json
+++ b/templates/monorepo-next/apps/web/package.json
@@ -13,7 +13,7 @@
     "@workspace/ui": "workspace:*",
     "lucide-react": "0.456.0",
     "next-themes": "^0.4.3",
-    "next": "^15.1.0",
+    "next": "15.1.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
This upgrade fixes CVE-2025-55182, a React Server Components RCE vulnerability.