### PR TITLE
fix(docs): update CSS variable syntax for Tailwind v4 compatibility

### DIFF
--- a/apps/v4/content/docs/components/base/sidebar.mdx
+++ b/apps/v4/content/docs/components/base/sidebar.mdx
@@ -245,7 +245,7 @@ Use the `SidebarHeader` component to add a sticky header to the sidebar.
               <ChevronDown className="ml-auto" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-[--radix-popper-anchor-width]">
+          <DropdownMenuContent className="w-(--radix-popper-anchor-width)">
             <DropdownMenuItem>
               <span>Acme Inc</span>
             </DropdownMenuItem>

--- a/apps/v4/content/docs/components/radix/sidebar.mdx
+++ b/apps/v4/content/docs/components/radix/sidebar.mdx
@@ -245,7 +245,7 @@ Use the `SidebarHeader` component to add a sticky header to the sidebar.
               <ChevronDown className="ml-auto" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-[--radix-popper-anchor-width]">
+          <DropdownMenuContent className="w-(--radix-popper-anchor-width)">
             <DropdownMenuItem>
               <span>Acme Inc</span>
             </DropdownMenuItem>


### PR DESCRIPTION
## Summary
Updated the sidebar documentation to use the correct Tailwind CSS v4 syntax for CSS variables.

## Changes
- Changed `w-[--radix-popper-anchor-width]` to `w-(--radix-popper-anchor-width)` in sidebar header and footer examples
- In Tailwind v4, CSS variables in utility classes use parentheses `()` instead of square brackets `[]`

## Why This Matters
The current documentation uses `w-[--radix-popper-anchor-width]` which doesn't work correctly with Tailwind v4. The popover width doesn't inherit the anchor width, causing layout issues.

## Related Issue
Fixes #7979