### PR TITLE
fix(components): replaced sm:text-left with sm:text-start for better …

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/alert-dialog.tsx
+++ b/apps/v4/registry/new-york-v4/ui/alert-dialog.tsx
@@ -70,7 +70,7 @@ function AlertDialogHeader({
   return (
     <div
       data-slot="alert-dialog-header"
-      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      className={cn("flex flex-col gap-2 text-center sm:text-start", className)}
       {...props}
     />
   )


### PR DESCRIPTION
## RTL Support for AlertDialogContent

In the examples I Added `dir="rtl"` to the root HTML element.

**Before:**
![before-change](https://github.com/user-attachments/assets/eb445e56-95fe-4eb1-8525-b6c3333a581c)
*Text remains LTR despite the rest of the site being RTL*

**After:**
![after-change](https://github.com/user-attachments/assets/41eda4b1-94f8-4f2d-94b8-40cd1530317b)
*Text now correctly follows RTL direction*

**LTR sites unaffected:**
![after-change-en](https://github.com/user-attachments/assets/cce44d6f-abaf-4a87-9eee-ef5895022bfe)
*No changes to standard left-to-right layouts*