### PR TITLE
fix(docs): add missing radix-ui manual install dependency

### DIFF
--- a/apps/v4/content/docs/installation/manual.mdx
+++ b/apps/v4/content/docs/installation/manual.mdx
@@ -16,7 +16,7 @@ Components are styled using Tailwind CSS. You need to install Tailwind CSS in yo
 Add the following dependencies to your project:
 
 ```bash
-npm install shadcn class-variance-authority clsx tailwind-merge lucide-react tw-animate-css
+npm install shadcn class-variance-authority clsx tailwind-merge lucide-react radix-ui tw-animate-css
 ```
 
 ### Configure path aliases


### PR DESCRIPTION
## Summary
- add `radix-ui` to the manual installation dependency list
- keep the guide aligned with the default `radix-nova` setup so `button.tsx` imports work after `shadcn add`

## Verification
- `git diff --check`
- confirmed the manual install command now includes `radix-ui`

Closes #9677