### PR TITLE
feat(shadcn): Customize code style for components (ESLint / Prettier / TS)

### DIFF
--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -104,7 +104,7 @@
     "recast": "^0.23.11",
     "stringify-object": "^5.0.0",
     "ts-morph": "^26.0.0",
-    "ts-morph-react": "^1.0.4",
+    "ts-morph-react": "^1.0.5",
     "tsconfig-paths": "^4.2.0",
     "zod": "^3.24.1",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -104,6 +104,7 @@
     "recast": "^0.23.11",
     "stringify-object": "^5.0.0",
     "ts-morph": "^26.0.0",
+    "ts-morph-react": "^1.0.3",
     "tsconfig-paths": "^4.2.0",
     "zod": "^3.24.1",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -104,7 +104,7 @@
     "recast": "^0.23.11",
     "stringify-object": "^5.0.0",
     "ts-morph": "^26.0.0",
-    "ts-morph-react": "^1.0.5",
+    "ts-morph-react": "^1.0.6",
     "tsconfig-paths": "^4.2.0",
     "zod": "^3.24.1",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -104,7 +104,7 @@
     "recast": "^0.23.11",
     "stringify-object": "^5.0.0",
     "ts-morph": "^26.0.0",
-    "ts-morph-react": "^1.0.3",
+    "ts-morph-react": "^1.0.4",
     "tsconfig-paths": "^4.2.0",
     "zod": "^3.24.1",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/shadcn/src/registry/schema.ts
+++ b/packages/shadcn/src/registry/schema.ts
@@ -41,6 +41,19 @@ export const rawConfigSchema = z
     iconLibrary: z.string().optional(),
     menuColor: z.enum(["default", "inverted"]).default("default").optional(),
     menuAccent: z.enum(["subtle", "bold"]).default("subtle").optional(),
+    transform: z
+      .object({
+        enforceDirectExports: z.boolean().default(false).optional(),
+        enforceFunctionComponent: z.boolean().default(false).optional(),
+        enforceNamedImports: z.boolean().default(false).optional(),
+        enforceFormat: z.boolean().default(false).optional(),
+        enforceEslint: z.boolean().default(false).optional(),
+        enforcePrettier: z.boolean().default(false).optional(),
+        format: z.any(),
+        eslint: z.any(),
+        prettier: z.any(),
+      })
+      .optional(),
     aliases: z.object({
       components: z.string(),
       utils: z.string(),

--- a/packages/shadcn/src/registry/schema.ts
+++ b/packages/shadcn/src/registry/schema.ts
@@ -49,6 +49,7 @@ export const rawConfigSchema = z
         enforceFormat: z.boolean().default(false).optional(),
         enforceEslint: z.boolean().default(false).optional(),
         enforcePrettier: z.boolean().default(false).optional(),
+        enforceLineSeparation: z.boolean().default(false).optional(),
         format: z.any(),
         eslint: z.any(),
         prettier: z.any(),

--- a/packages/shadcn/src/utils/transformers/index.ts
+++ b/packages/shadcn/src/utils/transformers/index.ts
@@ -7,6 +7,7 @@ import { transformCssVars } from "@/src/utils/transformers/transform-css-vars"
 import { transformIcons } from "@/src/utils/transformers/transform-icons"
 import { transformImport } from "@/src/utils/transformers/transform-import"
 import { transformJsx } from "@/src/utils/transformers/transform-jsx"
+import { transformReact } from "@/src/utils/transformers/transform-react"
 import { transformRsc } from "@/src/utils/transformers/transform-rsc"
 import { Project, ScriptKind, type SourceFile } from "ts-morph"
 import { z } from "zod"
@@ -45,6 +46,7 @@ export async function transform(
     transformCssVars,
     transformTwPrefixes,
     transformIcons,
+    transformReact,
   ]
 ) {
   const tempFile = await createTempSourceFile(opts.filename)

--- a/packages/shadcn/src/utils/transformers/transform-react.ts
+++ b/packages/shadcn/src/utils/transformers/transform-react.ts
@@ -1,0 +1,10 @@
+import { Transformer } from "@/src/utils/transformers"
+import { transform } from "ts-morph-react"
+
+export const transformReact: Transformer = async ({ sourceFile, config }) => {
+  if (!config.tsx) {
+    return sourceFile
+  }
+  await transform(sourceFile, { ...config.transform })
+  return sourceFile
+}

--- a/packages/shadcn/src/utils/updaters/update-files.ts
+++ b/packages/shadcn/src/utils/updaters/update-files.ts
@@ -24,6 +24,7 @@ import { transformIcons } from "@/src/utils/transformers/transform-icons"
 import { transformImport } from "@/src/utils/transformers/transform-import"
 import { transformMenu } from "@/src/utils/transformers/transform-menu"
 import { transformNext } from "@/src/utils/transformers/transform-next"
+import { transformReact } from "@/src/utils/transformers/transform-react"
 import { transformRsc } from "@/src/utils/transformers/transform-rsc"
 import { transformTwPrefixes } from "@/src/utils/transformers/transform-tw-prefix"
 import prompts from "prompts"
@@ -146,6 +147,7 @@ export async function updateFiles(
             ...(_isNext16Middleware(filePath, projectInfo, config)
               ? [transformNext]
               : []),
+            transformReact,
           ]
         )
 

--- a/packages/shadcn/test/fixtures/transform-react/example.ts
+++ b/packages/shadcn/test/fixtures/transform-react/example.ts
@@ -1,0 +1,42 @@
+export const example = `"use client"
+
+import * as React from "react"
+import { Button as ButtonPrimitive } from "@base-ui/react/button"
+
+import { cn } from "@/lib/utils"
+
+type ExampleContextProps = {
+  content: string
+}
+
+const ExampleContext = React.createContext<ExampleContextProps | null>(null)
+
+function ExampleProvider({
+  value,
+  ...props
+}: React.PropsWithChildren<{
+  value: ExampleContextProps
+}>) {
+  return (
+    <ExampleContext.Provider value={value}>
+      {props.children}
+    </ExampleContext.Provider>
+  )
+}
+
+function Example({
+  content,
+  className,
+  ...props
+}: ButtonPrimitive.Props & {
+  content: string
+}) {
+  return (
+    <ExampleProvider value={{ content }}>
+      <ButtonPrimitive className={cn('p-2', className)} {...props} />
+    </ExampleProvider>
+  )
+}
+
+export { ExampleProvider, Example }
+`

--- a/packages/shadcn/test/utils/__snapshots__/transform-react.test.ts.snap
+++ b/packages/shadcn/test/utils/__snapshots__/transform-react.test.ts.snap
@@ -17,8 +17,11 @@ export const ExampleProvider: FunctionComponent<PropsWithChildren<{ value: Examp
 }) => {
   return <ExampleContext.Provider value={value}>{props.children}</ExampleContext.Provider>
 }
