### PR TITLE
fix(shadcn): normalize Windows paths for tar in create-project

### DIFF
--- a/packages/shadcn/src/utils/create-project.ts
+++ b/packages/shadcn/src/utils/create-project.ts
@@ -15,6 +15,13 @@ import { z } from "zod"
 const GITHUB_TEMPLATE_URL =
   "https://codeload.github.com/shadcn-ui/ui/tar.gz/main"
 
+// Windows BSD tar (built into Windows 10+) interprets `C:\path` as a remote
+// SSH host `C` with path `\path`. Convert backslashes to forward slashes so
+// that `C:\Users\...` becomes `C:/Users/...`, which Windows tar accepts.
+function toTarPath(p: string): string {
+  return p.replace(/\\/g, "/")
+}
+
 export const TEMPLATES = {
   next: "next",
   "next-monorepo": "next-monorepo",
@@ -250,9 +257,9 @@ async function createMonorepoProject(
     await fs.writeFile(tarPath, Buffer.from(await response.arrayBuffer()))
     await execa("tar", [
       "-xzf",
-      tarPath,
+      toTarPath(tarPath),
       "-C",
-      templatePath,
+      toTarPath(templatePath),
       "--strip-components=2",
       "ui-main/templates/monorepo-next",
     ])
@@ -315,9 +322,9 @@ async function createViteProject(
     await fs.writeFile(tarPath, Buffer.from(await response.arrayBuffer()))
     await execa("tar", [
       "-xzf",
-      tarPath,
+      toTarPath(tarPath),
       "-C",
-      templatePath,
+      toTarPath(templatePath),
       "--strip-components=2",
       "ui-main/templates/vite-app",
     ])
@@ -386,9 +393,9 @@ async function createStartProject(
     await fs.writeFile(tarPath, Buffer.from(await response.arrayBuffer()))
     await execa("tar", [
       "-xzf",
-      tarPath,
+      toTarPath(tarPath),
       "-C",
-      templatePath,
+      toTarPath(templatePath),
       "--strip-components=2",
       "ui-main/templates/start-app",
     ])


### PR DESCRIPTION
## Summary

Fixes #9629

### Problem

On Windows, `shadcn init` (with `--template` flags like `vite`, `next-monorepo`, or `start`) fails with:

```
tar (child): Cannot connect to C: resolve failed
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```

Windows ships with BSD tar (`bsdtar`) built in since Windows 10. When `tar -xzf C:\path\to\file.tar.gz -C C:\path\to\dir` is passed, BSD tar parses `C:` as a remote SSH hostname (the same syntax as `user@host:path`), and then fails trying to connect to a host named `C`.

### Root Cause

In `packages/shadcn/src/utils/create-project.ts`, three functions — `createMonorepoProject`, `createViteProject`, and `createStartProject` — build `tarPath` and `templatePath` via `path.resolve(os.tmpdir(), ...)`. On Windows, these produce backslash-separated absolute paths like `C:\Users\...\AppData\Local\Temp\shadcn-template-...`. These are then passed directly to `execa("tar", ["-xzf", tarPath, "-C", templatePath, ...])`, triggering the SSH hostname misparse.

### Fix

Add a `toTarPath(p: string)` helper that replaces all backslashes with forward slashes:

```ts
function toTarPath(p: string): string {
  return p.replace(/\/g, "/")
}
```

Apply it to `tarPath` and `templatePath` before passing them to `execa("tar", ...)` in all three functions. Windows BSD tar accepts `C:/Users/...` style paths without issue. On macOS/Linux, `path.resolve()` already returns forward-slash paths, so this is a no-op on those platforms.

### Testing

Manually verified the path transformation:
- `C:\Users\foo\AppData\Local\Temp\shadcn-template-123` → `C:/Users/foo/AppData/Local/Temp/shadcn-template-123`
- macOS/Linux paths are unchanged (no backslashes present)