### PR TITLE
fix(Base UI): missing dependencies

### DIFF
--- a/apps/v4/public/r/styles/base-lyra/accordion.json
+++ b/apps/v4/public/r/styles/base-lyra/accordion.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "accordion",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/accordion.tsx",

--- a/apps/v4/public/r/styles/base-lyra/alert-dialog.json
+++ b/apps/v4/public/r/styles/base-lyra/alert-dialog.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "alert-dialog",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-lyra/aspect-ratio.json
+++ b/apps/v4/public/r/styles/base-lyra/aspect-ratio.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "aspect-ratio",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/aspect-ratio.tsx",

--- a/apps/v4/public/r/styles/base-lyra/avatar.json
+++ b/apps/v4/public/r/styles/base-lyra/avatar.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "avatar",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/avatar.tsx",

--- a/apps/v4/public/r/styles/base-lyra/button-group.json
+++ b/apps/v4/public/r/styles/base-lyra/button-group.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "button-group",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "separator"
   ],

--- a/apps/v4/public/r/styles/base-lyra/button.json
+++ b/apps/v4/public/r/styles/base-lyra/button.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "button",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/button.tsx",

--- a/apps/v4/public/r/styles/base-lyra/checkbox.json
+++ b/apps/v4/public/r/styles/base-lyra/checkbox.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "checkbox",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/checkbox.tsx",

--- a/apps/v4/public/r/styles/base-lyra/collapsible.json
+++ b/apps/v4/public/r/styles/base-lyra/collapsible.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "collapsible",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/collapsible.tsx",

--- a/apps/v4/public/r/styles/base-lyra/context-menu.json
+++ b/apps/v4/public/r/styles/base-lyra/context-menu.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "context-menu",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/context-menu.tsx",

--- a/apps/v4/public/r/styles/base-lyra/dialog.json
+++ b/apps/v4/public/r/styles/base-lyra/dialog.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "dialog",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-lyra/dropdown-menu.json
+++ b/apps/v4/public/r/styles/base-lyra/dropdown-menu.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "dropdown-menu",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/dropdown-menu.tsx",

--- a/apps/v4/public/r/styles/base-lyra/hover-card.json
+++ b/apps/v4/public/r/styles/base-lyra/hover-card.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "hover-card",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/hover-card.tsx",

--- a/apps/v4/public/r/styles/base-lyra/label.json
+++ b/apps/v4/public/r/styles/base-lyra/label.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "label",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/label.tsx",

--- a/apps/v4/public/r/styles/base-lyra/menubar.json
+++ b/apps/v4/public/r/styles/base-lyra/menubar.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "menubar",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "dropdown-menu"
   ],

--- a/apps/v4/public/r/styles/base-lyra/navigation-menu.json
+++ b/apps/v4/public/r/styles/base-lyra/navigation-menu.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "navigation-menu",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/navigation-menu.tsx",

--- a/apps/v4/public/r/styles/base-lyra/popover.json
+++ b/apps/v4/public/r/styles/base-lyra/popover.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "popover",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/popover.tsx",

--- a/apps/v4/public/r/styles/base-lyra/progress.json
+++ b/apps/v4/public/r/styles/base-lyra/progress.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "progress",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/progress.tsx",

--- a/apps/v4/public/r/styles/base-lyra/radio-group.json
+++ b/apps/v4/public/r/styles/base-lyra/radio-group.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "radio-group",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/radio-group.tsx",

--- a/apps/v4/public/r/styles/base-lyra/registry.json
+++ b/apps/v4/public/r/styles/base-lyra/registry.json
@@ -4,6 +4,9 @@
   "items": [
     {
       "name": "accordion",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/accordion.tsx",
@@ -24,6 +27,9 @@
     },
     {
       "name": "alert-dialog",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "button"
       ],
@@ -37,6 +43,9 @@
     },
     {
       "name": "aspect-ratio",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/aspect-ratio.tsx",
@@ -47,6 +56,9 @@
     },
     {
       "name": "avatar",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/avatar.tsx",
@@ -77,6 +89,9 @@
     },
     {
       "name": "button",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/button.tsx",
@@ -87,6 +102,9 @@
     },
     {
       "name": "button-group",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "separator"
       ],
@@ -159,6 +177,9 @@
     },
     {
       "name": "checkbox",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/checkbox.tsx",
@@ -169,6 +190,9 @@
     },
     {
       "name": "collapsible",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/collapsible.tsx",
@@ -213,6 +237,9 @@
     },
     {
       "name": "context-menu",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/context-menu.tsx",
@@ -223,6 +250,9 @@
     },
     {
       "name": "dialog",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "button"
       ],
@@ -249,6 +279,9 @@
     },
     {
       "name": "dropdown-menu",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/dropdown-menu.tsx",
@@ -287,6 +320,9 @@
     },
     {
       "name": "hover-card",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/hover-card.tsx",
@@ -348,6 +384,9 @@
     },
     {
       "name": "label",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/label.tsx",
@@ -358,6 +397,9 @@
     },
     {
       "name": "menubar",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "dropdown-menu"
       ],
@@ -371,6 +413,9 @@
     },
     {
       "name": "navigation-menu",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/navigation-menu.tsx",
@@ -394,6 +439,9 @@
     },
     {
       "name": "popover",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/popover.tsx",
@@ -404,6 +452,9 @@
     },
     {
       "name": "progress",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/progress.tsx",
@@ -414,6 +465,9 @@
     },
     {
       "name": "radio-group",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/radio-group.tsx",
@@ -437,6 +491,9 @@
     },
     {
       "name": "scroll-area",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/scroll-area.tsx",
@@ -447,6 +504,9 @@
     },
     {
       "name": "select",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/select.tsx",
@@ -457,6 +517,9 @@
     },
     {
       "name": "separator",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/separator.tsx",
@@ -467,6 +530,9 @@
     },
     {
       "name": "sheet",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "button"
       ],
