### PR TITLE
feat: add lmscn registry

### DIFF
--- a/apps/v4/content/docs/registry/registry-item-json.mdx
+++ b/apps/v4/content/docs/registry/registry-item-json.mdx
@@ -153,10 +153,7 @@ Use `@version` to specify the version of the package.
 
 ```json title="registry-item.json" showLineNumbers
 {
-  "devDependencies": [
-    "tw-animate-css",
-    "name@1.2.0"
-  ]
+  "devDependencies": ["tw-animate-css", "name@1.2.0"]
 }
 ```
 

--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -1,5 +1,11 @@
 [
   {
+    "name": "@lmscn",
+    "homepage": "https://lmscn.vercel.app",
+    "url": "https://lmscn.vercel.app/r/{name}.json",
+    "description": "LMS components for building interactive learning experiences — quiz, flashcards, matching, fill-in-the-blank, word scramble, sequencing, reading comprehension, spaced repetition and more."
+  },
+  {
     "name": "@8bitcn",
     "homepage": "https://www.8bitcn.com",
     "url": "https://www.8bitcn.com/r/{name}.json",

--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1,5 +1,12 @@
 [
   {
+    "name": "@lmscn",
+    "homepage": "https://lmscn.vercel.app",
+    "url": "https://lmscn.vercel.app/r/{name}.json",
+    "description": "LMS components for building interactive learning experiences — quiz, flashcards, matching, fill-in-the-blank, word scramble, sequencing, reading comprehension, spaced repetition and more.",
+    "logo": "<svg width=\"125\" height=\"125\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 400 90\" fill=\"none\" role=\"img\" aria-label=\"lmscn\"><g transform=\"translate(5,5)\"><path d=\"M 2,2 L 40,2 L 40,13 A 7,7 0 0,1 40,27 L 40,40 L 27,40 A 7,7 0 0,1 13,40 L 2,40 Z\" fill=\"#06b6d4\"/><path d=\"M 40,2 L 78,2 L 78,40 L 67,40 A 7,7 0 0,1 53,40 L 40,40 L 40,27 A 7,7 0 0,0 40,13 L 40,2 Z\" fill=\"#2563eb\"/><path d=\"M 2,40 L 13,40 A 7,7 0 0,0 27,40 L 40,40 L 40,53 A 7,7 0 0,1 40,67 L 40,78 L 2,78 Z\" fill=\"#f59e0b\"/><path d=\"M 40,40 L 53,40 A 7,7 0 0,0 67,40 L 78,40 L 78,78 L 40,78 L 40,67 A 7,7 0 0,0 40,53 L 40,40 Z\" fill=\"#8b5cf6\"/></g><text x=\"108\" y=\"80\" font-family=\"'DM Mono', 'Fira Code', ui-monospace, monospace\" font-weight=\"700\" font-size=\"64\" letter-spacing=\"-2\" fill=\"currentColor\">lmscn</text></svg>"
+  },
+  {
     "name": "@8bitcn",
     "homepage": "https://www.8bitcn.com",
     "url": "https://www.8bitcn.com/r/{name}.json",

--- a/packages/shadcn/src/registry/fetcher.test.ts
+++ b/packages/shadcn/src/registry/fetcher.test.ts
@@ -128,7 +128,9 @@ describe("fetchRegistry", () => {
   })
 
   it("should handle 410 errors", async () => {
-    await expect(fetchRegistry(["gone.json"])).rejects.toThrow(RegistryGoneError)
+    await expect(fetchRegistry(["gone.json"])).rejects.toThrow(
+      RegistryGoneError
+    )
   })
 
   it("should handle network errors", async () => {


### PR DESCRIPTION
Add lmscn registry

[lmscn](https://lmscn.vercel.app/) is an open source registry of LMS (Learning Management System) components built with shadcn/ui. It provides ready-to-use interactive learning components for building educational applications.
Components included:

Quiz — Multi-type quiz (single-choice, multi-select, true/false) with per-question scoring, progress bar and pass/fail results
Flashcards — CSS 3D flip-card deck with optional self-rating (Again / Hard / Good / Easy)
Match — Click-to-match term/definition pairs with mistake tracking
Fill in the Blank — Inline blank-filling exercise with multiple blanks and keyboard navigation
Word Scramble — Letter-tile word unscrambling game with optional image/text clues
Order / Sequence — Drag-and-drop item-sequencing exercise
Reading Passage — Three-phase reading comprehension with passage view, inline questions and results
Progress Tracker — Gamified zigzag lesson map with XP bar, level badge and daily streak
Spaced Repetition — SM-2 algorithm review session with interval and ease factor computation
Image Hotspot — Click labelled markers on a diagram or photo and type answers in a popover

Registry URL: https://lmscn.vercel.app/r/registry.json