### PR TITLE
fix(dialog): include button registry dependency for new-york-v4

### DIFF
--- a/apps/v4/public/r/styles/new-york-v4/dialog.json
+++ b/apps/v4/public/r/styles/new-york-v4/dialog.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "dialog",
+  "registryDependencies": ["button"],
   "dependencies": [
     "radix-ui"
   ],

--- a/apps/v4/registry.json
+++ b/apps/v4/registry.json
@@ -214,6 +214,7 @@
       "name": "dialog",
       "type": "registry:ui",
       "dependencies": ["@radix-ui/react-dialog"],
+      "registryDependencies": ["button"],
       "files": [
         {
           "path": "registry/new-york-v4/ui/dialog.tsx",

--- a/apps/v4/registry/__index__.tsx
+++ b/apps/v4/registry/__index__.tsx
@@ -352,7 +352,7 @@ export const Index: Record<string, Record<string, any>> = {
       title: "undefined",
       description: "",
       type: "registry:ui",
-      registryDependencies: undefined,
+      registryDependencies: ["button"],
       files: [{
         path: "registry/new-york-v4/ui/dialog.tsx",
         type: "registry:ui",

--- a/apps/v4/registry/new-york-v4/ui/_registry.ts
+++ b/apps/v4/registry/new-york-v4/ui/_registry.ts
@@ -206,6 +206,7 @@ export const ui: Registry["items"] = [
   {
     name: "dialog",
     type: "registry:ui",
+    registryDependencies: ["button"],
     dependencies: ["radix-ui"],
     files: [
       {

--- a/packages/shadcn/test/utils/registry.test.ts
+++ b/packages/shadcn/test/utils/registry.test.ts
@@ -1,3 +1,6 @@
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+
 import { expect, test } from "vitest"
 import { z } from "zod"
 
@@ -69,4 +72,15 @@ test("resolve tree", async () => {
       .map((entry) => entry.name)
       .sort()
   ).toEqual(["button"])
+})
+
+test("new-york-v4 dialog registry includes button dependency", async () => {
+  const registryPath = path.resolve(
+    process.cwd(),
+    "../../apps/v4/public/r/styles/new-york-v4/dialog.json"
+  )
+  const registryItem = JSON.parse(await readFile(registryPath, "utf8"))
+
+  expect(registryItem.name).toBe("dialog")
+  expect(registryItem.registryDependencies).toContain("button")
 })


### PR DESCRIPTION
## Summary
- add the missing `button` registry dependency to the `new-york-v4` `dialog` item
- sync the generated registry artifacts so the published `dialog.json` matches the current dialog source
- add a regression test that guards the published `new-york-v4` dialog registry payload

The current `new-york-v4` dialog source imports `Button`, but its registry metadata did not declare `button` as a `registryDependency`. That means `add dialog` could install an incomplete dependency tree even though the registry file content had already moved forward.

Closes #9714

## Verification
- `jq '.registryDependencies' apps/v4/public/r/styles/new-york-v4/dialog.json`
- `jq '.items[] | select(.name=="dialog") | .registryDependencies' apps/v4/registry.json`
- `git diff --check`
