### PR TITLE
fix: fixed registry link in changelog page

### DIFF
--- a/apps/v4/content/docs/changelog/2026-03-cli-v4.mdx
+++ b/apps/v4/content/docs/changelog/2026-03-cli-v4.mdx
@@ -150,4 +150,4 @@ npx shadcn add font-inter
 - [shadcn/skills](/skills)
 - [shadcn/create](/create)
 - [shadcn/cli](/cli)
-- [shadcn/registry](/registry)
+- [shadcn/registry](/docs/registry)


### PR DESCRIPTION
Fixed the link to the registry inside the changelog (https://ui.shadcn.com/docs/changelog/2026-03-cli-v4#registrybase-and-registryfont) - it was leading to a 404
