### PR TITLE
fix(theme): correct Safari date input colors in dark mode

### DIFF
--- a/apps/v4/styles/globals.css
+++ b/apps/v4/styles/globals.css
@@ -134,7 +134,7 @@
   --destructive: oklch(0.704 0.191 22.216);
   --destructive-foreground: oklch(0.58 0.22 27);
   --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
+  --input: oklch(0.98 0 0 / 15%);
   --ring: oklch(0.556 0 0);
   --chart-1: var(--color-blue-300);
   --chart-2: var(--color-blue-500);


### PR DESCRIPTION
## Summary
- Fix date input visual feedback in Safari dark mode
- Change `--input` oklch lightness from `1` to `0.98`

## Problem
In Safari dark mode, when a user deletes part of a date input (day, month, or year), the empty portion should appear muted to indicate it's not set. However, with `oklch(1 0 0 / 15%)`, Safari doesn't render this feedback correctly.

This causes:
- No visual indication that date parts are missing
- Broken native browser form validation UX
- Users thinking a date is set when it's not

## Root Cause
Safari has a quirk where `oklch(1 0 0 / ...)` (exactly 1.0 lightness = pure white) doesn't trigger the expected "empty" styling for date inputs. Using `0.98` (visually identical, 99.8% white) fixes this.

## Solution
```css
/* Before */
--input: oklch(1 0 0 / 15%);

/* After */  
--input: oklch(0.98 0 0 / 15%);
```

## File Changed
- `apps/v4/styles/globals.css` (line 137)

## Test plan
- [ ] Open Safari in dark mode
- [ ] Go to a date input field
- [ ] Delete the year portion
- [ ] Verify the year shows muted/empty styling

Fixes #9212