### PR TITLE
fix(charts): added gap between tooltip label and value

### DIFF
--- a/apps/v4/registry/bases/base/ui/chart.tsx
+++ b/apps/v4/registry/bases/base/ui/chart.tsx
@@ -224,7 +224,7 @@ function ChartTooltipContent({
                     )}
                     <div
                       className={cn(
-                        "flex flex-1 justify-between leading-none",
+                        "flex flex-1 gap-1 justify-between leading-none",
                         nestLabel ? "items-end" : "items-center"
                       )}
                     >

--- a/apps/v4/registry/bases/radix/ui/chart.tsx
+++ b/apps/v4/registry/bases/radix/ui/chart.tsx
@@ -224,7 +224,7 @@ function ChartTooltipContent({
                     )}
                     <div
                       className={cn(
-                        "flex flex-1 justify-between leading-none",
+                        "flex flex-1 gap-1 justify-between leading-none",
                         nestLabel ? "items-end" : "items-center"
                       )}
                     >

--- a/apps/v4/registry/new-york-v4/ui/chart.tsx
+++ b/apps/v4/registry/new-york-v4/ui/chart.tsx
@@ -224,7 +224,7 @@ function ChartTooltipContent({
                     )}
                     <div
                       className={cn(
-                        "flex flex-1 justify-between leading-none",
+                        "flex flex-1 gap-1 justify-between leading-none",
                         nestLabel ? "items-end" : "items-center"
                       )}
                     >


### PR DESCRIPTION
**What:** Fixes tooltip label visually touching value in chart component.

**Why:** It looks visually nicer.

**How:** Added property `gap-1` on the existing flex container for the tooltip.

### Screenshots
Before:
<img width="167" height="135" alt="image" src="https://github.com/user-attachments/assets/f85a2401-991d-40a6-8455-81824849fa5a" />
After:
<img width="182" height="130" alt="image" src="https://github.com/user-attachments/assets/5d9763a0-de13-4f77-a879-d2ba92712514" />

### Checklist
NOTE: I haven't run any required commands or tests regarding this, since I've had some trouble with it (a skill issue on my end), though I believe this does not warrant it.