### PR TITLE
fix(templates): correct monorepo Tailwind app source paths

### DIFF
--- a/templates/astro-monorepo/packages/ui/src/styles/globals.css
+++ b/templates/astro-monorepo/packages/ui/src/styles/globals.css
@@ -1,4 +1,4 @@
 @import "tailwindcss";
-@source "../../../apps/**/*.{ts,tsx,astro}";
+@source "../../../../apps/**/*.{ts,tsx,astro}";
 @source "../../../components/**/*.{ts,tsx}";
 @source "../**/*.{ts,tsx}";

--- a/templates/next-monorepo/packages/ui/src/styles/globals.css
+++ b/templates/next-monorepo/packages/ui/src/styles/globals.css
@@ -1,4 +1,4 @@
 @import "tailwindcss";
-@source "../../../apps/**/*.{ts,tsx}";
+@source "../../../../apps/**/*.{ts,tsx}";
 @source "../../../components/**/*.{ts,tsx}";
 @source "../**/*.{ts,tsx}";

--- a/templates/react-router-monorepo/packages/ui/src/styles/globals.css
+++ b/templates/react-router-monorepo/packages/ui/src/styles/globals.css
@@ -4,7 +4,7 @@
 @import "@fontsource-variable/outfit";
 
 @custom-variant dark (&:is(.dark *));
-@source "../../../apps/**/*.{ts,tsx}";
+@source "../../../../apps/**/*.{ts,tsx}";
 @source "../../../components/**/*.{ts,tsx}";
 @source "../**/*.{ts,tsx}";
 

--- a/templates/start-monorepo/packages/ui/src/styles/globals.css
+++ b/templates/start-monorepo/packages/ui/src/styles/globals.css
@@ -1,4 +1,4 @@
 @import "tailwindcss";
-@source "../../../apps/**/*.{ts,tsx}";
+@source "../../../../apps/**/*.{ts,tsx}";
 @source "../../../components/**/*.{ts,tsx}";
 @source "../**/*.{ts,tsx}";

--- a/templates/vite-monorepo/packages/ui/src/styles/globals.css
+++ b/templates/vite-monorepo/packages/ui/src/styles/globals.css
@@ -1,4 +1,4 @@
 @import "tailwindcss";
-@source "../../../apps/**/*.{ts,tsx}";
+@source "../../../../apps/**/*.{ts,tsx}";
 @source "../../../components/**/*.{ts,tsx}";
 @source "../**/*.{ts,tsx}";


### PR DESCRIPTION
## Summary
- fix the monorepo `packages/ui/src/styles/globals.css` app scan path so Tailwind resolves from the repo root instead of `packages/`
- apply the same path correction across the monorepo templates that share the same layout
- keep the change minimal by only touching the broken `@source .../apps/**` line

## Verification
- ran a targeted path-resolution check to confirm each updated `@source ../../../../apps/**` path now resolves to an existing template `apps/` directory
- ran `git diff --check`

Fixes #9713.
