### PR TITLE
fix(v4): add missing xs size to Item component

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/item.tsx
+++ b/apps/v4/registry/new-york-v4/ui/item.tsx
@@ -42,6 +42,7 @@ const itemVariants = cva(
       size: {
         default: "p-4 gap-4 ",
         sm: "py-3 px-4 gap-2.5",
+        xs: "py-2 px-2 gap-2", // ADDED: xs size support to resolve #9699
       },
     },
     defaultVariants: {


### PR DESCRIPTION
Fixes #9699.

This PR adds the xs variant to the Item component in the v4 registry. Previously, using size="xs" caused a TypeScript error because the variant was only defined in the documentation but missing from the itemVariants configuration.

Changes:

- Added xs to size variants in itemVariants.
 
- Updated padding and gap values for the xs size to match design tokens.