### PR TITLE
Fix button console error

### DIFF
--- a/apps/v4/registry/bases/base/ui/button.tsx
+++ b/apps/v4/registry/bases/base/ui/button.tsx
@@ -41,6 +41,7 @@ function Button({
 }: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
   return (
     <ButtonPrimitive
+      nativeButton={props.render ? false : undefined}
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}


### PR DESCRIPTION
## Reproduction

When using the `dashboard-01` block, I get this error. https://ui.shadcn.com/blocks

<img width="1038" height="828" alt="image" src="https://github.com/user-attachments/assets/e2272bf7-faaa-44cc-8032-5214622c6dfb" />

I think the problem stems from using `render` when `nativeButton` is true.
```
<Button
  variant='ghost'
  render={
    <a
      href='https://github.com/shadcn-ui/ui'
      rel='noopener noreferrer'
      target='_blank'
      className='dark:text-foreground'
    />
  }
  size='sm'
  className='hidden sm:flex'
>
  GitHub
</Button>
```
