### PR TITLE
docs: clarify gray scale defaults for New York and Default styles

### DIFF
--- a/apps/v4/content/docs/(root)/theming.mdx
+++ b/apps/v4/content/docs/(root)/theming.mdx
@@ -194,8 +194,7 @@ See the [Tailwind CSS documentation](https://tailwindcss.com/docs/colors) for mo
 
 ## Base Colors
 
-For reference, here's a list of the base colors that are available.
-
+For reference, here's a list of the base colors that are available. For the **New York** style, the default gray is **Zinc**. For the **Default** style, the gray scale is **Neutral**.
 ### Neutral
 
 <CodeCollapsibleWrapper>


### PR DESCRIPTION
Closes #9337. This PR clarifies which gray scales (Zinc vs. Neutral) are used as defaults for the New York and Default styles to improve documentation clarity.