### PR TITLE
fix(ExampleNav) : prevent focus ring clipping in ScrollArea navigation

### DIFF
--- a/apps/v4/components/examples-nav.tsx
+++ b/apps/v4/components/examples-nav.tsx
@@ -41,8 +41,8 @@ export function ExamplesNav({
 
   return (
     <div className={cn("flex items-center", className)} {...props}>
-      <ScrollArea className="max-w-[96%] md:max-w-[600px] lg:max-w-none">
-        <div className="flex items-center">
+      <ScrollArea className="max-w-[96%] md:max-w-[600px] lg:w-full">
+        <div className="flex items-center p-2">
           <ExampleLink
             example={{ name: "Examples", href: "/", code: "", hidden: false }}
             isActive={pathname === "/"}
@@ -72,11 +72,12 @@ function ExampleLink({
     return null
   }
 
+  // TODO: use focus-visible:ring-inset which makes the ring render inside the border box instead of outside.
   return (
     <Link
       href={example.href}
       key={example.href}
-      className="text-muted-foreground hover:text-primary data-[active=true]:text-primary flex h-7 items-center justify-center px-4 text-center text-base font-medium transition-colors"
+      className="text-muted-foreground hover:text-primary data-[active=true]:text-primary flex h-7 items-center justify-center px-4 text-center text-base font-medium transition-colors outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive rounded-md"
       data-active={isActive}
     >
       {example.name}


### PR DESCRIPTION
## Description
Fixes the incomplete focus ring issue when navigating with the Tab key through ScrollArea components.

Closes #9003

## Problem
When using keyboard navigation (Tab key) through links inside a ScrollArea component, the focus rings were being clipped and incomplete.

## Solution
Instead of modifying the ScrollArea component itself, the fix adds padding to the content container within the ScrollArea. This gives the focus rings adequate space to render without being clipped by the viewport's overflow.

### Changes
- **ExamplesNav component**: Added `p-2` padding to the inner flex container wrapping the navigation links
- **ExampleLink component**: Added comprehensive focus-visible styles including:
  - `focus-visible:ring-[3px]` for 3px focus ring
  - `focus-visible:ring-ring/50` for ring color with opacity
  - `focus-visible:border-ring` for border color
  - `rounded-md` for rounded corners
  - Proper aria-invalid states for accessibility
- **Responsive adjustment**: Changed `lg:max-w-none` to `lg:w-full` for better width handling

## Testing
- [x] Tested keyboard navigation (Tab/Shift+Tab) through all navigation links
- [x] Verified focus ring is fully visible and not clipped
- [x] Checked responsive behavior on mobile, tablet, and desktop
- [x] Verified scrolling still works correctly

## Screenshots
Before:
<img width="770" height="118" alt="image" src="https://github.com/user-attachments/assets/342831c0-9e9f-4a14-a804-5b34be5f5337" />
<img width="673" height="81" alt="image" src="https://github.com/user-attachments/assets/4ce970c6-9a9a-4682-8d33-41c2d50b3e91" />

After:
<img width="720" height="80" alt="image" src="https://github.com/user-attachments/assets/113508dd-a2c7-45ee-a416-f29169fee5b3" />
<img width="717" height="92" alt="image" src="https://github.com/user-attachments/assets/846ce7aa-52eb-441e-9a3a-d10e0fbab8f8" />
