### PR TITLE
tooltip color issue fixed

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/tooltip.tsx
+++ b/apps/v4/registry/new-york-v4/ui/tooltip.tsx
@@ -48,7 +48,10 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow className={cn(
+          "bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]",
+          className
+        )} />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )


### PR DESCRIPTION
Issue: #9604 
type: `fix`

the className is passed to the `TooltipPrimitive.Arrow` className

now the fill color and the bg color will be applied to the arrow also

we can also change the tooltip arrow color using className

Color Applied - Black:
<img width="388" height="120" alt="image" src="https://github.com/user-attachments/assets/f1993c3c-f5c5-4e98-8658-152d7c12365e" />

Color Applied - Red:
<img width="369" height="101" alt="image" src="https://github.com/user-attachments/assets/49044569-d46a-436b-a587-91baceecc09a" />
