### PR TITLE
fix(components): resolve noArrayIndexKey lint error in FieldError

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/field.tsx
+++ b/apps/v4/registry/new-york-v4/ui/field.tsx
@@ -211,8 +211,8 @@ function FieldError({
     return (
       <ul className="ml-4 flex list-disc flex-col gap-1">
         {uniqueErrors.map(
-          (error, index) =>
-            error?.message && <li key={index}>{error.message}</li>
+          (error) =>
+            error?.message && <li key={error.message}>{error.message}</li>
         )}
       </ul>
     )


### PR DESCRIPTION
This PR fixes the following linter error in components/ui/field.tsx: lint/suspicious/noArrayIndexKey

Change:

- Replaced the array index with `error.message` as the key prop in the FieldError component.