### PR TITLE
fix: show block preview iframe on mobile in ComponentPreview

### DIFF
--- a/apps/v4/components/component-preview.tsx
+++ b/apps/v4/components/component-preview.tsx
@@ -1,5 +1,4 @@
 import * as React from "react"
-import Image from "next/image"
 
 import { getRegistryComponent } from "@/lib/registry"
 import { ComponentPreviewTabs } from "@/components/component-preview-tabs"
@@ -32,21 +31,7 @@ export function ComponentPreview({
   if (type === "block") {
     const content = (
       <div className="relative mt-6 aspect-[4/2.5] w-full overflow-hidden rounded-xl border md:-mx-1">
-        <Image
-          src={`/r/styles/new-york-v4/${name}-light.png`}
-          alt={name}
-          width={1440}
-          height={900}
-          className="absolute top-0 left-0 z-20 w-[970px] max-w-none bg-background sm:w-[1280px] md:hidden dark:hidden md:dark:hidden"
-        />
-        <Image
-          src={`/r/styles/new-york-v4/${name}-dark.png`}
-          alt={name}
-          width={1440}
-          height={900}
-          className="absolute top-0 left-0 z-20 hidden w-[970px] max-w-none bg-background sm:w-[1280px] md:hidden dark:block md:dark:hidden"
-        />
-        <div className="absolute inset-0 hidden w-[1600px] bg-background md:block">
+        <div className="absolute inset-0 w-[970px] bg-background sm:w-[1280px] md:w-[1600px]">
           <iframe src={`/view/${styleName}/${name}`} className="size-full" />
         </div>
       </div>


### PR DESCRIPTION
This pull request simplifies the `ComponentPreview` component by removing the use of the `next/image` package and replacing multiple image elements with a single `iframe` for block previews. This streamlines the preview rendering logic and reduces complexity.

Preview rendering simplification:

* Removed the import of `Image` from `next/image` in `component-preview.tsx`, eliminating dependency on external image rendering.
* Replaced multiple conditional `Image` elements for light and dark themes with a single `iframe` inside the block preview, consolidating preview logic and reducing code complexity.

close: #9952