@@ -508,6 +574,9 @@
     },
     {
       "name": "slider",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/slider.tsx",
@@ -542,6 +611,9 @@
     },
     {
       "name": "switch",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/switch.tsx",
@@ -562,6 +634,9 @@
     },
     {
       "name": "tabs",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/tabs.tsx",
@@ -582,6 +657,9 @@
     },
     {
       "name": "toggle",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/toggle.tsx",
@@ -592,6 +670,9 @@
     },
     {
       "name": "toggle-group",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "toggle"
       ],
@@ -605,6 +686,9 @@
     },
     {
       "name": "tooltip",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-lyra/ui/tooltip.tsx",

--- a/apps/v4/public/r/styles/base-lyra/scroll-area.json
+++ b/apps/v4/public/r/styles/base-lyra/scroll-area.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "scroll-area",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/scroll-area.tsx",

--- a/apps/v4/public/r/styles/base-lyra/select.json
+++ b/apps/v4/public/r/styles/base-lyra/select.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "select",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/select.tsx",

--- a/apps/v4/public/r/styles/base-lyra/separator.json
+++ b/apps/v4/public/r/styles/base-lyra/separator.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "separator",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/separator.tsx",

--- a/apps/v4/public/r/styles/base-lyra/sheet.json
+++ b/apps/v4/public/r/styles/base-lyra/sheet.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "sheet",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-lyra/slider.json
+++ b/apps/v4/public/r/styles/base-lyra/slider.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "slider",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/slider.tsx",

--- a/apps/v4/public/r/styles/base-lyra/switch.json
+++ b/apps/v4/public/r/styles/base-lyra/switch.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "switch",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/switch.tsx",

--- a/apps/v4/public/r/styles/base-lyra/tabs.json
+++ b/apps/v4/public/r/styles/base-lyra/tabs.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "tabs",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/tabs.tsx",

--- a/apps/v4/public/r/styles/base-lyra/toggle-group.json
+++ b/apps/v4/public/r/styles/base-lyra/toggle-group.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "toggle-group",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "toggle"
   ],

--- a/apps/v4/public/r/styles/base-lyra/toggle.json
+++ b/apps/v4/public/r/styles/base-lyra/toggle.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "toggle",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/toggle.tsx",

--- a/apps/v4/public/r/styles/base-lyra/tooltip.json
+++ b/apps/v4/public/r/styles/base-lyra/tooltip.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "tooltip",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-lyra/ui/tooltip.tsx",

--- a/apps/v4/public/r/styles/base-maia/accordion.json
+++ b/apps/v4/public/r/styles/base-maia/accordion.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "accordion",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/accordion.tsx",

--- a/apps/v4/public/r/styles/base-maia/alert-dialog.json
+++ b/apps/v4/public/r/styles/base-maia/alert-dialog.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "alert-dialog",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-maia/aspect-ratio.json
+++ b/apps/v4/public/r/styles/base-maia/aspect-ratio.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "aspect-ratio",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/aspect-ratio.tsx",

--- a/apps/v4/public/r/styles/base-maia/avatar.json
+++ b/apps/v4/public/r/styles/base-maia/avatar.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "avatar",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/avatar.tsx",

--- a/apps/v4/public/r/styles/base-maia/button-group.json
+++ b/apps/v4/public/r/styles/base-maia/button-group.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "button-group",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "separator"
   ],

--- a/apps/v4/public/r/styles/base-maia/button.json
+++ b/apps/v4/public/r/styles/base-maia/button.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "button",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/button.tsx",

--- a/apps/v4/public/r/styles/base-maia/checkbox.json
+++ b/apps/v4/public/r/styles/base-maia/checkbox.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "checkbox",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/checkbox.tsx",

--- a/apps/v4/public/r/styles/base-maia/collapsible.json
+++ b/apps/v4/public/r/styles/base-maia/collapsible.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "collapsible",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/collapsible.tsx",

--- a/apps/v4/public/r/styles/base-maia/context-menu.json
+++ b/apps/v4/public/r/styles/base-maia/context-menu.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "context-menu",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/context-menu.tsx",

--- a/apps/v4/public/r/styles/base-maia/dialog.json
+++ b/apps/v4/public/r/styles/base-maia/dialog.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "dialog",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-maia/dropdown-menu.json
+++ b/apps/v4/public/r/styles/base-maia/dropdown-menu.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "dropdown-menu",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/dropdown-menu.tsx",

--- a/apps/v4/public/r/styles/base-maia/hover-card.json
+++ b/apps/v4/public/r/styles/base-maia/hover-card.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "hover-card",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/hover-card.tsx",

--- a/apps/v4/public/r/styles/base-maia/label.json
+++ b/apps/v4/public/r/styles/base-maia/label.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "label",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/label.tsx",

--- a/apps/v4/public/r/styles/base-maia/menubar.json
+++ b/apps/v4/public/r/styles/base-maia/menubar.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "menubar",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "dropdown-menu"
   ],

--- a/apps/v4/public/r/styles/base-maia/navigation-menu.json
+++ b/apps/v4/public/r/styles/base-maia/navigation-menu.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "navigation-menu",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/navigation-menu.tsx",

--- a/apps/v4/public/r/styles/base-maia/popover.json
+++ b/apps/v4/public/r/styles/base-maia/popover.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "popover",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/popover.tsx",

--- a/apps/v4/public/r/styles/base-maia/progress.json
+++ b/apps/v4/public/r/styles/base-maia/progress.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "progress",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/progress.tsx",

