### PR TITLE
fix: update Claude Code MCP documentation link

### DIFF
--- a/apps/v4/content/docs/(root)/mcp.mdx
+++ b/apps/v4/content/docs/(root)/mcp.mdx
@@ -153,7 +153,7 @@ To use the shadcn MCP server with Claude Code, add the following configuration t
 
 After adding the configuration, restart Claude Code and run `/mcp` to see the shadcn MCP server in the list. If you see `Connected`, you're good to go.
 
-See the [Claude Code MCP documentation](https://docs.anthropic.com/en/docs/claude-code/mcp) for more details.
+See the [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp) for more details.
 
 ### Cursor
 


### PR DESCRIPTION
Fixes: #9270

fix: broken Anthropic MCP link in docs

This PR fixes a broken Anthropic MCP link on the documentation page.

The previous URL pointed to a non-existent page on platform.claude.com. It has been updated to the correct and working MCP documentation link.

Updated files:

/shadcn/ui/apps/v4/content/docs/(root)/mcp.mdx

