### PR TITLE
docs(figma): add shadcn/ui components kit by Sitsiilia Bergmann

### DIFF
--- a/apps/v4/content/docs/(root)/figma.mdx
+++ b/apps/v4/content/docs/(root)/figma.mdx
@@ -10,8 +10,8 @@ description: Every component recreated in Figma. With customizable props, typogr
 
 ## Free
 
-- [shadcn/ui components](https://www.figma.com/community/file/1342715840824755935) by [Sitsiilia Bergmann](https://x.com/sitsiilia) - A well-structured component library aligned with the shadcn component system, regularly maintained.
 - [Obra shadcn/ui](https://www.figma.com/community/file/1514746685758799870/obra-shadcn-ui) by [Obra Studio](https://obra.studio/) - Carefully crafted kit designed in the philosophy of shadcn, tracks v4, MIT licensed
+- [shadcn/ui components](https://www.figma.com/community/file/1342715840824755935) by [Sitsiilia Bergmann](https://x.com/sitsiilia) - A well-structured component library aligned with the shadcn component system, regularly maintained.
 - [shadcn/ui design system](https://www.figma.com/community/file/1203061493325953101) by [Pietro Schirano](https://twitter.com/skirano) - A design companion for shadcn/ui. Each component was painstakingly crafted to perfectly match the code implementation.
 
 ## Paid


### PR DESCRIPTION
## Summary
- Add shadcn/ui components Figma kit to the Free section

## Changes
Added [shadcn/ui components](https://www.figma.com/community/file/1342715840824755935) by [Sitsiilia Bergmann](https://x.com/sitsiilia) as the first entry in the Free section of the Figma documentation page.

## Details
- **Figma file:** https://www.figma.com/community/file/1342715840824755935
- **Description:** A well-structured component library aligned with the shadcn component system, regularly maintained.