### PR TITLE
docs(cli): remove duplicated list options section

### DIFF
--- a/apps/v4/content/docs/(root)/cli.mdx
+++ b/apps/v4/content/docs/(root)/cli.mdx
@@ -175,19 +175,7 @@ list items from registries
 
 Arguments:
   registries             the registry names or urls to list items from. Names
-    must be prefixed with @.
-```
-
-**Options**
-
-```bash
-Usage: shadcn list [options] <registries...>
-
-list items from registries
-
-Arguments:
-  registries             the registry names or urls to list items from. Names
-    must be prefixed with @.
+                         must be prefixed with @.
 ```
 
 ---


### PR DESCRIPTION
Fix the CLI docs for `shadcn list` where the Options/Usage block was duplicated. This removes the duplicate section and keeps a single, properly wrapped snippet for readability.

This change is docs-only.