### PR TITLE
chore(docs): update sonner docs link

### DIFF
--- a/apps/v4/content/docs/components/base/sonner.mdx
+++ b/apps/v4/content/docs/components/base/sonner.mdx
@@ -123,4 +123,4 @@ Use the `position` prop to change the position of the toast.
 
 ## API Reference
 
-See the [Sonner API Reference](https://sonner.emilkowal.ski/api) for more information.
+See the [Sonner API Reference](https://sonner.emilkowal.ski/getting-started) for more information.

--- a/apps/v4/content/docs/components/radix/sonner.mdx
+++ b/apps/v4/content/docs/components/radix/sonner.mdx
@@ -123,4 +123,4 @@ Use the `position` prop to change the position of the toast.
 
 ## API Reference
 
-See the [Sonner API Reference](https://sonner.emilkowal.ski/api) for more information.
+See the [Sonner API Reference](https://sonner.emilkowal.ski/getting-started) for more information.


### PR DESCRIPTION
Hi @shadcn 

Old Sonner link was broken `(500 Internal Server Error)`
Now points to the correct Sonner documentation start page