### PR TITLE
[FIX]: Add missing workspaces configuration to package.json on monorepo template

### DIFF
--- a/templates/monorepo-next/package.json
+++ b/templates/monorepo-next/package.json
@@ -15,6 +15,10 @@
     "turbo": "^2.8.1",
     "typescript": "5.9.3"
   },
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
   "packageManager": "pnpm@10.4.1",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
`workspaces` property was missing, causing the init command to fail when selecting `Next.js (monorepo)`