### PR TITLE
feat(registry): add @popapp registry

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -498,6 +498,12 @@
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='lucide lucide-minus-icon lucide-minus'><path d='M5 12h14'/></svg>"
   },
   {
+    "name": "@popapp",
+    "homepage": "https://popapp.dev/docs",
+    "url": "https://popapp-ai.github.io/ui/r/{name}.json",
+    "description": "Native UI components for React Native and Expo. StyleSheet-native, gesture-first, with haptic feedback and Liquid Glass support. Open Source."
+  },
+  {
     "name": "@prompt-kit",
     "homepage": "https://www.prompt-kit.com",
     "url": "https://www.prompt-kit.com/c/{name}.json",


### PR DESCRIPTION
## Summary

- Adds **@popapp** to the registry index
- **PopApp UI** is an open-source React Native / Expo component registry with 35+ components
- StyleSheet-native (no Tailwind/NativeWind), gesture-first, with haptic feedback and Liquid Glass support
- Fully conforms to the shadcn registry JSON schema
- Registry URL: `https://popapp-ai.github.io/ui/r/{name}.json`
- Homepage: [popapp.dev](https://popapp.dev)

## Checklist

- [x] Open source and publicly accessible
- [x] Conforms to the registry JSON schema (`$schema: "https://ui.shadcn.com/schema/registry.json"`)
- [x] Flat structure with `/registry.json` at root and individual items at `/r/{name}.json`
- [x] No `content` properties in `registry.json` files array