### PR TITLE
chore(docs): update registry item types table

### DIFF
--- a/apps/v4/content/docs/registry/registry-item-json.mdx
+++ b/apps/v4/content/docs/registry/registry-item-json.mdx
@@ -103,18 +103,20 @@ The `type` property is used to specify the type of your registry item. This is u
 
 The following types are supported:
 
-| Type                 | Description                                      |
-| -------------------- | ------------------------------------------------ |
-| `registry:block`     | Use for complex components with multiple files.  |
-| `registry:component` | Use for simple components.                       |
-| `registry:lib`       | Use for lib and utils.                           |
-| `registry:hook`      | Use for hooks.                                   |
-| `registry:ui`        | Use for UI components and single-file primitives |
-| `registry:page`      | Use for page or file-based routes.               |
-| `registry:file`      | Use for miscellaneous files.                     |
-| `registry:style`     | Use for registry styles. eg. `new-york`          |
-| `registry:theme`     | Use for themes.                                  |
-| `registry:item`      | Use for universal registry items.                |
+| Type                 | Description                                       |
+| -------------------- | ------------------------------------------------- |
+| `registry:base`      | Use for entire design systems.                    |
+| `registry:block`     | Use for complex components with multiple files.   |
+| `registry:component` | Use for simple components.                        |
+| `registry:font`      | Use for fonts.                                    |
+| `registry:lib`       | Use for lib and utils.                            |
+| `registry:hook`      | Use for hooks.                                    |
+| `registry:ui`        | Use for UI components and single-file primitives. |
+| `registry:page`      | Use for page or file-based routes.                |
+| `registry:file`      | Use for miscellaneous files.                      |
+| `registry:style`     | Use for registry styles. eg. `new-york`.          |
+| `registry:theme`     | Use for themes.                                   |
+| `registry:item`      | Use for universal registry items.                 |
 
 ### author
 


### PR DESCRIPTION
### Changes
* Adds `registry:base`.
* Adds `registry:font`.
* Fix: Add missing periods to `registry:ui` and `registry:style` descriptions for consistency.