### PR TITLE
fix: add indeterminate state support to base-ui Checkbox

### DIFF
--- a/apps/v4/registry/bases/base/ui/checkbox.tsx
+++ b/apps/v4/registry/bases/base/ui/checkbox.tsx
@@ -5,7 +5,14 @@ import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
 import { cn } from "@/registry/bases/base/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
+function Checkbox({
+  className,
+  checked,
+  ...props
+}: Omit<CheckboxPrimitive.Root.Props, "checked"> & {
+  checked?: boolean | "indeterminate"
+}) {
+  const isIndeterminate = checked === "indeterminate"
   return (
     <CheckboxPrimitive.Root
       data-slot="checkbox"
@@ -13,19 +20,31 @@ function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
         "cn-checkbox peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
+      checked={isIndeterminate ? false : checked}
+      indeterminate={isIndeterminate}
       {...props}
     >
       <CheckboxPrimitive.Indicator
         data-slot="checkbox-indicator"
         className="cn-checkbox-indicator grid place-content-center text-current transition-none"
       >
-        <IconPlaceholder
-          lucide="CheckIcon"
-          tabler="IconCheck"
-          hugeicons="Tick02Icon"
-          phosphor="CheckIcon"
-          remixicon="RiCheckLine"
-        />
+        {isIndeterminate ? (
+          <IconPlaceholder
+            lucide="MinusIcon"
+            tabler="IconMinus"
+            hugeicons="MinusSignIcon"
+            phosphor="MinusIcon"
+            remixicon="RiSubtractLine"
+          />
+        ) : (
+          <IconPlaceholder
+            lucide="CheckIcon"
+            tabler="IconCheck"
+            hugeicons="Tick02Icon"
+            phosphor="CheckIcon"
+            remixicon="RiCheckLine"
+          />
+        )}
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   )


### PR DESCRIPTION
This PR adds support for the `indeterminate` state to the base-ui Checkbox component, resolves [issue #9357](https://github.com/shadcn-ui/ui/issues/9357).

The base-ui Checkbox component was missing support for the indeterminate state that was available in the previous radix-ui implementation. This PR adds backward compatibility by accepting `checked="indeterminate"` and properly converting it to base-ui's native API.

## Changes

- Added type support for `checked` prop to accept `boolean | "indeterminate"`
- Converted `checked="indeterminate"` to base-ui's native API (`checked={false}` + `indeterminate={true}`)
- Added conditional rendering to display minus icon when in indeterminate state
- Maintained backward compatibility with existing radix-ui API patterns

## Testing

- ✅ TypeScript compilation passes
- ✅ Existing data table examples using indeterminate state now work correctly
- ✅ Shows minus icon (─) when `checked="indeterminate"`
- ✅ Shows check icon (✓) when `checked={true}`

## Related Issue
Fixes https://github.com/shadcn-ui/ui/issues/9357   

## Example Usage

```tsx
<Checkbox checked="indeterminate" />

