### PR TITLE
fix(lint): resolve @typescript-eslint/no-unused-vars warns in combobox and scroll-area

### DIFF
--- a/apps/v4/registry/bases/base/ui/combobox.tsx
+++ b/apps/v4/registry/bases/base/ui/combobox.tsx
@@ -277,7 +277,6 @@ function ComboboxChip({
 
 function ComboboxChipsInput({
   className,
-  children,
   ...props
 }: ComboboxPrimitive.Input.Props) {
   return (

--- a/apps/v4/registry/bases/base/ui/scroll-area.tsx
+++ b/apps/v4/registry/bases/base/ui/scroll-area.tsx
@@ -38,7 +38,7 @@ function ScrollBar({
       data-slot="scroll-area-scrollbar"
       data-orientation={orientation}
       orientation={orientation}
-      className="cn-scroll-area-scrollbar flex touch-none p-px transition-colors select-none"
+      className={cn("cn-scroll-area-scrollbar flex touch-none p-px transition-colors select-none", className)}
       {...props}
     >
       <ScrollAreaPrimitive.Thumb

--- a/apps/v4/registry/bases/radix/ui/combobox.tsx
+++ b/apps/v4/registry/bases/radix/ui/combobox.tsx
@@ -279,7 +279,6 @@ function ComboboxChip({
 
 function ComboboxChipsInput({
   className,
-  children,
   ...props
 }: ComboboxPrimitive.Input.Props) {
   return (

--- a/apps/v4/registry/bases/radix/ui/scroll-area.tsx
+++ b/apps/v4/registry/bases/radix/ui/scroll-area.tsx
@@ -38,7 +38,7 @@ function ScrollBar({
       data-slot="scroll-area-scrollbar"
       data-orientation={orientation}
       orientation={orientation}
-      className="cn-scroll-area-scrollbar flex touch-none p-px transition-colors select-none"
+      className={cn("cn-scroll-area-scrollbar flex touch-none p-px transition-colors select-none", className)}
       {...props}
     >
       <ScrollAreaPrimitive.ScrollAreaThumb


### PR DESCRIPTION
This PR fixes `@typescript-eslint/no-unused-vars` lint errors in combobox and scroll-area components.

### Changes
- Removes unused `children` prop from `ComboboxChipsInput`
- Properly applies the `className` prop in `ScrollBar` component using `cn`