--- a/apps/v4/public/r/styles/base-maia/radio-group.json
+++ b/apps/v4/public/r/styles/base-maia/radio-group.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "radio-group",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/radio-group.tsx",

--- a/apps/v4/public/r/styles/base-maia/registry.json
+++ b/apps/v4/public/r/styles/base-maia/registry.json
@@ -4,6 +4,9 @@
   "items": [
     {
       "name": "accordion",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/accordion.tsx",
@@ -24,6 +27,9 @@
     },
     {
       "name": "alert-dialog",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "button"
       ],
@@ -37,6 +43,9 @@
     },
     {
       "name": "aspect-ratio",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/aspect-ratio.tsx",
@@ -47,6 +56,9 @@
     },
     {
       "name": "avatar",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/avatar.tsx",
@@ -77,6 +89,9 @@
     },
     {
       "name": "button",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/button.tsx",
@@ -87,6 +102,9 @@
     },
     {
       "name": "button-group",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "separator"
       ],
@@ -159,6 +177,9 @@
     },
     {
       "name": "checkbox",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/checkbox.tsx",
@@ -169,6 +190,9 @@
     },
     {
       "name": "collapsible",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/collapsible.tsx",
@@ -213,6 +237,9 @@
     },
     {
       "name": "context-menu",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/context-menu.tsx",
@@ -223,6 +250,9 @@
     },
     {
       "name": "dialog",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "button"
       ],
@@ -249,6 +279,9 @@
     },
     {
       "name": "dropdown-menu",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/dropdown-menu.tsx",
@@ -287,6 +320,9 @@
     },
     {
       "name": "hover-card",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/hover-card.tsx",
@@ -348,6 +384,9 @@
     },
     {
       "name": "label",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/label.tsx",
@@ -358,6 +397,9 @@
     },
     {
       "name": "menubar",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "dropdown-menu"
       ],
@@ -371,6 +413,9 @@
     },
     {
       "name": "navigation-menu",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/navigation-menu.tsx",
@@ -394,6 +439,9 @@
     },
     {
       "name": "popover",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/popover.tsx",
@@ -404,6 +452,9 @@
     },
     {
       "name": "progress",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/progress.tsx",
@@ -414,6 +465,9 @@
     },
     {
       "name": "radio-group",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/radio-group.tsx",
@@ -437,6 +491,9 @@
     },
     {
       "name": "scroll-area",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/scroll-area.tsx",
@@ -447,6 +504,9 @@
     },
     {
       "name": "select",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/select.tsx",
@@ -457,6 +517,9 @@
     },
     {
       "name": "separator",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/separator.tsx",
@@ -467,6 +530,9 @@
     },
     {
       "name": "sheet",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "button"
       ],
@@ -508,6 +574,9 @@
     },
     {
       "name": "slider",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/slider.tsx",
@@ -542,6 +611,9 @@
     },
     {
       "name": "switch",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/switch.tsx",
@@ -562,6 +634,9 @@
     },
     {
       "name": "tabs",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/tabs.tsx",
@@ -582,6 +657,9 @@
     },
     {
       "name": "toggle",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/toggle.tsx",
@@ -592,6 +670,9 @@
     },
     {
       "name": "toggle-group",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "toggle"
       ],
@@ -605,6 +686,9 @@
     },
     {
       "name": "tooltip",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-maia/ui/tooltip.tsx",

--- a/apps/v4/public/r/styles/base-maia/scroll-area.json
+++ b/apps/v4/public/r/styles/base-maia/scroll-area.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "scroll-area",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/scroll-area.tsx",

--- a/apps/v4/public/r/styles/base-maia/select.json
+++ b/apps/v4/public/r/styles/base-maia/select.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "select",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/select.tsx",

--- a/apps/v4/public/r/styles/base-maia/separator.json
+++ b/apps/v4/public/r/styles/base-maia/separator.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "separator",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/separator.tsx",

--- a/apps/v4/public/r/styles/base-maia/sheet.json
+++ b/apps/v4/public/r/styles/base-maia/sheet.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "sheet",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-maia/slider.json
+++ b/apps/v4/public/r/styles/base-maia/slider.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "slider",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/slider.tsx",

--- a/apps/v4/public/r/styles/base-maia/switch.json
+++ b/apps/v4/public/r/styles/base-maia/switch.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "switch",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/switch.tsx",

--- a/apps/v4/public/r/styles/base-maia/tabs.json
+++ b/apps/v4/public/r/styles/base-maia/tabs.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "tabs",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/tabs.tsx",

--- a/apps/v4/public/r/styles/base-maia/toggle-group.json
+++ b/apps/v4/public/r/styles/base-maia/toggle-group.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "toggle-group",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "toggle"
   ],

--- a/apps/v4/public/r/styles/base-maia/toggle.json
+++ b/apps/v4/public/r/styles/base-maia/toggle.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "toggle",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/toggle.tsx",

--- a/apps/v4/public/r/styles/base-maia/tooltip.json
+++ b/apps/v4/public/r/styles/base-maia/tooltip.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "tooltip",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-maia/ui/tooltip.tsx",

--- a/apps/v4/public/r/styles/base-mira/accordion.json
+++ b/apps/v4/public/r/styles/base-mira/accordion.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "accordion",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/accordion.tsx",

--- a/apps/v4/public/r/styles/base-mira/alert-dialog.json
+++ b/apps/v4/public/r/styles/base-mira/alert-dialog.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "alert-dialog",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-mira/aspect-ratio.json
+++ b/apps/v4/public/r/styles/base-mira/aspect-ratio.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "aspect-ratio",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/aspect-ratio.tsx",

