### PR TITLE
docs(Select): Bring radix usage example in line with base ui usage

### DIFF
--- a/apps/v4/content/docs/components/radix/select.mdx
+++ b/apps/v4/content/docs/components/radix/select.mdx
@@ -67,15 +67,23 @@ import {
 ```
 
 ```tsx showLineNumbers
+const items = [
+  { label: "Light", value: "light" },
+  { label: "Dark", value: "dark" },
+  { label: "System", value: "system" },
+]
+
 <Select>
   <SelectTrigger className="w-[180px]">
     <SelectValue placeholder="Theme" />
   </SelectTrigger>
   <SelectContent>
     <SelectGroup>
-      <SelectItem value="light">Light</SelectItem>
-      <SelectItem value="dark">Dark</SelectItem>
-      <SelectItem value="system">System</SelectItem>
+      {items.map((item) => (
+        <SelectItem key={item.value} value={item.value}>
+          {item.label}
+        </SelectItem>
+      ))}
     </SelectGroup>
   </SelectContent>
 </Select>


### PR DESCRIPTION
Currently, the examples diverge more than they have to, obscuring the fact that the only difference is the [`items` prop on `Select`](https://ui.shadcn.com/docs/components/base/select#usage).