### PR TITLE
removed duplicate gap-2 in <DialogFooter>

### DIFF
--- a/apps/v4/registry/bases/base/ui/dialog.tsx
+++ b/apps/v4/registry/bases/base/ui/dialog.tsx
@@ -104,8 +104,8 @@ function DialogFooter({
     <div
       data-slot="dialog-footer"
       className={cn(
-        "cn-dialog-footer flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className
+        "cn-dialog-footer flex flex-col-reverse sm:flex-row sm:justify-end",
+        className,
       )}
       {...props}
     >
@@ -116,7 +116,7 @@ function DialogFooter({
         </DialogPrimitive.Close>
       )}
     </div>
-  )
+  );
 }
 
 function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {

--- a/apps/v4/registry/bases/radix/ui/dialog.tsx
+++ b/apps/v4/registry/bases/radix/ui/dialog.tsx
@@ -105,8 +105,8 @@ function DialogFooter({
     <div
       data-slot="dialog-footer"
       className={cn(
-        "cn-dialog-footer flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className
+        "cn-dialog-footer flex flex-col-reverse sm:flex-row sm:justify-end",
+        className,
       )}
       {...props}
     >
@@ -117,7 +117,7 @@ function DialogFooter({
         </DialogPrimitive.Close>
       )}
     </div>
-  )
+  );
 }
 
 function DialogTitle({


### PR DESCRIPTION
removed `gap-2` as className in the `<DialogFooter/>` as it appears twice when the component is installed (check screenshot). This is because it is already added in the className `cn-dialog-footer`.

<img width="656" height="638" alt="image" src="https://github.com/user-attachments/assets/55c8a4a7-ba1e-42e9-aa03-f37ec7b862dd" />
