### PR TITLE
fix(cli): use detected package manager for monorepo templates

### DIFF
--- a/packages/shadcn/src/utils/create-project.test.ts
+++ b/packages/shadcn/src/utils/create-project.test.ts
@@ -133,6 +133,28 @@ describe("createProject", () => {
     })
   })
 
+  it("should use the detected package manager for monorepo, not the template default", async () => {
+    const { getPackageManager } = await import("@/src/utils/get-package-manager")
+    vi.mocked(getPackageManager).mockResolvedValue("bun")
+
+    vi.mocked(prompts).mockResolvedValue({
+      type: "next",
+      name: "my-monorepo",
+    })
+
+    await createProject({
+      cwd: "/test",
+      force: false,
+      monorepo: true,
+    })
+
+    expect(execa).toHaveBeenCalledWith(
+      "bun",
+      expect.arrayContaining(["install"]),
+      expect.any(Object)
+    )
+  })
+
   it("should force next template for remote components", async () => {
     const result = await createProject({
       cwd: "/test",

--- a/packages/shadcn/src/utils/create-project.ts
+++ b/packages/shadcn/src/utils/create-project.ts
@@ -70,11 +70,9 @@ export async function createProject(
     monorepo: options.monorepo,
   })
 
-  const packageManager =
-    effectiveTemplate.packageManager ??
-    (await getPackageManager(options.cwd, {
-      withFallback: true,
-    }))
+  const packageManager = await getPackageManager(options.cwd, {
+    withFallback: true,
+  })
 
   const projectPath = path.join(options.cwd, projectName)
 


### PR DESCRIPTION
## Summary

Fix `shadcn init --monorepo` ignoring the user's actual package manager and always using `pnpm`.

## Root Cause

All monorepo template configs hardcode `packageManager: "pnpm"`. In `create-project.ts`, the package manager is resolved as:

```ts
const packageManager =
  effectiveTemplate.packageManager ??
  (await getPackageManager(options.cwd, { withFallback: true }))
```

Because `effectiveTemplate.packageManager` is always `"pnpm"` for monorepo templates, the `??` operator short-circuits and `getPackageManager()` is never called. This means bun/yarn/npm users get `pnpm install` executed — failing with `'pnpm' is not recognized` when pnpm is not installed.

## Fix

Always call `getPackageManager()` with fallback. The scaffold already handles removing `pnpm-lock.yaml` when a non-pnpm package manager is used, so this is safe.

```ts
const packageManager = await getPackageManager(options.cwd, {
  withFallback: true,
})
```

## Testing

Added a test that verifies bun is used when `getPackageManager` detects bun, even in monorepo mode. All 6 tests pass.

Closes #9867