### PR TITLE
Correct combobox doc for custom items

### DIFF
--- a/apps/v4/content/docs/components/base/combobox.mdx
+++ b/apps/v4/content/docs/components/base/combobox.mdx
@@ -92,7 +92,7 @@ export function ExampleCombobox() {
 
 ## Custom Items
 
-Use `itemToStringValue` when your items are objects.
+Use `itemToStringLabel` when your items are objects. Alternatively, have a `label` key.
 
 ```tsx showLineNumbers
 import * as React from "react"
@@ -107,21 +107,21 @@ import {
 } from "@/components/ui/combobox"
 
 type Framework = {
-  label: string
+  name: string
   value: string
 }
 
 const frameworks: Framework[] = [
-  { label: "Next.js", value: "next" },
-  { label: "SvelteKit", value: "sveltekit" },
-  { label: "Nuxt", value: "nuxt" },
+  { name: "Next.js", value: "next" },
+  { name: "SvelteKit", value: "sveltekit" },
+  { name: "Nuxt", value: "nuxt" },
 ]
 
 export function ExampleComboboxCustomItems() {
   return (
     <Combobox
       items={frameworks}
-      itemToStringValue={(framework) => framework.label}
+      itemToStringLabel={(framework) => framework.name}
     >
       <ComboboxInput placeholder="Select a framework" />
       <ComboboxContent>


### PR DESCRIPTION
The Combobox (Base UI) - Custom Items example is incorrectly suggesting to use `itemToStringValue` instead of the correct `itemToStringLabel`. The reason the example still works is because the shape of the item contains the `label` key. 

Compare the Base UI docs: https://base-ui.com/react/components/combobox#ComboboxRoot-itemToStringLabel