### PR TITLE
FixBase UI select scroll jitter and retain scrollbar

### DIFF
--- a/apps/v4/registry/bases/base/examples/select-example.tsx
+++ b/apps/v4/registry/bases/base/examples/select-example.tsx
@@ -78,7 +78,7 @@ function SelectBasic() {
         <SelectTrigger>
           <SelectValue />
         </SelectTrigger>
-        <SelectContent>
+        <SelectContent alignItemWithTrigger={false} sideOffset={8}>
           <SelectGroup>
             {items.map((item) => (
               <SelectItem key={item.value} value={item.value}>

--- a/apps/v4/registry/bases/base/ui/select.tsx
+++ b/apps/v4/registry/bases/base/ui/select.tsx
@@ -68,13 +68,18 @@ function SelectContent({
   sideOffset = 4,
   align = "center",
   alignOffset = 0,
-  alignItemWithTrigger = true,
+  alignItemWithTrigger = false,
+  style,
   ...props
 }: SelectPrimitive.Popup.Props &
   Pick<
     SelectPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
   >) {
+  const mergedStyle = {
+    maxHeight: "min(var(--available-height), 20rem)",
+    ...style,
+  }
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Positioner
@@ -88,9 +93,10 @@ function SelectContent({
         <SelectPrimitive.Popup
           data-slot="select-content"
           className={cn(
-            "cn-select-content cn-menu-target relative isolate z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto",
+            "cn-select-content cn-menu-target relative isolate z-50 max-h-80 w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto no-scrollbar data-[side=bottom]:mt-1 data-[side=top]:mb-1",
             className
           )}
+          style={mergedStyle}
           {...props}
         >
           <SelectScrollUpButton />


### PR DESCRIPTION
# Fix Base UI select scroll jitter and retain scrollbar

<table>
	<tr>
		<th>Before</th>
		<th>After</th>
	</tr>
	<tr>
		<td>
			<video src="https://github.com/user-attachments/assets/527132501-ad5d7813-1d56-45dc-9b5c-a952b83ddd43.mp4" controls muted playsinline autoplay></video>
		</td>
		<td>
			<video src="https://github.com/user-attachments/assets/e58e44ce-2edb-43cf-ac41-c381eab8f08f" controls muted playsinline autoplay></video>
		</td>
	</tr>
</table>

## Issue
- Base UI select popups jump/resize when `alignItemWithTrigger` is enabled on long lists (see before video).
- Fixes [#9108](https://github.com/shadcn-ui/ui/issues/9108).

## Changes
- Default Base UI select content to `alignItemWithTrigger={false}` to stop long-list jitter.
- Cap popup height via inline `maxHeight: min(var(--available-height), 20rem)` (plus existing class cap) while keeping trigger width alignment.
- Keep scrollbar hidden via `no-scrollbar` utility for a clean surface; videos show scroll interaction.
- Added before/after captures for quick visual verification.

## Scope & Risks
- Behavior change: Base UI selects no longer item-align by default; consumers needing alignment must opt in per instance.
- Scrollbar is hidden by default (`no-scrollbar`); consumers who need a visible scrollbar should remove that class.
- Height cap prevents the menu from stretching off-screen; relies on both inline and class caps.

## Verification / Testing
- Manually opened Base UI select Large List in Create flow, scrolled through all items; no popup jump in the after build.
- pnpm test (start-server-and-test): v4 dev server + test suites ran and passed after freeing port 4000; turbopack lockfile warning observed but benign.
