### PR TITLE
docs: make init --template copy button copy command only

### DIFF
--- a/apps/v4/content/docs/changelog/2026-03-cli-v4.mdx
+++ b/apps/v4/content/docs/changelog/2026-03-cli-v4.mdx
@@ -75,7 +75,11 @@ npx shadcn@latest add button --diff
 
 ```bash
 npx shadcn@latest init
+```
 
+You'll be prompted to choose a template:
+
+```text
 Select a template › - Use arrow-keys. Return to submit.
 ❯ Next.js
   Vite


### PR DESCRIPTION
## Summary
- keep the `shadcn init` command in its own `bash` block
- move interactive prompt output into a separate `text` block
- this makes the command block copy button paste just the runnable command

Fixes #9866
