### PR TITLE
fix: docs copy button copies full code even when collapsed

### DIFF
--- a/apps/v4/components/component-source.tsx
+++ b/apps/v4/components/component-source.tsx
@@ -52,6 +52,7 @@ export async function ComponentSource({
 
   code = await formatCode(code, styleName)
   code = code.replaceAll("/* eslint-disable react/no-children-prop */\n", "")
+  const fullCode = code
 
   // Truncate code if maxLines is set.
   if (maxLines) {
@@ -69,6 +70,7 @@ export async function ComponentSource({
           highlightedCode={highlightedCode}
           language={lang}
           title={title}
+          fullCode={fullCode}
         />
       </div>
     )
@@ -81,6 +83,7 @@ export async function ComponentSource({
         highlightedCode={highlightedCode}
         language={lang}
         title={title}
+        fullCode={fullCode}
       />
     </CodeCollapsibleWrapper>
   )
@@ -91,12 +94,16 @@ function ComponentCode({
   highlightedCode,
   language,
   title,
+  fullCode,
 }: {
   code: string
   highlightedCode: string
   language: string
   title: string | undefined
+  fullCode?: string
 }) {
+  const copyValue = fullCode ?? code
+
   return (
     <figure data-rehype-pretty-code-figure="" className="[&>pre]:max-h-96">
       {title && (
@@ -109,7 +116,7 @@ function ComponentCode({
           {title}
         </figcaption>
       )}
-      <CopyButton value={code} />
+      <CopyButton value={copyValue} />
       <div dangerouslySetInnerHTML={{ __html: highlightedCode }} />
     </figure>
   )


### PR DESCRIPTION
In the docs, the copy button for code snippets was broken. If the code snippet was collapsed, it would only copy the trunacted code, not the full snippet. this fixes that.

that being said, i'm not super confident about the implementation. it feels a bit redundant, so feel free to tell me what to change!

✌️

## Summary
- Copy button on collapsed code snippets now copies the full code instead of only the visible (truncated) lines
- Preserves `fullCode` before applying `maxLines` truncation and passes it to `CopyButton`

## Problem
When a code snippet is collapsed (showing only 2-3 lines), clicking the copy button only copied those visible lines instead of the entire code block.

## Solution
Store the complete formatted code before truncation and pass it through to `CopyButton`, so the clipboard always receives the full snippet regardless of the visual state.