### PR TITLE
docs: preserve current base when switching preset codes

### DIFF
--- a/skills/shadcn/SKILL.md
+++ b/skills/shadcn/SKILL.md
@@ -173,10 +173,10 @@ npx shadcn@latest docs button dialog select
 7. **Review added components** — After adding a component or block from any registry, **always read the added files and verify they are correct**. Check for missing sub-components (e.g. `SelectItem` without `SelectGroup`), missing imports, incorrect composition, or violations of the [Critical Rules](#critical-rules). Also replace any icon imports with the project's `iconLibrary` from the project context (e.g. if the registry item uses `lucide-react` but the project uses `hugeicons`, swap the imports and icon names accordingly). Fix all issues before moving on.
 8. **Registry must be explicit** — When the user asks to add a block or component, **do not guess the registry**. If no registry is specified (e.g. user says "add a login block" without specifying `@shadcn`, `@tailark`, etc.), ask which registry to use. Never default to a registry on behalf of the user.
 9. **Switching presets** — Ask the user first: **reinstall**, **merge**, or **skip**?
-   - **First preserve the current base**: read `npx shadcn@latest info` (or `components.json`) and keep the existing component-library base (`base` vs `radix`) when applying a preset code. **Preset codes are opaque and do not tell you which base to switch to.** If you need to run the command outside the target project (for example in a scratch/merge workflow), pass `--base <current-base>` explicitly.
-   - **Reinstall**: `npx shadcn@latest init --preset <code> --base <current-base> --force --reinstall`. Overwrites all components.
-   - **Merge**: `npx shadcn@latest init --preset <code> --base <current-base> --force --no-reinstall`, then run `npx shadcn@latest info` to list installed components, then for each installed component use `--dry-run` and `--diff` to [smart merge](#updating-components) it individually.
-   - **Skip**: `npx shadcn@latest init --preset <code> --base <current-base> --force --no-reinstall`. Only updates config and CSS, leaves components as-is.
+   - **Reinstall**: `npx shadcn@latest init --preset <code> --force --reinstall`. Overwrites all components.
+   - **Merge**: `npx shadcn@latest init --preset <code> --force --no-reinstall`, then run `npx shadcn@latest info` to list installed components, then for each installed component use `--dry-run` and `--diff` to [smart merge](#updating-components) it individually.
+   - **Skip**: `npx shadcn@latest init --preset <code> --force --no-reinstall`. Only updates config and CSS, leaves components as-is.
+   - **Important**: Always run preset commands inside the user's project directory. The CLI automatically preserves the current base (`base` vs `radix`) from `components.json`. If you must use a scratch/temp directory (e.g. for `--dry-run` comparisons), pass `--base <current-base>` explicitly — preset codes do not encode the base.
 
 ## Updating Components
 

--- a/skills/shadcn/cli.md
+++ b/skills/shadcn/cli.md
@@ -245,15 +245,13 @@ Three ways to specify a preset via `--preset`:
 3. **URL:** `--preset "https://ui.shadcn.com/init?base=radix&style=nova&..."`
 
 > **IMPORTANT:** Never try to decode, fetch, or resolve preset codes manually. Preset codes are opaque — pass them directly to `npx shadcn@latest init --preset <code>` and let the CLI handle resolution.
->
-> When switching a preset in an existing project, preserve the current component-library base (`base` vs `radix`). Get it from `npx shadcn@latest info` or `components.json`, and if you are running the preset command outside that project (for example in a scratch/merge workflow), pass `--base <current-base>` explicitly. Do not infer the base from the preset code.
 
 ## Switching Presets
 
 Ask the user first: **reinstall**, **merge**, or **skip** existing components?
 
-Before running the command, read `npx shadcn@latest info` (or `components.json`) and preserve the current component-library base (`base` vs `radix`). Preset codes are base-agnostic. If you are applying the preset in a scratch/temp project during a merge workflow, pass `--base <current-base>` explicitly.
+- **Re-install** → `npx shadcn@latest init --preset <code> --force --reinstall`. Overwrites all component files with the new preset styles. Use when the user hasn't customized components.
+- **Merge** → `npx shadcn@latest init --preset <code> --force --no-reinstall`, then run `npx shadcn@latest info` to get the list of installed components and use the [smart merge workflow](./SKILL.md#updating-components) to update them one by one, preserving local changes. Use when the user has customized components.
+- **Skip** → `npx shadcn@latest init --preset <code> --force --no-reinstall`. Only updates config and CSS variables, leaves existing components as-is.
 
-- **Re-install** → `npx shadcn@latest init --preset <code> --base <current-base> --force --reinstall`. Overwrites all component files with the new preset styles. Use when the user hasn't customized components.
-- **Merge** → `npx shadcn@latest init --preset <code> --base <current-base> --force --no-reinstall`, then run `npx shadcn@latest info` to get the list of installed components and use the [smart merge workflow](./SKILL.md#updating-components) to update them one by one, preserving local changes. Use when the user has customized components.
-- **Skip** → `npx shadcn@latest init --preset <code> --base <current-base> --force --no-reinstall`. Only updates config and CSS variables, leaves existing components as-is.
+Always run preset commands inside the user's project directory. The CLI automatically preserves the current base (`base` vs `radix`) from `components.json`. If you must use a scratch/temp directory (e.g. for `--dry-run` comparisons), pass `--base <current-base>` explicitly — preset codes do not encode the base.


### PR DESCRIPTION
## Summary
- clarify in the bundled shadcn skill/docs that preset codes are opaque and do not imply a `base` vs `radix` switch
- tell agents to preserve the current project base from `shadcn info` / `components.json`
- add `--base <current-base>` to the preset-switch examples used for reinstall / merge / skip workflows

Closes #9914.

## Validation
- `git diff --check`