--- a/apps/v4/public/r/styles/base-mira/avatar.json
+++ b/apps/v4/public/r/styles/base-mira/avatar.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "avatar",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/avatar.tsx",

--- a/apps/v4/public/r/styles/base-mira/button-group.json
+++ b/apps/v4/public/r/styles/base-mira/button-group.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "button-group",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "separator"
   ],

--- a/apps/v4/public/r/styles/base-mira/button.json
+++ b/apps/v4/public/r/styles/base-mira/button.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "button",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/button.tsx",

--- a/apps/v4/public/r/styles/base-mira/checkbox.json
+++ b/apps/v4/public/r/styles/base-mira/checkbox.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "checkbox",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/checkbox.tsx",

--- a/apps/v4/public/r/styles/base-mira/collapsible.json
+++ b/apps/v4/public/r/styles/base-mira/collapsible.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "collapsible",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/collapsible.tsx",

--- a/apps/v4/public/r/styles/base-mira/context-menu.json
+++ b/apps/v4/public/r/styles/base-mira/context-menu.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "context-menu",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/context-menu.tsx",

--- a/apps/v4/public/r/styles/base-mira/dialog.json
+++ b/apps/v4/public/r/styles/base-mira/dialog.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "dialog",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-mira/dropdown-menu.json
+++ b/apps/v4/public/r/styles/base-mira/dropdown-menu.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "dropdown-menu",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/dropdown-menu.tsx",

--- a/apps/v4/public/r/styles/base-mira/hover-card.json
+++ b/apps/v4/public/r/styles/base-mira/hover-card.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "hover-card",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/hover-card.tsx",

--- a/apps/v4/public/r/styles/base-mira/label.json
+++ b/apps/v4/public/r/styles/base-mira/label.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "label",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/label.tsx",

--- a/apps/v4/public/r/styles/base-mira/menubar.json
+++ b/apps/v4/public/r/styles/base-mira/menubar.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "menubar",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "dropdown-menu"
   ],

--- a/apps/v4/public/r/styles/base-mira/navigation-menu.json
+++ b/apps/v4/public/r/styles/base-mira/navigation-menu.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "navigation-menu",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/navigation-menu.tsx",

--- a/apps/v4/public/r/styles/base-mira/popover.json
+++ b/apps/v4/public/r/styles/base-mira/popover.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "popover",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/popover.tsx",

--- a/apps/v4/public/r/styles/base-mira/progress.json
+++ b/apps/v4/public/r/styles/base-mira/progress.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "progress",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/progress.tsx",

--- a/apps/v4/public/r/styles/base-mira/radio-group.json
+++ b/apps/v4/public/r/styles/base-mira/radio-group.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "radio-group",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/radio-group.tsx",

--- a/apps/v4/public/r/styles/base-mira/registry.json
+++ b/apps/v4/public/r/styles/base-mira/registry.json
@@ -4,6 +4,9 @@
   "items": [
     {
       "name": "accordion",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/accordion.tsx",
@@ -24,6 +27,9 @@
     },
     {
       "name": "alert-dialog",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "button"
       ],
@@ -37,6 +43,9 @@
     },
     {
       "name": "aspect-ratio",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/aspect-ratio.tsx",
@@ -47,6 +56,9 @@
     },
     {
       "name": "avatar",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/avatar.tsx",
@@ -77,6 +89,9 @@
     },
     {
       "name": "button",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/button.tsx",
@@ -87,6 +102,9 @@
     },
     {
       "name": "button-group",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "separator"
       ],
@@ -159,6 +177,9 @@
     },
     {
       "name": "checkbox",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/checkbox.tsx",
@@ -169,6 +190,9 @@
     },
     {
       "name": "collapsible",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/collapsible.tsx",
@@ -213,6 +237,9 @@
     },
     {
       "name": "context-menu",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/context-menu.tsx",
@@ -223,6 +250,9 @@
     },
     {
       "name": "dialog",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "button"
       ],
@@ -249,6 +279,9 @@
     },
     {
       "name": "dropdown-menu",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/dropdown-menu.tsx",
@@ -287,6 +320,9 @@
     },
     {
       "name": "hover-card",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/hover-card.tsx",
@@ -348,6 +384,9 @@
     },
     {
       "name": "label",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/label.tsx",
@@ -358,6 +397,9 @@
     },
     {
       "name": "menubar",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "dropdown-menu"
       ],
@@ -371,6 +413,9 @@
     },
     {
       "name": "navigation-menu",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/navigation-menu.tsx",
@@ -394,6 +439,9 @@
     },
     {
       "name": "popover",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/popover.tsx",
@@ -404,6 +452,9 @@
     },
     {
       "name": "progress",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/progress.tsx",
@@ -414,6 +465,9 @@
     },
     {
       "name": "radio-group",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/radio-group.tsx",
@@ -437,6 +491,9 @@
     },
     {
       "name": "scroll-area",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/scroll-area.tsx",
@@ -447,6 +504,9 @@
     },
     {
       "name": "select",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/select.tsx",
@@ -457,6 +517,9 @@
     },
     {
       "name": "separator",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/separator.tsx",
@@ -467,6 +530,9 @@
     },
     {
       "name": "sheet",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "button"
       ],
@@ -508,6 +574,9 @@
     },
     {
       "name": "slider",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/slider.tsx",
@@ -542,6 +611,9 @@
     },
     {
       "name": "switch",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/switch.tsx",
@@ -562,6 +634,9 @@
     },
     {
       "name": "tabs",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/tabs.tsx",
@@ -582,6 +657,9 @@
     },
     {
       "name": "toggle",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/toggle.tsx",
@@ -592,6 +670,9 @@
     },
     {
       "name": "toggle-group",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "toggle"
       ],
