### PR TITLE
feat(icons): transform svg props to RemixiconComponentType for remixicon

### DIFF
--- a/packages/shadcn/src/icons/libraries.ts
+++ b/packages/shadcn/src/icons/libraries.ts
@@ -39,6 +39,7 @@ export const iconLibraries = {
     import: "import { ICON } from '@remixicon/react'",
     usage: "<ICON />",
     export: "@remixicon/react",
+    componentType: "RemixiconComponentType",
   },
 } as const
 

--- a/packages/shadcn/src/utils/transformers/transform-icons.test.ts
+++ b/packages/shadcn/src/utils/transformers/transform-icons.test.ts
@@ -684,4 +684,64 @@ export function Component() {
       }"
     `)
   })
+
+  test("transforms React.ComponentProps<'svg'> to RemixiconComponentType for remixicon", async () => {
+    expect(
+      await transform(
+        {
+          filename: "test.tsx",
+          raw: `import * as React from "react"
+import { IconPlaceholder } from "@/app/(create)/create/components/icon-placeholder"
+
+function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return <IconPlaceholder lucide="Loader2Icon" remixicon="RiLoaderLine" className={className} {...props} />
+}
+
+export { Spinner }`,
+          config: {
+            ...testConfig,
+            iconLibrary: "remixicon",
+          },
+        },
+        [transformIcons]
+      )
+    ).toMatchInlineSnapshot(`
+      "import * as React from "react"
+      import { RiLoaderLine, type RemixiconComponentType } from "@remixicon/react"
+
+      function Spinner({ className, ...props }: React.ComponentProps<RemixiconComponentType>) {
+        return <RiLoaderLine className={className} {...props} />
+      }
+
+      export { Spinner }"
+    `)
+  })
+
+  test("does not import RemixiconComponentType when no React.ComponentProps<'svg'> is present", async () => {
+    expect(
+      await transform(
+        {
+          filename: "test.tsx",
+          raw: `import * as React from "react"
+import { IconPlaceholder } from "@/app/(create)/create/components/icon-placeholder"
+
+export function Component() {
+  return <IconPlaceholder lucide="CheckIcon" remixicon="RiCheckLine" className="size-4" />
+}`,
+          config: {
+            ...testConfig,
+            iconLibrary: "remixicon",
+          },
+        },
+        [transformIcons]
+      )
+    ).toMatchInlineSnapshot(`
+      "import * as React from "react"
+      import { RiCheckLine } from "@remixicon/react"
+
+      export function Component() {
+        return <RiCheckLine className="size-4" />
+      }"
+    `)
+  })
 })


### PR DESCRIPTION
### Issue
When using Remixicon as the icon library, components like `Spinner` use `React.ComponentProps<"svg">` which doesn't accurately type Remixicon components. Remixicon exports a `RemixiconComponentType` that should be used instead.

<img width="1732" height="842" alt="CleanShot 2026-01-17 at 10 16 53@2x" src="https://github.com/user-attachments/assets/e15093d6-6a6a-4afe-8ee5-f3b0af405238" />

### Solution
Introduced a new optional `componentType` key in `packages/shadcn/src/icons/libraries.ts` for the remixicon library config. The transformer now:

1. Transforms `React.ComponentProps<"svg">` → `React.ComponentProps<RemixiconComponentType>` when the icon library has a `componentType` defined
2. Only imports `type RemixiconComponentType` when the transformation is actually needed (files with `React.ComponentProps<"svg">`)

### Changes
- `packages/shadcn/src/icons/libraries.ts` - Added `componentType: "RemixiconComponentType"` to remixicon config
- `packages/shadcn/src/utils/transformers/transform-icons.ts` - Added logic to transform component props type and conditionally import the type
- `packages/shadcn/src/utils/transformers/transform-icons.test.ts` - Added tests for the new behavior

### Before
```tsx
import { RiLoaderLine } from "@remixicon/react"

function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
  return <RiLoaderLine ... />
}
```

### After
```tsx
import { RiLoaderLine, type RemixiconComponentType } from "@remixicon/react"

function Spinner({ className, ...props }: React.ComponentProps<RemixiconComponentType>) {
  return <RiLoaderLine ... />
}
```

### Test Plan
- [x] Unit tests pass (24/24)
- [x] Verified spinner component gets `RemixiconComponentType` import and type
- [x] Verified button component (no `React.ComponentProps<"svg">`) does NOT get the type import