### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deprecated.yml
+++ b/.github/workflows/deprecated.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             apps/www/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Create Version PR or Publish to NPM
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@v1.7.0
         with:
           commit: "chore(release): version packages"
           title: "chore(release): version packages"


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `changesets/action` | [`v1`](https://github.com/changesets/action/releases/tag/v1) | [`v1.7.0`](https://github.com/changesets/action/releases/tag/v1.7.0) | [Release](https://github.com/changesets/action/releases/tag/v1.7.0) | release.yml |
| `tj-actions/changed-files` | [`v46`](https://github.com/tj-actions/changed-files/releases/tag/v46) | [`v47`](https://github.com/tj-actions/changed-files/releases/tag/v47) | [Release](https://github.com/tj-actions/changed-files/releases/tag/v47) | deprecated.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### ⚠️ Breaking Changes

- **tj-actions/changed-files** (v46 → v47): Major version upgrade — review the [release notes](https://github.com/tj-actions/changed-files/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
