### PR TITLE
fix(init): respect --base when resolving prefixed styles

### DIFF
--- a/packages/shadcn/src/commands/init.ts
+++ b/packages/shadcn/src/commands/init.ts
@@ -21,6 +21,7 @@ import {
   templates,
 } from "@/src/templates/index"
 import { addComponents } from "@/src/utils/add-components"
+import { applyBaseToStyle } from "@/src/utils/base-style"
 import { createProject } from "@/src/utils/create-project"
 import { loadEnvFiles } from "@/src/utils/env-loader"
 import * as ERRORS from "@/src/utils/errors"
@@ -685,6 +686,11 @@ export async function runInit(
   // Ensure rtl is set from CLI option (takes priority over registryBaseConfig).
   if (options.rtl !== undefined) {
     config.rtl = options.rtl
+  }
+
+  // Ensure --base flag wins when style has a base prefix.
+  if (options.base) {
+    config.style = applyBaseToStyle(config.style, options.base)
   }
 
   // Make sure to filter out built-in registries.

--- a/packages/shadcn/src/utils/base-style.test.ts
+++ b/packages/shadcn/src/utils/base-style.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+
+import { applyBaseToStyle } from "./base-style"
+
+describe("applyBaseToStyle", () => {
+  it("should switch radix-prefixed styles to base", () => {
+    expect(applyBaseToStyle("radix-nova", "base")).toBe("base-nova")
+  })
+
+  it("should switch base-prefixed styles to radix", () => {
+    expect(applyBaseToStyle("base-vega", "radix")).toBe("radix-vega")
+  })
+
+  it("should leave unprefixed styles unchanged", () => {
+    expect(applyBaseToStyle("new-york", "base")).toBe("new-york")
+  })
+})

--- a/packages/shadcn/src/utils/base-style.ts
+++ b/packages/shadcn/src/utils/base-style.ts
@@ -1,0 +1,11 @@
+export function applyBaseToStyle(style: string, base: "radix" | "base") {
+  if (style.startsWith("radix-")) {
+    return `${base}-${style.slice("radix-".length)}`
+  }
+
+  if (style.startsWith("base-")) {
+    return `${base}-${style.slice("base-".length)}`
+  }
+
+  return style
+}


### PR DESCRIPTION
## Summary
- ensure the explicit `--base` flag wins for prefixed styles (`radix-*` / `base-*`) during init
- apply base normalization after config merges so registry overrides cannot flip the selected base
- add focused unit tests for style base normalization

## Testing
- `corepack pnpm --filter shadcn test -- src/utils/base-style.test.ts`
- `corepack pnpm --filter shadcn build`

Closes #9873
