### PR TITLE
fix(BlockViewerToolbar): fix device type switching not working

### DIFF
--- a/apps/v4/components/block-viewer.tsx
+++ b/apps/v4/components/block-viewer.tsx
@@ -170,22 +170,22 @@ function BlockViewerToolbar({ styleName }: { styleName: Style["name"] }) {
         <div className="h-8 items-center gap-1.5 rounded-md border p-[3px] shadow-none">
           <ToggleGroup
             type="single"
-            defaultValue="100"
+            defaultValue="100%"
             onValueChange={(value) => {
               setView("preview")
               if (resizablePanelRef?.current) {
-                resizablePanelRef.current.resize(parseInt(value))
+                resizablePanelRef.current.resize(value)
               }
             }}
             className="gap-1 *:data-[slot=toggle-group-item]:size-6! *:data-[slot=toggle-group-item]:rounded-sm!"
           >
-            <ToggleGroupItem value="100" title="Desktop">
+            <ToggleGroupItem value="100%" title="Desktop">
               <Monitor />
             </ToggleGroupItem>
-            <ToggleGroupItem value="60" title="Tablet">
+            <ToggleGroupItem value="60%" title="Tablet">
               <Tablet />
             </ToggleGroupItem>
-            <ToggleGroupItem value="30" title="Mobile">
+            <ToggleGroupItem value="30%" title="Mobile">
               <Smartphone />
             </ToggleGroupItem>
             <Separator orientation="vertical" className="h-4!" />


### PR DESCRIPTION
Hi @shadcn, I found the following issue:

**BlockViewerToolbar:** When changing the device type, the panel does not resize as expected. See the video for a quicker understanding.

**Before:** The panel does not resize correctly when changing the device type.

https://github.com/user-attachments/assets/71f7eca6-6786-4e44-9dcf-e6828b655ee1

**After:** The panel resizes as expected.

https://github.com/user-attachments/assets/3f119a7f-6afe-47aa-bbd5-7a76fc6c57d2

