### PR TITLE
fix: hide changelog TOC at lg breakpointC

### DIFF
--- a/apps/v4/app/(app)/docs/changelog/page.tsx
+++ b/apps/v4/app/(app)/docs/changelog/page.tsx
@@ -106,7 +106,7 @@ export default function ChangelogPage() {
           </div>
         </div>
       </div>
-      <div className="sticky top-[calc(var(--header-height)+1px)] z-30 ml-auto hidden h-[90svh] w-72 flex-col gap-4 overflow-hidden overscroll-none pb-8 lg:flex">
+      <div className="sticky top-[calc(var(--header-height)+1px)] z-30 ml-auto hidden h-[90svh] w-72 flex-col gap-4 overflow-hidden overscroll-none pb-8 xl:flex">
         <div className="h-(--top-spacing) shrink-0"></div>
         <div className="no-scrollbar flex flex-col gap-8 overflow-y-auto px-8">
           <div className="flex flex-col gap-2 p-4 pt-0 text-sm">


### PR DESCRIPTION
### Title: 

- Fix changelog table of contents showing at lg breakpoint

### Description: 

- The TOC on the changelog page was visible at the lg breakpoint, unlike the docs pages where it only shows at xl. Updated the changelog sidebar from lg:flex to xl:flex so it matches the docs behavior.

fix: #9647