### PR TITLE
Fix Base UI dropdown menu links

### DIFF
--- a/apps/v4/content/docs/components/base/dropdown-menu.mdx
+++ b/apps/v4/content/docs/components/base/dropdown-menu.mdx
@@ -5,8 +5,8 @@ featured: true
 base: base
 component: true
 links:
-  doc: https://base-ui.com/react/components/dropdown-menu
-  api: https://base-ui.com/react/components/dropdown-menu#api-reference
+  doc: https://base-ui.com/react/components/menu
+  api: https://base-ui.com/react/components/menu#api-reference
 ---
 
 <ComponentPreview
@@ -162,4 +162,4 @@ A richer example combining groups, icons, and submenus.
 
 ## API Reference
 
-See the [Base UI documentation](https://base-ui.com/react/components/dropdown-menu) for the full API reference.
+See the [Base UI documentation](https://base-ui.com/react/components/menu) for the full API reference.


### PR DESCRIPTION
Base UI does not have a `dropdown-menu` but rather just `menu` This PR fixes the link that lead to Base UI docs