### PR TITLE
chore: add .pnpm-store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules
 .pnp
 .pnp.js
 
+# pnpm
+.pnpm-store
+
 # testing
 coverage
 


### PR DESCRIPTION
Not very familiar with pnpm, but in a new devcontainer created for this project, after running `pnpm install` I end up with a `.pnpm-store` folder at the repo root. Since this should not be checked in to git, I added the folder to `.gitignore`, even though I read that under 'normal' circumstances pnpm should add the store to a global folder on the disk.

Feel free to close this PR as a workaround to a env (being devcontainers) specific problem.