### PR TITLE
fix(sidebar): change isActive default from false to undefined to prevent unwanted highlighting

### DIFF
--- a/apps/v4/registry/bases/base/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/base/ui/sidebar.tsx
@@ -504,7 +504,7 @@ const sidebarMenuButtonVariants = cva(
 
 function SidebarMenuButton({
   render,
-  isActive = false,
+  isActive = undefined,
   variant = "default",
   size = "default",
   tooltip,
@@ -572,7 +572,7 @@ function SidebarMenuAction({
         className: cn(
           "cn-sidebar-menu-action flex items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0",
           showOnHover &&
-            "peer-data-active/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-open:opacity-100 md:opacity-0",
+          "peer-data-active/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-open:opacity-100 md:opacity-0",
           className
         ),
       },
@@ -669,7 +669,7 @@ function SidebarMenuSubItem({
 function SidebarMenuSubButton({
   render,
   size = "md",
-  isActive = false,
+  isActive = undefined,
   className,
   ...props
 }: useRender.ComponentProps<"a"> &

--- a/apps/v4/registry/bases/radix/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/radix/ui/sidebar.tsx
@@ -495,7 +495,7 @@ const sidebarMenuButtonVariants = cva(
 
 function SidebarMenuButton({
   asChild = false,
-  isActive = false,
+  isActive = undefined,
   variant = "default",
   size = "default",
   tooltip,
@@ -561,7 +561,7 @@ function SidebarMenuAction({
       className={cn(
         "cn-sidebar-menu-action flex items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0",
         showOnHover &&
-          "peer-data-active/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-open:opacity-100 md:opacity-0",
+        "peer-data-active/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-open:opacity-100 md:opacity-0",
         className
       )}
       {...props}
@@ -652,7 +652,7 @@ function SidebarMenuSubItem({
 function SidebarMenuSubButton({
   asChild = false,
   size = "md",
-  isActive = false,
+  isActive = undefined,
   className,
   ...props
 }: React.ComponentProps<"a"> & {

--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -497,7 +497,7 @@ const sidebarMenuButtonVariants = cva(
 
 function SidebarMenuButton({
   asChild = false,
-  isActive = false,
+  isActive = undefined,
   variant = "default",
   size = "default",
   tooltip,
@@ -569,7 +569,7 @@ function SidebarMenuAction({
         "peer-data-[size=lg]/menu-button:top-2.5",
         "group-data-[collapsible=icon]:hidden",
         showOnHover &&
-          "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
+        "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
         className
       )}
       {...props}


### PR DESCRIPTION
## Description
Fixes #9134 

Changes the default value of `isActive` parameter in `SidebarMenuButton` from `false` to `undefined` to prevent inactive sidebar buttons from being incorrectly highlighted.

## Problem
When `isActive` defaulted to `false`, the component would set `data-active="false"` on the DOM element. Tailwind CSS's `data-active:` attribute selector matches any element with the `data-active` attribute present, regardless of its value. This caused all sidebar menu buttons to be highlighted even when they weren't active.

## Solution
By changing the default from `false` to `undefined`, the `data-active` attribute is only added to the DOM when explicitly needed (when `isActive={true}`). When `isActive` is `undefined`, no attribute is added, and the Tailwind selector correctly ignores the element.

## Changes
- Changed `isActive = false` to `isActive = undefined` in `SidebarMenuButton` component

## Testing
- Verified that only explicitly active buttons (`isActive={true}`) receive the `data-active="true"` attribute
- Confirmed inactive buttons have no `data-active` attribute in the DOM
- Tested that Tailwind's `data-active:` styles only apply to active buttons

## Before
```typescript
isActive = false,  // Adds data-active="false" to DOM
```

## After
```typescript
isActive = undefined,  // No data-active attribute added when inactive
```