### PR TITLE
fix(mcp): honor cwd when resolving project registries

### DIFF
--- a/packages/shadcn/src/commands/mcp.test.ts
+++ b/packages/shadcn/src/commands/mcp.test.ts
@@ -1,0 +1,22 @@
+import path from "path"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { setMcpWorkingDirectory } from "./mcp"
+
+describe("setMcpWorkingDirectory", () => {
+  const originalCwd = process.cwd()
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+  })
+
+  it("resolves the provided cwd and switches the process working directory", () => {
+    const targetCwd = path.dirname(originalCwd)
+    const relativeTarget = path.relative(originalCwd, targetCwd) || "."
+
+    const resolvedCwd = setMcpWorkingDirectory(relativeTarget)
+
+    expect(resolvedCwd).toBe(path.resolve(originalCwd, relativeTarget))
+    expect(process.cwd()).toBe(resolvedCwd)
+  })
+})

--- a/packages/shadcn/src/commands/mcp.ts
+++ b/packages/shadcn/src/commands/mcp.ts
@@ -87,6 +87,13 @@ args = ["shadcn@${SHADCN_MCP_VERSION}", "mcp"]
 
 const DEPENDENCIES = [`shadcn@${SHADCN_MCP_VERSION}`]
 
+export function setMcpWorkingDirectory(cwd = process.cwd()) {
+  const resolvedCwd = path.resolve(cwd)
+  process.chdir(resolvedCwd)
+
+  return resolvedCwd
+}
+
 export const mcp = new Command()
   .name("mcp")
   .description("MCP server and configuration commands")
@@ -97,7 +104,8 @@ export const mcp = new Command()
   )
   .action(async (options) => {
     try {
-      await loadEnvFiles(options.cwd)
+      const cwd = setMcpWorkingDirectory(options.cwd)
+      await loadEnvFiles(cwd)
       const transport = new StdioServerTransport()
       await server.connect(transport)
     } catch (error) {

--- a/packages/shadcn/src/mcp/index.ts
+++ b/packages/shadcn/src/mcp/index.ts
@@ -15,6 +15,7 @@ import {
   formatSearchResultsWithPagination,
   getMcpConfig,
   npxShadcn,
+  resolveMcpCwd,
 } from "./utils"
 
 export const server = new Server(
@@ -30,6 +31,17 @@ export const server = new Server(
   }
 )
 
+const cwdSchema = z
+  .string()
+  .optional()
+  .describe(
+    "Project directory to use when resolving components.json. Defaults to the MCP server working directory."
+  )
+
+function getToolCwd(args?: { cwd?: string }) {
+  return resolveMcpCwd(args?.cwd)
+}
+
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
     tools: [
@@ -37,7 +49,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "get_project_registries",
         description:
           "Get configured registry names from components.json - Returns error if no components.json exists (use init_project to create one)",
-        inputSchema: zodToJsonSchema(z.object({})),
+        inputSchema: zodToJsonSchema(
+          z.object({
+            cwd: cwdSchema,
+          })
+        ),
       },
       {
         name: "list_items_in_registries",
@@ -85,6 +101,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               .number()
               .optional()
               .describe("Number of items to skip for pagination"),
+            cwd: cwdSchema,
           })
         ),
       },
@@ -99,6 +116,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               .describe(
                 "Array of item names with registry prefix (e.g., ['@shadcn/button', '@shadcn/card'])"
               ),
+            cwd: cwdSchema,
           })
         ),
       },
@@ -118,6 +136,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               .describe(
                 "Search query for examples (e.g., 'accordion-demo', 'button demo', 'card example', 'tooltip-demo', 'example-booking-form', 'example-hero'). Common patterns: '{item-name}-demo', '{item-name} example', 'example {item-name}'"
               ),
+            cwd: cwdSchema,
           })
         ),
       },
@@ -153,7 +172,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     switch (request.params.name) {
       case "get_project_registries": {
-        const config = await getMcpConfig(process.cwd())
+        const args = z.object({ cwd: cwdSchema }).parse(request.params.arguments)
+        const config = await getMcpConfig(getToolCwd(args))
 
         if (!config?.registries) {
           return {
@@ -200,6 +220,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           query: z.string(),
           limit: z.number().optional(),
           offset: z.number().optional(),
+          cwd: cwdSchema,
         })
 
         const args = inputSchema.parse(request.params.arguments)
@@ -207,7 +228,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           query: args.query,
           limit: args.limit,
           offset: args.offset,
-          config: await getMcpConfig(process.cwd()),
+          config: await getMcpConfig(getToolCwd(args)),
           useCache: false,
         })
 
