### PR TITLE
fix(docs): remove redundant check icon from combobox example

### DIFF
--- a/apps/v4/content/docs/components/combobox.mdx
+++ b/apps/v4/content/docs/components/combobox.mdx
@@ -23,9 +23,8 @@ See installation instructions for the [Popover](/docs/components/popover#install
 "use client"
 
 import * as React from "react"
-import { CheckIcon, ChevronsUpDownIcon } from "lucide-react"
+import { ChevronsUpDownIcon } from "lucide-react"
 
-import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import {
   Command,
@@ -93,17 +92,12 @@ export function ExampleCombobox() {
                 <CommandItem
                   key={framework.value}
                   value={framework.value}
+                  data-checked={framework.value === value}
                   onSelect={(currentValue) => {
                     setValue(currentValue === value ? "" : currentValue)
                     setOpen(false)
                   }}
                 >
-                  <CheckIcon
-                    className={cn(
-                      "mr-2 h-4 w-4",
-                      value === framework.value ? "opacity-100" : "opacity-0"
-                    )}
-                  />
                   {framework.label}
                 </CommandItem>
               ))}

--- a/apps/v4/registry/new-york-v4/examples/combobox-demo.tsx
+++ b/apps/v4/registry/new-york-v4/examples/combobox-demo.tsx
@@ -1,9 +1,8 @@
 "use client"
 
 import * as React from "react"
-import { Check, ChevronsUpDown } from "lucide-react"
+import { ChevronsUpDown } from "lucide-react"
 
-import { cn } from "@/lib/utils"
 import { Button } from "@/registry/new-york-v4/ui/button"
 import {
   Command,
@@ -71,18 +70,13 @@ export default function ComboboxDemo() {
                 <CommandItem
                   key={framework.value}
                   value={framework.value}
+                  data-checked={framework.value === value}
                   onSelect={(currentValue) => {
                     setValue(currentValue === value ? "" : currentValue)
                     setOpen(false)
                   }}
                 >
                   {framework.label}
-                  <Check
-                    className={cn(
-                      "ml-auto",
-                      value === framework.value ? "opacity-100" : "opacity-0"
-                    )}
-                  />
                 </CommandItem>
               ))}
             </CommandGroup>


### PR DESCRIPTION
## Summary
- Remove manual `<Check>` icon from combobox example since `CommandItem` has a built-in check icon
- Use `data-checked` attribute to control the check icon visibility
- Remove unused `cn` import from example code

## Problem
When users install the Command component via CLI, the `CommandItem` includes a built-in check icon controlled by `data-checked`. However, the combobox documentation example manually renders a `<Check>` icon, causing duplicate check marks to appear.

This was reported in #9225.

## Solution
Updated the combobox example to use the `data-checked` attribute on `CommandItem` instead of manually rendering a `<Check>` icon. This aligns with how other blocks (like github.tsx) handle selection state.

## Test plan
- [x] Verified the combobox page loads without errors at `http://localhost:4000/docs/components/combobox`
- [x] Confirmed no TypeScript compilation errors

Fixes #9225