### PR TITLE
Add 'Calender' category to categories list

### DIFF
--- a/apps/v4/lib/categories.ts
+++ b/apps/v4/lib/categories.ts
@@ -24,4 +24,9 @@ export const registryCategories = [
     slug: "signup",
     hidden: false,
   },
+  {
+    name: "Calender",
+    slug: "calender",
+    hidden: false,
+  }, 
 ]


### PR DESCRIPTION
Fixes #9595 
This pull request makes a small update by adding the missing category "Calender" entry to the `registryCategories` array in `categories.ts`. 

This makes sure that `https://ui.shadcn.com/blocks/calender` doesnt give 404 as mentioned in the issue