### PR TITLE
fix: directory search typo, separator logic, and null handling

### DIFF
--- a/apps/v4/components/directory-list.tsx
+++ b/apps/v4/components/directory-list.tsx
@@ -5,7 +5,6 @@ import { IconArrowUpRight } from "@tabler/icons-react"
 
 import { useSearchRegistry } from "@/hooks/use-search-registry"
 import { DirectoryAddButton } from "@/components/directory-add-button"
-import globalRegistries from "@/registry/directory.json"
 import { Button } from "@/registry/new-york-v4/ui/button"
 import {
   Item,
@@ -72,7 +71,7 @@ export function DirectoryList() {
                 <DirectoryAddButton registry={registry} />
               </ItemFooter>
             </Item>
-            {index < globalRegistries.length - 1 && (
+            {index < registries.length - 1 && (
               <ItemSeparator className="my-1" />
             )}
           </React.Fragment>

--- a/apps/v4/components/search-directory.tsx
+++ b/apps/v4/components/search-directory.tsx
@@ -26,7 +26,7 @@ export const SearchDirectory = () => {
         </InputGroupAddon>
         <InputGroupInput
           placeholder="Search"
-          value={query}
+          value={query ?? ""}
           onChange={onQueryChange}
         />
         <InputGroupAddon align="inline-end">
@@ -37,7 +37,7 @@ export const SearchDirectory = () => {
         </InputGroupAddon>
         <InputGroupAddon
           align="inline-end"
-          data-disabled={!query.length}
+          data-disabled={!(query ?? "").length}
           className="data-[disabled=true]:hidden"
         >
           <InputGroupButton

--- a/apps/v4/hooks/use-search-registry.ts
+++ b/apps/v4/hooks/use-search-registry.ts
@@ -2,27 +2,25 @@ import { debounce, useQueryState } from "nuqs"
 
 import globalRegistries from "@/registry/directory.json"
 
-const normalizeQuery = (query: string) =>
-  query.toLowerCase().replaceAll(" ", "").replaceAll("@", "")
+const normalizeQuery = (value: string) =>
+  value.toLowerCase().replaceAll(" ", "").replaceAll("@", "")
 
-function finderFn<T extends (typeof globalRegistries)[0]>(
-  registry: T,
+function matchesRegistry(
+  registry: (typeof globalRegistries)[0],
   query: string
-) {
-  const normalizedName = normalizeQuery(registry.name)
-  const normalizedDecription = normalizeQuery(registry.description)
+): boolean {
   const normalizedQuery = normalizeQuery(query)
-
-  return (
-    normalizedName.includes(normalizedQuery) ||
-    normalizedDecription.includes(normalizedQuery)
-  )
+  const nameMatch = normalizeQuery(registry.name).includes(normalizedQuery)
+  const descriptionMatch = normalizeQuery(
+    registry.description ?? ""
+  ).includes(normalizedQuery)
+  return nameMatch || descriptionMatch
 }
 
 const searchDirectory = (query: string | null) => {
   if (!query) return globalRegistries
 
-  return globalRegistries.filter((registry) => finderFn(registry, query))
+  return globalRegistries.filter((registry) => matchesRegistry(registry, query))
 }
 
 export const useSearchRegistry = () => {


### PR DESCRIPTION
### summary

- Fix directory search description matching.
- Use filtered list length for separators.
- Safely handle empty/null query and descriptions.
- Remove unused globalRegistries import.

fix: #9776