### PR TITLE
fix(rtl): use logical margin for password link alignment

### DIFF
--- a/apps/v4/examples/base/card-rtl.tsx
+++ b/apps/v4/examples/base/card-rtl.tsx
@@ -93,7 +93,7 @@ export function CardRtl() {
                 <Label htmlFor="password-rtl">{t.password}</Label>
                 <a
                   href="#"
-                  className="ml-auto inline-block text-sm underline-offset-4 hover:underline"
+                  className="ms-auto inline-block text-sm underline-offset-4 hover:underline"
                 >
                   {t.forgotPassword}
                 </a>

--- a/apps/v4/examples/radix/card-rtl.tsx
+++ b/apps/v4/examples/radix/card-rtl.tsx
@@ -93,7 +93,7 @@ export function CardRtl() {
                 <Label htmlFor="password-rtl">{t.password}</Label>
                 <a
                   href="#"
-                  className="ml-auto inline-block text-sm underline-offset-4 hover:underline"
+                  className="ms-auto inline-block text-sm underline-offset-4 hover:underline"
                 >
                   {t.forgotPassword}
                 </a>


### PR DESCRIPTION
  Change ml-auto to ms-auto (margin-inline-start) so the Forgot your
  password link aligns correctly in both LTR and RTL layouts.

  Fixes #9515
