### PR TITLE
Fix conditional rendering for collapsible items

### DIFF
--- a/apps/v4/registry/new-york-v4/blocks/sidebar-07/components/nav-main.tsx
+++ b/apps/v4/registry/new-york-v4/blocks/sidebar-07/components/nav-main.tsx
@@ -48,10 +48,12 @@ export function NavMain({
                 <SidebarMenuButton tooltip={item.title}>
                   {item.icon && <item.icon />}
                   <span>{item.title}</span>
-                  <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+                  {item.items && <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />}
                 </SidebarMenuButton>
               </CollapsibleTrigger>
-              <CollapsibleContent>
+              {
+                item.items &&
+                <CollapsibleContent>
                 <SidebarMenuSub>
                   {item.items?.map((subItem) => (
                     <SidebarMenuSubItem key={subItem.title}>
@@ -64,6 +66,7 @@ export function NavMain({
                   ))}
                 </SidebarMenuSub>
               </CollapsibleContent>
+              }
             </SidebarMenuItem>
           </Collapsible>
         ))}


### PR DESCRIPTION
If there are no sub items, don’t show the arrow or allow expansion.