### PR TITLE
fix: added shadcn@latest to command

### DIFF
--- a/apps/v4/content/docs/changelog/2026-03-cli-v4.mdx
+++ b/apps/v4/content/docs/changelog/2026-03-cli-v4.mdx
@@ -27,7 +27,7 @@ A preset packs your entire design system config into a short code. Colors, theme
 Build your preset on [shadcn/create](/create), preview it live and grab the code when you're ready.
 
 ```bash
-npx shadcn init --preset a1Dg5eFl
+npx shadcn@latest init --preset a1Dg5eFl
 ```
 
 Use it to scaffold projects from custom config, share with your team or publish in your registry. Drop it in prompts so your agent knows where to start. Use it across Claude, Codex, v0, Replit. Take your preset with you.
@@ -37,7 +37,7 @@ Use it to scaffold projects from custom config, share with your team or publish 
 When you're working on a new app, it can take a few tries to find something you like so we've made switching presets really easy. Run init --preset in your app, and the cli will take care of reconfiguring everything including your components.
 
 ```bash
-npx shadcn init --preset ad3qkJ7
+npx shadcn@latest init --preset ad3qkJ7
 ```
 
 ### Skills + Presets
@@ -56,9 +56,9 @@ To help you build custom presets, we rebuilt [shadcn/create](/create). It now in
 Inspect what a registry will add to your project before anything gets written. Review the payload yourself or pipe it to your coding agent for a second look.
 
 ```bash
-npx shadcn add button --dry-run
-npx shadcn add button --diff
-npx shadcn add button --view
+npx shadcn@latest add button --dry-run
+npx shadcn@latest add button --diff
+npx shadcn@latest add button --view
 ```
 
 ### Updating primitives
@@ -66,7 +66,7 @@ npx shadcn add button --view
 You can use the `--diff` flag to check for registry updates. Or ask your agent: "check for updates from @shadcn and merge with my local changes".
 
 ```bash
-npx shadcn add button --diff
+npx shadcn@latest add button --diff
 ```
 
 ### shadcn init --template
@@ -74,7 +74,7 @@ npx shadcn add button --diff
 `shadcn init` now scaffolds full project templates for Next.js, Vite, Laravel, React Router, Astro and TanStack Start. Dark mode included for Next.js and Vite.
 
 ```bash
-npx shadcn init
+npx shadcn@latest init
 
 Select a template › - Use arrow-keys. Return to submit.
 ❯ Next.js
@@ -88,7 +88,7 @@ Select a template › - Use arrow-keys. Return to submit.
 Use `--monorepo` to set up a monorepo.
 
 ```bash
-npx shadcn init -t next --monorepo
+npx shadcn@latest init -t next --monorepo
 ```
 
 ### shadcn init --base
@@ -96,7 +96,7 @@ npx shadcn init -t next --monorepo
 Pick your primitives. Use `--base` to start a project with Radix or Base UI.
 
 ```bash
-npx shadcn init --base radix
+npx shadcn@latest init --base radix
 ```
 
 ### shadcn info
@@ -104,7 +104,7 @@ npx shadcn init --base radix
 The `info` command now shows the full picture: framework, version, CSS vars, which components are installed, and where to find docs and examples for every component. Great for giving coding agents the context they need to work with your project.
 
 ```bash
-npx shadcn info
+npx shadcn@latest info
 ```
 
 ### shadcn docs
@@ -112,7 +112,7 @@ npx shadcn info
 Get docs, code and examples for any UI component right from the CLI. Gives your coding agent the context to use your primitives correctly.
 
 ```bash
-npx shadcn docs combobox
+npx shadcn@latest docs combobox
 
 combobox
   - docs      https://ui.shadcn.com/docs/components/radix/combobox
@@ -142,7 +142,7 @@ Fonts are now a first-class registry type. Install and configure them the same w
 ```
 
 ```bash
-npx shadcn add font-inter
+npx shadcn@latest add font-inter
 ```
 
 ## Links


### PR DESCRIPTION
I tried running --diff and got an error:

```
bunx --bun shadcn add drawer --diff
error: unknown option '--diff'
```

It happened because Bun didn’t install the new version. What if we add `shadcn@latest` in the changelog to simplify the user experience for now? What do you think?