### PR TITLE
fix: correct Sonner documentation link

### DIFF
--- a/apps/v4/content/docs/components/base/sonner.mdx
+++ b/apps/v4/content/docs/components/base/sonner.mdx
@@ -123,4 +123,4 @@ Use the `position` prop to change the position of the toast.
 
 ## API Reference
 
-See the [Sonner API Reference](https://sonner.emilkowal.ski/api) for more information.
+See the [Sonner API Reference](https://sonner.emilkowal.ski/getting-started) for more information.


### PR DESCRIPTION
Fixes incorrect link in Sonner component documentation.

The docs were pointing to the API page instead of the correct
getting started page.

Fixes #9424