### PR TITLE
fix: skip unsupported laravel template in init preset URL

### DIFF
--- a/packages/shadcn/src/preset/presets.test.ts
+++ b/packages/shadcn/src/preset/presets.test.ts
@@ -66,6 +66,12 @@ describe("buildInitUrl", () => {
     expect(parsed.searchParams.get("template")).toBe("next")
   })
 
+  it("should not include laravel template", () => {
+    const url = resolveInitUrl(mockPreset, { template: "laravel" })
+    const parsed = new URL(url)
+    expect(parsed.searchParams.has("template")).toBe(false)
+  })
+
   it("should not include template when not provided", () => {
     const url = resolveInitUrl(mockPreset)
     const parsed = new URL(url)

--- a/packages/shadcn/src/preset/presets.ts
+++ b/packages/shadcn/src/preset/presets.ts
@@ -132,7 +132,7 @@ export function resolveInitUrl(
     radius: preset.radius,
   })
 
-  if (options?.template) {
+  if (options?.template && options.template !== "laravel") {
     params.set("template", options.template)
   }
 


### PR DESCRIPTION
## Summary
- avoid sending `template=laravel` to the `/init` endpoint when building preset URLs
- keep template query params for supported templates
- add a regression test to ensure laravel template is omitted

## Why
`shadcn init --preset <code> --template laravel` currently builds an init URL with `template=laravel`, but `/init` does not accept that enum and returns HTTP 400. Omitting this param allows init to proceed for existing Laravel projects.

Fixes #9863

## Testing
- `corepack pnpm --filter shadcn test -- src/preset/presets.test.ts`