@@ -605,6 +686,9 @@
     },
     {
       "name": "tooltip",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-mira/ui/tooltip.tsx",

--- a/apps/v4/public/r/styles/base-mira/scroll-area.json
+++ b/apps/v4/public/r/styles/base-mira/scroll-area.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "scroll-area",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/scroll-area.tsx",

--- a/apps/v4/public/r/styles/base-mira/select.json
+++ b/apps/v4/public/r/styles/base-mira/select.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "select",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/select.tsx",

--- a/apps/v4/public/r/styles/base-mira/separator.json
+++ b/apps/v4/public/r/styles/base-mira/separator.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "separator",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/separator.tsx",

--- a/apps/v4/public/r/styles/base-mira/sheet.json
+++ b/apps/v4/public/r/styles/base-mira/sheet.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "sheet",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-mira/slider.json
+++ b/apps/v4/public/r/styles/base-mira/slider.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "slider",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/slider.tsx",

--- a/apps/v4/public/r/styles/base-mira/switch.json
+++ b/apps/v4/public/r/styles/base-mira/switch.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "switch",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/switch.tsx",

--- a/apps/v4/public/r/styles/base-mira/tabs.json
+++ b/apps/v4/public/r/styles/base-mira/tabs.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "tabs",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/tabs.tsx",

--- a/apps/v4/public/r/styles/base-mira/toggle-group.json
+++ b/apps/v4/public/r/styles/base-mira/toggle-group.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "toggle-group",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "toggle"
   ],

--- a/apps/v4/public/r/styles/base-mira/toggle.json
+++ b/apps/v4/public/r/styles/base-mira/toggle.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "toggle",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/toggle.tsx",

--- a/apps/v4/public/r/styles/base-mira/tooltip.json
+++ b/apps/v4/public/r/styles/base-mira/tooltip.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "tooltip",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-mira/ui/tooltip.tsx",

--- a/apps/v4/public/r/styles/base-nova/accordion.json
+++ b/apps/v4/public/r/styles/base-nova/accordion.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "accordion",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/accordion.tsx",

--- a/apps/v4/public/r/styles/base-nova/alert-dialog.json
+++ b/apps/v4/public/r/styles/base-nova/alert-dialog.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "alert-dialog",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-nova/aspect-ratio.json
+++ b/apps/v4/public/r/styles/base-nova/aspect-ratio.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "aspect-ratio",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/aspect-ratio.tsx",

--- a/apps/v4/public/r/styles/base-nova/avatar.json
+++ b/apps/v4/public/r/styles/base-nova/avatar.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "avatar",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/avatar.tsx",

--- a/apps/v4/public/r/styles/base-nova/button-group.json
+++ b/apps/v4/public/r/styles/base-nova/button-group.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "button-group",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "separator"
   ],

--- a/apps/v4/public/r/styles/base-nova/button.json
+++ b/apps/v4/public/r/styles/base-nova/button.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "button",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/button.tsx",

--- a/apps/v4/public/r/styles/base-nova/checkbox.json
+++ b/apps/v4/public/r/styles/base-nova/checkbox.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "checkbox",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/checkbox.tsx",

--- a/apps/v4/public/r/styles/base-nova/collapsible.json
+++ b/apps/v4/public/r/styles/base-nova/collapsible.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "collapsible",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/collapsible.tsx",

--- a/apps/v4/public/r/styles/base-nova/context-menu.json
+++ b/apps/v4/public/r/styles/base-nova/context-menu.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "context-menu",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/context-menu.tsx",

--- a/apps/v4/public/r/styles/base-nova/dialog.json
+++ b/apps/v4/public/r/styles/base-nova/dialog.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "dialog",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-nova/dropdown-menu.json
+++ b/apps/v4/public/r/styles/base-nova/dropdown-menu.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "dropdown-menu",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/dropdown-menu.tsx",

--- a/apps/v4/public/r/styles/base-nova/hover-card.json
+++ b/apps/v4/public/r/styles/base-nova/hover-card.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "hover-card",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/hover-card.tsx",

--- a/apps/v4/public/r/styles/base-nova/label.json
+++ b/apps/v4/public/r/styles/base-nova/label.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "label",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/label.tsx",

--- a/apps/v4/public/r/styles/base-nova/menubar.json
+++ b/apps/v4/public/r/styles/base-nova/menubar.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "menubar",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "dropdown-menu"
   ],

--- a/apps/v4/public/r/styles/base-nova/navigation-menu.json
+++ b/apps/v4/public/r/styles/base-nova/navigation-menu.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "navigation-menu",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/navigation-menu.tsx",

--- a/apps/v4/public/r/styles/base-nova/popover.json
+++ b/apps/v4/public/r/styles/base-nova/popover.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "popover",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/popover.tsx",

--- a/apps/v4/public/r/styles/base-nova/progress.json
+++ b/apps/v4/public/r/styles/base-nova/progress.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "progress",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/progress.tsx",

--- a/apps/v4/public/r/styles/base-nova/radio-group.json
+++ b/apps/v4/public/r/styles/base-nova/radio-group.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "radio-group",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/radio-group.tsx",

--- a/apps/v4/public/r/styles/base-nova/registry.json
+++ b/apps/v4/public/r/styles/base-nova/registry.json
@@ -4,6 +4,9 @@
   "items": [
     {
       "name": "accordion",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/accordion.tsx",
@@ -24,6 +27,9 @@
     },
     {
       "name": "alert-dialog",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "button"
       ],
@@ -37,6 +43,9 @@
     },
     {
       "name": "aspect-ratio",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/aspect-ratio.tsx",
@@ -47,6 +56,9 @@
     },
     {
       "name": "avatar",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/avatar.tsx",
@@ -77,6 +89,9 @@
     },
     {
       "name": "button",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/button.tsx",
@@ -87,6 +102,9 @@
     },
     {
       "name": "button-group",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "separator"
       ],
