### PR TITLE
feat(command): expose shouldFilter and filter props in CommandDialog

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/command.tsx
+++ b/apps/v4/registry/new-york-v4/ui/command.tsx
@@ -35,13 +35,19 @@ function CommandDialog({
   children,
   className,
   showCloseButton = true,
+  shouldFilter,
+  filter,
   ...props
-}: React.ComponentProps<typeof Dialog> & {
-  title?: string
-  description?: string
-  className?: string
-  showCloseButton?: boolean
-}) {
+}: React.ComponentProps<typeof Dialog> &
+  Pick<
+    React.ComponentProps<typeof CommandPrimitive>,
+    "shouldFilter" | "filter"
+  > & {
+    title?: string
+    description?: string
+    className?: string
+    showCloseButton?: boolean
+  }) {
   return (
     <Dialog {...props}>
       <DialogHeader className="sr-only">
@@ -52,7 +58,11 @@ function CommandDialog({
         className={cn("overflow-hidden p-0", className)}
         showCloseButton={showCloseButton}
       >
-        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command
+          className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+          shouldFilter={shouldFilter}
+          filter={filter}
+        >
           {children}
         </Command>
       </DialogContent>


### PR DESCRIPTION
Add support for shouldFilter and filter props in CommandDialog

Currently, CommandDialog doesn't expose the shouldFilter parameter from CommandPrimitive, which prevents manual control over the filtering behavior. This PR adds support for both shouldFilter and filter props, allowing users to disable default filtering or implement custom filtering logic.

Example usage:
```
<CommandDialog shouldFilter={false}>
  {/* content */}
</CommandDialog>
```