### PR TITLE
feat(components): add inline-edit component

### DIFF
--- a/apps/v4/content/docs/components/inline-edit.mdx
+++ b/apps/v4/content/docs/components/inline-edit.mdx
@@ -1,0 +1,52 @@
+---
+title: Inline Edit
+description: An inline edit displays a custom input component that switches between reading and editing on the same page.
+component: true
+---
+
+<ComponentPreview
+  name="inline-edit-demo"
+  description="An inline edit component."
+/>
+
+## Installation
+
+<CodeTabs>
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add inline-edit
+```
+
+</TabsContent>
+
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<ComponentSource name="inline-edit" title="components/ui/inline-edit.tsx" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</CodeTabs>
+
+## Usage
+
+```tsx
+import { InlineEdit } from "@/components/ui/inline-edit"
+```
+
+```tsx
+<InlineEdit defaultValue="Click to edit" />
+```

--- a/apps/v4/registry/new-york-v4/examples/_registry.ts
+++ b/apps/v4/registry/new-york-v4/examples/_registry.ts
@@ -1273,6 +1273,17 @@ export const examples: Registry["items"] = [
     ],
   },
   {
+    name: "inline-edit-demo",
+    type: "registry:example",
+    registryDependencies: ["inline-edit", "textarea"],
+    files: [
+      {
+        path: "examples/inline-edit-demo.tsx",
+        type: "registry:example",
+      },
+    ],
+  },
+  {
     name: "input-demo",
     type: "registry:example",
     registryDependencies: ["input"],

--- a/apps/v4/registry/new-york-v4/examples/inline-edit-demo.tsx
+++ b/apps/v4/registry/new-york-v4/examples/inline-edit-demo.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { InlineEdit } from "@/registry/new-york-v4/ui/inline-edit"
+import { Textarea } from "@/registry/new-york-v4/ui/textarea"
+
+export default function InlineEditDemo() {
+  return (
+    <div className="flex w-full max-w-sm flex-col gap-8">
+      <div className="space-y-2">
+        <h3 className="text-muted-foreground text-sm font-medium">
+          Basic Input
+        </h3>
+        <InlineEdit defaultValue="Click to edit me" />
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="text-muted-foreground text-sm font-medium">
+          With Textarea
+        </h3>
+        <InlineEdit
+          defaultValue="This uses a textarea for multiline editing."
+          renderInput={(props) => <Textarea {...props} />}
+          className="items-start"
+          submitOnEnter={false}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="text-muted-foreground text-sm font-medium">
+          Controlled, No Controls
+        </h3>
+        <InlineEdit defaultValue="Press Enter to save" showControls={false} />
+      </div>
+    </div>
+  )
+}

--- a/apps/v4/registry/new-york-v4/ui/_registry.ts
+++ b/apps/v4/registry/new-york-v4/ui/_registry.ts
@@ -275,6 +275,17 @@ export const ui: Registry["items"] = [
     ],
   },
   {
+    name: "inline-edit",
+    type: "registry:ui",
+    registryDependencies: ["button", "input"],
+    files: [
+      {
+        path: "ui/inline-edit.tsx",
+        type: "registry:ui",
+      },
+    ],
+  },
+  {
     name: "input",
     type: "registry:ui",
     files: [

--- a/apps/v4/registry/new-york-v4/ui/inline-edit.tsx
+++ b/apps/v4/registry/new-york-v4/ui/inline-edit.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import * as React from "react"
+import { Check, Pencil, X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/registry/new-york-v4/ui/button"
+import { Input } from "@/registry/new-york-v4/ui/input"
+
+interface InlineEditProps extends React.HTMLAttributes<HTMLDivElement> {
+  defaultValue?: string
+  value?: string
+  onSave?: (value: string) => void
+  onCancel?: () => void
+  showControls?: boolean
+  disabled?: boolean
+  renderInput?: (props: any) => React.ReactNode
+  submitOnEnter?: boolean
+}
+
+const InlineEdit = React.forwardRef<HTMLDivElement, InlineEditProps>(
+  (
+    {
+      className,
+      defaultValue = "",
+      value: controlledValue,
+      onSave,
+      onCancel,
+      showControls = true,
+      submitOnEnter = true,
+      disabled = false,
+      children,
+      renderInput,
+      ...props
+    },
+    ref
+  ) => {
+    const [isEditing, setIsEditing] = React.useState(false)
+    const [value, setValue] = React.useState(defaultValue)
+    const [tempValue, setTempValue] = React.useState(defaultValue)
+    const inputRef = React.useRef<HTMLInputElement>(null)
+
+    const isControlled = controlledValue !== undefined
+    const currentValue = isControlled ? controlledValue : value
+
+    React.useEffect(() => {
+      if (isEditing && inputRef.current) {
+        inputRef.current.focus()
+      }
+    }, [isEditing])
+
+    const handleEdit = () => {
+      if (disabled) return
+      setTempValue(currentValue)
+      setIsEditing(true)
+    }
+
+    const handleSave = () => {
+      if (!isControlled) {
+        setValue(tempValue)
+      }
+      onSave?.(tempValue)
+      setIsEditing(false)
+    }
+
+    const handleCancel = () => {
+      setTempValue(currentValue)
+      setIsEditing(false)
+      onCancel?.()
+    }
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        handleSave()
+        return
+      }
+      if (e.key === "Enter" && submitOnEnter) {
+        e.preventDefault()
+        handleSave()
+      } else if (e.key === "Escape") {
+        handleCancel()
+      }
+    }
+
+    if (isEditing) {
+      return (
+        <div
+          ref={ref}
+          className={cn("flex items-center gap-2", className)}
+          {...props}
+        >
+          {renderInput ? (
+            renderInput({
+              value: tempValue,
+              onChange: (e: any) => setTempValue(e.target.value),
+              onKeyDown: handleKeyDown,
+              autoFocus: true,
+            })
+          ) : (
+            <Input
+              ref={inputRef}
+              value={tempValue}
+              onChange={(e) => setTempValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={disabled}
+            />
+          )}
+          {showControls && (
+            <div className="flex items-center gap-1">
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={handleSave}
+                className="h-8 w-8"
+              >
+                <Check className="h-4 w-4" />
+                <span className="sr-only">Save</span>
+              </Button>
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={handleCancel}
+                className="h-8 w-8"
+              >
+                <X className="h-4 w-4" />
+                <span className="sr-only">Cancel</span>
+              </Button>
+            </div>
+          )}
+        </div>
+      )
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "group hover:bg-muted/50 flex cursor-pointer items-center gap-2 rounded-md border border-transparent px-3 py-1",
+          className
+        )}
+        onClick={handleEdit}
+        {...props}
+      >
+        <span className="flex-1 truncate">
+          {currentValue || (
+            <span className="text-muted-foreground italic">
+              Click to edit...
+            </span>
+          )}
+        </span>
+        {!disabled && (
+          <Pencil className="text-muted-foreground h-3 w-3 opacity-0 transition-opacity group-hover:opacity-100" />
+        )}
+      </div>
+    )
+  }
+)
+InlineEdit.displayName = "InlineEdit"
+
+export { InlineEdit }


### PR DESCRIPTION
## Summary

This PR adds a new **InlineEdit** component to the registry. It allows users to toggle between a read-only view and an editable input field inline, improving the UX for quick edits.

Fixes #268



## Features

- **Flexible Modes**  
  Supports both controlled and uncontrolled usage.

- **Custom Inputs**  
  Can render standard `<Input />` or `<Textarea />` via the `renderInput` prop.

- **Keyboard Support**
  - `Enter` to save (customizable for textareas via `submitOnEnter`)
  - `Esc` to cancel
  - `Cmd + Enter` / `Ctrl + Enter` to save at any time

- **Controls**  
  Optional check / cross controls for explicit saving and canceling.

- **Neutral Styling**  
  Designed to fit seamlessly with existing shadcn/ui styles.



## Files Added / Modified

- `apps/v4/registry/new-york-v4/ui/inline-edit.tsx`  
  Core component logic.

- `apps/v4/registry/new-york-v4/examples/inline-edit-demo.tsx`  
  Usage examples (Basic, Multiline, Controlled).

- `apps/v4/content/docs/components/inline-edit.mdx`  
  Documentation page.

- `apps/v4/registry/new-york-v4/ui/_registry.ts`  
  Component registration.

- `apps/v4/registry/new-york-v4/examples/_registry.ts`  
  Demo registration.
