### PR TITLE
fix: update theme toggle key detection to exclude Alt key

### DIFF
--- a/apps/v4/components/mode-switcher.tsx
+++ b/apps/v4/components/mode-switcher.tsx
@@ -29,7 +29,7 @@ export function ModeSwitcher() {
 
   React.useEffect(() => {
     const down = (e: KeyboardEvent) => {
-      if ((e.key === "d" || e.key === "D") && !e.metaKey && !e.ctrlKey) {
+      if ((e.key === "d" || e.key === "D") && !e.metaKey && !e.ctrlKey && !e.altKey) {
         if (
           (e.target instanceof HTMLElement && e.target.isContentEditable) ||
           e.target instanceof HTMLInputElement ||
@@ -96,7 +96,7 @@ export function DarkModeScript() {
             (function() {
               // Forward D key
               document.addEventListener('keydown', function(e) {
-                if ((e.key === 'd' || e.key === 'D') && !e.metaKey && !e.ctrlKey) {
+                if ((e.key === 'd' || e.key === 'D') && !e.metaKey && !e.ctrlKey && !e.altKey) {
                   if (
                     (e.target instanceof HTMLElement && e.target.isContentEditable) ||
                     e.target instanceof HTMLInputElement ||


### PR DESCRIPTION
Fixes: #9198
fix: avoid overriding browser ALT + D shortcut

This PR fixes an accessibility and UX issue where ALT + D was overriding the browser’s default shortcut behavior.

On Chrome (Windows and Linux), ALT + D is reserved for focusing the address bar. The site was intercepting this shortcut to toggle the theme between light and dark mode. This change prevents the site from overriding the browser default behavior.

Affected pages:

Documentation pages (e.g. /docs/installation/react-router)