### PR TITLE
ci: declare explicit least-privilege workflow permissions

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["*"]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -6,6 +6,8 @@ on:
     # This runs every day 20 minutes before midnight: https://crontab.guru/#40_23_*_*_*
     - cron: "40 23 * * *"
 
+permissions: {}
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/prerelease-comment.yml
+++ b/.github/workflows/prerelease-comment.yml
@@ -7,6 +7,11 @@ on:
     types:
       - completed
 
+permissions:
+  actions: read
+  issues: write
+  pull-requests: write
+
 jobs:
   comment:
     if: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["*"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary\n- add explicit `permissions: contents: read` to read-only PR CI workflows\n- add explicit scoped permissions for prerelease PR-comment workflow (`actions: read`, `issues: write`, `pull-requests: write`)\n- disable default `GITHUB_TOKEN` scopes for stale handler (`permissions: {}`) since it already uses dedicated `STALE_TOKEN`\n\n## Why\nThese workflows currently rely on implicit token scopes. Explicit permissions reduce risk and make each workflow’s required access clear and auditable.\n\n## Changed files\n- `.github/workflows/code-check.yml`\n- `.github/workflows/test.yml`\n- `.github/workflows/prerelease-comment.yml`\n- `.github/workflows/issue-stale.yml`\n\n## Notes\n- configuration-only change; no build/test/release logic modified\n