### PR TITLE
fix: respect --cwd package root resolution for sibling projects

### DIFF
--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -170,8 +170,19 @@ export async function getWorkspaceConfig(config: Config) {
 }
 
 export async function findPackageRoot(cwd: string, resolvedPath: string) {
-  const commonRoot = findCommonRoot(cwd, resolvedPath)
-  const relativePath = path.relative(commonRoot, resolvedPath)
+  const absoluteCwd = path.resolve(cwd)
+  const absoluteResolvedPath = path.isAbsolute(resolvedPath)
+    ? resolvedPath
+    : path.resolve(absoluteCwd, resolvedPath)
+
+  const commonRoot = findCommonRoot(absoluteCwd, absoluteResolvedPath)
+
+  // Guard against mixed relative/absolute inputs that produce an empty root.
+  if (!commonRoot) {
+    return null
+  }
+
+  const relativePath = path.normalize(path.relative(commonRoot, absoluteResolvedPath))
 
   const packageRoots = await fg.glob("**/package.json", {
     cwd: commonRoot,
@@ -180,10 +191,29 @@ export async function findPackageRoot(cwd: string, resolvedPath: string) {
   })
 
   const matchingPackageRoot = packageRoots
-    .map((pkgPath) => path.dirname(pkgPath))
-    .find((pkgDir) => relativePath.startsWith(pkgDir))
+    .map((pkgPath) => path.normalize(path.dirname(pkgPath)))
+    // Prefer the deepest match first.
+    .sort((a, b) => b.split(path.sep).length - a.split(path.sep).length)
+    .find((pkgDir) => {
+      // package.json in commonRoot.
+      if (pkgDir === ".") {
+        return true
+      }
 
-  return matchingPackageRoot ? path.join(commonRoot, matchingPackageRoot) : null
+      // Match by path segment, not simple string prefix.
+      return (
+        relativePath === pkgDir ||
+        relativePath.startsWith(`${pkgDir}${path.sep}`)
+      )
+    })
+
+  if (!matchingPackageRoot) {
+    return null
+  }
+
+  return matchingPackageRoot === "."
+    ? commonRoot
+    : path.join(commonRoot, matchingPackageRoot)
 }
 
 function isAliasKey(

--- a/packages/shadcn/test/utils/get-config.test.ts
+++ b/packages/shadcn/test/utils/get-config.test.ts
@@ -1,8 +1,11 @@
+import os from "os"
 import path from "path"
+import fs from "fs-extra"
 import { describe, expect, test } from "vitest"
 
 import {
   createConfig,
+  findPackageRoot,
   getBase,
   getConfig,
   getRawConfig,
@@ -211,6 +214,50 @@ describe("getBase", () => {
 
   test("returns radix for undefined", () => {
     expect(getBase(undefined)).toBe("radix")
+  })
+})
+
+describe("findPackageRoot", () => {
+  test("matches package root by path segment (not prefix)", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "shadcn-find-root-"))
+
+    try {
+      const sibling = path.join(tempDir, "directory")
+      const target = path.join(tempDir, "directory-2")
+      await fs.ensureDir(sibling)
+      await fs.ensureDir(target)
+      await fs.writeJson(path.join(sibling, "package.json"), { name: "sibling" })
+      await fs.writeJson(path.join(target, "package.json"), { name: "target" })
+
+      const result = await findPackageRoot(
+        tempDir,
+        path.join(target, "lib", "utils.ts")
+      )
+
+      expect(result).toBe(target)
+    } finally {
+      await fs.remove(tempDir)
+    }
+  })
+
+  test("resolves relative paths against cwd", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "shadcn-find-root-"))
+    const originalCwd = process.cwd()
+
+    try {
+      const target = path.join(tempDir, "directory-2")
+      await fs.ensureDir(target)
+      await fs.writeJson(path.join(target, "package.json"), { name: "target" })
+
+      process.chdir(tempDir)
+
+      const result = await findPackageRoot(target, path.join("lib", "utils.ts"))
+
+      expect(result).toBe(target)
+    } finally {
+      process.chdir(originalCwd)
+      await fs.remove(tempDir)
+    }
   })
 })
 


### PR DESCRIPTION
## Summary
- normalize `cwd` and `resolvedPath` to absolute paths before package-root matching
- guard against empty common roots to avoid globbing from an unintended cwd
- match package roots by path segment boundaries (not simple string prefixes)
- prefer deeper package-root matches and correctly support root-level `package.json`

## Testing
- `corepack pnpm --filter=shadcn test -- test/utils/get-config.test.ts`
- `corepack pnpm --filter=shadcn test`

Fixes #6767.
