### PR TITLE
fix(init): respect invoking package manager when creating projects

### DIFF
--- a/packages/shadcn/src/utils/get-package-manager.ts
+++ b/packages/shadcn/src/utils/get-package-manager.ts
@@ -6,32 +6,35 @@ export async function getPackageManager(
     withFallback: false,
   }
 ): Promise<"yarn" | "pnpm" | "bun" | "npm" | "deno"> {
-  const packageManager = await detect({ programmatic: true, cwd: targetDir })
+  const detected = await detect({ programmatic: true, cwd: targetDir })
 
-  if (packageManager === "yarn@berry") return "yarn"
-  if (packageManager === "pnpm@6") return "pnpm"
-  if (packageManager === "bun") return "bun"
-  if (packageManager === "deno") return "deno"
-  if (!withFallback) {
-    return packageManager ?? "npm"
+  let packageManager: "yarn" | "pnpm" | "bun" | "npm" | "deno" | null =
+    null
+
+  if (detected === "yarn@berry") packageManager = "yarn"
+  else if (detected === "pnpm@6") packageManager = "pnpm"
+  else if (
+    detected === "yarn" ||
+    detected === "pnpm" ||
+    detected === "bun" ||
+    detected === "npm" ||
+    detected === "deno"
+  ) {
+    packageManager = detected
   }
 
-  // Fallback to user agent if not detected.
-  const userAgent = process.env.npm_config_user_agent || ""
+  if (withFallback) {
+    // When fallback is enabled (new project scaffolding),
+    // prefer the package manager used to invoke the CLI.
+    const userAgent = process.env.npm_config_user_agent || ""
 
-  if (userAgent.startsWith("yarn")) {
-    return "yarn"
+    if (userAgent.startsWith("yarn")) return "yarn"
+    if (userAgent.startsWith("pnpm")) return "pnpm"
+    if (userAgent.startsWith("bun")) return "bun"
+    if (userAgent.startsWith("npm")) return "npm"
   }
 
-  if (userAgent.startsWith("pnpm")) {
-    return "pnpm"
-  }
-
-  if (userAgent.startsWith("bun")) {
-    return "bun"
-  }
-
-  return "npm"
+  return packageManager ?? "npm"
 }
 
 export async function getPackageRunner(cwd: string) {

--- a/packages/shadcn/test/utils/get-package-manager.test.ts
+++ b/packages/shadcn/test/utils/get-package-manager.test.ts
@@ -30,3 +30,29 @@ test("get package manager", async () => {
     await getPackageManager(path.resolve(__dirname, "../fixtures/next"))
   ).toBe("pnpm")
 })
+
+test("prefers invoking package manager when withFallback is enabled", async () => {
+  const originalUserAgent = process.env.npm_config_user_agent
+
+  try {
+    process.env.npm_config_user_agent = "npm/10.0.0 node/v22.0.0"
+    await expect(
+      getPackageManager(path.resolve(__dirname, "../fixtures/project-bun"), {
+        withFallback: true,
+      })
+    ).resolves.toBe("npm")
+
+    process.env.npm_config_user_agent = "pnpm/9.0.0 npm/? node/v22.0.0"
+    await expect(
+      getPackageManager(path.resolve(__dirname, "../fixtures/project-npm"), {
+        withFallback: true,
+      })
+    ).resolves.toBe("pnpm")
+  } finally {
+    if (typeof originalUserAgent === "undefined") {
+      delete process.env.npm_config_user_agent
+    } else {
+      process.env.npm_config_user_agent = originalUserAgent
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- prefer the package manager from `npm_config_user_agent` when `withFallback` is enabled
- keep directory-based detection as fallback only when user agent is unavailable
- add coverage to ensure `npx shadcn init` does not switch to bun/pnpm based on cwd locks

## Verification
- `corepack pnpm --filter shadcn test -- test/utils/get-package-manager.test.ts`
- `corepack pnpm --filter shadcn typecheck`

Closes #9874