### PR TITLE
docs(next): mention Tailwind CSS prerequisite for existing projects

### DIFF
--- a/apps/v4/content/docs/installation/next.mdx
+++ b/apps/v4/content/docs/installation/next.mdx
@@ -13,7 +13,13 @@ description: Install and configure shadcn/ui for Next.js.
 
 ### Create Project
 
-Run the `init` command to create a new Next.js project or to setup an existing one:
+Run the `init` command to create a new Next.js project or to setup an existing one.
+
+If you're setting up an existing Next.js project, install and configure Tailwind CSS first. The `init` command validates your Tailwind CSS setup before continuing.
+
+[Follow the Tailwind CSS installation guide for Next.js.](https://tailwindcss.com/docs/installation/framework-guides/nextjs)
+
+Run:
 
 ```bash
 npx shadcn@latest init -t next


### PR DESCRIPTION
## Summary
- clarify that existing Next.js projects need Tailwind CSS installed/configured before running `shadcn init`
- link directly to the Tailwind CSS Next.js installation guide
- keep the new-project flow unchanged

## Verification
- `prettier --check apps/v4/content/docs/installation/next.mdx`
- `git diff --check`

Closes #4809