### PR TITLE
feat: inline component list on components page

### DIFF
--- a/apps/v4/app/(app)/(root)/page.tsx
+++ b/apps/v4/app/(app)/(root)/page.tsx
@@ -1,6 +1,7 @@
 import { type Metadata } from "next"
 import Image from "next/image"
 import Link from "next/link"
+
 import { Announcement } from "@/components/announcement"
 import { ExamplesNav } from "@/components/examples-nav"
 import {

--- a/apps/v4/lib/llm.ts
+++ b/apps/v4/lib/llm.ts
@@ -1,9 +1,32 @@
 import fs from "fs"
 
+import { source } from "@/lib/source"
 import { Index } from "@/registry/__index__"
 import { type Style } from "@/registry/_legacy-styles"
 
+function getComponentsList() {
+  const components = source.pageTree.children.find(
+    (page) => page.$id === "components"
+  )
+
+  if (components?.type !== "folder") {
+    return ""
+  }
+
+  const list = components.children.filter(
+    (component) => component.type === "page"
+  )
+
+  return list
+    .map((component) => `- [${component.name}](${component.url})`)
+    .join("\n")
+}
+
 export function processMdxForLLMs(content: string, style: Style["name"]) {
+  // Replace <ComponentsList /> with a markdown list of components.
+  const componentsListRegex = /<ComponentsList\s*\/>/g
+  content = content.replace(componentsListRegex, getComponentsList())
+
   const componentPreviewRegex =
     /<ComponentPreview[\s\S]*?name="([^"]+)"[\s\S]*?\/>/g
 


### PR DESCRIPTION
## Summary
- Adds support for inlining `<ComponentsList />` in the LLM endpoint
- The component list is now rendered as markdown links instead of a JSX component that can't be processed by LLMs

## Test plan
- [ ] Visit `/llm/docs/components` and verify the component list is rendered as markdown links

🤖 Generated with [Claude Code](https://claude.com/claude-code)