### PR TITLE
fix: add aria-controls to combobox elements for accessibility

### DIFF
--- a/apps/v4/app/(app)/examples/playground/components/model-selector.tsx
+++ b/apps/v4/app/(app)/examples/playground/components/model-selector.tsx
@@ -62,6 +62,7 @@ export function ModelSelector({ models, types, ...props }: ModelSelectorProps) {
             role="combobox"
             aria-expanded={open}
             aria-label="Select a model"
+            aria-controls="model-selector-content"
             className="w-full justify-between"
           >
             {selectedModel ? selectedModel.name : "Select a model..."}

--- a/apps/v4/app/(app)/examples/playground/components/preset-selector.tsx
+++ b/apps/v4/app/(app)/examples/playground/components/preset-selector.tsx
@@ -40,6 +40,7 @@ export function PresetSelector({ presets, ...props }: PresetSelectorProps) {
           role="combobox"
           aria-label="Load a preset..."
           aria-expanded={open}
+          aria-controls="preset-selector-content"
           className="flex-1 justify-between md:max-w-[200px] lg:max-w-[300px]"
         >
           {selectedPreset ? selectedPreset.name : "Load a preset..."}

--- a/apps/v4/registry/new-york-v4/examples/combobox-demo.tsx
+++ b/apps/v4/registry/new-york-v4/examples/combobox-demo.tsx
@@ -53,6 +53,7 @@ export default function ComboboxDemo() {
           variant="outline"
           role="combobox"
           aria-expanded={open}
+          aria-controls="combobox-content"
           className="w-[200px] justify-between"
         >
           {value


### PR DESCRIPTION
This PR adds the required `aria-controls` attribute to elements with `role="combobox"` to fix accessibility issues.

Fixed 3 files:
- apps/v4/registry/new-york-v4/examples/combobox-demo.tsx
- apps/v4/app/(app)/examples/playground/components/preset-selector.tsx
- apps/v4/app/(app)/examples/playground/components/model-selector.tsx