### PR TITLE
fix(create): preserve base in copied preset flows

### DIFF
--- a/apps/v4/app/(create)/components/copy-preset.tsx
+++ b/apps/v4/app/(create)/components/copy-preset.tsx
@@ -6,9 +6,16 @@ import { Button } from "@/examples/base/ui/button"
 import { cn } from "@/lib/utils"
 import { copyToClipboardWithMeta } from "@/components/copy-button"
 import { usePresetCode } from "@/app/(create)/hooks/use-design-system"
+import { useDesignSystemSearchParams } from "@/app/(create)/lib/search-params"
+import { buildPresetArgs } from "@/app/(create)/lib/preset-links"
 
 export function CopyPreset({ className }: React.ComponentProps<typeof Button>) {
+  const [params] = useDesignSystemSearchParams()
   const presetCode = usePresetCode()
+  const presetArgs = React.useMemo(
+    () => buildPresetArgs(presetCode, { base: params.base }),
+    [params.base, presetCode]
+  )
   const [hasCopied, setHasCopied] = React.useState(false)
 
   React.useEffect(() => {
@@ -19,14 +26,14 @@ export function CopyPreset({ className }: React.ComponentProps<typeof Button>) {
   }, [hasCopied])
 
   const handleCopy = React.useCallback(() => {
-    copyToClipboardWithMeta(`--preset ${presetCode}`, {
+    copyToClipboardWithMeta(presetArgs, {
       name: "copy_preset_command",
       properties: {
         preset: presetCode,
       },
     })
     setHasCopied(true)
-  }, [presetCode])
+  }, [presetArgs, presetCode])
 
   return (
     <Button
@@ -37,7 +44,7 @@ export function CopyPreset({ className }: React.ComponentProps<typeof Button>) {
         className
       )}
     >
-      <span>{hasCopied ? "Copied" : `--preset ${presetCode}`}</span>
+      <span>{hasCopied ? "Copied" : presetArgs}</span>
     </Button>
   )
 }

--- a/apps/v4/app/(create)/components/project-form.tsx
+++ b/apps/v4/app/(create)/components/project-form.tsx
@@ -36,6 +36,7 @@ import { cn } from "@/lib/utils"
 import { useConfig } from "@/hooks/use-config"
 import { copyToClipboardWithMeta } from "@/components/copy-button"
 import { usePresetCode } from "@/app/(create)/hooks/use-design-system"
