### PR TITLE
fix(drawer): swap direction prop and use ltr/rtl variants for full RTL support

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/drawer.tsx
+++ b/apps/v4/registry/new-york-v4/ui/drawer.tsx
@@ -4,11 +4,18 @@ import * as React from "react"
 import { Drawer as DrawerPrimitive } from "vaul"
 
 import { cn } from "@/lib/utils"
+import { useDirection } from "@/registry/new-york-v4/ui/direction"
 
 function Drawer({
+  direction,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  const dir = useDirection()
+  const resolvedDirection =
+    dir === "rtl" && direction === "right" ? "left" :
+    dir === "rtl" && direction === "left" ? "right" :
+    direction
+  return <DrawerPrimitive.Root data-slot="drawer" direction={resolvedDirection} {...props} />
 }
 
 function DrawerTrigger({
@@ -59,8 +66,8 @@ function DrawerContent({
           "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
           "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
           "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
-          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
-          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=right]:inset-y-0 ltr:data-[vaul-drawer-direction=right]:end-0 rtl:data-[vaul-drawer-direction=right]:start-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-s data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=left]:inset-y-0 ltr:data-[vaul-drawer-direction=left]:start-0 rtl:data-[vaul-drawer-direction=left]:end-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-e data-[vaul-drawer-direction=left]:sm:max-w-sm",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary

Fixes #9519
Related to #9684

PR #9684 fixes visual positioning using CSS logical properties, but the issue still persists because vaul's animation engine reads the `direction` prop directly to compute the drag/animation axis. In RTL, passing `direction="right"` still tells vaul to animate from the right — so the animation origin is wrong even if the element is visually placed correctly.

## Changes

**1. Swap the `direction` prop value for RTL in the `Drawer` root**

When `dir === "rtl"`, `right` is swapped to `left` and vice versa before being passed to `DrawerPrimitive.Root`. This ensures vaul computes the correct animation axis.

```tsx
function Drawer({
  direction,
  ...props
}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
  const dir = useDirection()
  const resolvedDirection =
    dir === "rtl" && direction === "right" ? "left" :
    dir === "rtl" && direction === "left" ? "right" :
    direction
  return <DrawerPrimitive.Root data-slot="drawer" direction={resolvedDirection} {...props} />
}
```

**2. Use `ltr:`/`rtl:` Tailwind variants in `DrawerContent` for correct visual placement**

```
ltr:data-[vaul-drawer-direction=left]:start-0
rtl:data-[vaul-drawer-direction=left]:end-0
ltr:data-[vaul-drawer-direction=right]:end-0
rtl:data-[vaul-drawer-direction=right]:start-0
```

## Testing

1. Add `dir="rtl"` to `<html>` or a parent element
2. Render `<Drawer direction="right">` and `<Drawer direction="left">`
3. Open each drawer — animation and position should originate from the correct visual side in both LTR and RTL
