### PR TITLE
fix(base-ui): set role=link when Button renders as anchor element

### DIFF
--- a/apps/v4/examples/base/ui-rtl/button.tsx
+++ b/apps/v4/examples/base/ui-rtl/button.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import * as React from "react"
 import { cn } from "@/examples/base/lib/utils"
 import { Button as ButtonPrimitive } from "@base-ui/react/button"
 import { cva, type VariantProps } from "class-variance-authority"
@@ -45,12 +46,29 @@ function Button({
   className,
   variant = "default",
   size = "default",
+  nativeButton,
+  render,
+  role,
   ...props
 }: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  const isRenderingAsLink =
+    nativeButton === false &&
+    render &&
+    React.isValidElement(render) &&
+    render.type === "a"
+
+  const finalRender =
+    isRenderingAsLink && !role
+      ? React.cloneElement(render, { role: "link" })
+      : render
+
   return (
     <ButtonPrimitive
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
+      nativeButton={nativeButton}
+      render={finalRender}
+      role={role}
       {...props}
     />
   )

--- a/apps/v4/examples/base/ui/button.tsx
+++ b/apps/v4/examples/base/ui/button.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import * as React from "react"
 import { cn } from "@/examples/base/lib/utils"
 import { Button as ButtonPrimitive } from "@base-ui/react/button"
 import { cva, type VariantProps } from "class-variance-authority"
@@ -45,12 +46,29 @@ function Button({
   className,
   variant = "default",
   size = "default",
+  nativeButton,
+  render,
+  role,
   ...props
 }: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  const isRenderingAsLink =
+    nativeButton === false &&
+    render &&
+    React.isValidElement(render) &&
+    render.type === "a"
+
+  const finalRender =
+    isRenderingAsLink && !role
+      ? React.cloneElement(render, { role: "link" })
+      : render
+
   return (
     <ButtonPrimitive
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
+      nativeButton={nativeButton}
+      render={finalRender}
+      role={role}
       {...props}
     />
   )

--- a/apps/v4/registry/bases/base/ui/button.tsx
+++ b/apps/v4/registry/bases/base/ui/button.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import * as React from "react"
 import { Button as ButtonPrimitive } from "@base-ui/react/button"
 import { cva, type VariantProps } from "class-variance-authority"
 
@@ -39,12 +40,29 @@ function Button({
   className,
   variant = "default",
   size = "default",
+  nativeButton,
+  render,
+  role,
   ...props
 }: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  const isRenderingAsLink =
+    nativeButton === false &&
+    render &&
+    React.isValidElement(render) &&
+    render.type === "a"
+
+  const finalRender =
+    isRenderingAsLink && !role
+      ? React.cloneElement(render, { role: "link" })
+      : render
+
   return (
     <ButtonPrimitive
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
+      nativeButton={nativeButton}
+      render={finalRender}
+      role={role}
       {...props}
     />
   )


### PR DESCRIPTION
### PR Description:

- fixes incorrect role attribute when Base UI Button renders as a link.

### Problem:

- when using <Button nativeButton={false} render={<a />}>, the anchor had role="button" instead of role="link".

### Solution:

- detect when rendering as an anchor and set role="link" on the render element.

### Changes:

- Set role="link" when nativeButton={false} and render is an anchor
- Respect explicit role prop when provided
- Ensures links rendered through Button have the correct ARIA role.

fix: #9614