### PR TITLE
docs: fix NavigationMenuLink example to include required context wrappers

### DIFF
--- a/apps/v4/content/docs/components/navigation-menu.mdx
+++ b/apps/v4/content/docs/components/navigation-menu.mdx
@@ -87,14 +87,24 @@ You can use the `asChild` prop to make another component look like a navigation 
 
 ```tsx showLineNumbers title="components/example-navigation-menu.tsx"
 import Link from "next/link"
+import { 
+  NavigationMenu, 
+  NavigationMenuList, 
+  NavigationMenuItem, 
+  NavigationMenuLink 
+} from "@/components/ui/navigation-menu"
 
 export function NavigationMenuDemo() {
   return (
-    <NavigationMenuItem>
-      <NavigationMenuLink asChild>
-        <Link href="/docs">Documentation</Link>
-      </NavigationMenuLink>
-    </NavigationMenuItem>
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuLink asChild>
+            <Link href="/docs">Documentation</Link>
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
   )
 }
 ```


### PR DESCRIPTION
### Description
The current example for the `Link` component in the Navigation Menu documentation causes a runtime error:
`FocusGroupItem` must be used within `NavigationMenu`.

This is because `NavigationMenuLink` (and its sub-components) requires the context provided by `NavigationMenu` and `NavigationMenuList`.

### Changes
Updated the code example in `navigation-menu.mdx` to include the necessary wrapper components (`NavigationMenu` and `NavigationMenuList`) to prevent this error when users copy-paste the example.