### PR TITLE
registry: add @tool-ui to registry directory

### DIFF
--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -78,6 +78,12 @@
     "description": "Radix-style React primitives for AI chat with adapters for AI SDK, LangGraph, Mastra, and custom backends."
   },
   {
+    "name": "@tool-ui",
+    "homepage": "https://www.tool-ui.com",
+    "url": "https://www.tool-ui.com/r/{name}.json",
+    "description": "Open source React components for rendering AI tool call widgets and rich assistant outputs."
+  },
+  {
     "name": "@better-upload",
     "homepage": "https://better-upload.com",
     "url": "https://better-upload.com/r/{name}.json",

--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -91,6 +91,13 @@
     "logo": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"32\" height=\"32\" viewBox=\"0 0 32 32\"><rect width=\"32\" height=\"32\" fill=\"var(--foreground)\" /><g transform=\"translate(4,4)\" fill=\"var(--foreground)\" stroke=\"var(--background)\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M14 9a2 2 0 0 1-2 2H6l-4 4V4c0-1.1.9-2 2-2h8a2 2 0 0 1 2 2z\" /><path d=\"M18 9h2a2 2 0 0 1 2 2v11l-4-4h-6a2 2 0 0 1-2-2v-1\" /></g></svg>"
   },
   {
+    "name": "@tool-ui",
+    "homepage": "https://www.tool-ui.com",
+    "url": "https://www.tool-ui.com/r/{name}.json",
+    "description": "Open source React components for rendering AI tool call widgets and rich assistant outputs.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='var(--foreground)' d='M12 1 21.526 6.5v11L12 23 2.474 17.5v-11z'/><circle cx='12' cy='12' r='5' fill='var(--background)'/></svg>"
+  },
+  {
     "name": "@better-upload",
     "homepage": "https://better-upload.com",
     "url": "https://better-upload.com/r/{name}.json",


### PR DESCRIPTION
## Summary
Add `@tool-ui` to the open source shadcn registry directory so users can discover and install Tool UI components via the registry index.

## Changes
- Added `@tool-ui` entry to `apps/v4/registry/directory.json` (includes logo metadata).
- Added corresponding entry to `apps/v4/public/r/registries.json`.

## Validation
- `bun run scripts/validate-registries.mts` from `apps/v4`.
- Verified `https://www.tool-ui.com/r/registry.json` is reachable and conforms to the expected flat registry shape.
