### PR TITLE
add React.CSSProperties type annotation to SidebarProvider style example

### DIFF
--- a/apps/v4/content/docs/components/base/sidebar.mdx
+++ b/apps/v4/content/docs/components/base/sidebar.mdx
@@ -151,7 +151,7 @@ For multiple sidebars in your application, you can use the `--sidebar-width` and
   style={{
     "--sidebar-width": "20rem",
     "--sidebar-width-mobile": "20rem",
-  }}
+  } as React.CSSProperties}
 >
   <Sidebar />
 </SidebarProvider>

--- a/apps/v4/content/docs/components/radix/sidebar.mdx
+++ b/apps/v4/content/docs/components/radix/sidebar.mdx
@@ -151,7 +151,7 @@ For multiple sidebars in your application, you can use the `--sidebar-width` and
   style={{
     "--sidebar-width": "20rem",
     "--sidebar-width-mobile": "20rem",
-  }}
+  } as React.CSSProperties}
 >
   <Sidebar />
 </SidebarProvider>


### PR DESCRIPTION
This PR adds the `React.CSSProperties` type annotation to the `style` prop in the SidebarProvider example, improving type safety and developer experience.

**Changes:**
- Cast the inline style object to `React.CSSProperties` to eliminate TypeScript type errors when specifying CSS custom properties (`--sidebar-width` and `--sidebar-width-mobile`)

**Related to:** Issue #9566 