### PR TITLE
fix: adding missing "Geist Sans" that casing issues  in "Create a Project"

### DIFF
--- a/apps/v4/app/(create)/lib/fonts.ts
+++ b/apps/v4/app/(create)/lib/fonts.ts
@@ -76,7 +76,7 @@ const outfit = Outfit({
 export const FONTS = [
   {
     name: "Geist Sans",
-    value: "geist",
+    value: "geist-sans",
     font: geistSans,
     type: "sans",
   },

--- a/apps/v4/registry/config.ts
+++ b/apps/v4/registry/config.ts
@@ -139,7 +139,7 @@ export const PRESETS: Preset[] = [
     baseColor: "neutral",
     theme: "neutral",
     iconLibrary: "lucide",
-    font: "geist",
+    font: "geist-sans",
     item: "Item",
     menuAccent: "subtle",
     menuColor: "default",


### PR DESCRIPTION
closes: #9066

When selecting the preset "Vega / Lucide / Geist Sans," it doesn't find any "Geist Sans" font because it was commented out.

Website then: 
<img width="476" height="505" alt="image" src="https://github.com/user-attachments/assets/ac8181e0-c7ba-4482-bb9d-6f47d305e0a7" />


Website now: 
<img width="400" height="452" alt="image" src="https://github.com/user-attachments/assets/b0b16b27-7cbc-4063-8a31-40384fecd092" />