@@ -251,7 +272,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const results = await searchRegistries(args.registries, {
           limit: args.limit,
           offset: args.offset,
-          config: await getMcpConfig(process.cwd()),
+          config: await getMcpConfig(getToolCwd(args)),
           useCache: false,
         })
 
@@ -283,11 +304,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "view_items_in_registries": {
         const inputSchema = z.object({
           items: z.array(z.string()),
+          cwd: cwdSchema,
         })
 
         const args = inputSchema.parse(request.params.arguments)
         const registryItems = await getRegistryItems(args.items, {
-          config: await getMcpConfig(process.cwd()),
+          config: await getMcpConfig(getToolCwd(args)),
           useCache: false,
         })
 
@@ -322,10 +344,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const inputSchema = z.object({
           query: z.string(),
           registries: z.array(z.string()),
+          cwd: cwdSchema,
         })
 
         const args = inputSchema.parse(request.params.arguments)
-        const config = await getMcpConfig()
+        const config = await getMcpConfig(getToolCwd(args))
 
         const results = await searchRegistries(args.registries, {
           query: args.query,

--- a/packages/shadcn/src/mcp/utils.test.ts
+++ b/packages/shadcn/src/mcp/utils.test.ts
@@ -1,0 +1,56 @@
+import path from "path"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/src/registry/api", () => ({
+  getRegistriesConfig: vi.fn(),
+}))
+
+vi.mock("@/src/utils/get-package-manager", () => ({
+  getPackageRunner: vi.fn(async () => "pnpm dlx"),
+}))
+
+import { getRegistriesConfig } from "@/src/registry/api"
+
+import { getMcpConfig, resolveMcpCwd } from "./utils"
+
+describe("mcp utils cwd helpers", () => {
+  const originalCwd = process.cwd()
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    vi.clearAllMocks()
+  })
+
+  it("resolves an explicit cwd relative to the current working directory", () => {
+    const targetCwd = path.dirname(originalCwd)
+    const relativeTarget = path.relative(originalCwd, targetCwd) || "."
+
+    expect(resolveMcpCwd(relativeTarget)).toBe(
+      path.resolve(originalCwd, relativeTarget)
+    )
+  })
+
+  it("falls back to process.cwd when no cwd is provided", () => {
+    expect(resolveMcpCwd()).toBe(originalCwd)
+  })
+
+  it("uses the resolved cwd when loading MCP registries config", async () => {
+    vi.mocked(getRegistriesConfig).mockResolvedValue({
+      registries: {
+        "@acme": "https://example.com/r/{name}.json",
+      },
+    } as any)
+
+    const targetCwd = path.dirname(originalCwd)
+    const relativeTarget = path.relative(originalCwd, targetCwd) || "."
+
+    await getMcpConfig(relativeTarget)
+
+    expect(getRegistriesConfig).toHaveBeenCalledWith(
+      path.resolve(originalCwd, relativeTarget),
+      {
+        useCache: false,
+      }
+    )
+  })
+})

--- a/packages/shadcn/src/mcp/utils.ts
+++ b/packages/shadcn/src/mcp/utils.ts
@@ -1,3 +1,4 @@
+import path from "path"
 import { getRegistriesConfig } from "@/src/registry/api"
 import { registryItemSchema, searchResultsSchema } from "@/src/schema"
 import { getPackageRunner } from "@/src/utils/get-package-manager"
@@ -10,8 +11,12 @@ export async function npxShadcn(command: string) {
   return `${packageRunner} ${SHADCN_CLI_COMMAND} ${command}`
 }
 
+export function resolveMcpCwd(cwd?: string) {
+  return path.resolve(cwd ?? process.cwd())
+}
+
 export async function getMcpConfig(cwd = process.cwd()) {
-  const config = await getRegistriesConfig(cwd, {
+  const config = await getRegistriesConfig(resolveMcpCwd(cwd), {
     useCache: false,
   })
 


### PR DESCRIPTION
## Summary
- respect the configured `--cwd` when starting the MCP server by switching the process working directory
- allow MCP registry tools to accept an optional `cwd` and resolve `components.json` against that path
- add focused tests for the MCP cwd helpers and server cwd setup

## Testing
- corepack pnpm --filter shadcn test -- src/mcp/utils.test.ts src/commands/mcp.test.ts
- corepack pnpm --filter shadcn typecheck

Closes #9730