### PR TITLE
fix(sidebar): correct active state handling for menu buttons

### DIFF
--- a/apps/v4/registry/bases/radix/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/radix/ui/sidebar.tsx
@@ -514,7 +514,7 @@ function SidebarMenuButton({
       data-slot="sidebar-menu-button"
       data-sidebar="menu-button"
       data-size={size}
-      data-active={isActive}
+      {...(isActive && { "data-active": true })}
       className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
       {...props}
     />
@@ -667,7 +667,7 @@ function SidebarMenuSubButton({
       data-slot="sidebar-menu-sub-button"
       data-sidebar="menu-sub-button"
       data-size={size}
-      data-active={isActive}
+      {...(isActive && { "data-active": true })}
       className={cn(
         "cn-sidebar-menu-sub-button flex min-w-0 -translate-x-px items-center overflow-hidden outline-hidden group-data-[collapsible=icon]:hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:shrink-0",
         className


### PR DESCRIPTION
Sidebar buttons were always rendered as active because the `data-active` attribute was set with a boolean value.

Tailwind attribute selectors check for the presence of an attribute, not its value, so `data-active="false"` still matched active styles.

This PR fixes the issue by only applying the `data-active` attribute when the item is actually active.