@@ -159,6 +177,9 @@
     },
     {
       "name": "checkbox",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/checkbox.tsx",
@@ -169,6 +190,9 @@
     },
     {
       "name": "collapsible",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/collapsible.tsx",
@@ -213,6 +237,9 @@
     },
     {
       "name": "context-menu",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/context-menu.tsx",
@@ -223,6 +250,9 @@
     },
     {
       "name": "dialog",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "button"
       ],
@@ -249,6 +279,9 @@
     },
     {
       "name": "dropdown-menu",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/dropdown-menu.tsx",
@@ -287,6 +320,9 @@
     },
     {
       "name": "hover-card",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/hover-card.tsx",
@@ -348,6 +384,9 @@
     },
     {
       "name": "label",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/label.tsx",
@@ -358,6 +397,9 @@
     },
     {
       "name": "menubar",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "dropdown-menu"
       ],
@@ -371,6 +413,9 @@
     },
     {
       "name": "navigation-menu",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/navigation-menu.tsx",
@@ -394,6 +439,9 @@
     },
     {
       "name": "popover",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/popover.tsx",
@@ -404,6 +452,9 @@
     },
     {
       "name": "progress",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/progress.tsx",
@@ -414,6 +465,9 @@
     },
     {
       "name": "radio-group",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/radio-group.tsx",
@@ -437,6 +491,9 @@
     },
     {
       "name": "scroll-area",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/scroll-area.tsx",
@@ -447,6 +504,9 @@
     },
     {
       "name": "select",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/select.tsx",
@@ -457,6 +517,9 @@
     },
     {
       "name": "separator",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/separator.tsx",
@@ -467,6 +530,9 @@
     },
     {
       "name": "sheet",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "button"
       ],
@@ -508,6 +574,9 @@
     },
     {
       "name": "slider",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/slider.tsx",
@@ -542,6 +611,9 @@
     },
     {
       "name": "switch",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/switch.tsx",
@@ -562,6 +634,9 @@
     },
     {
       "name": "tabs",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/tabs.tsx",
@@ -582,6 +657,9 @@
     },
     {
       "name": "toggle",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/toggle.tsx",
@@ -592,6 +670,9 @@
     },
     {
       "name": "toggle-group",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "toggle"
       ],
@@ -605,6 +686,9 @@
     },
     {
       "name": "tooltip",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-nova/ui/tooltip.tsx",

--- a/apps/v4/public/r/styles/base-nova/scroll-area.json
+++ b/apps/v4/public/r/styles/base-nova/scroll-area.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "scroll-area",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/scroll-area.tsx",

--- a/apps/v4/public/r/styles/base-nova/select.json
+++ b/apps/v4/public/r/styles/base-nova/select.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "select",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/select.tsx",

--- a/apps/v4/public/r/styles/base-nova/separator.json
+++ b/apps/v4/public/r/styles/base-nova/separator.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "separator",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/separator.tsx",

--- a/apps/v4/public/r/styles/base-nova/sheet.json
+++ b/apps/v4/public/r/styles/base-nova/sheet.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "sheet",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-nova/slider.json
+++ b/apps/v4/public/r/styles/base-nova/slider.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "slider",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/slider.tsx",

--- a/apps/v4/public/r/styles/base-nova/switch.json
+++ b/apps/v4/public/r/styles/base-nova/switch.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "switch",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/switch.tsx",

--- a/apps/v4/public/r/styles/base-nova/tabs.json
+++ b/apps/v4/public/r/styles/base-nova/tabs.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "tabs",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/tabs.tsx",

--- a/apps/v4/public/r/styles/base-nova/toggle-group.json
+++ b/apps/v4/public/r/styles/base-nova/toggle-group.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "toggle-group",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "toggle"
   ],

--- a/apps/v4/public/r/styles/base-nova/toggle.json
+++ b/apps/v4/public/r/styles/base-nova/toggle.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "toggle",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/toggle.tsx",

--- a/apps/v4/public/r/styles/base-nova/tooltip.json
+++ b/apps/v4/public/r/styles/base-nova/tooltip.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "tooltip",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-nova/ui/tooltip.tsx",

--- a/apps/v4/public/r/styles/base-vega/accordion.json
+++ b/apps/v4/public/r/styles/base-vega/accordion.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "accordion",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/accordion.tsx",

--- a/apps/v4/public/r/styles/base-vega/alert-dialog.json
+++ b/apps/v4/public/r/styles/base-vega/alert-dialog.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "alert-dialog",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-vega/aspect-ratio.json
+++ b/apps/v4/public/r/styles/base-vega/aspect-ratio.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "aspect-ratio",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/aspect-ratio.tsx",

--- a/apps/v4/public/r/styles/base-vega/avatar.json
+++ b/apps/v4/public/r/styles/base-vega/avatar.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "avatar",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/avatar.tsx",

--- a/apps/v4/public/r/styles/base-vega/button-group.json
+++ b/apps/v4/public/r/styles/base-vega/button-group.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "button-group",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "separator"
   ],

--- a/apps/v4/public/r/styles/base-vega/button.json
+++ b/apps/v4/public/r/styles/base-vega/button.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "button",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/button.tsx",

--- a/apps/v4/public/r/styles/base-vega/checkbox.json
+++ b/apps/v4/public/r/styles/base-vega/checkbox.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "checkbox",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/checkbox.tsx",

--- a/apps/v4/public/r/styles/base-vega/collapsible.json
+++ b/apps/v4/public/r/styles/base-vega/collapsible.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "collapsible",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/collapsible.tsx",

