### PR TITLE
fix(components): use DialogOverlay in CommandMenu to fix button interactions

### DIFF
--- a/apps/v4/components/command-menu.tsx
+++ b/apps/v4/components/command-menu.tsx
@@ -30,6 +30,7 @@ import {
   Dialog,
   DialogDescription,
   DialogHeader,
+  DialogOverlay,
   DialogPortal,
   DialogTitle,
   DialogTrigger,
@@ -534,10 +535,7 @@ function DialogContent({
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
-      <DialogPrimitive.Overlay
-        data-slot="dialog-overlay"
-        className="fixed inset-0 z-50 bg-black/50"
-      />
+      <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(


### PR DESCRIPTION
Fixes #9403

## Description

This PR fixes a bug where buttons on documentation pages (e.g., Sonner demo, Input Group demos) were not working. The issue affected all browsers and was caused by improper overlay lifecycle management in the `CommandMenu` component.

## Root Cause

The `CommandMenu` component used `DialogPrimitive.Overlay` directly instead of the standard `DialogOverlay` component. The standard `DialogOverlay` includes critical animation state classes (`data-[state=open]:animate-in`, `data-[state=closed]:animate-out`, etc.) that Radix uses to manage the overlay lifecycle.

Without these state transitions, `react-remove-scroll` could get into a corrupted global state, causing the `inert` attribute to remain on page content and blocking all interactions.

## Changes

- Added `DialogOverlay` to imports from `@/registry/new-york-v4/ui/dialog`
- Replaced `DialogPrimitive.Overlay` with `DialogOverlay` in the custom `DialogContent` function

## Testing

1. Clear `localStorage` completely (including `shadcn-create-welcome-dialog`)
2. Refresh the page
3. Navigate to docs pages (e.g., `/docs/components/radix/sonner`)
4. Open and close the command menu (⌘K)
5. Click buttons on component demos — they should now work without needing to visit the Create page first

