### PR TITLE
fix(select): prevent popup jumping when scrolling large lists

### DIFF
--- a/apps/v4/registry/bases/base/ui/select.tsx
+++ b/apps/v4/registry/bases/base/ui/select.tsx
@@ -88,7 +88,7 @@ function SelectContent({
         <SelectPrimitive.Popup
           data-slot="select-content"
           className={cn(
-            "cn-select-content cn-menu-target relative isolate z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto",
+            "cn-select-content cn-menu-target relative isolate z-50  w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto",
             className
           )}
           {...props}


### PR DESCRIPTION
## Fix Base UI Select popup jumping on scroll

Closes #9108

### Problem
When using the Base UI `Select` with large option lists, scrolling inside the popup caused the content to visually jump/move. This happened consistently when the popup height was constrained.

### Root cause
The issue was caused by using a dynamic height (`max-h-(--available-height)`) on the Select popup.  
Base UI recalculates `--available-height` while scrolling, which triggers continuous repositioning of the popup via the Positioner.

### Solution
Removed the dynamic max-height from the Select popup to prevent layout recalculation during scroll.  
This stabilizes the popup position and eliminates the jumping behavior for large lists.

### Notes
- This appears to be a Base UI positioning behavior rather than a consumer misuse.
- Removing the height constraint avoids the feedback loop between scroll, layout, and repositioning.
- A more robust fix may belong upstream in Base UI.

### Testing
- Verified scrolling behavior with large option lists
- Popup position remains stable during scroll
