### PR TITLE
fix(docs): update navigation-menu docs package name and add styleName

### DIFF
--- a/apps/v4/content/docs/components/base/navigation-menu.mdx
+++ b/apps/v4/content/docs/components/base/navigation-menu.mdx
@@ -37,7 +37,7 @@ npx shadcn@latest add navigation-menu
 <Step>Install the following dependencies:</Step>
 
 ```bash
-npm install @base-ui-components/react
+npm install @base-ui/react
 ```
 
 <Step>Copy and paste the following code into your project.</Step>
@@ -45,6 +45,7 @@ npm install @base-ui-components/react
 <ComponentSource
   name="navigation-menu"
   title="components/ui/navigation-menu.tsx"
+  styleName="base-nova"
 />
 
 <Step>Update the import paths to match your project setup.</Step>


### PR DESCRIPTION
This pull request updates the installation instructions and component configuration for the navigation menu documentation.

* Added the `styleName="base-nova"` prop to the `ComponentSource`.

* Updated the dependency in the installation instructions from `@base-ui-components/react` to `@base-ui/react` to reflect the correct package name.