### PR TITLE
Fix ignore errors on glob

### DIFF
--- a/.changeset/plain-shirts-cover.md
+++ b/.changeset/plain-shirts-cover.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Fix shadcn for projects with unreadable permission files

--- a/packages/shadcn/src/migrations/migrate-radix.ts
+++ b/packages/shadcn/src/migrations/migrate-radix.ts
@@ -116,6 +116,7 @@ export async function migrateRadix(
         cwd: basePath,
         onlyFiles: true,
         ignore: ["**/node_modules/**"],
+        suppressErrors: true,
       })
     } else {
       const fullPath = path.resolve(basePath, options.path)

--- a/packages/shadcn/src/migrations/migrate-rtl.ts
+++ b/packages/shadcn/src/migrations/migrate-rtl.ts
@@ -36,6 +36,7 @@ export async function migrateRtl(
         cwd: basePath,
         onlyFiles: true,
         ignore: ["**/node_modules/**"],
+        suppressErrors: true,
       })
     } else {
       const fullPath = path.resolve(basePath, options.path)

--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -177,6 +177,7 @@ export async function findPackageRoot(cwd: string, resolvedPath: string) {
     cwd: commonRoot,
     deep: 3,
     ignore: ["**/node_modules/**", "**/dist/**", "**/build/**", "**/public/**"],
+    suppressErrors: true,
   })
 
   const matchingPackageRoot = packageRoots

--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -280,6 +280,7 @@ export async function findPackageRoot(cwd: string, resolvedPath: string) {
     cwd: commonRoot,
     deep: 3,
     ignore: ["**/node_modules/**", "**/dist/**", "**/build/**", "**/public/**"],
+    suppressErrors: true,
   })
 
   const matchingPackageRoot = packageRoots

--- a/packages/shadcn/src/utils/get-project-info.ts
+++ b/packages/shadcn/src/utils/get-project-info.ts
@@ -53,6 +53,7 @@ export async function getProjectInfo(cwd: string): Promise<ProjectInfo | null> {
         cwd,
         deep: 3,
         ignore: PROJECT_SHARED_IGNORE,
+        suppressErrors: true,
       }
     ),
     fs.pathExists(path.resolve(cwd, "src")),
@@ -246,6 +247,7 @@ export async function getTailwindCssFile(cwd: string) {
       cwd,
       deep: 5,
       ignore: PROJECT_SHARED_IGNORE,
+      suppressErrors: true,
     }),
     getTailwindVersion(cwd),
   ])

--- a/packages/shadcn/src/utils/get-project-info.ts
+++ b/packages/shadcn/src/utils/get-project-info.ts
@@ -63,6 +63,7 @@ export async function getProjectInfo(
         cwd,
         deep: 3,
         ignore: PROJECT_SHARED_IGNORE,
+        suppressErrors: true,
       }
     ),
     fs.pathExists(path.resolve(cwd, "src")),
@@ -264,6 +265,7 @@ export async function getTailwindCssFile(cwd: string, configCssFile?: string) {
       cwd,
       deep: 5,
       ignore: PROJECT_SHARED_IGNORE,
+      suppressErrors: true,
     }),
     getTailwindVersion(cwd),
   ])

--- a/packages/shadcn/src/utils/workspace.ts
+++ b/packages/shadcn/src/utils/workspace.ts
@@ -140,6 +140,7 @@ async function loadWorkspacePackages(root: string) {
     {
       cwd: root,
       ignore: ["**/node_modules/**"],
+      suppressErrors: true,
     }
   )
 


### PR DESCRIPTION
When using the add command in a project with unreachable file it generates an error and we can't use the add command at all.
The issue comes from `fast-glob` that throws an EACCESS error instead of just ignoring the directory. 

Fix #4813 