### PR TITLE
feat(shadcn): allow configurable file casing for components

### DIFF
--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -83,6 +83,7 @@
     "@dotenvx/dotenvx": "^1.48.4",
     "@modelcontextprotocol/sdk": "^1.17.2",
     "browserslist": "^4.26.2",
+    "change-case": "^5.4.4",
     "commander": "^14.0.0",
     "cosmiconfig": "^9.0.0",
     "dedent": "^1.6.0",

--- a/packages/shadcn/src/registry/schema.ts
+++ b/packages/shadcn/src/registry/schema.ts
@@ -1,3 +1,4 @@
+import { formatCases } from "@/src/utils/format"
 import { z } from "zod"
 
 // Note: if you edit the schema here, you must also edit the schema in the
@@ -41,6 +42,7 @@ export const rawConfigSchema = z
     iconLibrary: z.string().optional(),
     menuColor: z.enum(["default", "inverted"]).default("default").optional(),
     menuAccent: z.enum(["subtle", "bold"]).default("subtle").optional(),
+    fileCase: z.enum(formatCases).default("pathCase").optional(),
     aliases: z.object({
       components: z.string(),
       utils: z.string(),

--- a/packages/shadcn/src/utils/format.ts
+++ b/packages/shadcn/src/utils/format.ts
@@ -1,0 +1,59 @@
+import { basename, extname } from "path"
+import {
+  camelCase,
+  capitalCase,
+  constantCase,
+  dotCase,
+  kebabCase,
+  pascalCase,
+  pascalSnakeCase,
+  pathCase,
+  sentenceCase,
+  snakeCase,
+  trainCase,
+} from "change-case"
+
+export const formatCase = {
+  camelCase,
+  capitalCase,
+  constantCase,
+  dotCase,
+  kebabCase,
+  pascalCase,
+  pascalSnakeCase,
+  pathCase,
+  sentenceCase,
+  snakeCase,
+  trainCase,
+} as const
+
+export const formatCases = [
+  "camelCase",
+  "capitalCase",
+  "constantCase",
+  "dotCase",
+  "kebabCase",
+  "pascalCase",
+  "pascalSnakeCase",
+  "pathCase",
+  "sentenceCase",
+  "snakeCase",
+  "trainCase",
+] as const
+
+export type FormatCase = (typeof formatCases)[number]
+
+export function formatFileName(fileName: string, fileCase?: FormatCase) {
+  if (!fileCase) {
+    return fileName
+  }
+  const extName = extname(fileName)
+  const baseName = basename(fileName, extName)
+  const newName = formatCase[fileCase](baseName)
+  const pathIndex = fileName.lastIndexOf("/")
+  if (pathIndex === -1) {
+    return `${newName}${extName}`
+  } else {
+    return `${fileName.substring(0, pathIndex)}/${newName}${extName}`
+  }
+}

--- a/packages/shadcn/src/utils/transformers/transform-import.ts
+++ b/packages/shadcn/src/utils/transformers/transform-import.ts
@@ -1,3 +1,4 @@
+import { formatFileName } from "@/src/utils/format"
 import { Config } from "@/src/utils/get-config"
 import { Transformer } from "@/src/utils/transformers"
 import { SyntaxKind } from "ts-morph"
@@ -73,9 +74,12 @@ function updateImportAliases(
   }
 
   if (moduleSpecifier.match(/^@\/registry\/(.+)\/ui/)) {
-    return moduleSpecifier.replace(
-      /^@\/registry\/(.+)\/ui/,
-      config.aliases.ui ?? `${config.aliases.components}/ui`
+    return formatFileName(
+      moduleSpecifier.replace(
+        /^@\/registry\/(.+)\/ui/,
+        config.aliases.ui ?? `${config.aliases.components}/ui`
+      ),
+      config.fileCase
     )
   }
 
@@ -83,9 +87,12 @@ function updateImportAliases(
     config.aliases.components &&
     moduleSpecifier.match(/^@\/registry\/(.+)\/components/)
   ) {
-    return moduleSpecifier.replace(
-      /^@\/registry\/(.+)\/components/,
-      config.aliases.components
+    return formatFileName(
+      moduleSpecifier.replace(
+        /^@\/registry\/(.+)\/components/,
+        config.aliases.components
+      ),
+      config.fileCase
     )
   }
 

--- a/packages/shadcn/src/utils/updaters/update-files.ts
+++ b/packages/shadcn/src/utils/updaters/update-files.ts
@@ -11,6 +11,7 @@ import {
   mergeEnvContent,
   parseEnvContent,
 } from "@/src/utils/env-helpers"
+import { FormatCase, formatFileName } from "@/src/utils/format"
 import { Config } from "@/src/utils/get-config"
 import { ProjectInfo, getProjectInfo } from "@/src/utils/get-project-info"
 import { highlighter } from "@/src/utils/highlighter"
@@ -378,7 +379,11 @@ export function resolveFilePath(
 
   const targetDir = resolveFileTargetDirectory(file, config)
 
-  const relativePath = resolveNestedFilePath(file.path, targetDir)
+  const relativePath = resolveNestedFilePath(
+    file.path,
+    targetDir,
+    config.fileCase
+  )
   return path.join(targetDir, relativePath)
 }
 
@@ -439,7 +444,8 @@ export function findCommonRoot(paths: string[], needle: string): string {
 
 export function resolveNestedFilePath(
   filePath: string,
-  targetDir: string
+  targetDir: string,
+  fileCase?: FormatCase
 ): string {
   // Normalize paths by removing leading/trailing slashes
   const normalizedFilePath = filePath.replace(/^\/|\/$/g, "")
@@ -457,11 +463,12 @@ export function resolveNestedFilePath(
 
   if (commonDirIndex === -1) {
     // Return just the filename if no common directory is found
-    return fileSegments[fileSegments.length - 1]
+    return formatFileName(fileSegments[fileSegments.length - 1], fileCase)
   }
 
   // Return everything after the common directory
-  return fileSegments.slice(commonDirIndex + 1).join("/")
+  const outputFileName = fileSegments.slice(commonDirIndex + 1).join("/")
+  return formatFileName(outputFileName, fileCase)
 }
 
 export function resolvePageTarget(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,6 +461,9 @@ importers:
       browserslist:
         specifier: ^4.26.2
         version: 4.26.2
+      change-case:
+        specifier: ^5.4.4
+        version: 5.4.4
       commander:
         specifier: ^14.0.0
         version: 14.0.0
@@ -12789,7 +12792,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12800,7 +12803,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12822,7 +12825,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12851,7 +12854,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.33.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Description
Adds support for configurable file casing when installing components from the registry.

## Changes
* Added `change-case` dependency to package.json
* Added `fileCase` setting to config schema (see enum options below)
* Updated `transform-import.ts` to ensure import dependencies follow the same case
* Updated `update-files.ts` to apply the file case setting

## Supported File Cases
* **camelCase:** `exampleComponent.tsx`
* **capitalCase:** `Example Component.tsx`
* **constantCase:** `EXAMPLE_COMPONENT.tsx`
* **dotCase:** `example.component.tsx`
* **kebabCase:** `example-component.tsx`
* **pascalCase:** `ExampleComponent.tsx`
* **pascalSnakeCase:** `Example_Component.tsx`
* **pathCase:** `example/component.tsx`
* **sentenceCase:** `Example component.tsx`
* **snakeCase:** `example_component.tsx`
* **trainCase:** `Example-Component.tsx`

## Testing
* ✅ Tested `npx shadcn@latest add` command to ensure file casing applies correctly
* ✅ Tested adding multiple components to ensure relative imports are correct
* ✅ Ensured all existing tests are passing

## Related
- Fixes #7593
- Fixes #1123
