### PR TITLE
fix: typo "overriden" → "overridden" in test comment

### DIFF
--- a/packages/tests/src/tests/init.test.ts
+++ b/packages/tests/src/tests/init.test.ts
@@ -308,7 +308,7 @@ describe("shadcn init - custom style", async () => {
       true
     )
 
-    // Then add foo.ts from the custom registry with overriden payload.
+    // Then add foo.ts from the custom registry with overridden payload.
     expect(
       await fs.readFile(path.join(fixturePath, "lib/foo.ts"), "utf-8")
     ).toBe("const foo = 'baz-qux'")


### PR DESCRIPTION
## Summary
- Fix typo "overriden" → "overridden" in `packages/tests/src/tests/init.test.ts` (line 311)

## Test plan
- [x] Comment-only change, no logic affected