### PR TITLE
fix: add missing options to schema.json

### DIFF
--- a/apps/v4/public/schema.json
+++ b/apps/v4/public/schema.json
@@ -57,6 +57,14 @@
       },
       "required": ["utils", "components"]
     },
+    "menuColor": {
+      "type": "string",
+      "enum": ["default", "inverted"]
+    },
+    "menuAccent": {
+      "type": "string",
+      "enum": ["subtle", "bold"]
+    },
     "registries": {
       "type": "object",
       "patternProperties": {


### PR DESCRIPTION
The schema at ui.shadcn.com/schema.json is missing new options used by ui.shadcn.com/create.

This causes JSON schema validation errors on components.json file generated by the CLI.

This PR updates the schema.json to include new options used by ui.shadcn.com/create.