### PR TITLE
docs: clarify when to use button variants and icon size

### DIFF
--- a/apps/v4/content/docs/components/radix/button.mdx
+++ b/apps/v4/content/docs/components/radix/button.mdx
@@ -60,6 +60,11 @@ import { Button } from "@/components/ui/button"
 <Button variant="outline">Button</Button>
 ```
 
+> Tip:  
+> Use `variant="outline"` for secondary actions, `variant="destructive"` for irreversible actions, and `variant="link"` when the button should visually behave like a text link.
+
+> For icon-only buttons, use `size="icon"` and include an accessible label using `aria-label`.
+
 ## Cursor
 
 Tailwind v4 [switched](https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor) from `cursor: pointer` to `cursor: default` for the button component.


### PR DESCRIPTION
Adds a short usage tip explaining common button variants and accessibility guidance for icon-only buttons.

This improves clarity for new users without changing any component behavior.
