### PR TITLE
Add !important to button cursor style

### DIFF
--- a/apps/v4/content/docs/components/button.mdx
+++ b/apps/v4/content/docs/components/button.mdx
@@ -81,7 +81,7 @@ If you want to keep the `cursor: pointer` behavior, add the following code to yo
 @layer base {
   button:not(:disabled),
   [role="button"]:not(:disabled) {
-    cursor: pointer;
+    cursor: pointer !important;
   }
 }
 ```


### PR DESCRIPTION
This pull request makes a minor update to the button styling documentation. The change ensures that the `cursor: pointer` style is always applied to enabled buttons by adding `!important` to the CSS rule.

* Updated the CSS example to use `cursor: pointer !important;` for enabled buttons as the pointer cursor is not yet shown without important.