### PR TITLE
fix: use bun install for monorepo init when invoked via bunx

### DIFF
--- a/packages/shadcn/src/templates/create-template.ts
+++ b/packages/shadcn/src/templates/create-template.ts
@@ -154,7 +154,11 @@ function defaultScaffold({
       }
 
       // Run install.
-      const args = ["install", ...(installArgs ?? [])]
+      // `--no-frozen-lockfile` is pnpm-specific and breaks for Bun.
+      const normalizedInstallArgs = (installArgs ?? []).filter(
+        (arg) => packageManager === "pnpm" || arg !== "--no-frozen-lockfile"
+      )
+      const args = ["install", ...normalizedInstallArgs]
       await execa(packageManager, args, {
         cwd: projectPath,
       })

--- a/packages/shadcn/src/utils/create-project.test.ts
+++ b/packages/shadcn/src/utils/create-project.test.ts
@@ -1,3 +1,4 @@
+import { getPackageManager } from "@/src/utils/get-package-manager"
 import { spinner } from "@/src/utils/spinner"
 import { execa } from "execa"
 import fs from "fs-extra"
@@ -35,6 +36,7 @@ describe("createProject", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getPackageManager).mockResolvedValue("npm")
 
     // Reset all fs mocks
     vi.mocked(fs.access).mockResolvedValue(undefined)
@@ -131,6 +133,42 @@ describe("createProject", () => {
       projectName: "my-monorepo",
       template: "next",
     })
+  })
+
+  it("should use bun for monorepo templates when bun is detected", async () => {
+    vi.mocked(getPackageManager).mockResolvedValue("bun")
+
+    await createProject({
+      cwd: "/test",
+      force: true,
+      template: "vite",
+      name: "bun-monorepo",
+      monorepo: true,
+    })
+
+    expect(execa).toHaveBeenCalledWith("bun", ["install"], {
+      cwd: "/test/bun-monorepo",
+    })
+  })
+
+  it("should keep pnpm for monorepo templates when bun is not detected", async () => {
+    vi.mocked(getPackageManager).mockResolvedValue("npm")
+
+    await createProject({
+      cwd: "/test",
+      force: true,
+      template: "vite",
+      name: "pnpm-monorepo",
+      monorepo: true,
+    })
+
+    expect(execa).toHaveBeenCalledWith(
+      "pnpm",
+      ["install", "--no-frozen-lockfile"],
+      {
+        cwd: "/test/pnpm-monorepo",
+      }
+    )
   })
 
   it("should force next template for remote components", async () => {

--- a/packages/shadcn/src/utils/create-project.ts
+++ b/packages/shadcn/src/utils/create-project.ts
@@ -70,11 +70,16 @@ export async function createProject(
     monorepo: options.monorepo,
   })
 
+  const detectedPackageManager = await getPackageManager(options.cwd, {
+    withFallback: true,
+  })
+
   const packageManager =
-    effectiveTemplate.packageManager ??
-    (await getPackageManager(options.cwd, {
-      withFallback: true,
-    }))
+    options.monorepo &&
+    effectiveTemplate.packageManager === "pnpm" &&
+    detectedPackageManager === "bun"
+      ? "bun"
+      : effectiveTemplate.packageManager ?? detectedPackageManager
 
   const projectPath = path.join(options.cwd, projectName)
 


### PR DESCRIPTION
## Summary\n- prefer Bun as the install package manager for monorepo templates when the CLI is invoked with Bun\n- keep pnpm as the monorepo default for non-Bun invocations\n- strip the pnpm-only `--no-frozen-lockfile` flag when the selected package manager is not pnpm\n\n## Testing\n- corepack pnpm --filter=shadcn test src/utils/create-project.test.ts\n- corepack pnpm --filter=shadcn typecheck\n\nCloses #9867