### PR TITLE
chore(shadcn): fix missing type declaration for babel transform

### DIFF
--- a/packages/shadcn/src/types.d.ts
+++ b/packages/shadcn/src/types.d.ts
@@ -1,0 +1,3 @@
+declare module "@babel/plugin-transform-typescript" {
+    export default function transformTypescript(): any
+}

--- a/packages/shadcn/src/utils/transformers/transform-jsx.ts
+++ b/packages/shadcn/src/utils/transformers/transform-jsx.ts
@@ -1,7 +1,6 @@
 import { type Transformer } from "@/src/utils/transformers"
 import { transformFromAstSync } from "@babel/core"
 import { ParserOptions, parse } from "@babel/parser"
-// @ts-ignore
 import transformTypescript from "@babel/plugin-transform-typescript"
 import * as recast from "recast"
 


### PR DESCRIPTION
This PR adds a missing type declaration for `@babel/plugin-transform-typescript` in `packages/shadcn/src/types.d.ts`, allowing the removal of a `// @ts-ignore` suppression in `packages/shadcn/src/utils/transformers/transform-jsx.ts`. This improves type safety and removes explicit error suppression.