### PR TITLE
fix text overflow on textarea

### DIFF
--- a/apps/v4/registry/bases/base/ui/textarea.tsx
+++ b/apps/v4/registry/bases/base/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "cn-textarea placeholder:text-muted-foreground flex field-sizing-content min-h-16 w-full outline-none disabled:cursor-not-allowed disabled:opacity-50",
+        "cn-textarea placeholder:text-muted-foreground flex field-sizing-content min-h-16 w-full break-all outline-none disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}


### PR DESCRIPTION
## Description
Added word-break: break-all as a tailwind class

## Changes Made
- Fixed bug where unbroken text would cause the component to overflow its container
