### PR TITLE
fix(resizable): add touchAction none to prevent scroll interference on mobile

### DIFF
--- a/apps/v4/registry/bases/base/ui/resizable.tsx
+++ b/apps/v4/registry/bases/base/ui/resizable.tsx
@@ -34,6 +34,7 @@ function ResizableHandle({
   return (
     <ResizablePrimitive.Separator
       data-slot="resizable-handle"
+      style={{ touchAction: "none" }}
       className={cn(
         "cn-resizable-handle bg-border focus-visible:ring-ring ring-offset-background relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90",
         className

--- a/apps/v4/registry/bases/radix/ui/resizable.tsx
+++ b/apps/v4/registry/bases/radix/ui/resizable.tsx
@@ -34,6 +34,7 @@ function ResizableHandle({
   return (
     <ResizablePrimitive.Separator
       data-slot="resizable-handle"
+      style={{ touchAction: "none" }}
       className={cn(
         "cn-resizable-handle bg-border focus-visible:ring-ring ring-offset-background relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90",
         className

--- a/apps/v4/registry/new-york-v4/ui/resizable.tsx
+++ b/apps/v4/registry/new-york-v4/ui/resizable.tsx
@@ -35,6 +35,7 @@ function ResizableHandle({
   return (
     <ResizablePrimitive.Separator
       data-slot="resizable-handle"
+      style={{ touchAction: "none" }}
       className={cn(
         "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90",
         className

--- a/deprecated/www/registry/default/ui/resizable.tsx
+++ b/deprecated/www/registry/default/ui/resizable.tsx
@@ -28,6 +28,7 @@ const ResizableHandle = ({
   withHandle?: boolean
 }) => (
   <ResizablePrimitive.PanelResizeHandle
+    style={{ touchAction: "none" }}
     className={cn(
       "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
       className

--- a/deprecated/www/registry/new-york/ui/resizable.tsx
+++ b/deprecated/www/registry/new-york/ui/resizable.tsx
@@ -28,6 +28,7 @@ const ResizableHandle = ({
   withHandle?: boolean
 }) => (
   <ResizablePrimitive.PanelResizeHandle
+    style={{ touchAction: "none" }}
     className={cn(
       "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
       className


### PR DESCRIPTION
## Summary

Fixes #9681

On touch devices, the browser intercepts `touchstart`/`touchmove` events for scrolling before `react-resizable-panels` can process them. This makes dragging the `ResizableHandle` unreliable or completely broken on mobile.

## Fix

Add `style={{ touchAction: "none" }}` to the resize handle separator element in all registry variants. This tells the browser not to handle touch events for scrolling on that element, allowing the drag handler to receive them instead.

This is the recommended approach for pointer-event based drag interactions (see [MDN: touch-action](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action)) and is consistent with how other drag libraries (e.g. `@dnd-kit`, `react-draggable`) solve the same problem.

## Files Changed

- `apps/v4/registry/new-york-v4/ui/resizable.tsx`
- `apps/v4/registry/bases/base/ui/resizable.tsx`
- `apps/v4/registry/bases/radix/ui/resizable.tsx`
- `deprecated/www/registry/new-york/ui/resizable.tsx`
- `deprecated/www/registry/default/ui/resizable.tsx`