### PR TITLE
fix: adjust class order in SearchForm and SiteHeader components

### DIFF
--- a/apps/v4/registry/new-york-v4/blocks/sidebar-16/components/search-form.tsx
+++ b/apps/v4/registry/new-york-v4/blocks/sidebar-16/components/search-form.tsx
@@ -15,7 +15,7 @@ export function SearchForm({ ...props }: React.ComponentProps<"form">) {
           placeholder="Type to search..."
           className="h-8 pl-7"
         />
-        <Search className="pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2 opacity-50 select-none" />
+        <Search className="pointer-events-none absolute left-2 top-1/2 size-4 -translate-y-1/2 select-none opacity-50" />
       </div>
     </form>
   )

--- a/apps/v4/registry/new-york-v4/blocks/sidebar-16/components/site-header.tsx
+++ b/apps/v4/registry/new-york-v4/blocks/sidebar-16/components/site-header.tsx
@@ -20,7 +20,7 @@ export function SiteHeader() {
 
   return (
     <header className="bg-background sticky top-0 z-50 flex w-full items-center border-b">
-      <div className="flex h-(--header-height) w-full items-center gap-2 px-4">
+      <div className="h-(--header-height) flex w-full items-center gap-2 px-4">
         <Button
           className="h-8 w-8"
           variant="ghost"


### PR DESCRIPTION
This PR addresses [issue #8203](https://github.com/shadcn-ui/ui/issues/8203), which reported multiple Tailwind CSS class ordering violations in the sidebar-16 components. These violations triggered ESLint errors (`tailwindcss/classnames-order`) and could break strict CI/CD pipelines.

### Changes

- Ran ESLint auto-fix on all files in sidebar-16 to enforce the correct Tailwind classnames order.
- All classnames are now sorted according to the project's standards.
- Confirmed that there are no remaining `tailwindcss/classnames-order` or related ESLint errors in these files.

### Why

Maintaining consistent Tailwind class order improves code readability, prevents linting errors, and ensures compatibility with CI/CD pipelines.

### Related Issue
Fixes [issue #8203](https://github.com/shadcn-ui/ui/issues/8203)