### PR TITLE
fix(docs): use yarn dlx for npx command transformation

### DIFF
--- a/apps/v4/lib/highlight-code.ts
+++ b/apps/v4/lib/highlight-code.ts
@@ -48,7 +48,7 @@ export const transformers = [
         // npx.
         if (raw.startsWith("npx")) {
           node.properties["__npm__"] = raw
-          node.properties["__yarn__"] = raw.replace("npx", "yarn")
+          node.properties["__yarn__"] = raw.replace("npx", "yarn dlx")
           node.properties["__pnpm__"] = raw.replace("npx", "pnpm dlx")
           node.properties["__bun__"] = raw.replace("npx", "bunx --bun")
         }


### PR DESCRIPTION
## Summary
- Fix yarn command transformation from `npx` → `yarn dlx` (was incorrectly `yarn`)
- `yarn shadcn@latest init` doesn't work - needs to be `yarn dlx shadcn@latest init`

Fixes #9232

## Test
When viewing docs with yarn package manager selected:
- Before: `yarn shadcn@latest init` ❌
- After: `yarn dlx shadcn@latest init` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)