### PR TITLE
fix(code): fix code block preventing scroll on mobile devices

### DIFF
--- a/apps/v4/lib/highlight-code.ts
+++ b/apps/v4/lib/highlight-code.ts
@@ -87,7 +87,7 @@ export async function highlightCode(code: string, language: string = "tsx") {
       {
         pre(node) {
           node.properties["class"] =
-            "no-scrollbar min-w-0 overflow-x-auto overscroll-none px-4 py-3.5 outline-none has-[[data-highlighted-line]]:px-0 has-[[data-line-numbers]]:px-0 has-[[data-slot=tabs]]:p-0 !bg-transparent"
+            "no-scrollbar min-w-0 overflow-x-auto overscroll-x-none px-4 py-3.5 outline-none has-[[data-highlighted-line]]:px-0 has-[[data-line-numbers]]:px-0 has-[[data-slot=tabs]]:p-0 !bg-transparent"
         },
         code(node) {
           node.properties["data-line-numbers"] = ""

--- a/apps/v4/mdx-components.tsx
+++ b/apps/v4/mdx-components.tsx
@@ -190,7 +190,7 @@ export const mdxComponents = {
     return (
       <pre
         className={cn(
-          "no-scrollbar min-w-0 overflow-x-auto overscroll-none px-4 py-3.5 outline-none has-[[data-highlighted-line]]:px-0 has-[[data-line-numbers]]:px-0 has-[[data-slot=tabs]]:p-0",
+          "no-scrollbar min-w-0 overflow-x-auto overscroll-x-none px-4 py-3.5 outline-none has-[[data-highlighted-line]]:px-0 has-[[data-line-numbers]]:px-0 has-[[data-slot=tabs]]:p-0",
           className
         )}
         {...props}


### PR DESCRIPTION
I encountered an issue where pages such as https://ui.shadcn.com/docs/components/radix/accordion is not scrollable when the screen width is small, and is mobile device.

The issue is now fixed by making it only change overscroll behavior horizontally.
I think it should be fine to set it to `overscroll-x-none` as the code blocks seem to only overflow horizontally, looking at the tailwind classes.

Alternatively, we can also make it so the code blocks remain the same, but line numbers let you scroll vertically on mobile devices.

This also fixes issues no desktop where the codeblock is really tall e.g. when expanding manual installation in https://ui.shadcn.com/docs/components/base/carousel.

Demo:

https://github.com/user-attachments/assets/00045ead-2268-4a66-9bbb-b55855189865