--- a/apps/v4/public/r/styles/base-vega/context-menu.json
+++ b/apps/v4/public/r/styles/base-vega/context-menu.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "context-menu",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/context-menu.tsx",

--- a/apps/v4/public/r/styles/base-vega/dialog.json
+++ b/apps/v4/public/r/styles/base-vega/dialog.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "dialog",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-vega/dropdown-menu.json
+++ b/apps/v4/public/r/styles/base-vega/dropdown-menu.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "dropdown-menu",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/dropdown-menu.tsx",

--- a/apps/v4/public/r/styles/base-vega/hover-card.json
+++ b/apps/v4/public/r/styles/base-vega/hover-card.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "hover-card",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/hover-card.tsx",

--- a/apps/v4/public/r/styles/base-vega/label.json
+++ b/apps/v4/public/r/styles/base-vega/label.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "label",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/label.tsx",

--- a/apps/v4/public/r/styles/base-vega/menubar.json
+++ b/apps/v4/public/r/styles/base-vega/menubar.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "menubar",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "dropdown-menu"
   ],

--- a/apps/v4/public/r/styles/base-vega/navigation-menu.json
+++ b/apps/v4/public/r/styles/base-vega/navigation-menu.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "navigation-menu",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/navigation-menu.tsx",

--- a/apps/v4/public/r/styles/base-vega/popover.json
+++ b/apps/v4/public/r/styles/base-vega/popover.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "popover",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/popover.tsx",

--- a/apps/v4/public/r/styles/base-vega/progress.json
+++ b/apps/v4/public/r/styles/base-vega/progress.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "progress",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/progress.tsx",

--- a/apps/v4/public/r/styles/base-vega/radio-group.json
+++ b/apps/v4/public/r/styles/base-vega/radio-group.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "radio-group",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/radio-group.tsx",

--- a/apps/v4/public/r/styles/base-vega/registry.json
+++ b/apps/v4/public/r/styles/base-vega/registry.json
@@ -4,6 +4,9 @@
   "items": [
     {
       "name": "accordion",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/accordion.tsx",
@@ -24,6 +27,9 @@
     },
     {
       "name": "alert-dialog",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "button"
       ],
@@ -37,6 +43,9 @@
     },
     {
       "name": "aspect-ratio",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/aspect-ratio.tsx",
@@ -47,6 +56,9 @@
     },
     {
       "name": "avatar",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/avatar.tsx",
@@ -77,6 +89,9 @@
     },
     {
       "name": "button",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/button.tsx",
@@ -87,6 +102,9 @@
     },
     {
       "name": "button-group",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "separator"
       ],
@@ -159,6 +177,9 @@
     },
     {
       "name": "checkbox",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/checkbox.tsx",
@@ -169,6 +190,9 @@
     },
     {
       "name": "collapsible",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/collapsible.tsx",
@@ -213,6 +237,9 @@
     },
     {
       "name": "context-menu",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/context-menu.tsx",
@@ -223,6 +250,9 @@
     },
     {
       "name": "dialog",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "button"
       ],
@@ -249,6 +279,9 @@
     },
     {
       "name": "dropdown-menu",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/dropdown-menu.tsx",
@@ -287,6 +320,9 @@
     },
     {
       "name": "hover-card",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/hover-card.tsx",
@@ -348,6 +384,9 @@
     },
     {
       "name": "label",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/label.tsx",
@@ -358,6 +397,9 @@
     },
     {
       "name": "menubar",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "dropdown-menu"
       ],
@@ -371,6 +413,9 @@
     },
     {
       "name": "navigation-menu",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/navigation-menu.tsx",
@@ -394,6 +439,9 @@
     },
     {
       "name": "popover",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/popover.tsx",
@@ -404,6 +452,9 @@
     },
     {
       "name": "progress",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/progress.tsx",
@@ -414,6 +465,9 @@
     },
     {
       "name": "radio-group",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/radio-group.tsx",
@@ -437,6 +491,9 @@
     },
     {
       "name": "scroll-area",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/scroll-area.tsx",
@@ -447,6 +504,9 @@
     },
     {
       "name": "select",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/select.tsx",
@@ -457,6 +517,9 @@
     },
     {
       "name": "separator",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/separator.tsx",
@@ -467,6 +530,9 @@
     },
     {
       "name": "sheet",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "button"
       ],
