### PR TITLE
feat: update shadcn-hooks link

### DIFF
--- a/apps/v4/public/r/registries-legacy.json
+++ b/apps/v4/public/r/registries-legacy.json
@@ -41,7 +41,7 @@
   "@gaia": "https://ui.heygaia.io/r/{name}.json",
   "@glass-ui": "https://glass-ui.crenspire.com/r/{name}.json",
   "@heseui": "https://www.heseui.com/r/{name}.json",
-  "@hooks": "https://shadcn-hooks.vercel.app/r/{name}.json",
+  "@hooks": "https://shadcn-hooks.com/r/{name}.json",
   "@intentui": "https://intentui.com/r/{name}",
   "@kibo-ui": "https://www.kibo-ui.com/r/{name}.json",
   "@kanpeki": "https://kanpeki.vercel.app/r/{name}.json",

--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -241,8 +241,8 @@
   },
   {
     "name": "@hooks",
-    "homepage": "https://shadcn-hooks.vercel.app",
-    "url": "https://shadcn-hooks.vercel.app/r/{name}.json",
+    "homepage": "https://shadcn-hooks.com",
+    "url": "https://shadcn-hooks.com/r/{name}.json",
     "description": "A comprehensive React Hooks Collection built with Shadcn."
   },
   {

--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -281,8 +281,8 @@
   },
   {
     "name": "@hooks",
-    "homepage": "https://shadcn-hooks.vercel.app",
-    "url": "https://shadcn-hooks.vercel.app/r/{name}.json",
+    "homepage": "https://shadcn-hooks.com",
+    "url": "https://shadcn-hooks.com/r/{name}.json",
     "description": "A comprehensive React Hooks Collection built with Shadcn.",
     "logo": "<svg width='256' height='256' viewBox='0 0 256 256' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M208 128L128 208' stroke='var(--foreground)' stroke-width='32' stroke-linecap='round' stroke-linejoin='round'/><path d='M192 40L40 192' stroke='var(--foreground)' stroke-width='32' stroke-linecap='round' stroke-linejoin='round'/><rect x='27' y='28' width='70' height='70' rx='7' fill='var(--foreground)'/></svg>"
   },

--- a/deprecated/www/public/r/registries.json
+++ b/deprecated/www/public/r/registries.json
@@ -27,7 +27,7 @@
   "@fancy": "https://fancycomponents.dev/r/{name}.json",
   "@formcn": "https://formcn.dev/r/{name}.json",
   "@heseui": "https://www.heseui.com/r/{name}.json",
-  "@hooks": "https://shadcn-hooks.vercel.app/r/{name}.json",
+  "@hooks": "https://shadcn-hooks.com/r/{name}.json",
   "@intentui": "https://intentui.com/r/{name}",
   "@kibo-ui": "https://www.kibo-ui.com/r/{name}.json",
   "@kokonutui": "https://kokonutui.com/r/{name}.json",


### PR DESCRIPTION
Hi, This PR updates the website URL for **shadcn-hooks**.

For better long-term maintenance and a more professional project presence, the site has moved from the previous Vercel domain to a dedicated domain:

https://shadcn-hooks.com/

The old Vercel URL has been permanently redirected to the new domain, but updating the link ensures users reach the official site directly.

Thanks!