### PR TITLE
Refactor: use canonical Tailwind translate class instead of arbitrary value

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/table.tsx
+++ b/apps/v4/registry/new-york-v4/ui/table.tsx
@@ -70,7 +70,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5",
         className
       )}
       {...props}
@@ -83,7 +83,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5",
         className
       )}
       {...props}


### PR DESCRIPTION
# Summary

Replaced arbitrary Tailwind value `translate-y-[2px]` with the canonical  
`translate-y-0.5` class as suggested by Tailwind CSS IntelliSense.

---

## Assignees

No one assigned

---

## Reason

- Aligns with Tailwind's default spacing scale  
- Improves consistency and readability  
- Removes IntelliSense hints  

---

## Labels

None yet

---

## Projects

None yet

---

## Impact

No visual or functional changes.  
Style-only refactor.