### PR TITLE
fix(calendar): hide navigation buttons at month boundaries

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/calendar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/calendar.tsx
@@ -9,6 +9,7 @@ import {
 import {
   DayPicker,
   getDefaultClassNames,
+  useDayPicker,
   type DayButton,
 } from "react-day-picker"
 
@@ -163,6 +164,8 @@ function Calendar({
           )
         },
         DayButton: CalendarDayButton,
+        PreviousMonthButton: CalendarPreviousMonthButton,
+        NextMonthButton: CalendarNextMonthButton,
         WeekNumber: ({ children, ...props }) => {
           return (
             <td {...props}>
@@ -176,6 +179,46 @@ function Calendar({
       }}
       {...props}
     />
+  )
+}
+
+function CalendarPreviousMonthButton(
+  props: React.ComponentProps<"button">
+) {
+  const { previousMonth, goToMonth } = useDayPicker()
+
+  if (!previousMonth) {
+    return <span />
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => goToMonth(previousMonth)}
+      {...props}
+    >
+      <ChevronLeftIcon className="size-4" />
+    </button>
+  )
+}
+
+function CalendarNextMonthButton(
+  props: React.ComponentProps<"button">
+) {
+  const { nextMonth, goToMonth } = useDayPicker()
+
+  if (!nextMonth) {
+    return <span />
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => goToMonth(nextMonth)}
+      {...props}
+    >
+      <ChevronRightIcon className="size-4" />
+    </button>
   )
 }
 
@@ -217,4 +260,9 @@ function CalendarDayButton({
   )
 }
 
-export { Calendar, CalendarDayButton }
+export {
+  Calendar,
+  CalendarDayButton,
+  CalendarPreviousMonthButton,
+  CalendarNextMonthButton,
+}


### PR DESCRIPTION
## Summary
Fixes #9330
Hide navigation buttons at month boundaries instead of showing them as disabled.

## Problem

When using `startMonth`/`endMonth` props, navigation arrows remain visible but disabled at boundaries.

## Screenshots

| Before | After |
|--------|-------|
| <img width="259" height="239" alt="image" src="https://github.com/user-attachments/assets/f7477164-264e-4a70-a7b7-52f15884e152" /> | <img width="265" height="239" alt="image" src="https://github.com/user-attachments/assets/89c39b2f-90b4-47b1-b870-db959109ffb5" /> |

## Changes
- Added custom `CalendarPreviousMonthButton` and `CalendarNextMonthButton` components
- Uses `useDayPicker()` hook to check `previousMonth`/`nextMonth` availability
- Returns empty `<span />` when at boundaries (hidden instead of disabled)

## Usage Example

```tsx
import { Calendar } from "@/components/ui/calendar"
import { addMonths } from "date-fns"

function MyComponent() {
  const today = new Date()
  const [selected, setSelected] = useState<Date>()

  return (
    <Calendar
      mode="single"
      selected={selected}
      onSelect={setSelected}
      startMonth={today}
      endMonth={addMonths(today, 1)}
    />
  )
}
```

## Test Plan
- [ ] First allowed month → left arrow hidden
- [ ] Last allowed month → right arrow hidden
- [ ] Between allowed months → both arrows visible