### PR TITLE
feat(shadcn): add HTTP 410 (Gone) support to registry fetcher

### DIFF
--- a/packages/shadcn/src/registry/errors.ts
+++ b/packages/shadcn/src/registry/errors.ts
@@ -5,6 +5,7 @@ export const RegistryErrorCode = {
   // Network errors
   NETWORK_ERROR: "NETWORK_ERROR",
   NOT_FOUND: "NOT_FOUND",
+  GONE: "GONE",
   UNAUTHORIZED: "UNAUTHORIZED",
   FORBIDDEN: "FORBIDDEN",
   FETCH_ERROR: "FETCH_ERROR",
@@ -87,6 +88,22 @@ export class RegistryNotFoundError extends RegistryError {
         "Check if the item name is correct and the registry URL is accessible.",
     })
     this.name = "RegistryNotFoundError"
+  }
+}
+
+export class RegistryGoneError extends RegistryError {
+  constructor(public readonly url: string, cause?: unknown) {
+    const message = `The item at ${url} is no longer available. It may have been removed or expired.`
+
+    super(message, {
+      code: RegistryErrorCode.GONE,
+      statusCode: 410,
+      cause,
+      context: { url },
+      suggestion:
+        "This resource was previously available but has been permanently removed. Check if a newer version exists or contact the registry maintainer.",
+    })
+    this.name = "RegistryGoneError"
   }
 }
 

--- a/packages/shadcn/src/registry/fetcher.test.ts
+++ b/packages/shadcn/src/registry/fetcher.test.ts
@@ -2,6 +2,7 @@ import { REGISTRY_URL } from "@/src/registry/constants"
 import {
   RegistryFetchError,
   RegistryForbiddenError,
+  RegistryGoneError,
   RegistryNotFoundError,
   RegistryUnauthorizedError,
 } from "@/src/registry/errors"
@@ -29,6 +30,9 @@ const server = setupServer(
   }),
   http.get(`${REGISTRY_URL}/forbidden.json`, () => {
     return new HttpResponse(null, { status: 403 })
+  }),
+  http.get(`${REGISTRY_URL}/gone.json`, () => {
+    return new HttpResponse(null, { status: 410 })
   }),
   http.get("https://external.com/component.json", () => {
     return HttpResponse.json({
@@ -121,6 +125,10 @@ describe("fetchRegistry", () => {
     await expect(fetchRegistry(["forbidden.json"])).rejects.toThrow(
       RegistryForbiddenError
     )
+  })
+
+  it("should handle 410 errors", async () => {
+    await expect(fetchRegistry(["gone.json"])).rejects.toThrow(RegistryGoneError)
   })
 
   it("should handle network errors", async () => {

--- a/packages/shadcn/src/registry/fetcher.ts
+++ b/packages/shadcn/src/registry/fetcher.ts
@@ -6,6 +6,7 @@ import { getRegistryHeadersFromContext } from "@/src/registry/context"
 import {
   RegistryFetchError,
   RegistryForbiddenError,
+  RegistryGoneError,
   RegistryLocalFileError,
   RegistryNotFoundError,
   RegistryParseError,
@@ -91,6 +92,10 @@ export async function fetchRegistry(
 
             if (response.status === 404) {
               throw new RegistryNotFoundError(url, messageFromServer)
+            }
+
+            if (response.status === 410) {
+              throw new RegistryGoneError(url, messageFromServer)
             }
 
             if (response.status === 403) {


### PR DESCRIPTION
Add explicit support for HTTP status code **410 (Gone)** in the [registry fetcher](https://github.com/shadcn-ui/ui/blob/main/packages/shadcn/src/registry/fetcher.ts) to differentiate permanently removed resources from not found.

**What I did in this PR**
- Add GONE error code to RegistryErrorCode enum
- Add RegistryGoneError class with appropriate message and suggestion
- Handle 410 responses in fetchRegistry function
- Add tests for 410 error handling

**Real Use Case**
This enables registries like pastecn to properly indicate that a resource has been permanently removed (e.g., expired snippets), providing users with semantically correct error messages.

I'm using 404 which works fine. But semantically speaking, 410 Gone is more accurate in my opinion.