@@ -508,6 +574,9 @@
     },
     {
       "name": "slider",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/slider.tsx",
@@ -542,6 +611,9 @@
     },
     {
       "name": "switch",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/switch.tsx",
@@ -562,6 +634,9 @@
     },
     {
       "name": "tabs",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/tabs.tsx",
@@ -582,6 +657,9 @@
     },
     {
       "name": "toggle",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/toggle.tsx",
@@ -592,6 +670,9 @@
     },
     {
       "name": "toggle-group",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "registryDependencies": [
         "toggle"
       ],
@@ -605,6 +686,9 @@
     },
     {
       "name": "tooltip",
+      "dependencies": [
+        "@base-ui/react"
+      ],
       "files": [
         {
           "path": "registry/base-vega/ui/tooltip.tsx",

--- a/apps/v4/public/r/styles/base-vega/scroll-area.json
+++ b/apps/v4/public/r/styles/base-vega/scroll-area.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "scroll-area",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/scroll-area.tsx",

--- a/apps/v4/public/r/styles/base-vega/select.json
+++ b/apps/v4/public/r/styles/base-vega/select.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "select",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/select.tsx",

--- a/apps/v4/public/r/styles/base-vega/separator.json
+++ b/apps/v4/public/r/styles/base-vega/separator.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "separator",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/separator.tsx",

--- a/apps/v4/public/r/styles/base-vega/sheet.json
+++ b/apps/v4/public/r/styles/base-vega/sheet.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "sheet",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-vega/slider.json
+++ b/apps/v4/public/r/styles/base-vega/slider.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "slider",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/slider.tsx",

--- a/apps/v4/public/r/styles/base-vega/switch.json
+++ b/apps/v4/public/r/styles/base-vega/switch.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "switch",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/switch.tsx",

--- a/apps/v4/public/r/styles/base-vega/tabs.json
+++ b/apps/v4/public/r/styles/base-vega/tabs.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "tabs",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/tabs.tsx",

--- a/apps/v4/public/r/styles/base-vega/toggle-group.json
+++ b/apps/v4/public/r/styles/base-vega/toggle-group.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "toggle-group",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "toggle"
   ],

--- a/apps/v4/public/r/styles/base-vega/toggle.json
+++ b/apps/v4/public/r/styles/base-vega/toggle.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "toggle",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/toggle.tsx",

--- a/apps/v4/public/r/styles/base-vega/tooltip.json
+++ b/apps/v4/public/r/styles/base-vega/tooltip.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "tooltip",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "files": [
     {
       "path": "registry/base-vega/ui/tooltip.tsx",

--- a/apps/v4/registry/bases/base/ui/_registry.ts
+++ b/apps/v4/registry/bases/base/ui/_registry.ts
@@ -4,6 +4,7 @@ export const ui: Registry["items"] = [
   {
     name: "accordion",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/accordion.tsx",
@@ -24,6 +25,7 @@ export const ui: Registry["items"] = [
   {
     name: "alert-dialog",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     registryDependencies: ["button"],
     files: [
       {
@@ -35,6 +37,7 @@ export const ui: Registry["items"] = [
   {
     name: "aspect-ratio",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/aspect-ratio.tsx",
@@ -45,6 +48,7 @@ export const ui: Registry["items"] = [
   {
     name: "avatar",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/avatar.tsx",
@@ -75,6 +79,7 @@ export const ui: Registry["items"] = [
   {
     name: "button",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/button.tsx",
@@ -85,6 +90,7 @@ export const ui: Registry["items"] = [
   {
     name: "button-group",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     registryDependencies: ["separator"],
     files: [
       {
@@ -142,6 +148,7 @@ export const ui: Registry["items"] = [
   {
     name: "checkbox",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/checkbox.tsx",
@@ -152,6 +159,7 @@ export const ui: Registry["items"] = [
   {
     name: "collapsible",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/collapsible.tsx",
@@ -186,6 +194,7 @@ export const ui: Registry["items"] = [
   {
     name: "context-menu",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/context-menu.tsx",
@@ -196,6 +205,7 @@ export const ui: Registry["items"] = [
   {
     name: "dialog",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     registryDependencies: ["button"],
     files: [
       {
@@ -218,6 +228,7 @@ export const ui: Registry["items"] = [
   {
     name: "dropdown-menu",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/dropdown-menu.tsx",
@@ -253,6 +264,7 @@ export const ui: Registry["items"] = [
   {
     name: "hover-card",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/hover-card.tsx",
@@ -306,6 +318,7 @@ export const ui: Registry["items"] = [
   {
     name: "label",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/label.tsx",
@@ -316,6 +329,7 @@ export const ui: Registry["items"] = [
   {
     name: "menubar",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     registryDependencies: ["dropdown-menu"],
     files: [
       {
@@ -327,6 +341,7 @@ export const ui: Registry["items"] = [
   {
     name: "navigation-menu",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/navigation-menu.tsx",
@@ -348,6 +363,7 @@ export const ui: Registry["items"] = [
   {
     name: "popover",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/popover.tsx",
@@ -358,6 +374,7 @@ export const ui: Registry["items"] = [
   {
     name: "progress",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/progress.tsx",
@@ -368,6 +385,7 @@ export const ui: Registry["items"] = [
   {
     name: "radio-group",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/radio-group.tsx",
@@ -389,6 +407,7 @@ export const ui: Registry["items"] = [
   {
     name: "scroll-area",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/scroll-area.tsx",
@@ -399,6 +418,7 @@ export const ui: Registry["items"] = [
   {
     name: "select",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/select.tsx",
@@ -409,6 +429,7 @@ export const ui: Registry["items"] = [
   {
     name: "separator",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/separator.tsx",
@@ -419,6 +440,7 @@ export const ui: Registry["items"] = [
   {
     name: "sheet",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     registryDependencies: ["button"],
     files: [
       {
@@ -458,6 +480,7 @@ export const ui: Registry["items"] = [
   {
     name: "slider",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/slider.tsx",
@@ -489,6 +512,7 @@ export const ui: Registry["items"] = [
   {
     name: "switch",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/switch.tsx",
@@ -509,6 +533,7 @@ export const ui: Registry["items"] = [
   {
     name: "tabs",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/tabs.tsx",
@@ -529,6 +554,7 @@ export const ui: Registry["items"] = [
   {
     name: "toggle",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/toggle.tsx",
@@ -539,6 +565,7 @@ export const ui: Registry["items"] = [
   {
     name: "toggle-group",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     registryDependencies: ["toggle"],
     files: [
       {
@@ -550,6 +577,7 @@ export const ui: Registry["items"] = [
   {
     name: "tooltip",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     files: [
       {
         path: "ui/tooltip.tsx",


### PR DESCRIPTION
Adding Base UI component doesn't add dependencies in package.json. For instance 

```console
bunx --bun shadcn@latest add alert-dialog
```

 is expected to add `@base-ui/react` but it doesn't. This PR fixes that.