+import { buildPresetArgs } from "@/app/(create)/lib/preset-links"
 import {
   useDesignSystemSearchParams,
   type DesignSystemSearchParams,
@@ -79,12 +80,11 @@ export function ProjectForm({
   )
 
   const commands = React.useMemo(() => {
-    const presetFlag = ` --preset ${presetCode}`
-    const baseFlag = params.base !== "radix" ? ` --base ${params.base}` : ""
+    const presetFlags = ` ${buildPresetArgs(presetCode, { base: params.base })}`
     const templateFlag = ` --template ${framework}`
     const monorepoFlag = isMonorepo ? " --monorepo" : ""
     const rtlFlag = params.rtl ? " --rtl" : ""
-    const flags = `${presetFlag}${baseFlag}${templateFlag}${monorepoFlag}${rtlFlag}`
+    const flags = `${presetFlags}${templateFlag}${monorepoFlag}${rtlFlag}`
 
     return IS_LOCAL_DEV && !process.env.NEXT_PUBLIC_RC
       ? {

--- a/apps/v4/app/(create)/components/share-button.tsx
+++ b/apps/v4/app/(create)/components/share-button.tsx
@@ -7,6 +7,7 @@ import { HugeiconsIcon } from "@hugeicons/react"
 
 import { copyToClipboardWithMeta } from "@/components/copy-button"
 import { usePresetCode } from "@/app/(create)/hooks/use-design-system"
+import { buildCreateShareUrl } from "@/app/(create)/lib/preset-links"
 import { useDesignSystemSearchParams } from "@/app/(create)/lib/search-params"
 
 export function ShareButton() {
@@ -16,8 +17,14 @@ export function ShareButton() {
 
   const shareUrl = React.useMemo(() => {
     const origin = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"
-    return `${origin}/create?preset=${presetCode}&item=${params.item}`
-  }, [presetCode, params.item])
+
+    return buildCreateShareUrl({
+      origin,
+      presetCode,
+      item: params.item,
+      base: params.base,
+    })
+  }, [params.base, params.item, presetCode])
 
   React.useEffect(() => {
     if (hasCopied) {

--- a/apps/v4/app/(create)/lib/preset-links.test.ts
+++ b/apps/v4/app/(create)/lib/preset-links.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+
+import { buildCreateShareUrl, buildPresetArgs } from "./preset-links"
+
+describe("buildPresetArgs", () => {
+  it("omits the base flag for radix presets", () => {
+    expect(buildPresetArgs("aurk9Z2", { base: "radix" })).toBe(
+      "--preset aurk9Z2"
+    )
+  })
+
+  it("preserves the base flag for base-ui presets", () => {
+    expect(buildPresetArgs("aurk9Z2", { base: "base" })).toBe(
+      "--preset aurk9Z2 --base base"
+    )
+  })
+})
+
+describe("buildCreateShareUrl", () => {
+  it("keeps base-ui in shared create URLs", () => {
+    expect(
+      buildCreateShareUrl({
+        origin: "https://ui.shadcn.com",
+        presetCode: "aurk9Z2",
+        item: "Item",
+        base: "base",
+      })
+    ).toBe("https://ui.shadcn.com/create?preset=aurk9Z2&item=Item&base=base")
+  })
+
+  it("omits the base query param for radix presets", () => {
+    expect(
+      buildCreateShareUrl({
+        origin: "https://ui.shadcn.com",
+        presetCode: "aurk9Z2",
+        item: "Item",
+        base: "radix",
+      })
+    ).toBe("https://ui.shadcn.com/create?preset=aurk9Z2&item=Item")
+  })
+})

--- a/apps/v4/app/(create)/lib/preset-links.ts
+++ b/apps/v4/app/(create)/lib/preset-links.ts
@@ -1,0 +1,38 @@
+export function buildPresetArgs(
+  presetCode: string,
+  options: { base?: string | null } = {}
+) {
+  const flags = [`--preset ${presetCode}`]
+
+  if (options.base && options.base !== "radix") {
+    flags.push(`--base ${options.base}`)
+  }
+
+  return flags.join(" ")
+}
+
+export function buildCreateShareUrl({
+  origin,
+  presetCode,
+  item,
+  base,
+}: {
+  origin: string
+  presetCode: string
+  item?: string | null
+  base?: string | null
+}) {
+  const url = new URL("/create", origin)
+
+  url.searchParams.set("preset", presetCode)
+
+  if (item) {
+    url.searchParams.set("item", item)
+  }
+
+  if (base && base !== "radix") {
+    url.searchParams.set("base", base)
+  }
+
+  return url.toString()
+}


### PR DESCRIPTION
## Summary
- preserve `--base base` when copying preset args from the create flow
- preserve `base=base` in shared create URLs so base-ui presets do not silently fall back to radix
- reuse the same helper in the project command path and cover it with focused tests

## Verification
- `./node_modules/.bin/vitest run "apps/v4/app/(create)/lib/preset-links.test.ts"`
- `cd apps/v4 && ../../node_modules/.bin/eslint app/\(create\)/components/copy-preset.tsx app/\(create\)/components/share-button.tsx app/\(create\)/components/project-form.tsx app/\(create\)/lib/preset-links.ts app/\(create\)/lib/preset-links.test.ts`

## Notes
- `../../node_modules/.bin/tsc --noEmit -p apps/v4/tsconfig.json` still fails on pre-existing missing `shadcn/*` module types and unrelated app-wide errors outside this change set.

Closes #9921