### PR TITLE
docs: add devDependencies section to registry-item-json.mdx

### DIFF
--- a/apps/v4/content/docs/registry/registry-item-json.mdx
+++ b/apps/v4/content/docs/registry/registry-item-json.mdx
@@ -155,7 +155,7 @@ Use `@version` to specify the version of the package.
 {
   "devDependencies": [
     "tw-animate-css",
-    "husky@^9.1.7"
+    "name@1.2.0"
   ]
 }
 ```


### PR DESCRIPTION
While reading the [registry-item.json](https://ui.shadcn.com/docs/registry/registry-item-json#dependencies) docs, I noticed the `devDependencies` section was missing, so I opened a small PR to add it.