### PR TITLE
fix(docs): separate command from output to fix copy button

### DIFF
--- a/apps/v4/content/docs/changelog/2026-03-cli-v4.mdx
+++ b/apps/v4/content/docs/changelog/2026-03-cli-v4.mdx
@@ -75,7 +75,9 @@ npx shadcn@latest add button --diff
 
 ```bash
 npx shadcn@latest init
+```
 
+```text
 Select a template › - Use arrow-keys. Return to submit.
 ❯ Next.js
   Vite


### PR DESCRIPTION
Fixes #9866

Split command and output into separate code blocks so copy button only copies the command.