### PR TITLE
fix: remove duplacated classname

### DIFF
--- a/apps/v4/registry/bases/base/ui/drawer.tsx
+++ b/apps/v4/registry/bases/base/ui/drawer.tsx
@@ -58,7 +58,7 @@ function DrawerContent({
         )}
         {...props}
       >
-        <div className="cn-drawer-handle mx-auto hidden shrink-0 group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        <div className="cn-drawer-handle" />
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>

--- a/apps/v4/registry/bases/radix/ui/drawer.tsx
+++ b/apps/v4/registry/bases/radix/ui/drawer.tsx
@@ -58,7 +58,7 @@ function DrawerContent({
         )}
         {...props}
       >
-        <div className="cn-drawer-handle mx-auto hidden shrink-0 group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        <div className="cn-drawer-handle" />
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>


### PR DESCRIPTION
## Changes
I removed the duplacated className
`bg-muted mx-auto hidden shrink-0 group-data-[vaul-drawer-direction=bottom]/drawer-content:block in bases`

It is already applied via cn-drawer-handle in style-lyra, style-maia, style-mira, style-nova, and style-vega.

## Affect
This only affects the base.
new-york-v4 is not affected because it does not use cn-drawer-handle.

close https://github.com/shadcn-ui/ui/issues/9516