### PR TITLE
docs: persist selected base in local storage

### DIFF
--- a/apps/v4/components/components-list.tsx
+++ b/apps/v4/components/components-list.tsx
@@ -1,15 +1,24 @@
+"use client"
+
 import Link from "next/link"
 
 import { PAGES_NEW } from "@/lib/docs"
 import { getPagesFromFolder, type PageTreeFolder } from "@/lib/page-tree"
+import { useConfig } from "@/hooks/use-config"
+import React from "react"
 
+// Links for each component, currentBase is setted to the last selected base or default to radix.
 export function ComponentsList({
   componentsFolder,
-  currentBase,
 }: {
   componentsFolder: PageTreeFolder
-  currentBase: string
 }) {
+  const [config] = useConfig()
+
+  const currentBase = React.useMemo(() => {
+    return config.currentBase || "radix"
+  }, [config])
+  
   const list = getPagesFromFolder(componentsFolder, currentBase)
 
   return (

--- a/apps/v4/components/docs-base-switcher.tsx
+++ b/apps/v4/components/docs-base-switcher.tsx
@@ -1,7 +1,9 @@
+"use client"
 import Link from "next/link"
 
 import { cn } from "@/lib/utils"
 import { BASES } from "@/registry/bases"
+import { useConfig } from "@/hooks/use-config"
 
 export function DocsBaseSwitcher({
   base,
@@ -13,12 +15,16 @@ export function DocsBaseSwitcher({
   className?: string
 }) {
   const activeBase = BASES.find((baseItem) => base === baseItem.name)
+  const [config, setConfig] = useConfig()
 
   return (
     <div className={cn("inline-flex w-full items-center gap-6", className)}>
       {BASES.map((baseItem) => (
         <Link
           key={baseItem.name}
+          onClick={() =>
+            setConfig({ ...config, currentBase: baseItem.name as "radix" | "base" })
+          }
           href={`/docs/components/${baseItem.name}/${component}`}
           data-active={base === baseItem.name}
           className="text-muted-foreground hover:text-foreground data-[active=true]:text-foreground after:bg-foreground relative inline-flex items-center justify-center gap-1 pt-1 pb-0.5 text-base font-medium transition-colors after:absolute after:inset-x-0 after:bottom-[-4px] after:h-0.5 after:opacity-0 after:transition-opacity data-[active=true]:after:opacity-100"

--- a/apps/v4/hooks/use-config.ts
+++ b/apps/v4/hooks/use-config.ts
@@ -5,12 +5,14 @@ type Config = {
   style: "new-york-v4"
   packageManager: "npm" | "yarn" | "pnpm" | "bun"
   installationType: "cli" | "manual"
+  currentBase: "radix" | "base"
 }
 
 const configAtom = atomWithStorage<Config>("config", {
   style: "new-york-v4",
   packageManager: "pnpm",
   installationType: "cli",
+  currentBase: "radix"
 })
 
 export function useConfig() {

--- a/apps/v4/mdx-components.tsx
+++ b/apps/v4/mdx-components.tsx
@@ -37,7 +37,7 @@ import {
 } from "@/registry/new-york-v4/ui/tabs"
 
 // Wrapper component that passes the components folder from the server.
-// This is only used on /docs/components/ index page, so default to radix.
+// This is only used on /docs/components/ index page
 function ComponentsListWrapper() {
   const componentsFolder = source.pageTree.children.find(
     (page) => page.$id === "components"
@@ -47,10 +47,10 @@ function ComponentsListWrapper() {
     return null
   }
 
+  //TODO: set
   return (
     <ComponentsList
       componentsFolder={componentsFolder as PageTreeFolder}
-      currentBase="radix"
     />
   )
 }


### PR DESCRIPTION
when navigating from components list(on the sidebar lists or page list), the default base is radix, this can be improved by extending the existing `useConfig` hook to include `currentBase` property, and persist it to local storage.

this is how it works:

1. by default it's setted to radix, but as soon as it's switched to base-ui, `currentBase` is stored.
2. the next the component link is clicked, it reads from ls and switchs the context or if it doesnt exist(from ls), it uses the default radix base type.

i prefer base-ui, but since the default is radix, i forgot to change the type and copy the radix code, this can solve such type of issues.