### PR TITLE
fix: invalid create command for v0

### DIFF
--- a/apps/v4/public/r/config.json
+++ b/apps/v4/public/r/config.json
@@ -9,7 +9,7 @@
       "baseColor": "neutral",
       "theme": "neutral",
       "iconLibrary": "lucide",
-      "font": "geist",
+      "font": "geist-sans",
       "item": "Item",
       "menuAccent": "subtle",
       "menuColor": "default",

--- a/apps/v4/registry/config.ts
+++ b/apps/v4/registry/config.ts
@@ -139,7 +139,7 @@ export const PRESETS: Preset[] = [
     baseColor: "neutral",
     theme: "neutral",
     iconLibrary: "lucide",
-    font: "geist",
+    font: "geist-sans",
     item: "Item",
     menuAccent: "subtle",
     menuColor: "default",


### PR DESCRIPTION
When using the create page to generate a v0 API link (`/create/v0?...`), requests with the `radix-vega` preset would fail with the following validation error:

```json
{
  "error": "Invalid enum value. Expected 'geist-sans' | 'inter' | 'noto-sans' | 'nunito-sans' | 'figtree' | 'roboto' | 'raleway' | 'dm-sans' | 'public-sans' | 'outfit' | 'jetbrains-mono', received 'geist'"
}
```

## Root Cause

The `designSystemConfigSchema` derives valid font values from `registry/fonts.ts` by stripping the `font-` prefix:
- `font-geist-sans` → `geist-sans`
- `font-inter` → `inter`

However, the preset configuration used `font: "geist"` instead of `font: "geist-sans"`, which doesn't match the schema.

## Changes

- **`apps/v4/registry/config.ts`**: Updated `radix-vega` preset to use `font: "geist-sans"`
- **`apps/v4/public/r/config.json`**: Updated `radix-vega` preset to use `"font": "geist-sans"`

## Reproduce

- link: https://ui.shadcn.com/create/v0?base=base&style=vega&baseColor=neutral&theme=neutral&iconLibrary=lucide&font=geist&menuAccent=subtle&menuColor=default&radius=default&item=preview