### PR TITLE
fix: Pass template into buildInitUrl

### DIFF
--- a/packages/shadcn/src/commands/create.ts
+++ b/packages/shadcn/src/commands/create.ts
@@ -147,7 +147,7 @@ export const create = new Command()
         baseColor = url.searchParams.get("baseColor") ?? "neutral"
       } else {
         // User selected a preset by name.
-        initUrl = buildInitUrl(presetResult)
+        initUrl = buildInitUrl(presetResult, template as Template)
         baseColor = presetResult.baseColor
       }
 
@@ -221,7 +221,7 @@ export const create = new Command()
     }
   })
 
-function buildInitUrl(preset: Preset) {
+function buildInitUrl(preset: Preset, template: Template) {
   const params = new URLSearchParams({
     base: preset.base,
     style: preset.style,
@@ -232,6 +232,7 @@ function buildInitUrl(preset: Preset) {
     menuAccent: preset.menuAccent,
     menuColor: preset.menuColor,
     radius: preset.radius,
+    template,
   })
 
   return `${getShadcnInitUrl()}?${params.toString()}`


### PR DESCRIPTION
The --preset option without a URL would previously fail as the generated URL would not include the template query string param.

Example:

```
~/Code ➜ pnpm dlx shadcn@latest create --preset radix-nova
✔ What is your project named? … my-app
✔ Which template would you like to use? › Next.js

Something went wrong. Please check the error below for more details.
If the problem persists, please open an issue on GitHub.

Message:
Failed to fetch from registry (400): https://ui.shadcn.com/init?base=radix&style=nova&baseColor=neutral&theme=neutral&iconLibrary=hugeicons&font=inter&menuAccent=subtle&menuColor=default&radius=default

Suggestion:
There was a client error. Check your request parameters.
```

This fixes this issue by passing along the template so that a proper URL is generated. In the example above the proper URL is:

https://ui.shadcn.com/init?base=radix&style=nova&baseColor=neutral&theme=neutral&iconLibrary=hugeicons&font=inter&menuAccent=subtle&menuColor=default&radius=default&template=next