### PR TITLE
docs(drawer & dialog): add responsive dialog example & media query hook

### DIFF
--- a/apps/v4/content/docs/components/dialog.mdx
+++ b/apps/v4/content/docs/components/dialog.mdx
@@ -85,6 +85,36 @@ import {
 
 <ComponentPreview name="dialog-close-button" />
 
+### Responsive Dialog
+
+You can combine the `Dialog` and `Drawer` components to create a responsive dialog. This renders a `Dialog` component on desktop and a `Drawer` on mobile.
+
+<ComponentPreview name="drawer-dialog" />
+
+#### Sample Media Query Hook
+
+```tsx showLineNumbers title="hooks/use-media-query.tsx"
+import * as React from "react"
+
+export function useMediaQuery(query: string) {
+  const [value, setValue] = React.useState(false)
+
+  React.useEffect(() => {
+    function onChange(event: MediaQueryListEvent) {
+      setValue(event.matches)
+    }
+
+    const result = matchMedia(query)
+    result.addEventListener("change", onChange)
+    setValue(result.matches)
+
+    return () => result.removeEventListener("change", onChange)
+  }, [query])
+
+  return value
+}
+```
+
 ## Notes
 
 To use the `Dialog` component from within a `Context Menu` or `Dropdown Menu`, you must encase the `Context Menu` or

--- a/apps/v4/content/docs/components/drawer.mdx
+++ b/apps/v4/content/docs/components/drawer.mdx
@@ -90,3 +90,27 @@ import {
 You can combine the `Dialog` and `Drawer` components to create a responsive dialog. This renders a `Dialog` component on desktop and a `Drawer` on mobile.
 
 <ComponentPreview name="drawer-dialog" />
+
+#### Sample Media Query Hook
+
+```tsx showLineNumbers title="hooks/use-media-query.tsx"
+import * as React from "react"
+
+export function useMediaQuery(query: string) {
+  const [value, setValue] = React.useState(false)
+
+  React.useEffect(() => {
+    function onChange(event: MediaQueryListEvent) {
+      setValue(event.matches)
+    }
+
+    const result = matchMedia(query)
+    result.addEventListener("change", onChange)
+    setValue(result.matches)
+
+    return () => result.removeEventListener("change", onChange)
+  }, [query])
+
+  return value
+}
+```


### PR DESCRIPTION
Added to docs:

- Drawer - sample media query (which is referenced in the responsive dialog example)
- Dialog - added the same responsive dialog sample that's in the drawer doc

Makes it easier to use the responsive dialog example. Users won't need to go look for the media query hook.
