### PR TITLE
docs: Update to correct url for vaul docs

### DIFF
--- a/apps/v4/content/docs/components/base/drawer.mdx
+++ b/apps/v4/content/docs/components/base/drawer.mdx
@@ -110,4 +110,4 @@ You can combine the `Dialog` and `Drawer` components to create a responsive dial
 
 ## API Reference
 
-See the [Vaul documentation](https://vaul.emilkowal.ski/components/drawer) for the full API reference.
+See the [Vaul documentation](https://vaul.emilkowal.ski/getting-started) for the full API reference.

--- a/apps/v4/content/docs/components/radix/drawer.mdx
+++ b/apps/v4/content/docs/components/radix/drawer.mdx
@@ -110,4 +110,4 @@ You can combine the `Dialog` and `Drawer` components to create a responsive dial
 
 ## API Reference
 
-See the [Vaul documentation](https://vaul.emilkowal.ski/components/drawer) for the full API reference.
+See the [Vaul documentation](https://vaul.emilkowal.ski/getting-started) for the full API reference.


### PR DESCRIPTION
fixes incorrect link to vaul documentation