### PR TITLE
fix(button): add dark hover style for destructive variant in new-york-v4

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/button.tsx
+++ b/apps/v4/registry/new-york-v4/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:hover:bg-destructive/70 dark:focus-visible:ring-destructive/40",
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:


### PR DESCRIPTION
## Problem

The destructive button variant in `new-york-v4` sets `dark:bg-destructive/60` but has no corresponding `dark:hover:` style. This means hovering in dark mode produces no visible effect.

Reported in #9796.

## Fix

Add `dark:hover:bg-destructive/70` to provide a visible hover state in dark mode.

- Light mode: base `bg-destructive` (100%) → hover `bg-destructive/90` (darkens slightly)
- Dark mode: base `dark:bg-destructive/60` → hover `dark:hover:bg-destructive/70` (brightens slightly)

This is consistent with how the other CSS-based styles (nova, maia, vega, lyra, mira) already handle dark hover for their destructive variants.

## Changes

- `apps/v4/registry/new-york-v4/ui/button.tsx` — 1 class added

Fixes #9796