### PR TITLE
docs(cli): add package manager equivalents section

### DIFF
--- a/apps/v4/content/docs/(root)/cli.mdx
+++ b/apps/v4/content/docs/(root)/cli.mdx
@@ -3,6 +3,19 @@ title: shadcn
 description: Use the shadcn CLI to add components to your project.
 ---
 
+## Package Managers
+
+The examples on this page use `npx`. You can use your preferred package manager:
+
+| Package Manager | Command |
+| --- | --- |
+| npm | `npx shadcn@latest` |
+| pnpm | `pnpm dlx shadcn@latest` |
+| yarn | `yarn dlx shadcn@latest` |
+| bun | `bunx --bun shadcn@latest` |
+
+---
+
 ## init
 
 Use the `init` command to initialize configuration and dependencies for a new project.


### PR DESCRIPTION
## Summary
- Add a "Package Managers" section at the top of the CLI docs
- Include a table showing equivalent commands for npm, pnpm, yarn, and bun

## Problem
The CLI documentation only shows `npx` commands. Users of other package managers (especially yarn) may incorrectly try commands like `yarn shadcn@latest init` which doesn't work.

The correct command for yarn is `yarn dlx shadcn@latest init`.

This was reported in #9232.

## Solution
Added a clear table at the top of the CLI docs showing the correct command syntax for each package manager:

| Package Manager | Command |
| --- | --- |
| npm | `npx shadcn@latest` |
| pnpm | `pnpm dlx shadcn@latest` |
| yarn | `yarn dlx shadcn@latest` |
| bun | `bunx --bun shadcn@latest` |

## Test plan
- [x] Verified the CLI docs page loads at `http://localhost:4000/docs/cli`
- [x] Confirmed the table renders correctly

Fixes #9232