### PR TITLE
fix(/colors): color copy not working due to nuqs adapter

### DIFF
--- a/apps/v4/app/layout.tsx
+++ b/apps/v4/app/layout.tsx
@@ -91,9 +91,11 @@ export default function RootLayout({
         <ThemeProvider>
           <LayoutProvider>
             <ActiveThemeProvider>
-              <NuqsAdapter>{children}</NuqsAdapter>
+              <NuqsAdapter>
+                {children}
+                <Toaster position="top-center" />
+              </NuqsAdapter>
               <TailwindIndicator />
-              <Toaster position="top-center" />
               <Analytics />
             </ActiveThemeProvider>
           </LayoutProvider>


### PR DESCRIPTION
## Problem

Copying a color on the `/colors` page throws a runtime error:

```
[nuqs] nuqs requires an adapter to work with your framework.
```

## Cause

The `Toaster` component was rendered **outside** the `NuqsAdapter` in the root layout. However, `Toaster` uses `IconPlaceholder`, which calls `useDesignSystemParam` → `useQueryStates` (nuqs hook). When a toast is triggered, it fails because it's not within the nuqs context.

## Solution

Move the `Toaster` component inside the `NuqsAdapter`.