### PR TITLE
fix: handle multi-segment scoped packages in alias resolution

### DIFF
--- a/packages/shadcn/src/utils/transformers/transform-import.ts
+++ b/packages/shadcn/src/utils/transformers/transform-import.ts
@@ -67,8 +67,14 @@ function updateImportAliases(
 
   // Not a registry import.
   if (!moduleSpecifier.startsWith("@/registry/")) {
-    // We fix the alias and return.
-    const alias = config.aliases.components.split("/")[0]
+    // Extract base alias, handling scoped packages like @scope/package/path
+    const componentsAlias = config.aliases.components;
+    const segments = componentsAlias.split('/');
+    
+    const alias = segments[0].startsWith('@') && segments.length > 2
+      ? segments.slice(0, 2).join('/')
+      : segments[0];
+    
     return moduleSpecifier.replace(/^@\//, `${alias}/`)
   }
 


### PR DESCRIPTION
## Description

Fixes [#9536 ](https://github.com/shadcn-ui/ui/issues/9536)

The alias resolution code in `transform-import.ts` was only extracting the first segment of alias paths, causing scoped packages like `@package/ui/components` to be incorrectly truncated to `@ package/components` instead of preserving the full scope and package name.

## Problem

When using scoped packages with multiple segments (e.g., `@ package/ui/components`), the existing code:
```javascript
const alias = config.aliases.components.split("/")[0]
```

Would only extract `@package`, resulting in incorrect imports like:
- Expected: `@ package/ui/components/ui/button`
- Actual: `@ package/components/ui/button`

This broke registry installations for any workspace using scoped packages other than `@workspace`.

## Solution

Updated the alias extraction logic to properly detect and preserve scoped package names:
```javascript
const componentsAlias = config.aliases.components;
const segments = componentsAlias.split('/');
const alias = segments[0].startsWith('@') && segments.length > 2
  ? segments.slice(0, 2).join('/')
  : segments[0];
```

Now correctly handles:
- `@ package/ui/components` → extracts `@package/ui` ✅
- `@workspace/ui/components` → extracts `@workspace/ui` ✅
- `@scope/package/path` → extracts `@scope/package` ✅
- `components/ui` → extracts `components` ✅

## Testing

Tested with a monorepo setup using:
- Package name: `@ package/ui`
- Aliases: 
```json
  {
    "components": "@package/ui/components",
    "ui": "@package/ui/components/ui",
    "lib": "@package/ui/lib",
    "hooks": "@package/ui/hooks"
  }
```

Before fix: Components installed with broken imports (`@package/components/...`)
After fix: Components installed with correct imports (`@package/ui/components/...`)

## Related Issues

- Fixes [#9536 ](https://github.com/shadcn-ui/ui/issues/9536)
- Related to https://github.com/shadcn-ui/ui/discussions/6162

## Checklist

- [x] Code follows the project's style guidelines
- [x] Changes address the root cause of the issue
- [x] Tested with multiple scoped package formats
- [ ] Added tests (if guidance provided)
- [x] Updated documentation (if needed)

## Additional Context

This issue prevented users from using custom scoped packages in monorepo setups, forcing them to use `@workspace` as a workaround. The fix enables proper support for any scoped package naming scheme.