### PR TITLE
fix: quote registry names in directory add commands

### DIFF
--- a/apps/v4/components/directory-add-button.tsx
+++ b/apps/v4/components/directory-add-button.tsx
@@ -52,11 +52,13 @@ export function DirectoryAddButton({
   const packageManager = config.packageManager || "pnpm"
 
   const commands = React.useMemo(() => {
+    const quotedRegistryName = JSON.stringify(registry.name)
+
     return {
-      pnpm: `pnpm dlx shadcn@latest registry add ${registry.name}`,
-      npm: `npx shadcn@latest registry add ${registry.name}`,
-      yarn: `yarn dlx shadcn@latest registry add ${registry.name}`,
-      bun: `bunx --bun shadcn@latest registry add ${registry.name}`,
+      pnpm: `pnpm dlx shadcn@latest registry add ${quotedRegistryName}`,
+      npm: `npx shadcn@latest registry add ${quotedRegistryName}`,
+      yarn: `yarn dlx shadcn@latest registry add ${quotedRegistryName}`,
+      bun: `bunx --bun shadcn@latest registry add ${quotedRegistryName}`,
     }
   }, [registry.name])
 


### PR DESCRIPTION
## Summary\n- quote registry names in the generated `registry add` command snippets\n- apply quoting consistently for npm, pnpm, yarn, and bun examples\n- keep behavior unchanged for other command parts\n\n## Why\nPowerShell treats bare `@name` arguments specially, so the unquoted command shown in the directory add modal can fail on Windows.\n\nFixes #9719