### PR TITLE
fix: radio-group indicator centering in base-ui styles

### DIFF
--- a/apps/v4/registry/styles/style-lyra.css
+++ b/apps/v4/registry/styles/style-lyra.css
@@ -909,7 +909,7 @@
   }
 
   .cn-radio-group-indicator {
-    @apply flex size-4 items-center justify-center;
+    @apply flex size-full items-center justify-center;
   }
 
   .cn-radio-group-indicator-icon {

--- a/apps/v4/registry/styles/style-maia.css
+++ b/apps/v4/registry/styles/style-maia.css
@@ -934,7 +934,7 @@
   }
 
   .cn-radio-group-indicator {
-    @apply flex size-4 items-center justify-center;
+    @apply flex size-full items-center justify-center;
   }
 
   .cn-radio-group-indicator-icon {

--- a/apps/v4/registry/styles/style-mira.css
+++ b/apps/v4/registry/styles/style-mira.css
@@ -934,7 +934,7 @@
   }
 
   .cn-radio-group-indicator {
-    @apply flex size-4 items-center justify-center;
+    @apply flex size-full items-center justify-center;
   }
 
   .cn-radio-group-indicator-icon {

--- a/apps/v4/registry/styles/style-nova.css
+++ b/apps/v4/registry/styles/style-nova.css
@@ -934,7 +934,7 @@
   }
 
   .cn-radio-group-indicator {
-    @apply flex size-4 items-center justify-center;
+    @apply flex size-full items-center justify-center;
   }
 
   .cn-radio-group-indicator-icon {

--- a/apps/v4/registry/styles/style-vega.css
+++ b/apps/v4/registry/styles/style-vega.css
@@ -930,7 +930,7 @@
   }
 
   .cn-radio-group-indicator {
-    @apply flex size-4 items-center justify-center;
+    @apply flex size-full items-center justify-center;
   }
 
   .cn-radio-group-indicator-icon {


### PR DESCRIPTION
## Summary

- Fixes #9764
- Changes `.cn-radio-group-indicator` from `size-4` to `size-full` in all 5 base-ui style files (lyra, maia, mira, nova, vega)

## Problem

The `.cn-radio-group-indicator` used `size-4` (16px), but its parent `RadioPrimitive.Root` is also `size-4` with a 1px border. With `border-box` sizing, the parent's content area is only 14px, so the 16px indicator overflows by 2px, causing the inner dot to render off-center.

## Fix

`size-full` makes the indicator fill the parent's content area correctly, regardless of border width.

The Radix variant is unaffected (its indicator already uses relative sizing).

## Test plan

- [ ] Render a radio-group in each style variant (lyra, maia, mira, nova, vega) — the dot should be perfectly centered