### PR TITLE
fix(docs): replace <ComponentsList /> in copy-page and markdown output

### DIFF
--- a/apps/v4/app/(app)/docs/[[...slug]]/page.tsx
+++ b/apps/v4/app/(app)/docs/[[...slug]]/page.tsx
@@ -4,6 +4,7 @@ import { mdxComponents } from "@/mdx-components"
 import { IconArrowLeft, IconArrowRight } from "@tabler/icons-react"
 import { findNeighbour } from "fumadocs-core/page-tree"
 
+import { replaceComponentsList } from "@/lib/llm"
 import { source } from "@/lib/source"
 import { absoluteUrl } from "@/lib/utils"
 import { DocsBaseSwitcher } from "@/components/docs-base-switcher"
@@ -83,7 +84,7 @@ export default async function Page(props: {
   const neighbours = isChangelog
     ? { previous: null, next: null }
     : findNeighbour(source.pageTree, page.url)
-  const raw = await page.data.getText("raw")
+  const raw = replaceComponentsList(await page.data.getText("raw"))
 
   return (
     <div

--- a/apps/v4/lib/llm.ts
+++ b/apps/v4/lib/llm.ts
@@ -1,7 +1,9 @@
 import fs from "fs"
 import { ExamplesIndex } from "@/examples/__index__"
 
+import { getPagesFromFolder, type PageTreeFolder } from "@/lib/page-tree"
 import { source } from "@/lib/source"
+import { absoluteUrl } from "@/lib/utils"
 import { Index as StylesIndex } from "@/registry/__index__"
 import { type Style } from "@/registry/_legacy-styles"
 import { BASES } from "@/registry/bases"
@@ -35,28 +37,28 @@ function getRegistryEntry(name: string, styleName: string) {
   )
 }
 
-function getComponentsList() {
-  const components = source.pageTree.children.find(
+export function replaceComponentsList(content: string) {
+  const componentsFolder = source.pageTree.children.find(
     (page) => page.$id === "components"
   )
-
-  if (components?.type !== "folder") {
-    return ""
-  }
-
-  const list = components.children.filter(
-    (component) => component.type === "page"
-  )
-
-  return list
-    .map((component) => `- [${component.name}](${component.url})`)
-    .join("\n")
+  const list =
+    componentsFolder?.type === "folder"
+      ? getPagesFromFolder(componentsFolder as PageTreeFolder, "radix")
+          .map((component) => {
+            const slug = component.url.replace(/^\/docs\//, "").split("/")
+            const description = source.getPage(slug)?.data.description?.trim()
+            const url = absoluteUrl(component.url.replace("/radix/", "/"))
+            return `- [${component.name}](${url})${
+              description ? `: ${description}` : ""
+            }`
+          })
+          .join("\n")
+      : ""
+  return content.replace(/<ComponentsList\s*\/>/g, list)
 }
 
 export function processMdxForLLMs(content: string, style: Style["name"]) {
-  // Replace <ComponentsList /> with a markdown list of components.
-  const componentsListRegex = /<ComponentsList\s*\/>/g
-  content = content.replace(componentsListRegex, getComponentsList())
+  content = replaceComponentsList(content)
 
   const componentPreviewRegex =
     /<ComponentPreview[\s\S]*?name="([^"]+)"[\s\S]*?\/>/g


### PR DESCRIPTION
Replaces `<ComponentsList />` on `/docs/components` in both the Copy Page button and the `/docs/components.md` endpoint. Today the tag ships to the clipboard as-is and gets silently stripped to an empty string in the markdown endpoint, because `getComponentsList()` walked `components.children` for pages directly, and #9304 restructured the folder into `components/radix/` and `components/base/` subfolders so the filter returns `[]`.

- Reuse `getPagesFromFolder` from `apps/v4/lib/page-tree.ts` so this walker stays in sync with the on-screen `ComponentsList` React component if the tree shape changes again
- Match the format already used in `apps/v4/public/llms.txt`: flat absolute URLs plus the MDX frontmatter description for each component. The flat URL is the canonical form because `apps/v4/next.config.mjs:53` redirects `/docs/components/:name` to `/docs/components/radix/:name` (`permanent: false`, default-to-radix)
- Export `replaceComponentsList` and call it from `apps/v4/app/(app)/docs/[[...slug]]/page.tsx:87` so the Copy Page button and `processMdxForLLMs` share the same replacement path

## Before

Copy Page button on `ui.shadcn.com/docs/components` (raw tag ships to clipboard):

````md
---
title: Components
description: Here you can find all the components available in the library. We are working on adding more components.
---

<ComponentsList />

---

Can't find what you need? Try the [registry directory](/docs/directory) for community-maintained components.
````

`https://ui.shadcn.com/docs/components.md` (tag silently stripped to empty string, LLMs get a useless file):

````md
---
title: Components
description: Here you can find all the components available in the library. We are working on adding more components.
---



---

Can't find what you need? Try the [registry directory](/docs/directory) for community-maintained components.
````

## After

Copy Page and `/docs/components.md` with this PR (both identical, format matches `llms.txt`):

````md
---
title: Components
description: Here you can find all the components available in the library. We are working on adding more components.
---

- [Accordion](https://ui.shadcn.com/docs/components/accordion): A vertically stacked set of interactive headings that each reveal a section of content.
- [Alert](https://ui.shadcn.com/docs/components/alert): Displays a callout for user attention.
- [Alert Dialog](https://ui.shadcn.com/docs/components/alert-dialog): A modal dialog that interrupts the user with important content and expects a response.
- [Button](https://ui.shadcn.com/docs/components/button): Displays a button or a component that looks like a button.
- ... 55 more

---

Can't find what you need? Try the [registry directory](/docs/directory) for community-maintained components.
````

## Verification

- `pnpm test` → 179 passed, 1 skipped
- `pnpm --filter=v4 dev`, then Copy Page on `/docs/components` and `curl http://localhost:4000/docs/components.md` both return the same flat list of 59 components with absolute URLs and descriptions
- Flat URLs work in both envs: local (`http://localhost:4000/docs/components/accordion` → 307 → `/radix/accordion`) and prod (`https://ui.shadcn.com/docs/components/accordion` → 307 → `/radix/accordion`)
