### PR TITLE
[base-ui]: fix disabled button when using focusableWhenDisabled

### DIFF
--- a/apps/v4/registry/bases/base/ui/button.tsx
+++ b/apps/v4/registry/bases/base/ui/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/registry/bases/base/lib/utils"
 
 const buttonVariants = cva(
-  "cn-button inline-flex items-center justify-center whitespace-nowrap  transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
+  "cn-button inline-flex items-center justify-center whitespace-nowrap  transition-all data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
   {
     variants: {
       variant: {


### PR DESCRIPTION
When using shadcn with base ui, disabled button styles do no work.
Reproduction:
```tsx
import { Button } from "@/components/ui/button";

export function App() {
  return (
    <Button disabled focusableWhenDisabled>
      Click me
    </Button>
  );
}
```

Docs: https://base-ui.com/react/components/button#loading-states

To apply styles based on if button is disabled `data-disabled` attribute should be used.