### PR TITLE
fix(cli): failing at shadcn create with --src-dir

### DIFF
--- a/packages/shadcn/src/utils/updaters/update-tailwind-content.ts
+++ b/packages/shadcn/src/utils/updaters/update-tailwind-content.ts
@@ -20,6 +20,10 @@ export async function updateTailwindContent(
     return
   }
 
+  if (!config.resolvedPaths.tailwindConfig) {
+    return
+  }
+
   options = {
     silent: false,
     ...options,


### PR DESCRIPTION
### Problem
Using `shadcn create` with `--src-dir` flag crashes the cli with `ENOENT: no such file or directory, open ''` as seen in #9081 & #9264.

### Description
The error occurs at the end of [`runInit`](https://github.com/shadcn-ui/ui/blob/e53bc92f412ed7d5a60e958b561676de7e7d52d7/packages/shadcn/src/commands/init.ts#L271C1-L409C2) in [init.ts](https://github.com/shadcn-ui/ui/blob/e53bc92f412ed7d5a60e958b561676de7e7d52d7/packages/shadcn/src/commands/init.ts), where [`updateTailwindContent`](https://github.com/shadcn-ui/ui/blob/e53bc92f412ed7d5a60e958b561676de7e7d52d7/packages/shadcn/src/utils/updaters/update-tailwind-content.ts#L12C1-L42C2) from [update-tailwind-content.ts](https://github.com/shadcn-ui/ui/blob/e53bc92f412ed7d5a60e958b561676de7e7d52d7/packages/shadcn/src/utils/updaters/update-tailwind-content.ts) is called for new projects with `--src-dir`. This function tries to read `config.resolvedPaths.tailwindConfig`, which resolves to an empty string for Tailwind v4 projects (since they don't have a `tailwind.config.js` file).

### Fix

Added an early return guard in `updateTailwindContent` when `config.resolvedPaths.tailwindConfig` is falsy. This mirrors the existing guard in the sister function [updateTailwindConfig](https://github.com/shadcn-ui/ui/blob/e53bc92f412ed7d5a60e958b561676de7e7d52d7/packages/shadcn/src/utils/updaters/update-tailwind-config.ts#L32-L71), which already returns early for v4 projects.

---

Resolves #9081
Resolves #9264