### PR TITLE
fix(registry): add missing {name} placeholder to motion-primitives url

### DIFF
--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -302,7 +302,7 @@
   {
     "name": "@motion-primitives",
     "homepage": "https://www.motion-primitives.com",
-    "url": "https://motion-primitives.com/c/registry.json",
+    "url": "https://motion-primitives.com/c/{name}.json",
     "description": "Beautifully designed motions components. Easy copy-paste. Customizable. Open Source. Built for engineers and designers."
   },
   {

--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -352,7 +352,7 @@
   {
     "name": "@motion-primitives",
     "homepage": "https://www.motion-primitives.com",
-    "url": "https://motion-primitives.com/c/registry.json",
+    "url": "https://motion-primitives.com/c/{name}.json",
     "description": "Beautifully designed motions components. Easy copy-paste. Customizable. Open Source. Built for engineers and designers.",
     "logo": "<svg role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 70 70' aria-label='MP Logo' width='70' height='70' fill='none'><path stroke='currentColor' stroke-linecap='round' stroke-width='3' d='M51.883 26.495c-7.277-4.124-18.08-7.004-26.519-7.425-2.357-.118-4.407-.244-6.364 1.06M59.642 51c-10.47-7.25-26.594-13.426-39.514-15.664-3.61-.625-6.744-1.202-9.991.263'/></svg>"
   },


### PR DESCRIPTION
## Summary
Fixes #9370

This PR updates the `@motion-primitives` registry URL to include the required `{name}` placeholder.

## Problem
The previous URL was set to a static path (`https://motion-primitives.com/c/registry.json`), which caused the CLI validation to fail because it could not resolve individual component paths dynamically.

## Solution
Updated the URL to the correct pattern: `https://motion-primitives.com/c/{name}.json`.

## Changes
- Updated `apps/v4/public/r/registries.json`
- Updated `apps/v4/registry/directory.json` (synced via build)