### PR TITLE
fix: remove aspect ratio

### DIFF
--- a/apps/v4/registry/new-york-v4/charts/chart-radar-dots.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-radar-dots.tsx
@@ -48,7 +48,7 @@ export function ChartRadarDots() {
       <CardContent className="pb-0">
         <ChartContainer
           config={chartConfig}
-          className="mx-auto aspect-square max-h-[250px]"
+          className="mx-auto max-h-[250px]"
         >
           <RadarChart data={chartData}>
             <ChartTooltip cursor={false} content={<ChartTooltipContent />} />


### PR DESCRIPTION
fixes #9948 

This pr removes the `aspect-square` class from the chart container, which fixes the months overflow issue.

Before:
<img width="906" height="862" alt="image" src="https://github.com/user-attachments/assets/030a38f7-7435-471b-88a9-5d9a6f5b4a46" />
After:
<img width="564" height="609" alt="image" src="https://github.com/user-attachments/assets/59146dde-5503-4138-8809-0865d8d0fa58" />