### PR TITLE
fix: make RTL migration idempotent across repeated runs

### DIFF
--- a/packages/shadcn/src/utils/transformers/transform-rtl.ts
+++ b/packages/shadcn/src/utils/transformers/transform-rtl.ts
@@ -139,22 +139,39 @@ function transformStringLiteralNode(node: {
 }
 
 export function applyRtlMapping(input: string) {
+  const existingClasses = new Set(input.split(" ").filter(Boolean))
+  const emittedClasses = new Set<string>()
+
+  const pushUnique = (classes: string[], className: string) => {
+    if (!className || emittedClasses.has(className)) {
+      return
+    }
+
+    emittedClasses.add(className)
+    classes.push(className)
+  }
+
   return input
     .split(" ")
     .flatMap((className) => {
+      const classes: string[] = []
+
       // Skip classes that already have rtl: or ltr: prefix.
       if (className.startsWith("rtl:") || className.startsWith("ltr:")) {
-        return [className]
+        pushUnique(classes, className)
+        return classes
       }
 
       // Replace the cn-rtl-flip marker with rtl:rotate-180.
       if (className === RTL_FLIP_MARKER) {
-        return ["rtl:rotate-180"]
+        pushUnique(classes, "rtl:rotate-180")
+        return classes
       }
       const [variant, value, modifier] = splitClassName(className)
 
       if (!value) {
-        return [className]
+        pushUnique(classes, className)
+        return classes
       }
 
       // Check for translate-x patterns first (add rtl: variant, don't replace).
@@ -164,7 +181,11 @@ export function applyRtlMapping(input: string) {
           const rtlClass = variant
             ? `rtl:${variant}:${rtlValue}${modifier ? `/${modifier}` : ""}`
             : `rtl:${rtlValue}${modifier ? `/${modifier}` : ""}`
-          return [className, rtlClass]
+          pushUnique(classes, className)
+          if (!existingClasses.has(rtlClass)) {
+            pushUnique(classes, rtlClass)
+          }
+          return classes
         }
       }
 
@@ -174,7 +195,11 @@ export function applyRtlMapping(input: string) {
           const rtlClass = variant
             ? `rtl:${variant}:${reverseClass}`
             : `rtl:${reverseClass}`
-          return [className, rtlClass]
+          pushUnique(classes, className)
+          if (!existingClasses.has(rtlClass)) {
+            pushUnique(classes, rtlClass)
+          }
+          return classes
         }
       }
 
@@ -184,7 +209,11 @@ export function applyRtlMapping(input: string) {
           const rtlClass = variant
             ? `rtl:${variant}:${swapped}`
             : `rtl:${swapped}`
-          return [className, rtlClass]
+          pushUnique(classes, className)
+          if (!existingClasses.has(rtlClass)) {
+            pushUnique(classes, rtlClass)
+          }
+          return classes
         }
       }
 
@@ -200,7 +229,8 @@ export function applyRtlMapping(input: string) {
           const result = modifier
             ? `${variant}:${mappedValue}/${modifier}`
             : `${variant}:${mappedValue}`
-          return [result]
+          pushUnique(classes, result)
+          return classes
         }
       }
 
@@ -241,7 +271,8 @@ export function applyRtlMapping(input: string) {
         result = modifier ? `${mappedValue}/${modifier}` : mappedValue
       }
 
-      return [result]
+      pushUnique(classes, result)
+      return classes
     })
     .join(" ")
 }

--- a/packages/shadcn/test/utils/transform-rtl.test.ts
+++ b/packages/shadcn/test/utils/transform-rtl.test.ts
@@ -321,6 +321,30 @@ describe("applyRtlMapping", () => {
       "ltr:-translate-x-1/2 rtl:-translate-x-1/2"
     )
   })
+
+  test("does not duplicate generated rtl: classes on repeated runs", () => {
+    const once = applyRtlMapping(
+      "space-x-2 divide-x-2 translate-x-1/2 cursor-w-resize"
+    )
+    const twice = applyRtlMapping(once)
+
+    expect(twice).toBe(once)
+    expect(twice).toBe(
+      "space-x-2 rtl:space-x-reverse divide-x-2 rtl:divide-x-reverse translate-x-1/2 rtl:-translate-x-1/2 cursor-w-resize rtl:cursor-e-resize"
+    )
+  })
+
+  test("preserves manually-added rtl variants without re-adding them", () => {
+    expect(applyRtlMapping("space-x-2 rtl:space-x-reverse")).toBe(
+      "space-x-2 rtl:space-x-reverse"
+    )
+    expect(applyRtlMapping("translate-x-1/2 rtl:-translate-x-1/2")).toBe(
+      "translate-x-1/2 rtl:-translate-x-1/2"
+    )
+    expect(applyRtlMapping("cursor-w-resize rtl:cursor-e-resize")).toBe(
+      "cursor-w-resize rtl:cursor-e-resize"
+    )
+  })
 })
 
 describe("transformRtl", () => {


### PR DESCRIPTION
## Summary
- prevent `migrate rtl` from appending duplicate RTL helper classes when run multiple times
- keep generated class order stable while avoiding duplicate emissions
- add regression tests for re-running mappings and preserving user-specified `rtl:` variants

## Root cause
`applyRtlMapping` always emitted generated RTL classes for patterns like `space-x-*`, `translate-x-*`, and resize cursors, even when an equivalent `rtl:*` class already existed in the same input.

## Testing
- `pnpm --filter=shadcn test -- test/utils/transform-rtl.test.ts`
- `pnpm --filter=shadcn test`
