### PR TITLE
Update react-resizable-panels documentation link

### DIFF
--- a/apps/v4/content/docs/components/base/resizable.mdx
+++ b/apps/v4/content/docs/components/base/resizable.mdx
@@ -94,4 +94,4 @@ Use the `withHandle` prop on `ResizableHandle` to show a visible handle.
 
 ## API Reference
 
-See the [react-resizable-panels](https://github.com/bvaughn/react-resizable-panels/tree/main/packages/react-resizable-panels) documentation.
+See the [react-resizable-panels](https://react-resizable-panels.vercel.app/) documentation.

--- a/apps/v4/content/docs/components/radix/resizable.mdx
+++ b/apps/v4/content/docs/components/radix/resizable.mdx
@@ -94,4 +94,4 @@ Use the `withHandle` prop on `ResizableHandle` to show a visible handle.
 
 ## API Reference
 
-See the [react-resizable-panels](https://github.com/bvaughn/react-resizable-panels/tree/main/packages/react-resizable-panels) documentation.
+See the [react-resizable-panels](https://react-resizable-panels.vercel.app/) documentation.


### PR DESCRIPTION
The current link is broken; directing to the official documentation link: https://react-resizable-panels.vercel.app/