### PR TITLE
fix: add fallback to default style for registry items

### DIFF
--- a/.changeset/fix-dashboard-fallback.md
+++ b/.changeset/fix-dashboard-fallback.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+fix: add fallback to default style in registry resolver when item is not found in configured style


### PR DESCRIPTION
### **title** 
**fix: add fallback to default style for registry items**
### 
description
This PR fixes an issue where installing components (like `dashboard-01`) fails when using a custom or experimental style (e.g., `radix-vega`) because the component does not exist in that specific style's registry path.

### Changes
Modified `fetchRegistryItems` in `packages/shadcn/src/registry/resolver.ts` to implement a fallback mechanism.
If a component is not found (404) in the user's configured style, the resolver now attempts to fetch it from the default new-york style before throwing an error.

Why
Users with custom styles configured were unable to install standard blocks like dashboard-01 because the CLI was constructing URLs like .../styles/radix-vega/dashboard-01.json, which do not exist. This ensures these components remain accessible regardless of the active theme.

Testing

- Validated via static analysis and reproduction steps (simulated).

- Existing tests should pass (could not verify locally due to missing dependencies).

### Changeset
Added `fix-dashboard-fallback.md`
