### PR TITLE
Fix FieldGroup disappearing on resize inside FieldSet

### DIFF
--- a/apps/v4/registry/bases/base/ui/field.tsx
+++ b/apps/v4/registry/bases/base/ui/field.tsx
@@ -1,19 +1,37 @@
-"use client"
+"use client";
 
-import { useMemo } from "react"
+import { Children, isValidElement, useMemo } from "react";
 import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/registry/bases/base/lib/utils";
+import { Label } from "@/registry/bases/base/ui/label";
+import { Separator } from "@/registry/bases/base/ui/separator";
 
-import { cn } from "@/registry/bases/base/lib/utils"
-import { Label } from "@/registry/bases/base/ui/label"
-import { Separator } from "@/registry/bases/base/ui/separator"
+function FieldSet({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"fieldset">) {
+  const childArray = Children.toArray(children)
+  const legend = childArray.find(
+    (child) =>
+      isValidElement(child) &&
+      (child.type === "legend" ||
+        (child.props as { "data-slot"?: string })?.["data-slot"] ===
+          "field-legend")
+  )
+  const otherChildren = childArray.filter((child) => child !== legend)
 
-function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
   return (
     <fieldset
       data-slot="field-set"
-      className={cn("cn-field-set flex flex-col", className)}
+      className={cn("cn-field-set min-w-0", className)}
       {...props}
-    />
+    >
+      {legend}
+      <div className="flex flex-col">
+        {otherChildren}
+      </div>
+    </fieldset>
   )
 }
 

--- a/apps/v4/registry/bases/radix/ui/field.tsx
+++ b/apps/v4/registry/bases/radix/ui/field.tsx
@@ -1,19 +1,43 @@
-"use client"
+"use client";
 
-import { useMemo } from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import { Children, isValidElement, useMemo } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/registry/bases/radix/lib/utils"
-import { Label } from "@/registry/bases/radix/ui/label"
-import { Separator } from "@/registry/bases/radix/ui/separator"
 
-function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+
+import { cn } from "@/registry/bases/radix/lib/utils";
+import { Label } from "@/registry/bases/radix/ui/label";
+import { Separator } from "@/registry/bases/radix/ui/separator";
+
+
+
+
+
+function FieldSet({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"fieldset">) {
+  const childArray = Children.toArray(children)
+  const legend = childArray.find(
+    (child) =>
+      isValidElement(child) &&
+      (child.type === "legend" ||
+        (child.props as { "data-slot"?: string })?.["data-slot"] ===
+          "field-legend")
+  )
+  const otherChildren = childArray.filter((child) => child !== legend)
   return (
     <fieldset
       data-slot="field-set"
-      className={cn("cn-field-set flex flex-col", className)}
+      className={cn("min-w-0", className)}
       {...props}
-    />
+    >
+      {legend}
+      <div className="flex flex-col gap-6 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3">
+        {otherChildren}
+      </div>
+    </fieldset>
   )
 }
 

--- a/apps/v4/registry/new-york-v4/ui/field.tsx
+++ b/apps/v4/registry/new-york-v4/ui/field.tsx
@@ -1,23 +1,38 @@
 "use client"
 
-import { useMemo } from "react"
+import { Children, isValidElement, useMemo } from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 import { Label } from "@/registry/new-york-v4/ui/label"
 import { Separator } from "@/registry/new-york-v4/ui/separator"
 
-function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+function FieldSet({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"fieldset">) {
+  const childArray = Children.toArray(children)
+  const legend = childArray.find(
+    (child) =>
+      isValidElement(child) &&
+      (child.type === "legend" ||
+        (child.props as { "data-slot"?: string })?.["data-slot"] ===
+          "field-legend")
+  )
+  const otherChildren = childArray.filter((child) => child !== legend)
+
   return (
     <fieldset
       data-slot="field-set"
-      className={cn(
-        "flex flex-col gap-6",
-        "has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
-        className
-      )}
+      className={cn("min-w-0", className)}
       {...props}
-    />
+    >
+      {legend}
+      <div className="flex flex-col gap-6 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3">
+        {otherChildren}
+      </div>
+    </fieldset>
   )
 }
 


### PR DESCRIPTION
### Summary

Fixes an issue where `FieldGroup` content disappears on viewport resize when used
inside `FieldSet` alongside a sibling that switches `display` at a breakpoint.

### Details

Applying container queries directly on `<fieldset>` can trigger a browser reflow
issue when a sibling element changes layout (e.g. `grid → flex`), causing the
container query context to break while content remains in the DOM.

This change keeps `<legend>` as a direct child of `<fieldset>` (HTML spec
compliant) and wraps remaining children in an inner `<div>` to isolate layout
and container queries.

### Notes

This is a non-breaking change. The only behavioral difference is that selectors
like `fieldset > [data-slot="field-group"]` no longer match, which is unlikely to
affect real-world usage.
