### PR TITLE
fix: make RTL migration idempotent

### DIFF
--- a/packages/shadcn/src/migrations/migrate-rtl.test.ts
+++ b/packages/shadcn/src/migrations/migrate-rtl.test.ts
@@ -121,5 +121,28 @@ export function Component() {
       expect(result).toContain("size-4")
       expect(result).not.toContain("cn-rtl-flip")
     })
+
+    it("should be idempotent when run multiple times", async () => {
+      const input = `
+import * as React from "react"
+
+export function Component() {
+  return (
+    <div className="group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] space-x-2 cursor-e-resize" />
+  )
+}`
+
+      const once = await transformDirection(input, true)
+      const twice = await transformDirection(once, true)
+
+      expect(twice).toBe(once)
+      expect(
+        twice.match(
+          /rtl:group-data-\[size=default\]\/switch:data-checked:-translate-x-\[calc\(100%-2px\)\]/g
+        )
+      ).toHaveLength(1)
+      expect(twice.match(/rtl:space-x-reverse/g)).toHaveLength(1)
+      expect(twice.match(/rtl:cursor-w-resize/g)).toHaveLength(1)
+    })
   })
 })

--- a/packages/shadcn/src/utils/transformers/transform-rtl.ts
+++ b/packages/shadcn/src/utils/transformers/transform-rtl.ts
@@ -139,8 +139,11 @@ function transformStringLiteralNode(node: {
 }
 
 export function applyRtlMapping(input: string) {
+  const seen = new Set<string>()
+
   return input
     .split(" ")
+    .filter(Boolean)
     .flatMap((className) => {
       // Skip classes that already have rtl: or ltr: prefix.
       if (className.startsWith("rtl:") || className.startsWith("ltr:")) {
@@ -242,6 +245,14 @@ export function applyRtlMapping(input: string) {
       }
 
       return [result]
+    })
+    .filter((className) => {
+      if (seen.has(className)) {
+        return false
+      }
+
+      seen.add(className)
+      return true
     })
     .join(" ")
 }


### PR DESCRIPTION
## Summary
- make the RTL transformer deduplicate generated class names while preserving order
- keep repeated runs of `shadcn migrate rtl` from appending the same `rtl:*` classes again
- add a regression test that runs the transform twice and asserts the output stays stable

## Testing
- corepack pnpm --filter=shadcn exec vitest run src/migrations/migrate-rtl.test.ts
- corepack pnpm --filter=shadcn exec vitest run src/utils/transformers/transform-cleanup.test.ts

Closes #9734