### PR TITLE
Fixed dead link for resizable

### DIFF
--- a/apps/v4/content/docs/components/radix/resizable.mdx
+++ b/apps/v4/content/docs/components/radix/resizable.mdx
@@ -100,7 +100,7 @@ To enable RTL support in shadcn/ui, see the [RTL configuration guide](/docs/rtl)
 
 ## API Reference
 
-See the [react-resizable-panels](https://github.com/bvaughn/react-resizable-panels/tree/main/packages/react-resizable-panels) documentation.
+See the [react-resizable-panels](https://github.com/bvaughn/react-resizable-panels/?tab=readme-ov-file#documentation) documentation.
 
 ## Changelog
 


### PR DESCRIPTION
The resizable documentation link was a dead link:
<img width="1919" height="436" alt="image" src="https://github.com/user-attachments/assets/c1b9630e-4d64-41f1-8ebc-949d8337f105" />

This change updates the link to the documentation section of resizable github repo