### PR TITLE
feat(registry): add type guard utilities for error handling

### DIFF
--- a/packages/shadcn/src/registry/errors.ts
+++ b/packages/shadcn/src/registry/errors.ts
@@ -343,3 +343,51 @@ export class InvalidConfigIconLibraryError extends RegistryError {
     this.name = "InvalidConfigIconLibraryError"
   }
 }
+
+/**
+ * Type guard to check if an error is a RegistryError
+ * @param error - The error to check
+ * @returns True if the error is a RegistryError
+ * @example
+ * ```ts
+ * try {
+ *   await getRegistryItems(config)
+ * } catch (error) {
+ *   if (isRegistryError(error)) {
+ *     console.log(error.code) // Type-safe access to error properties
+ *   }
+ * }
+ * ```
+ */
+export function isRegistryError(error: unknown): error is RegistryError {
+  return error instanceof RegistryError
+}
+
+/**
+ * Type guard to check if an error is a network-related error
+ * @param error - The error to check
+ * @returns True if the error is a network-related RegistryError
+ */
+export function isNetworkError(error: unknown): error is RegistryError {
+  if (!isRegistryError(error)) return false
+  return [
+    RegistryErrorCode.NETWORK_ERROR,
+    RegistryErrorCode.NOT_FOUND,
+    RegistryErrorCode.UNAUTHORIZED,
+    RegistryErrorCode.FORBIDDEN,
+    RegistryErrorCode.FETCH_ERROR,
+  ].includes(error.code)
+}
+
+/**
+ * Type guard to check if an error is recoverable (user can retry)
+ * @param error - The error to check
+ * @returns True if the error might succeed on retry
+ */
+export function isRetryableError(error: unknown): error is RegistryError {
+  if (!isRegistryError(error)) return false
+  return [
+    RegistryErrorCode.NETWORK_ERROR,
+    RegistryErrorCode.FETCH_ERROR,
+  ].includes(error.code)
+}

--- a/packages/shadcn/src/registry/index.ts
+++ b/packages/shadcn/src/registry/index.ts
@@ -20,4 +20,8 @@ export {
   RegistriesIndexParseError,
   RegistryMissingEnvironmentVariablesError,
   RegistryInvalidNamespaceError,
+  // Type guards for error handling
+  isRegistryError,
+  isNetworkError,
+  isRetryableError,
 } from "./errors"


### PR DESCRIPTION
## Summary

Added utility functions for type-safe error handling in the registry module:

- `isRegistryError()`: Type guard to check if an error is a RegistryError
- `isNetworkError()`: Type guard to check if an error is network-related
- `isRetryableError()`: Type guard to check if an error is recoverable (for retry logic)

## Motivation

Currently, developers need to manually check error types when handling registry errors. These utility functions provide a cleaner, type-safe way to handle different error scenarios.

## Example Usage

```ts
try {
  await getRegistryItems(config)
} catch (error) {
  if (isRetryableError(error)) {
    // Implement retry logic for transient failures
  } else if (isNetworkError(error)) {
    // Handle network-related errors
  }
}
```

## Changes

- Added `isRegistryError()`, `isNetworkError()`, and `isRetryableError()` functions to `errors.ts`
- Exported the new utilities from the registry module index
- Added JSDoc documentation with examples

## Test Plan

- The functions are simple type guards that use `instanceof` checks
- No breaking changes to existing functionality