### PR TITLE
fix(cli): handle Windows EPERM errors when loading tsconfig

### DIFF
--- a/packages/shadcn/src/registry/utils.ts
+++ b/packages/shadcn/src/registry/utils.ts
@@ -14,7 +14,7 @@ import {
   resolveFilePath,
 } from "@/src/utils/updaters/update-files"
 import { Project, ScriptKind } from "ts-morph"
-import { loadConfig } from "tsconfig-paths"
+import { loadTsConfig } from "@/src/utils/load-tsconfig"
 import { z } from "zod"
 
 const FILE_EXTENSIONS_FOR_LOOKUP = [".tsx", ".ts", ".jsx", ".js", ".css"]
@@ -96,7 +96,7 @@ export async function recursivelyResolveFileImports(
   const sourceFile = project.createSourceFile(tempFile, content, {
     scriptKind: ScriptKind.TSX,
   })
-  const tsConfig = await loadConfig(config.resolvedPaths.cwd)
+  const tsConfig = loadTsConfig(config.resolvedPaths.cwd)
   if (tsConfig.resultType === "failed") {
     return { dependencies: [], files: [] }
   }

--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -10,7 +10,7 @@ import { highlighter } from "@/src/utils/highlighter"
 import { resolveImport } from "@/src/utils/resolve-import"
 import { cosmiconfig } from "cosmiconfig"
 import fg from "fast-glob"
-import { loadConfig } from "tsconfig-paths"
+import { loadTsConfig } from "@/src/utils/load-tsconfig"
 import { z } from "zod"
 
 export const DEFAULT_STYLE = "default"
@@ -54,7 +54,7 @@ export async function resolveConfigPaths(
   }
 
   // Read tsconfig.json.
-  const tsConfig = await loadConfig(cwd)
+  const tsConfig = loadTsConfig(cwd)
 
   if (tsConfig.resultType === "failed") {
     throw new Error(

--- a/packages/shadcn/src/utils/get-project-info.ts
+++ b/packages/shadcn/src/utils/get-project-info.ts
@@ -5,7 +5,7 @@ import { Config, getConfig, resolveConfigPaths } from "@/src/utils/get-config"
 import { getPackageInfo } from "@/src/utils/get-package-info"
 import fg from "fast-glob"
 import fs from "fs-extra"
-import { loadConfig } from "tsconfig-paths"
+import { loadTsConfig } from "@/src/utils/load-tsconfig"
 import { z } from "zod"
 
 export type TailwindVersion = "v3" | "v4" | null
@@ -285,7 +285,7 @@ export async function getTailwindConfigFile(cwd: string) {
 }
 
 export async function getTsConfigAliasPrefix(cwd: string) {
-  const tsConfig = await loadConfig(cwd)
+  const tsConfig = loadTsConfig(cwd)
 
   if (
     tsConfig?.resultType === "failed" ||

--- a/packages/shadcn/src/utils/load-tsconfig.ts
+++ b/packages/shadcn/src/utils/load-tsconfig.ts
@@ -1,0 +1,126 @@
+import fs from "fs"
+import path from "path"
+import {
+  loadConfig,
+  type ConfigLoaderResult,
+  type ConfigLoaderSuccessResult,
+} from "tsconfig-paths"
+
+/**
+ * Safely loads tsconfig.json with proper error handling for Windows.
+ *
+ * On Windows, the tsconfig-paths library traverses up the directory tree
+ * using fs.readdirSync, which can fail with EPERM when encountering
+ * protected junction points like "Application Data" or localized system
+ * folders in user directories.
+ *
+ * This wrapper:
+ * 1. First tries to find tsconfig.json/jsconfig.json directly in the cwd
+ * 2. Falls back to the standard loadConfig with error handling
+ * 3. Gracefully handles EPERM errors by returning a failed result
+ */
+export function loadTsConfig(cwd: string): ConfigLoaderResult {
+  // First, try to find tsconfig.json or jsconfig.json directly in cwd
+  // This avoids walking up directories in most cases
+  const tsconfigPath = findTsConfigInDir(cwd)
+
+  if (tsconfigPath) {
+    // If we found a config file directly, use loadConfig with explicit path
+    // This avoids the directory walking that causes EPERM errors
+    try {
+      return loadConfig(cwd)
+    } catch (error) {
+      // If loadConfig throws (e.g., EPERM during path resolution),
+      // fall through to manual loading
+      if (isPermissionError(error)) {
+        return loadTsConfigManually(tsconfigPath)
+      }
+      throw error
+    }
+  }
+
+  // Try standard loadConfig, but catch EPERM errors
+  try {
+    return loadConfig(cwd)
+  } catch (error) {
+    if (isPermissionError(error)) {
+      // On Windows, walking up directories can hit protected folders
+      // Return a failed result instead of crashing
+      return {
+        resultType: "failed",
+        message: `Could not search for tsconfig.json due to permission error. Please ensure a tsconfig.json exists in your project root.`,
+      }
+    }
+    throw error
+  }
+}
+
+/**
+ * Check if tsconfig.json or jsconfig.json exists directly in the given directory
+ */
+function findTsConfigInDir(dir: string): string | null {
+  const candidates = ["tsconfig.json", "jsconfig.json"]
+
+  for (const filename of candidates) {
+    const filePath = path.join(dir, filename)
+    try {
+      if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+        return filePath
+      }
+    } catch {
+      // Ignore errors when checking file existence
+    }
+  }
+
+  return null
+}
+
+/**
+ * Manually load a tsconfig.json file and extract paths configuration
+ */
+function loadTsConfigManually(
+  configPath: string
+): ConfigLoaderSuccessResult | { resultType: "failed"; message: string } {
+  try {
+    const content = fs.readFileSync(configPath, "utf-8")
+    // Remove comments (simple approach - handles // and /* */ comments)
+    const jsonContent = content
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*/g, "")
+
+    const config = JSON.parse(jsonContent)
+    const compilerOptions = config.compilerOptions || {}
+
+    return {
+      resultType: "success",
+      configFileAbsolutePath: configPath,
+      baseUrl: compilerOptions.baseUrl,
+      absoluteBaseUrl: compilerOptions.baseUrl
+        ? path.resolve(path.dirname(configPath), compilerOptions.baseUrl)
+        : path.dirname(configPath),
+      paths: compilerOptions.paths || {},
+      addMatchAll: compilerOptions.baseUrl !== undefined,
+    }
+  } catch (error) {
+    return {
+      resultType: "failed",
+      message: `Failed to parse ${configPath}: ${error instanceof Error ? error.message : "Unknown error"}`,
+    }
+  }
+}
+
+/**
+ * Check if an error is a permission error (EPERM on Windows)
+ */
+function isPermissionError(error: unknown): boolean {
+  if (error instanceof Error) {
+    const nodeError = error as NodeJS.ErrnoException
+    return (
+      nodeError.code === "EPERM" ||
+      nodeError.code === "EACCES" ||
+      error.message.includes("operation not permitted") ||
+      error.message.includes("permission denied")
+    )
+  }
+  return false
+}

--- a/packages/shadcn/src/utils/updaters/update-files.ts
+++ b/packages/shadcn/src/utils/updaters/update-files.ts
@@ -28,7 +28,7 @@ import { transformRsc } from "@/src/utils/transformers/transform-rsc"
 import { transformTwPrefixes } from "@/src/utils/transformers/transform-tw-prefix"
 import prompts from "prompts"
 import { Project, ScriptKind } from "ts-morph"
-import { loadConfig } from "tsconfig-paths"
+import { loadTsConfig } from "@/src/utils/load-tsconfig"
 import { z } from "zod"
 
 export async function updateFiles(
@@ -505,7 +505,7 @@ async function resolveImports(filePaths: string[], config: Config) {
     compilerOptions: {},
   })
   const projectInfo = await getProjectInfo(config.resolvedPaths.cwd)
-  const tsConfig = loadConfig(config.resolvedPaths.cwd)
+  const tsConfig = loadTsConfig(config.resolvedPaths.cwd)
   const updatedFiles = []
 
   if (!projectInfo || tsConfig.resultType === "failed") {


### PR DESCRIPTION
## Summary

Fixes the `EPERM: operation not permitted, scandir` error that occurs on Windows when running `shadcn create` or `shadcn init` from user directories.

**Fixes:** #9043, #9177, #9047

## Problem

On Windows, the `tsconfig-paths` library's `walkForTsConfig` function uses `fs.readdirSync()` to traverse **up** the directory tree searching for `tsconfig.json`. When this traversal reaches user profile directories (e.g., `C:\Users\Username`), it attempts to list all directory contents, including **protected Windows junction points** like:

- `Application Data` (junction to AppData)
- `My Music` / `My Documents` / `My Pictures`
- `Ambiente de Impressão` (Portuguese: Print Environment)
- `Dados de Aplicativos` (Portuguese: Application Data)
- Other localized system folder names

These junction points are protected by Windows and throw `EPERM` (operation not permitted) when accessed, causing the CLI to crash.

### Error Example
```
√ What is your project named? ... my-app
✔ Creating a new Next.js project.
✔ Writing components.json.

Something went wrong. Please check the error below for more details.
If the problem persists, please open an issue on GitHub.

EPERM: operation not permitted, scandir 'C:\Users\Username\Application Data'
```

## Solution

Introduced a safe wrapper function `loadTsConfig()` in `packages/shadcn/src/utils/load-tsconfig.ts` that:

1. **Direct lookup first**: Checks if `tsconfig.json` or `jsconfig.json` exists directly in the project directory, avoiding unnecessary directory traversal
2. **Error handling**: Wraps the standard `loadConfig` call with proper try-catch for `EPERM` and `EACCES` errors
3. **Fallback parsing**: If permission errors occur, manually parses the tsconfig file instead of walking up directories
4. **Graceful degradation**: Returns a proper failed result with helpful message instead of crashing

## Changes

| File | Change |
|------|--------|
| `packages/shadcn/src/utils/load-tsconfig.ts` | **New file** - Safe tsconfig loader with Windows error handling |
| `packages/shadcn/src/utils/get-config.ts` | Use `loadTsConfig` instead of `loadConfig` |
| `packages/shadcn/src/utils/get-project-info.ts` | Use `loadTsConfig` instead of `loadConfig` |
| `packages/shadcn/src/registry/utils.ts` | Use `loadTsConfig` instead of `loadConfig` |
| `packages/shadcn/src/utils/updaters/update-files.ts` | Use `loadTsConfig` instead of `loadConfig` |

## Test Plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] Existing tests pass (some pre-existing Windows path separator failures unrelated to this change)
- [ ] Manual testing on Windows with protected directories

### How to Test

1. On Windows, navigate to a user directory (e.g., `C:\Users\YourName\Desktop`)
2. Run: `pnpm dlx shadcn@latest create --preset "https://ui.shadcn.com/init?..." --template next`
3. Previously: Crashes with `EPERM: operation not permitted, scandir`
4. With fix: Completes successfully

## Why This Approach

1. **Minimal changes**: Only wraps the problematic `loadConfig` calls, doesn't modify the library itself
2. **Backwards compatible**: Behaves identically on Unix systems and Windows systems without permission issues
3. **Proper error handling**: Catches specific permission errors rather than suppressing all errors
4. **Clear error messages**: If tsconfig truly can't be found due to permissions, provides helpful guidance

## Related Issues

- #9043 - shadcn create fails with EPERM scandir 'Application Data' on Windows
- #9177 - EPERM error on Windows during shadcn init (Admin mode does not help)
- #9047 - Permission error when creating a new project
- Similar issues in other projects: [Next.js #62281](https://github.com/vercel/next.js/discussions/62281), [Prisma #27934](https://github.com/prisma/prisma/discussions/27934)