### PR TITLE
fix(cli): use 'bun x' instead of 'bunx' for Windows PowerShell compatibility

### DIFF
--- a/apps/v4/lib/highlight-code.ts
+++ b/apps/v4/lib/highlight-code.ts
@@ -32,7 +32,7 @@ export const transformers = [
             "npx create-",
             "pnpm create "
           )
-          node.properties["__bun__"] = raw.replace("npx", "bunx --bun")
+          node.properties["__bun__"] = raw.replace("npx", "bun x --bun")
         } else if (raw.startsWith("npm create")) {
           // npm create.
           node.properties["__npm__"] = raw
@@ -44,7 +44,7 @@ export const transformers = [
           node.properties["__npm__"] = raw
           node.properties["__yarn__"] = raw.replace("npx", "yarn dlx")
           node.properties["__pnpm__"] = raw.replace("npx", "pnpm dlx")
-          node.properties["__bun__"] = raw.replace("npx", "bunx --bun")
+          node.properties["__bun__"] = raw.replace("npx", "bun x --bun")
         } else if (raw.startsWith("npm run")) {
           // npm run.
           node.properties["__npm__"] = raw

--- a/packages/shadcn/src/utils/get-package-manager.ts
+++ b/packages/shadcn/src/utils/get-package-manager.ts
@@ -39,7 +39,7 @@ export async function getPackageRunner(cwd: string) {
 
   if (packageManager === "pnpm") return "pnpm dlx"
 
-  if (packageManager === "bun") return "bunx"
+  if (packageManager === "bun") return "bun x"
 
   return "npx"
 }


### PR DESCRIPTION
## Summary

On Windows PowerShell, the `bunx` alias fails with a "Script not found" error, while the spaced `bun x` command works correctly.

This PR updates the CLI and documentation code to use `bun x` instead of `bunx` for cross-platform compatibility.

## Changes

- **`packages/shadcn/src/utils/get-package-manager.ts`**: Return `"bun x"` instead of `"bunx"` from `getPackageRunner()`
- **`apps/v4/lib/highlight-code.ts`**: Use `"bun x --bun"` instead of `"bunx --bun"` in documentation code transformers

## Testing

Tested on Windows PowerShell:
- ❌ `bunx shadcn@latest add switch` → "Script not found 'shadcn@latest'"
- ✅ `bun x shadcn@latest add switch` → Works correctly

## Related

Fixes #9213