-
-export function Example({ content, className, ...props }: ButtonPrimitive.Props & { content: string }) {
+export const Example: FunctionComponent<ButtonPrimitive.Props & { content: string }> = ({
+  content,
+  className,
+  ...props
+}) => {
   return (
     <ExampleProvider value={{ content }}>
       <ButtonPrimitive className={cn('p-2', className)} {...props} />
@@ -71,15 +74,17 @@ const ExampleProvider: React.FunctionComponent<React.PropsWithChildren<{ value: 
 }) => {
   return <ExampleContext.Provider value={value}>{props.children}</ExampleContext.Provider>
 }
-
-function Example({ content, className, ...props }: ButtonPrimitive.Props & { content: string }) {
+const Example: React.FunctionComponent<ButtonPrimitive.Props & { content: string }> = ({
+  content,
+  className,
+  ...props
+}) => {
   return (
     <ExampleProvider value={{ content }}>
       <ButtonPrimitive className={cn('p-2', className)} {...props} />
     </ExampleProvider>
   )
 }
-
 export { Example, ExampleProvider }
 "
 `;

--- a/packages/shadcn/test/utils/__snapshots__/transform-react.test.ts.snap
+++ b/packages/shadcn/test/utils/__snapshots__/transform-react.test.ts.snap
@@ -1,0 +1,119 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`combined 1`] = `
+"'use client'
+
+import { cn } from '@/lib/utils'
+import { Button as ButtonPrimitive } from '@base-ui/react/button'
+import { type FunctionComponent, type PropsWithChildren, createContext } from 'react'
+
+type ExampleContextProps = { content: string }
+
+const ExampleContext = createContext<ExampleContextProps | null>(null)
+
+export const ExampleProvider: FunctionComponent<PropsWithChildren<{ value: ExampleContextProps }>> = ({
+  value,
+  ...props
+}) => {
+  return <ExampleContext.Provider value={value}>{props.children}</ExampleContext.Provider>
+}
+
+export const Example: FunctionComponent<ButtonPrimitive.Props & { content: string }> = ({
+  content,
+  className,
+  ...props
+}) => {
+  return (
+    <ExampleProvider value={{ content }}>
+      <ButtonPrimitive className={cn('p-2', className)} {...props} />
+    </ExampleProvider>
+  )
+}
+"
+`;
+
+exports[`enforceDirectExports 1`] = `
+"'use client'
+
+import { cn } from '@/lib/utils'
+import { Button as ButtonPrimitive } from '@base-ui/react/button'
+import * as React from 'react'
+
+type ExampleContextProps = { content: string }
+
+const ExampleContext = React.createContext<ExampleContextProps | null>(null)
+
+export function ExampleProvider({ value, ...props }: React.PropsWithChildren<{ value: ExampleContextProps }>) {
+  return <ExampleContext.Provider value={value}>{props.children}</ExampleContext.Provider>
+}
+
+export function Example({ content, className, ...props }: ButtonPrimitive.Props & { content: string }) {
+  return (
+    <ExampleProvider value={{ content }}>
+      <ButtonPrimitive className={cn('p-2', className)} {...props} />
+    </ExampleProvider>
+  )
+}
+"
+`;
+
+exports[`enforceFunctionComponent 1`] = `
+"'use client'
+
+import { cn } from '@/lib/utils'
+import { Button as ButtonPrimitive } from '@base-ui/react/button'
+import * as React from 'react'
+
+type ExampleContextProps = { content: string }
+
+const ExampleContext = React.createContext<ExampleContextProps | null>(null)
+
+const ExampleProvider: React.FunctionComponent<React.PropsWithChildren<{ value: ExampleContextProps }>> = ({
+  value,
+  ...props
+}) => {
+  return <ExampleContext.Provider value={value}>{props.children}</ExampleContext.Provider>
+}
+
+const Example: React.FunctionComponent<ButtonPrimitive.Props & { content: string }> = ({
+  content,
+  className,
+  ...props
+}) => {
+  return (
+    <ExampleProvider value={{ content }}>
+      <ButtonPrimitive className={cn('p-2', className)} {...props} />
+    </ExampleProvider>
+  )
+}
+
+export { Example, ExampleProvider }
+"
+`;
+
+exports[`enforceNamedImports 1`] = `
+"'use client'
+
+import { cn } from '@/lib/utils'
+import { Button as ButtonPrimitive } from '@base-ui/react/button'
+import { type PropsWithChildren, createContext } from 'react'
+
+type ExampleContextProps = { content: string }
+
+const ExampleContext = createContext<ExampleContextProps | null>(null)
+
+function ExampleProvider({ value, ...props }: PropsWithChildren<{ value: ExampleContextProps }>) {
+  return <ExampleContext.Provider value={value}>{props.children}</ExampleContext.Provider>
+}
+
+function Example({ content, className, ...props }: ButtonPrimitive.Props & { content: string }) {
+  return (
+    <ExampleProvider value={{ content }}>
+      <ButtonPrimitive className={cn('p-2', className)} {...props} />
+    </ExampleProvider>
+  )
+}
+
+export { Example, ExampleProvider }
+"
+`;

--- a/packages/shadcn/test/utils/__snapshots__/transform-react.test.ts.snap
+++ b/packages/shadcn/test/utils/__snapshots__/transform-react.test.ts.snap
@@ -3,21 +3,20 @@
 exports[`combined 1`] = `
 "'use client'
 
-import { cn } from '@/lib/utils'
 import { Button as ButtonPrimitive } from '@base-ui/react/button'
 import { type FunctionComponent, type PropsWithChildren, createContext } from 'react'
+
+import { cn } from '@/lib/utils'
 
 type ExampleContextProps = { content: string }
 
 const ExampleContext = createContext<ExampleContextProps | null>(null)
-
 export const ExampleProvider: FunctionComponent<PropsWithChildren<{ value: ExampleContextProps }>> = ({
   value,
   ...props
 }) => {
   return <ExampleContext.Provider value={value}>{props.children}</ExampleContext.Provider>
 }
-
 export const Example: FunctionComponent<ButtonPrimitive.Props & { content: string }> = ({
   content,
   className,
@@ -35,9 +34,10 @@ export const Example: FunctionComponent<ButtonPrimitive.Props & { content: strin
 exports[`enforceDirectExports 1`] = `
 "'use client'
 
-import { cn } from '@/lib/utils'
 import { Button as ButtonPrimitive } from '@base-ui/react/button'
 import * as React from 'react'
+
+import { cn } from '@/lib/utils'
 
 type ExampleContextProps = { content: string }
 
@@ -60,21 +60,20 @@ export function Example({ content, className, ...props }: ButtonPrimitive.Props 
 exports[`enforceFunctionComponent 1`] = `
 "'use client'
 
-import { cn } from '@/lib/utils'
 import { Button as ButtonPrimitive } from '@base-ui/react/button'
 import * as React from 'react'
+
+import { cn } from '@/lib/utils'
 
 type ExampleContextProps = { content: string }
 
 const ExampleContext = React.createContext<ExampleContextProps | null>(null)
-
 const ExampleProvider: React.FunctionComponent<React.PropsWithChildren<{ value: ExampleContextProps }>> = ({
   value,
   ...props
 }) => {
   return <ExampleContext.Provider value={value}>{props.children}</ExampleContext.Provider>
 }
-
 const Example: React.FunctionComponent<ButtonPrimitive.Props & { content: string }> = ({
   content,
   className,
@@ -86,7 +85,6 @@ const Example: React.FunctionComponent<ButtonPrimitive.Props & { content: string
     </ExampleProvider>
   )
 }
-
 export { Example, ExampleProvider }
 "
 `;
@@ -94,9 +92,10 @@ export { Example, ExampleProvider }
 exports[`enforceNamedImports 1`] = `
 "'use client'
 
-import { cn } from '@/lib/utils'
 import { Button as ButtonPrimitive } from '@base-ui/react/button'
 import { type PropsWithChildren, createContext } from 'react'
+
+import { cn } from '@/lib/utils'
 
 type ExampleContextProps = { content: string }
 

--- a/packages/shadcn/test/utils/__snapshots__/transform-react.test.ts.snap
+++ b/packages/shadcn/test/utils/__snapshots__/transform-react.test.ts.snap
@@ -17,11 +17,8 @@ export const ExampleProvider: FunctionComponent<PropsWithChildren<{ value: Examp
 }) => {
   return <ExampleContext.Provider value={value}>{props.children}</ExampleContext.Provider>
 }
-export const Example: FunctionComponent<ButtonPrimitive.Props & { content: string }> = ({
-  content,
-  className,
-  ...props
-}) => {
+
+export function Example({ content, className, ...props }: ButtonPrimitive.Props & { content: string }) {
   return (
     <ExampleProvider value={{ content }}>
       <ButtonPrimitive className={cn('p-2', className)} {...props} />
@@ -74,17 +71,15 @@ const ExampleProvider: React.FunctionComponent<React.PropsWithChildren<{ value: 
 }) => {
   return <ExampleContext.Provider value={value}>{props.children}</ExampleContext.Provider>
 }
-const Example: React.FunctionComponent<ButtonPrimitive.Props & { content: string }> = ({
-  content,
-  className,
-  ...props
-}) => {
+
+function Example({ content, className, ...props }: ButtonPrimitive.Props & { content: string }) {
   return (
     <ExampleProvider value={{ content }}>
       <ButtonPrimitive className={cn('p-2', className)} {...props} />
     </ExampleProvider>
   )
 }
+
 export { Example, ExampleProvider }
 "
 `;

--- a/packages/shadcn/test/utils/transform-react.test.ts
+++ b/packages/shadcn/test/utils/transform-react.test.ts
@@ -1,0 +1,85 @@
+import { TransformerConfig } from "ts-morph-react"
+import { expect, test } from "vitest"
+import { transform } from "../../src/utils/transformers"
+import { example } from "../fixtures/transform-react/example"
+
+const sharedConfig = {
+  tsx: true,
+  rsc: true,
+  style: "base-lyra",
+  tailwind: { baseColor: "neutral", cssVariables: true },
+  aliases: { components: "@/components", lib: "@/lib", utils: "@/lib/utils" }
+}
+
+const transformConfig = {
+  enforceFormat: true,
+  enforceEslint: true,
+  enforcePrettier: true,
+  eslint: {},
+  format: {},
+  prettier: {}
+}
+
+test("enforceNamedImports", async () => {
+  expect(await transform({
+    filename: "test.tsx",
+    raw: example,
+    config: {
+      ...sharedConfig,
+      transform: {
+        enforceNamedImports: true,
+        enforceDirectExports: false,
+        enforceFunctionComponent: false,
+        ...transformConfig
+      } satisfies TransformerConfig
+    }
+  })).toMatchSnapshot()
+})
+
+test("enforceDirectExports", async () => {
+  expect(await transform({
+    filename: "test.tsx",
+    raw: example,
+    config: {
+      ...sharedConfig,
+      transform: {
+        enforceNamedImports: false,
+        enforceDirectExports: true,
+        enforceFunctionComponent: false,
+        ...transformConfig
+      } satisfies TransformerConfig
+    }
+  })).toMatchSnapshot()
+})
+
+test("enforceFunctionComponent", async () => {
+  expect(await transform({
+    filename: "test.tsx",
+    raw: example,
+    config: {
+      ...sharedConfig,
+      transform: {
+        enforceNamedImports: false,
+        enforceDirectExports: false,
+        enforceFunctionComponent: true,
+        ...transformConfig
+      } satisfies TransformerConfig
+    }
+  })).toMatchSnapshot()
+})
+
+test("combined", async () => {
+  expect(await transform({
+    filename: "test.tsx",
+    raw: example,
+    config: {
+      ...sharedConfig,
+      transform: {
+        enforceNamedImports: true,
+        enforceDirectExports: true,
+        enforceFunctionComponent: true,
+        ...transformConfig
+      } satisfies TransformerConfig
+    }
+  })).toMatchSnapshot()
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,8 +525,8 @@ importers:
         specifier: ^26.0.0
         version: 26.0.0
       ts-morph-react:
-        specifier: ^1.0.4
-        version: 1.0.4(jiti@2.6.1)(typescript@5.9.2)
+        specifier: ^1.0.5
+        version: 1.0.5(jiti@2.6.1)(typescript@5.9.2)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -7889,8 +7889,8 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  ts-morph-react@1.0.4:
-    resolution: {integrity: sha512-RkrNprnHSuKEVAjVmpypQqxvRGCM1f3cW4loS4c4TG8HoaIPECNF+PSH6WGdliXq/Ud6kPJvkCPgEMVo9KdVaw==}
+  ts-morph-react@1.0.5:
+    resolution: {integrity: sha512-xKdZCmBLsMY2a5ohBw+5cZeBvtWD+zlJjYk18jPwOzvR+gTWcnDBu0Yhw7P30IgzUJbXMsUHtoHHllBb9GvmKA==}
 
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
@@ -16919,7 +16919,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-morph-react@1.0.4(jiti@2.6.1)(typescript@5.9.2):
+  ts-morph-react@1.0.5(jiti@2.6.1)(typescript@5.9.2):
     dependencies:
       '@eslint/core': 1.0.0
       '@eslint/js': 9.39.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,8 +525,8 @@ importers:
         specifier: ^26.0.0
         version: 26.0.0
       ts-morph-react:
-        specifier: ^1.0.3
-        version: 1.0.3(jiti@2.6.1)(typescript@5.9.2)
+        specifier: ^1.0.4
+        version: 1.0.4(jiti@2.6.1)(typescript@5.9.2)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -7889,8 +7889,8 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  ts-morph-react@1.0.3:
-    resolution: {integrity: sha512-GudOt0Qq7wO43fiO29MW0KznPFpGlCf0VWwNrMWLVJ7yKikU5YMYq9D1VAXYZVzvhTCVIyLIBSvnmdZ6uThtcw==}
+  ts-morph-react@1.0.4:
+    resolution: {integrity: sha512-RkrNprnHSuKEVAjVmpypQqxvRGCM1f3cW4loS4c4TG8HoaIPECNF+PSH6WGdliXq/Ud6kPJvkCPgEMVo9KdVaw==}
 
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
@@ -9311,11 +9311,6 @@ snapshots:
   '@eslint-community/eslint-utils@4.7.0(eslint@9.33.0(jiti@2.6.1))':
     dependencies:
       eslint: 9.33.0(jiti@2.6.1)
-      eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.39.2(jiti@2.6.1))':
-    dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2(jiti@2.6.1))':
@@ -11210,7 +11205,7 @@ snapshots:
   '@stylistic/eslint-plugin@5.6.1(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@2.6.1))
-      '@typescript-eslint/types': 8.49.0
+      '@typescript-eslint/types': 8.50.1
       eslint: 9.39.2(jiti@2.6.1)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
@@ -11807,7 +11802,7 @@ snapshots:
 
   '@typescript-eslint/utils@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.50.1
       '@typescript-eslint/types': 8.50.1
       '@typescript-eslint/typescript-estree': 8.50.1(typescript@5.9.2)
@@ -16924,7 +16919,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-morph-react@1.0.3(jiti@2.6.1)(typescript@5.9.2):
+  ts-morph-react@1.0.4(jiti@2.6.1)(typescript@5.9.2):
     dependencies:
       '@eslint/core': 1.0.0
       '@eslint/js': 9.39.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -524,6 +524,9 @@ importers:
       ts-morph:
         specifier: ^26.0.0
         version: 26.0.0
+      ts-morph-react:
+        specifier: ^1.0.3
+        version: 1.0.3(jiti@2.6.1)(typescript@5.9.2)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -1416,6 +1419,12 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
+  '@eslint-community/eslint-utils@4.9.0':
+    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
   '@eslint-community/regexpp@4.12.1':
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
@@ -1424,13 +1433,29 @@ packages:
     resolution: {integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/config-array@0.21.1':
+    resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/config-helpers@0.3.1':
     resolution: {integrity: sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/core@0.15.2':
     resolution: {integrity: sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@1.0.0':
+    resolution: {integrity: sha512-PRfWP+8FOldvbApr6xL7mNCw4cJcSTq4GA7tYbgq15mRb0kWKO/wEB2jr+uwjFH3sZvEZneZyCUGTxsv4Sahyw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
@@ -1448,12 +1473,24 @@ packages:
     resolution: {integrity: sha512-5K1/mKhWaMfreBGJTwval43JJmkip0RmM+3+IuqupeSKNC/Th2Kc7ucaq5ovTSra/OOKB9c58CGSz3QMVbWt0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/js@9.39.2':
+    resolution: {integrity: sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/object-schema@2.1.6':
     resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/plugin-kit@0.3.5':
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@faker-js/faker@10.1.0':
@@ -3131,8 +3168,18 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@slimio/is@2.0.0':
+    resolution: {integrity: sha512-aEwQVndB4uVQsJ55HJjff3dnETpa2EfkNeAK/ldxT0VeqaNG9Q/zcCBmrRKJ9jsE9sXI4HsDUCotVBVswVKB+w==}
+    engines: {node: '>=16'}
+
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@stylistic/eslint-plugin@5.6.1':
+    resolution: {integrity: sha512-JCs+MqoXfXrRPGbGmho/zGS/jMcn3ieKl/A8YImqib76C8kjgZwq5uUFzc30lJkMvcchuRn6/v8IApLxli3Jyw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=9.0.0'
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -3326,6 +3373,9 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/eslint-plugin-jsx-a11y@6.10.1':
+    resolution: {integrity: sha512-5RtuPVe0xz8BAhrkn2oww6Uw885atf962Q4fqZo48QdO3EQA7oCEDSXa6optgJ1ZMds3HD9ITK5bfm4AWuoXFQ==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -3419,6 +3469,14 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/eslint-plugin@8.50.1':
+    resolution: {integrity: sha512-PKhLGDq3JAg0Jk/aK890knnqduuI/Qj+udH7wCf0217IGi4gt+acgCyPVe79qoT+qKUvHMDQkwJeKW9fwl8Cyw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.50.1
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/parser@5.62.0':
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3443,6 +3501,13 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/parser@8.50.1':
+    resolution: {integrity: sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/project-service@8.39.0':
     resolution: {integrity: sha512-CTzJqaSq30V/Z2Og9jogzZt8lJRR5TKlAdXmWgdu4hgcC9Kww5flQ+xFvMxIBWVNdxJO7OifgdOK4PokMIWPew==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3457,6 +3522,12 @@ packages:
 
   '@typescript-eslint/project-service@8.49.0':
     resolution: {integrity: sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/project-service@8.50.1':
+    resolution: {integrity: sha512-E1ur1MCVf+YiP89+o4Les/oBAVzmSbeRB0MQLfSlYtbWU17HPxZ6Bhs5iYmKZRALvEuBoXIZMOIRRc/P++Ortg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
@@ -3477,6 +3548,10 @@ packages:
     resolution: {integrity: sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.50.1':
+    resolution: {integrity: sha512-mfRx06Myt3T4vuoHaKi8ZWNTPdzKPNBhiblze5N50//TSHOAQQevl/aolqA/BcqqbJ88GUnLqjjcBc8EWdBcVw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.39.0':
     resolution: {integrity: sha512-Fd3/QjmFV2sKmvv3Mrj8r6N8CryYiCS8Wdb/6/rgOXAWGcFuc+VkQuG28uk/4kVNVZBQuuDHEDUpo/pQ32zsIQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3495,6 +3570,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/tsconfig-utils@8.50.1':
+    resolution: {integrity: sha512-ooHmotT/lCWLXi55G4mvaUF60aJa012QzvLK0Y+Mp4WdSt17QhMhWOaBWeGTFVkb2gDgBe19Cxy1elPXylslDw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/type-utils@8.46.2':
     resolution: {integrity: sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3504,6 +3585,13 @@ packages:
 
   '@typescript-eslint/type-utils@8.49.0':
     resolution: {integrity: sha512-KTExJfQ+svY8I10P4HdxKzWsvtVnsuCifU5MvXrRwoP2KOlNZ9ADNEWWsQTJgMxLzS5VLQKDjkCT/YzgsnqmZg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.50.1':
+    resolution: {integrity: sha512-7J3bf022QZE42tYMO6SL+6lTPKFk/WphhRPe9Tw/el+cEwzLz1Jjz2PX3GtGQVxooLDKeMVmMt7fWpYRdG5Etg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -3523,6 +3611,10 @@ packages:
 
   '@typescript-eslint/types@8.49.0':
     resolution: {integrity: sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.50.1':
+    resolution: {integrity: sha512-v5lFIS2feTkNyMhd7AucE/9j/4V9v5iIbpVRncjk/K0sQ6Sb+Np9fgYS/63n6nwqahHQvbmujeBL7mp07Q9mlA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@5.62.0':
@@ -3552,6 +3644,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/typescript-estree@8.50.1':
+    resolution: {integrity: sha512-woHPdW+0gj53aM+cxchymJCrh0cyS7BTIdcDxWUNsclr9VDkOSbqC13juHzxOmQ22dDkMZEpZB+3X1WpUvzgVQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/utils@8.46.2':
     resolution: {integrity: sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3561,6 +3659,13 @@ packages:
 
   '@typescript-eslint/utils@8.49.0':
     resolution: {integrity: sha512-N3W7rJw7Rw+z1tRsHZbK395TWSYvufBXumYtEGzypgMUthlg0/hmCImeA8hgO2d2G4pd7ftpxxul2J8OdtdaFA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.50.1':
+    resolution: {integrity: sha512-lCLp8H1T9T7gPbEuJSnHwnSuO9mDf8mfK/Nion5mZmiEaQD9sWf9W4dfeFqRyqRjF06/kBuTmAqcs9sewM2NbQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -3580,6 +3685,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.49.0':
     resolution: {integrity: sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.50.1':
+    resolution: {integrity: sha512-IrDKrw7pCRUR94zeuCSUWQ+w8JEf5ZX5jl/e6AHGSLi1/zIr0lgutfn/7JpfCey+urpgQEdrZVYzCaVVKiTwhQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
@@ -4831,6 +4940,16 @@ packages:
 
   eslint@9.33.0:
     resolution: {integrity: sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  eslint@9.39.2:
+    resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -6429,6 +6548,9 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-estree@4.0.0:
+    resolution: {integrity: sha512-XMU4U91meO+XFZaZLqkr7iEZdje7ftiqx4hlQ0LMb6h+gJBPgzSTeU++dUpGxH8v6wdkKrbpf4mifX5vPg8rAg==}
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -6915,6 +7037,11 @@ packages:
 
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  prettier@3.7.4:
+    resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -7762,6 +7889,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  ts-morph-react@1.0.3:
+    resolution: {integrity: sha512-GudOt0Qq7wO43fiO29MW0KznPFpGlCf0VWwNrMWLVJ7yKikU5YMYq9D1VAXYZVzvhTCVIyLIBSvnmdZ6uThtcw==}
+
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
 
@@ -7896,6 +8026,13 @@ packages:
 
   typescript-eslint@8.46.2:
     resolution: {integrity: sha512-vbw8bOmiuYNdzzV3lsiWv6sRwjyuKJMQqWulBOU7M0RrxedXledX8G8kBbQeiOYDnTfiXz0Y4081E1QMNB6iQg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  typescript-eslint@8.50.1:
+    resolution: {integrity: sha512-ytTHO+SoYSbhAH9CrYnMhiLx8To6PSSvqnvXyPUgPETCvB6eBKmTI9w6XMPS3HsBRGkwTVBX+urA8dYQx6bHfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -9176,6 +9313,16 @@ snapshots:
       eslint: 9.33.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.39.2(jiti@2.6.1))':
+    dependencies:
+      eslint: 9.39.2(jiti@2.6.1)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2(jiti@2.6.1))':
+    dependencies:
+      eslint: 9.39.2(jiti@2.6.1)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.1': {}
 
   '@eslint/config-array@0.21.0':
@@ -9186,9 +9333,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/config-array@0.21.1':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/config-helpers@0.3.1': {}
 
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
   '@eslint/core@0.15.2':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/core@1.0.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
@@ -9224,11 +9391,20 @@ snapshots:
 
   '@eslint/js@9.33.0': {}
 
+  '@eslint/js@9.39.2': {}
+
   '@eslint/object-schema@2.1.6': {}
+
+  '@eslint/object-schema@2.1.7': {}
 
   '@eslint/plugin-kit@0.3.5':
     dependencies:
       '@eslint/core': 0.15.2
+      levn: 0.4.1
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
       levn: 0.4.1
 
   '@faker-js/faker@10.1.0': {}
@@ -11027,7 +11203,19 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@slimio/is@2.0.0': {}
+
   '@standard-schema/spec@1.0.0': {}
+
+  '@stylistic/eslint-plugin@5.6.1(eslint@9.39.2(jiti@2.6.1))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@2.6.1))
+      '@typescript-eslint/types': 8.49.0
+      eslint: 9.39.2(jiti@2.6.1)
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      estraverse: 5.3.0
+      picomatch: 4.0.3
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -11215,6 +11403,13 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/eslint-plugin-jsx-a11y@6.10.1(jiti@2.6.1)':
+    dependencies:
+      eslint: 9.39.2(jiti@2.6.1)
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -11325,6 +11520,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.50.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/scope-manager': 8.50.1
+      '@typescript-eslint/type-utils': 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.50.1
+      eslint: 9.39.2(jiti@2.6.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
@@ -11361,6 +11572,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.50.1
+      '@typescript-eslint/types': 8.50.1
+      '@typescript-eslint/typescript-estree': 8.50.1(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.50.1
+      debug: 4.4.3
+      eslint: 9.39.2(jiti@2.6.1)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.39.0(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.9.2)
@@ -11388,6 +11611,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.50.1(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.50.1(typescript@5.9.2)
+      '@typescript-eslint/types': 8.50.1
+      debug: 4.4.3
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@5.62.0':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -11408,6 +11640,11 @@ snapshots:
       '@typescript-eslint/types': 8.49.0
       '@typescript-eslint/visitor-keys': 8.49.0
 
+  '@typescript-eslint/scope-manager@8.50.1':
+    dependencies:
+      '@typescript-eslint/types': 8.50.1
+      '@typescript-eslint/visitor-keys': 8.50.1
+
   '@typescript-eslint/tsconfig-utils@8.39.0(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
@@ -11417,6 +11654,10 @@ snapshots:
       typescript: 5.9.2
 
   '@typescript-eslint/tsconfig-utils@8.49.0(typescript@5.9.2)':
+    dependencies:
+      typescript: 5.9.2
+
+  '@typescript-eslint/tsconfig-utils@8.50.1(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
 
@@ -11444,6 +11685,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.50.1
+      '@typescript-eslint/typescript-estree': 8.50.1(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      debug: 4.4.3
+      eslint: 9.39.2(jiti@2.6.1)
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@5.62.0': {}
 
   '@typescript-eslint/types@8.39.0': {}
@@ -11451,6 +11704,8 @@ snapshots:
   '@typescript-eslint/types@8.46.2': {}
 
   '@typescript-eslint/types@8.49.0': {}
+
+  '@typescript-eslint/types@8.50.1': {}
 
   '@typescript-eslint/typescript-estree@5.62.0(typescript@5.9.2)':
     dependencies:
@@ -11513,6 +11768,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.50.1(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.50.1(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.50.1(typescript@5.9.2)
+      '@typescript-eslint/types': 8.50.1
+      '@typescript-eslint/visitor-keys': 8.50.1
+      debug: 4.4.3
+      minimatch: 9.0.5
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.46.2(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.33.0(jiti@2.6.1))
@@ -11535,6 +11805,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.39.2(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.50.1
+      '@typescript-eslint/types': 8.50.1
+      '@typescript-eslint/typescript-estree': 8.50.1(typescript@5.9.2)
+      eslint: 9.39.2(jiti@2.6.1)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@5.62.0':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -11553,6 +11834,11 @@ snapshots:
   '@typescript-eslint/visitor-keys@8.49.0':
     dependencies:
       '@typescript-eslint/types': 8.49.0
+      eslint-visitor-keys: 4.2.1
+
+  '@typescript-eslint/visitor-keys@8.50.1':
+    dependencies:
+      '@typescript-eslint/types': 8.50.1
       eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.0': {}
@@ -12789,7 +13075,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12800,7 +13086,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -12822,7 +13108,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12851,7 +13137,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.33.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12907,6 +13193,25 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.10.3
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.39.2(jiti@2.6.1)
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
+
   eslint-plugin-react-hooks@4.6.2(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
@@ -12916,6 +13221,17 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/parser': 7.28.0
       eslint: 9.33.0(jiti@2.6.1)
+      hermes-parser: 0.25.1
+      zod: 3.25.76
+      zod-validation-error: 4.0.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/parser': 7.28.0
+      eslint: 9.39.2(jiti@2.6.1)
       hermes-parser: 0.25.1
       zod: 3.25.76
       zod-validation-error: 4.0.2(zod@3.25.76)
@@ -12953,6 +13269,28 @@ snapshots:
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.1
       eslint: 9.33.0(jiti@2.6.1)
+      estraverse: 5.3.0
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.2
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.5
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
+
+  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.2.1
+      eslint: 9.39.2(jiti@2.6.1)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -13053,6 +13391,47 @@ snapshots:
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.1
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint@9.39.2(jiti@2.6.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@2.6.1))
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.21.1
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.1
+      '@eslint/js': 9.39.2
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.6
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -14991,6 +15370,10 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-estree@4.0.0:
+    dependencies:
+      '@slimio/is': 2.0.0
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
@@ -15404,6 +15787,8 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.6.2: {}
+
+  prettier@3.7.4: {}
 
   pretty-ms@9.2.0:
     dependencies:
@@ -16539,6 +16924,26 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-morph-react@1.0.3(jiti@2.6.1)(typescript@5.9.2):
+    dependencies:
+      '@eslint/core': 1.0.0
+      '@eslint/js': 9.39.2
+      '@stylistic/eslint-plugin': 5.6.1(eslint@9.39.2(jiti@2.6.1))
+      '@types/eslint-plugin-jsx-a11y': 6.10.1(jiti@2.6.1)
+      '@typescript-eslint/typescript-estree': 8.50.1(typescript@5.9.2)
+      eslint: 9.39.2(jiti@2.6.1)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
+      node-estree: 4.0.0
+      prettier: 3.7.4
+      ts-morph: 26.0.0
+      typescript-eslint: 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - typescript
+
   ts-morph@26.0.0:
     dependencies:
       '@ts-morph/common': 0.27.0
@@ -16692,6 +17097,17 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.9.2)
       '@typescript-eslint/utils': 8.46.2(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2)
       eslint: 9.33.0(jiti@2.6.1)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript-eslint@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.50.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.50.1(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,8 +525,8 @@ importers:
         specifier: ^26.0.0
         version: 26.0.0
       ts-morph-react:
-        specifier: ^1.0.5
-        version: 1.0.5(jiti@2.6.1)(typescript@5.9.2)
+        specifier: ^1.0.6
+        version: 1.0.6(jiti@2.6.1)(typescript@5.9.2)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -7889,8 +7889,8 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  ts-morph-react@1.0.5:
-    resolution: {integrity: sha512-xKdZCmBLsMY2a5ohBw+5cZeBvtWD+zlJjYk18jPwOzvR+gTWcnDBu0Yhw7P30IgzUJbXMsUHtoHHllBb9GvmKA==}
+  ts-morph-react@1.0.6:
+    resolution: {integrity: sha512-61v5pTZngC2oRqKqCpS+m5pfdklQY1/XSxHXJUncIF+MjN/AEY5Cn1k9nszyFY3fxdZ0qm3wuYuAVsHZhlTHtQ==}
 
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
@@ -16919,7 +16919,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-morph-react@1.0.5(jiti@2.6.1)(typescript@5.9.2):
+  ts-morph-react@1.0.6(jiti@2.6.1)(typescript@5.9.2):
     dependencies:
       '@eslint/core': 1.0.0
       '@eslint/js': 9.39.2


### PR DESCRIPTION
## Description
Adds support for configurable code style adjustment using ESLint, Prettier and TypeScript Language Service.

## Changes
* Added `ts-morph-react` dependency to package.json (I maintain this library separately to avoid bloating the codebase)
* Added `transform` setting to config schema (see details below)
* Created `transform-react.ts` to run the code style adjustments

## Configuration

Documentation available on [ts-morph-react github page](https://github.com/atomicbi/ts-morph-react)

```json
{
  "transform": {
    // Avoid export assignment `export =`, and instead enfore specific exports `export const Button`
    "enforceDirectExports": true,
    // Transform functions to react function components / arrow functions `export const Button: FunctionComponent = `
    "enforceFunctionComponent": true,
    // Use named imports for react, e.g. `import { type FunctionComponent } from 'react'`
    "enforceNamedImports": true,
    // Ensure newline separation on root level (imports group, components)
    "enforceLineSeparation": true,
    // Enfore TypeScript Language Service code style adjustments
    "enforceFormat": true,
    // Enfore ESLint code style adjustments
    "enforceEslint": true,
    // Enfore Prettier code style adjustments
    "enforcePrettier": true,
    // TypeScript Language Service format options
    "format": { ... },
    // ESLint rules (@typescript-eslint/*, @stylistic/* supported)
    "eslint": { ... },
    // Prettier options
    "prettier": { ... }
  }
}
```

## Testing
* ✅ Tested `npx shadcn@latest add` command to ensure code style adjustments apply
* ✅ Tested adding multiple components to ensure compatibility across files
* ✅ Create multiple tests for `transform-react` and different configuration options
* ✅ Ensured all existing tests are passing

## Related
- Fixes #2205
- Fixes #1334
- Fixes #1202
