### PR TITLE
feat(component): add new size variants in monorepo

### DIFF
--- a/templates/monorepo-next/packages/ui/src/components/button.tsx
+++ b/templates/monorepo-next/packages/ui/src/components/button.tsx
@@ -26,6 +26,9 @@ const buttonVariants = cva(
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
+        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm": "size-8",
+        "icon-lg": "size-10",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## What changed
- Updated button size variants to match the official documentation when initializing a monorepo NextJs using the CLI.

## Why
- The default generated variants were inconsistent with the documented API.
https://ui.shadcn.com/docs/components/radix/button#size

<img width="619" height="146" alt="스크린샷 2026-01-29 오후 4 36 58" src="https://github.com/user-attachments/assets/3caeec03-ce29-456c-82e5-2c1ee09047b4" />

I initialized the project using the next-monorepo setup and noticed that the size type in the [breadcrumb](https://ui.shadcn.com/docs/components/radix/breadcrumb) example from the official documentation did not match the actual implementation.

## Test
I tested the changes locally by updating the **GITHUB_TEMPLATE_URL** and the **templatePath** to point to local paths.
After building the templates/monorepo-next package, I verified that the changes were applied correctly.

```diff
// create-project.ts
const GITHUB_TEMPLATE_URL =
-  "https://codeload.github.com/shadcn-ui/ui/tar.gz/main"
const GITHUB_TEMPLATE_URL =
+  "https://codeload.github.com/dkpark10/ui/tar.gz/add-button-size-monorepo"

await execa("tar", [
      "-xzf",
      tarPath,
      "-C",
      templatePath,
      "--strip-components=2",
-    "ui-main/templates/monorepo-next",
+    "ui-add-button-size-monorepo/templates/monorepo-next",
    ])
```