### PR TITLE
fix: cleanup setTimeout on component unmount

### DIFF
--- a/apps/v4/app/(app)/examples/authentication/components/user-auth-form.tsx
+++ b/apps/v4/app/(app)/examples/authentication/components/user-auth-form.tsx
@@ -19,12 +19,21 @@ export function UserAuthForm({
   ...props
 }: React.ComponentProps<"div">) {
   const [isLoading, setIsLoading] = React.useState<boolean>(false)
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  React.useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [])
 
   async function onSubmit(event: React.SyntheticEvent) {
     event.preventDefault()
     setIsLoading(true)
 
-    setTimeout(() => {
+    timeoutRef.current = setTimeout(() => {
       setIsLoading(false)
     }, 3000)
   }

--- a/apps/v4/components/chart-copy-button.tsx
+++ b/apps/v4/components/chart-copy-button.tsx
@@ -26,9 +26,12 @@ export function ChartCopyButton({
   const [hasCopied, setHasCopied] = React.useState(false)
 
   React.useEffect(() => {
-    setTimeout(() => {
-      setHasCopied(false)
-    }, 2000)
+    if (hasCopied) {
+      const timer = setTimeout(() => {
+        setHasCopied(false)
+      }, 2000)
+      return () => clearTimeout(timer)
+    }
   }, [hasCopied])
 
   return (

--- a/apps/v4/components/copy-button.tsx
+++ b/apps/v4/components/copy-button.tsx
@@ -35,10 +35,13 @@ export function CopyButton({
   const [hasCopied, setHasCopied] = React.useState(false)
 
   React.useEffect(() => {
-    setTimeout(() => {
-      setHasCopied(false)
-    }, 2000)
-  }, [])
+    if (hasCopied) {
+      const timer = setTimeout(() => {
+        setHasCopied(false)
+      }, 2000)
+      return () => clearTimeout(timer)
+    }
+  }, [hasCopied])
 
   return (
     <Tooltip>

--- a/apps/v4/components/theme-customizer.tsx
+++ b/apps/v4/components/theme-customizer.tsx
@@ -177,9 +177,10 @@ function CustomizerCode({ themeName }: { themeName: string }) {
 
   React.useEffect(() => {
     if (hasCopied) {
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         setHasCopied(false)
       }, 2000)
+      return () => clearTimeout(timer)
     }
   }, [hasCopied])
 

--- a/apps/v4/hooks/use-copy-to-clipboard.ts
+++ b/apps/v4/hooks/use-copy-to-clipboard.ts
@@ -10,6 +10,15 @@ export function useCopyToClipboard({
   onCopy?: () => void
 } = {}) {
   const [isCopied, setIsCopied] = React.useState(false)
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  React.useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [])
 
   const copyToClipboard = (value: string) => {
     if (typeof window === "undefined" || !navigator.clipboard.writeText) {
@@ -26,7 +35,10 @@ export function useCopyToClipboard({
       }
 
       if (timeout !== 0) {
-        setTimeout(() => {
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current)
+        }
+        timeoutRef.current = setTimeout(() => {
           setIsCopied(false)
         }, timeout)
       }

--- a/apps/v4/registry/bases/base/blocks/elevenlabs.tsx
+++ b/apps/v4/registry/bases/base/blocks/elevenlabs.tsx
@@ -294,11 +294,11 @@ export function useMultibandVolume(
   useEffect(() => {
     if (!mediaStream) {
       const emptyBands = new Array(opts.bands).fill(0)
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         setFrequencyBands(emptyBands)
       }, 0)
       bandsRef.current = emptyBands
-      return
+      return () => clearTimeout(timer)
     }
 
     const { analyser, cleanup } = createAudioAnalyser(
@@ -402,9 +402,10 @@ export const useBarAnimator = (
 
   useEffect(() => {
     indexRef.current = 0
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       setCurrentFrame(sequence[0] || [])
     }, 0)
+    return () => clearTimeout(timer)
   }, [sequence])
 
   useEffect(() => {
@@ -513,10 +514,10 @@ const BarVisualizerComponent = React.forwardRef<
       if (state !== "speaking" && state !== "listening") {
         const bands = new Array(barCount).fill(0.2)
         fakeVolumeBandsRef.current = bands
-        setTimeout(() => {
+        const timer = setTimeout(() => {
           setFakeVolumeBands(bands)
         }, 0)
-        return
+        return () => clearTimeout(timer)
       }
 
       let lastUpdate = 0


### PR DESCRIPTION
## What

I inspected some of the components and found that they are missing proper cleanup after attaching a timeout.

These components are :

- copy-button.tsx
  

- use-copy-to-clipboard.ts


- theme-customizer.tsx

- chart-copy-button.tsx

- user-auth-form.tsx

- elevenlabs.tsx

## Why

Without clearing the timeout, the callback may still execute after the component has unmounted. 

This can lead to unexpected side effects, memory leaks, and state updates on unmounted components.