### PR TITLE
fix(spinner): narrow strokeWidth type for hugeicons compatibility

### DIFF
--- a/apps/v4/registry/bases/base/ui/spinner.tsx
+++ b/apps/v4/registry/bases/base/ui/spinner.tsx
@@ -1,7 +1,11 @@
 import { cn } from "@/registry/bases/base/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  strokeWidth = 2,
+  ...props
+}: React.ComponentProps<"svg"> & { strokeWidth?: number }) {
   return (
     <IconPlaceholder
       lucide="Loader2Icon"
@@ -12,6 +16,7 @@ function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
       role="status"
       aria-label="Loading"
       className={cn("size-4 animate-spin", className)}
+      strokeWidth={strokeWidth}
       {...props}
     />
   )

--- a/apps/v4/registry/bases/radix/ui/spinner.tsx
+++ b/apps/v4/registry/bases/radix/ui/spinner.tsx
@@ -1,7 +1,11 @@
 import { cn } from "@/registry/bases/radix/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  strokeWidth = 2,
+  ...props
+}: React.ComponentProps<"svg"> & { strokeWidth?: number }) {
   return (
     <IconPlaceholder
       lucide="Loader2Icon"
@@ -12,6 +16,7 @@ function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
       role="status"
       aria-label="Loading"
       className={cn("size-4 animate-spin", className)}
+      strokeWidth={strokeWidth}
       {...props}
     />
   )

--- a/packages/shadcn/src/utils/transformers/transform-icons.test.ts
+++ b/packages/shadcn/src/utils/transformers/transform-icons.test.ts
@@ -367,6 +367,35 @@ export function Component() {
       `)
     })
 
+    test("does not add strokeWidth if already forwarded as expression (Spinner pattern)", async () => {
+      expect(
+        await transform(
+          {
+            filename: "test.tsx",
+            raw: `import * as React from "react"
+import { IconPlaceholder } from "@/app/(create)/create/components/icon-placeholder"
+
+function Spinner({ className, strokeWidth = 2, ...props }: React.ComponentProps<"svg"> & { strokeWidth?: number }) {
+  return <IconPlaceholder hugeicons="Loading03Icon" strokeWidth={strokeWidth} className={className} {...props} />
+}`,
+            config: {
+              ...testConfig,
+              iconLibrary: "hugeicons",
+            },
+          },
+          [transformIcons]
+        )
+      ).toMatchInlineSnapshot(`
+        "import * as React from "react"
+        import { HugeiconsIcon } from "@hugeicons/react"
+        import { Loading03Icon } from "@hugeicons/core-free-icons"
+
+        function Spinner({ className, strokeWidth = 2, ...props }: React.ComponentProps<"svg"> & { strokeWidth?: number }) {
+          return <HugeiconsIcon icon={Loading03Icon} strokeWidth={strokeWidth} className={className} {...props} />
+        }"
+      `)
+    })
+
     test("handles multiple icons", async () => {
       expect(
         await transform(


### PR DESCRIPTION
## Summary

Fixes #9163

When using `iconLibrary: "hugeicons"` in `components.json`, the CLI generates a `Spinner` component that fails TypeScript compilation.

### Root Cause

The spinner template types props as `React.ComponentProps<"svg">`, which allows `strokeWidth` as `string | number`. However, `HugeiconsIcon` strictly requires `strokeWidth` as `number | undefined`. Spreading `{...props}` onto `HugeiconsIcon` causes the type conflict:

```
Type 'string | number' is not assignable to type 'number | undefined'.
Type 'string' is not assignable to type 'number'.
```

### Fix

In the `base` and `radix` spinner templates, `strokeWidth` is now explicitly extracted from props with a `number` type and a default of `2`. The type intersection `React.ComponentProps<"svg"> & { strokeWidth?: number }` narrows `strokeWidth` to `number | undefined`, eliminating the conflict.

```tsx
// Before
function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
  return (
    <IconPlaceholder
      ...
      {...props}
    />
  )
}

// After
function Spinner({
  className,
  strokeWidth = 2,
  ...props
}: React.ComponentProps<"svg"> & { strokeWidth?: number }) {
  return (
    <IconPlaceholder
      ...
      strokeWidth={strokeWidth}
      {...props}
    />
  )
}
```

This also ensures that when the transformer processes the `IconPlaceholder` for hugeicons, it detects `strokeWidth` as an already-present prop and does not add the duplicate default `strokeWidth={2}` from the usage template.

### Testing

- All 22 existing `transform-icons` tests continue to pass
- Added 1 new test case covering the Spinner pattern with `strokeWidth={strokeWidth}` as an expression prop