### PR TITLE
docs: Add missing documentation for @gc-solid registry

### DIFF
--- a/apps/v4/content/docs/registry/gc-solid.mdx
+++ b/apps/v4/content/docs/registry/gc-solid.mdx
@@ -1,0 +1,27 @@
+---
+title: @gc-solid
+description: SolidJS port of shadcn-ui components.
+---
+
+# @gc-solid
+
+Production-ready UI components designed for SolidJS, built with Kobalte primitives.
+
+## Registry
+
+```json
+{
+  "name": "@gc-solid",
+  "url": "https://binnodon.github.io/gc-solid-ui/r/{name}.json"
+}
+```
+
+## Homepage
+
+[https://binnodon.github.io/gc-solid-ui](https://binnodon.github.io/gc-solid-ui)
+
+## Installation
+
+```bash
+npx shadcn@latest add http://binnodon.github.io/gc-solid-ui/r/button.json
+```


### PR DESCRIPTION
Detected that `@gc-solid` was added to `registry.json` but lacked a corresponding docs page.

Generated a basic documentation page to keep docs in sync with the registry configuration.

*Auto-generated by [DocuBot](https://clawftw.com)* 🏗️