### PR TITLE
fix(cli): respect rsc: false and avoid adding 'use client' directive

### DIFF
--- a/packages/shadcn/src/utils/transformers/transform-rsc.ts
+++ b/packages/shadcn/src/utils/transformers/transform-rsc.ts
@@ -1,8 +1,6 @@
 import { Transformer } from "@/src/utils/transformers"
 import { SyntaxKind } from "ts-morph"
 
-const directiveRegex = /^["']use client["']$/g
-
 export const transformRsc: Transformer = async ({ sourceFile, config }) => {
   if (config.rsc) {
     return sourceFile
@@ -10,8 +8,11 @@ export const transformRsc: Transformer = async ({ sourceFile, config }) => {
 
   // Remove "use client" from the top of the file.
   const first = sourceFile.getFirstChildByKind(SyntaxKind.ExpressionStatement)
-  if (first && directiveRegex.test(first.getText())) {
-    first.remove()
+  if (first) {
+    const text = first.getText().trim()
+    if (text === '"use client"' || text === "'use client'") {
+      first.remove()
+    }
   }
 
   return sourceFile

--- a/packages/shadcn/test/utils/transform-rsc.test.ts
+++ b/packages/shadcn/test/utils/transform-rsc.test.ts
@@ -111,3 +111,73 @@ import { Foo } from 'bar'
     })
   ).toMatchSnapshot()
 })
+
+test("transform rsc - sequential calls (regression test for #8991)", async () => {
+  // Regression test to verify that the stateful regex bug in transformRsc is fixed.
+  // This test specifically checks that the "use client" directive is removed
+  // consistently across multiple sequential transformations.
+  //
+  // The original bug: Using /^["']use client["']$/g with .test() created a
+  // stateful regex that alternated between true/false on successive calls,
+  // causing the directive to be inconsistently removed when rsc: false.
+
+  const rscFalseConfig = {
+    tsx: true,
+    rsc: false,
+  }
+
+  const inputWithDoubleQuotes = `"use client"
+
+import * as React from "react"
+import { Foo } from "bar"`
+
+  // Test 1: First transformation
+  const result1 = await transform({
+    filename: "test1.ts",
+    raw: inputWithDoubleQuotes,
+    config: rscFalseConfig,
+  })
+  expect(result1).not.toContain('"use client"')
+  expect(result1).toContain('import * as React from "react"')
+
+  // Test 2: Second transformation
+  // Before the fix, this would FAIL because the regex state would alternate
+  const result2 = await transform({
+    filename: "test2.ts",
+    raw: inputWithDoubleQuotes,
+    config: rscFalseConfig,
+  })
+  expect(result2).not.toContain('"use client"')
+  expect(result2).toContain('import * as React from "react"')
+
+  // Test 3: Third transformation for additional confidence
+  const result3 = await transform({
+    filename: "test3.ts",
+    raw: inputWithDoubleQuotes,
+    config: rscFalseConfig,
+  })
+  expect(result3).not.toContain('"use client"')
+  expect(result3).toContain('import * as React from "react"')
+
+  // Test 4: Single quotes variant
+  const inputWithSingleQuotes = `'use client'
+
+import * as React from "react"
+import { Foo } from "bar"`
+
+  const result4 = await transform({
+    filename: "test4.ts",
+    raw: inputWithSingleQuotes,
+    config: rscFalseConfig,
+  })
+  expect(result4).not.toContain("'use client'")
+  expect(result4).toContain('import * as React from "react"')
+
+  // Test 5: Mixed quotes - another sequential call
+  const result5 = await transform({
+    filename: "test5.ts",
+    raw: inputWithDoubleQuotes,
+    config: rscFalseConfig,
+  })
+  expect(result5).not.toContain('"use client"')
+})


### PR DESCRIPTION
## Fix: Remove Stateful Regex Bug in `transform-rsc` (Fixes #8991)

### Problem
The `transformRsc` function uses a global regex with `.test()` method, which maintains state in the regex's `lastIndex` property. This causes the directive removal to **alternate between working and not working** on successive component installations.

**Symptom:** When `rsc: false` is configured, components are installed inconsistently:
- Component 1: ✓ "use client" removed correctly
- Component 2: ✗ "use client" NOT removed (BUG)
- Component 3: ✓ "use client" removed correctly
- Component 4: ✗ "use client" NOT removed (BUG)
- Pattern: ✓ ✗ ✓ ✗ ✓ ✗ (alternating)

### Root Cause
```typescript
// BEFORE (Broken)
const directiveRegex = /^["']use client["']$/g  // Global flag + .test() = stateful!

if (first && directiveRegex.test(first.getText())) {  // State maintained in lastIndex
  first.remove()
}
```

On first call: `.test()` returns `true`, advances `lastIndex` to end
On second call: `lastIndex` is at end, `.test()` returns `false` (resets to 0 internally after match failure)
On third call: `lastIndex` is 0 again, `.test()` returns `true`
→ Alternating behavior

### Solution
Replace the stateful regex with simple string comparison:

```typescript
// AFTER (Fixed)
const text = first.getText().trim()
if (text === '"use client"' || text === "'use client'") {
  first.remove()
}
```

**Advantages:**
- No state management
- No regex parsing overhead
- Handles both quote styles
- Clearer intent and more maintainable

### Changes Made
**File: `packages/shadcn/src/utils/transformers/transform-rsc.ts`**
- Removed: `const directiveRegex = /^["']use client["']$/g`
- Changed: Condition from regex test to string comparison
- Added: `.trim()` for whitespace handling
- Result: 6 lines modified

**File: `packages/shadcn/test/utils/transform-rsc.test.ts`**
- Added: Comprehensive regression test "transform rsc - sequential calls (regression test for #8991)"
- Coverage: 5 sequential transformations with both quote styles
- Purpose: Prevents future regressions of stateful regex patterns

### Testing
✅ **Targeted test pass:**
```
pnpm --filter shadcn test -- test/utils/transform-rsc.test.ts
✓ test/utils/transform-rsc.test.ts (2 tests)
  ✓ transform rsc
  ✓ transform rsc - sequential calls (regression test for #8991)
```

✅ **Build success:**
```
pnpm --filter shadcn build
→ No TypeScript errors
→ dist/ artifacts generated successfully
```

### Impact Analysis
- **Breaking Changes:** None (API unchanged, only fixes broken behavior)
- **Backward Compatibility:** ✓ Full (only fixes when `rsc: false` is used)
- **Side Effects:** None (isolated to transform-rsc.ts; no other files affected)
- **Dependencies:** No new dependencies added
- **Guidelines Compliance:** Follows shadcn conventions (minimal, focused change)

### Before & After
**Before (Broken):**
```
npx shadcn add accordion   → ✓ OK (no "use client")
npx shadcn add alert       → ✗ BROKEN (includes "use client" when it shouldn't)
npx shadcn add button      → ✓ OK (no "use client")
npx shadcn add card        → ✗ BROKEN (includes "use client" when it shouldn't)
```

**After (Fixed):**
```
npx shadcn add accordion   → ✓ OK (no "use client")
npx shadcn add alert       → ✓ OK (no "use client")
npx shadcn add button      → ✓ OK (no "use client")
npx shadcn add card        → ✓ OK (no "use client")
```

### Related Issue
Fixes #8991: "CLI ignores `rsc: false` setting and adds `"use client"` directive"

### Checklist
- [] Code follows project style guidelines
- [] TypeScript compiles without errors
- [] Tests added for regression prevention
- [] Existing tests still pass
- [] No new dependencies added
- [] Changes are minimal and focused
- [] Documentation updated (comments explain the fix)
- [] Backward compatible
