### PR TITLE
fix(docs): normalize sidebar spacing between BaseUI and Radix implementations (#9668)

### DIFF
--- a/apps/v4/examples/base/ui/sidebar.tsx
+++ b/apps/v4/examples/base/ui/sidebar.tsx
@@ -370,7 +370,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden p-2",
         className
       )}
       {...props}
@@ -383,7 +383,7 @@ function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="sidebar-group"
       data-sidebar="group"
-      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      className={cn("relative flex w-full min-w-0 flex-col", className)}
       {...props}
     />
   )

--- a/apps/v4/examples/radix/ui/sidebar.tsx
+++ b/apps/v4/examples/radix/ui/sidebar.tsx
@@ -369,7 +369,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden p-2",
         className
       )}
       {...props}
@@ -382,7 +382,7 @@ function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="sidebar-group"
       data-sidebar="group"
-      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      className={cn("relative flex w-full min-w-0 flex-col", className)}
       {...props}
     />
   )


### PR DESCRIPTION
Fixes #9668

## Summary

The misalignment in the collapsed sidebar was caused by inconsistent spacing between the BaseUI and Radix implementations.

Previously:
- `SidebarGroup` applied `p-2` padding.
- BaseUI wrapped `TeamSwitcher` in `SidebarGroup`.
- Radix did not.
- This resulted in layout differences and misalignment in collapsed mode.

## Changes

- Removed padding from `SidebarGroup` to keep it purely structural.
- Moved `p-2` spacing to `SidebarContent`.
- Applied the same changes to both BaseUI and Radix examples for consistency.

## Result

- Consistent spacing across BaseUI and Radix implementations.
- Correct alignment in collapsed mode.
- Clear separation of structural and spacing responsibilities.
- Future-proofed behavior if `SidebarGroup` usage changes.

