### PR TITLE
feat(registry): add @jalco registry

### DIFF
--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -270,6 +270,12 @@
     "description": "Accessible React component library to copy, customize, and own your UI."
   },
   {
+    "name": "@jalco",
+    "homepage": "https://ui.justinlevine.me",
+    "url": "https://ui.justinlevine.me/r/{name}.json",
+    "description": "A curated collection of GitHub-integrated, documentation, and developer-facing components. Self-contained, zero-dependency, and production-ready."
+  },
+  {
     "name": "@kibo-ui",
     "homepage": "https://www.kibo-ui.com/",
     "url": "https://www.kibo-ui.com/r/{name}.json",

--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -59,7 +59,7 @@
     "name": "@aevr",
     "homepage": "https://ui.aevr.space",
     "url": "https://ui.aevr.space/r/{name}.json",
-    "description": "A small collection of focused, production\u2011ready components and primitives for React/Next.js projects\u2014built on shadcn/ui and complementary libraries.",
+    "description": "A small collection of focused, production‑ready components and primitives for React/Next.js projects—built on shadcn/ui and complementary libraries.",
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' width='115' height='105' viewBox='0 0 115 105' fill='none'><path d='M111.78 48.3601C117.803 51.2224 113.769 60.4081 105.635 62.3522L72.9714 70.1593C70.4141 70.7705 67.9525 72.2666 66.2322 74.255L44.2597 99.6532C38.7881 105.978 28.7766 105.329 29.0097 98.6642L29.9457 71.9017C30.019 69.8064 28.9714 68.0828 27.0779 67.1829L2.89121 55.6888C-3.13172 52.8266 0.902578 43.6409 9.03642 41.6967L41.7 33.8896C44.2572 33.2784 46.7189 31.7823 48.4391 29.7939L70.4117 4.3957C75.8832 -1.92893 85.8948 -1.27963 85.6617 5.38474L84.7256 32.1472C84.6524 34.2425 85.6999 35.9662 87.5935 36.866L111.78 48.3601Z' fill='var(--foreground)'/></svg>"
   },
   {
@@ -199,7 +199,7 @@
     "name": "@cult-ui",
     "homepage": "https://www.cult-ui.com",
     "url": "https://cult-ui.com/r/{name}.json",
-    "description": "Cult UI is a rare, curated set of shadcn-compatible, headless and composable components\u2014tastefully animated with Framer Motion.",
+    "description": "Cult UI is a rare, curated set of shadcn-compatible, headless and composable components—tastefully animated with Framer Motion.",
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'><defs><style>.cls-1{fill:none;}</style></defs><g><rect class='cls-1' width='200' height='200'/><g><circle cx='100.18' cy='86.7' r='10.7'/><circle cx='78.79' cy='54.62' r='10.7'/><circle cx='121.57' cy='54.62' r='10.7'/><circle cx='100.18' cy='151.32' r='10.7'/><circle cx='78.79' cy='119.24' r='10.7'/><circle cx='121.57' cy='119.24' r='10.7'/></g></g></svg>"
   },
   {
@@ -368,7 +368,7 @@
     "name": "@lmscn",
     "homepage": "https://lmscn.vercel.app",
     "url": "https://lmscn.vercel.app/r/{name}.json",
-    "description": "LMS components for building interactive learning experiences \u2014 quiz, flashcards, matching, fill-in-the-blank, word scramble, sequencing, reading comprehension, spaced repetition and more.",
+    "description": "LMS components for building interactive learning experiences — quiz, flashcards, matching, fill-in-the-blank, word scramble, sequencing, reading comprehension, spaced repetition and more.",
     "logo": "<svg width=\"125\" height=\"125\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 400 90\" fill=\"none\" role=\"img\" aria-label=\"lmscn\"><g transform=\"translate(5,5)\"><path d=\"M 2,2 L 40,2 L 40,13 A 7,7 0 0,1 40,27 L 40,40 L 27,40 A 7,7 0 0,1 13,40 L 2,40 Z\" fill=\"#06b6d4\"/><path d=\"M 40,2 L 78,2 L 78,40 L 67,40 A 7,7 0 0,1 53,40 L 40,40 L 40,27 A 7,7 0 0,0 40,13 L 40,2 Z\" fill=\"#2563eb\"/><path d=\"M 2,40 L 13,40 A 7,7 0 0,0 27,40 L 40,40 L 40,53 A 7,7 0 0,1 40,67 L 40,78 L 2,78 Z\" fill=\"#f59e0b\"/><path d=\"M 40,40 L 53,40 A 7,7 0 0,0 67,40 L 78,40 L 78,78 L 40,78 L 40,67 A 7,7 0 0,0 40,53 L 40,40 Z\" fill=\"#8b5cf6\"/></g><text x=\"108\" y=\"80\" font-family=\"'DM Mono', 'Fira Code', ui-monospace, monospace\" font-weight=\"700\" font-size=\"64\" letter-spacing=\"-2\" fill=\"currentColor\">lmscn</text></svg>"
   },
   {
@@ -508,7 +508,7 @@
     "name": "@paykit-sdk",
     "homepage": "https://www.usepaykit.dev",
     "url": "https://www.usepaykit.dev/r/{name}.json",
-    "description": "Unified payments SDK for builders \u2014 handle checkout, billing, and webhooks across Stripe, PayPal, Adyen, and regional gateways with a single integration.",
+    "description": "Unified payments SDK for builders — handle checkout, billing, and webhooks across Stripe, PayPal, Adyen, and regional gateways with a single integration.",
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 24 24' fill='none' stroke='var(--foreground)' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round'><path d='M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z' /><path d='M20 3v4' /><path d='M22 5h-4' /><path d='M4 17v2' /><path d='M5 18H3' /></svg>"
   },
   {
@@ -697,7 +697,7 @@
     "name": "@smoothui",
     "homepage": "https://smoothui.dev",
     "url": "https://smoothui.dev/r/{name}.json",
-    "description": "A collection of beautifully crafted motion components built with React, Framer Motion, and TailwindCSS. Designed to elevate microinteractions, each component focuses on smooth animations, subtle feedback, and delightful UX. Perfect for designers and developers who want to add refined motion to their interfaces \u2014 copy, paste, and make your UI come alive.",
+    "description": "A collection of beautifully crafted motion components built with React, Framer Motion, and TailwindCSS. Designed to elevate microinteractions, each component focuses on smooth animations, subtle feedback, and delightful UX. Perfect for designers and developers who want to add refined motion to their interfaces — copy, paste, and make your UI come alive.",
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512' viewBox='0 0 512 512' fill='none'><path d='M329.205 6.05469C331.396 0.985458 337.281 -1.34888 342.351 0.84082L355.644 6.58301C356.018 6.74496 356.377 6.93032 356.722 7.13086L439.729 42.9902C444.799 45.1805 447.134 51.066 444.944 56.1357L439.202 69.4277C437.012 74.4976 431.126 76.8315 426.056 74.6416L351.12 42.2705L330.918 89.0332C376.141 114.344 408.567 159.794 416.052 213.239H429.756V278.752H397.765L397.27 282.408L386.144 369.047C383.266 392.108 380.937 415.238 377.957 438.284C376.66 448.318 375.865 459.058 373.398 468.858C372.384 471.375 371.168 473.657 369.527 475.817C353.072 497.475 312.68 504.556 287.003 508.111C273.789 510.037 260.45 510.964 247.098 510.888C217.287 510.485 162.338 502.749 138.37 484.41C133.049 480.338 128.118 475.314 126.057 468.793C124.143 462.739 123.772 455.672 122.899 449.391L117.649 411.719L99.9443 278.752H67.7119V213.239H80.5723C92.1014 130.913 162.808 67.5599 248.312 67.5596C266.066 67.5596 283.183 70.2933 299.265 75.3594L329.205 6.05469ZM298.618 347.714C290.008 349.185 284.699 357.994 277.604 362.6C260.758 373.533 233.532 371.369 217.451 359.928C211.198 355.48 206.551 346.709 197.798 348.069C194.209 348.628 190.796 350.598 188.722 353.611C186.781 356.428 186.276 360.028 186.956 363.345C188.187 369.351 193.243 374.041 197.507 378.105C213.771 391.889 237.722 397.757 258.754 395.938C277.382 394.327 294.852 386.112 306.932 371.629C309.792 368.2 311.798 364.372 311.3 359.786C310.918 356.283 309.287 352.397 306.453 350.188C304.098 348.351 301.526 347.879 298.618 347.714ZM187.43 188.242C177.489 188.242 169.43 196.301 169.43 206.242V305.578C169.43 315.519 177.489 323.578 187.43 323.578H194.529C204.47 323.578 212.529 315.519 212.529 305.578V206.242C212.529 196.301 204.47 188.242 194.529 188.242H187.43ZM302.939 188.242C292.998 188.242 284.94 196.301 284.939 206.242V305.578C284.939 315.519 292.998 323.578 302.939 323.578H310.04C319.981 323.578 328.04 315.519 328.04 305.578V206.242C328.04 196.301 319.981 188.242 310.04 188.242H302.939Z' fill='var(--foreground)'/></svg>"
   },
   {
@@ -809,7 +809,7 @@
     "name": "@ui-layouts",
     "homepage": "https://ui-layouts.com/",
     "url": "https://ui-layouts.com/r/{name}.json",
-    "description": "UI Layouts offers components, effects, design tools, and ready-made blocks that make building modern interfaces more efficient\u2014built with React, Next.js, Tailwind CSS, and shadcn/ui.",
+    "description": "UI Layouts offers components, effects, design tools, and ready-made blocks that make building modern interfaces more efficient—built with React, Next.js, Tailwind CSS, and shadcn/ui.",
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' width='500' height='500' viewBox='0 0 500 500'><rect width='500' height='500' fill='var(--foreground)'/><path d='M150 100 C150 100, 170 80, 200 90 C230 100, 250 120, 250 120 C250 120, 270 100, 300 110 C330 120, 350 100, 350 100 L360 150 C360 150, 380 130, 400 140 C420 150, 400 170, 400 170 L400 330 C400 330, 420 310, 400 320 C380 330, 360 310, 360 310 L350 360 C350 360, 330 340, 300 350 C270 360, 250 340, 250 340 C250 340, 230 360, 200 350 C170 340, 150 360, 150 360 L140 310 C140 310, 120 330, 100 320 C80 310, 100 290, 100 290 L100 170 C100 170, 80 190, 100 180 C120 170, 140 190, 140 190 Z' fill='var(--background)'/><rect x='280' y='180' width='60' height='140' fill='var(--foreground)'/></svg>"
   },
   {
@@ -865,7 +865,7 @@
     "name": "@shadcn-dashboard",
     "homepage": "https://shadcn-dashboard.com",
     "url": "https://shadcn-dashboard.com/r/{name}.json",
-    "description": "ShadcnDashboard is a collection of modern, production-ready dashboard layouts, components, and UI patterns built on top of shadcn/ui and Tailwind CSS. It\u2019s designed to help developers build clean, scalable, and data-driven dashboards faster\u2014without compromising on performance, accessibility, or customization.",
+    "description": "ShadcnDashboard is a collection of modern, production-ready dashboard layouts, components, and UI patterns built on top of shadcn/ui and Tailwind CSS. It’s designed to help developers build clean, scalable, and data-driven dashboards faster—without compromising on performance, accessibility, or customization.",
     "logo": "<svg width='40' height='40' viewBox='0 0 40 40' fill='none' xmlns='http://www.w3.org/2000/svg'><rect width='40' height='40' rx='20' fill='#053B25'/><path d='M32.1327 19.501C31.5178 19.6123 30.8844 19.6705 30.2375 19.6705C24.3886 19.6705 19.6471 14.9189 19.6471 9.05765C19.6471 8.89469 19.6507 8.73258 19.658 8.57141C13.8411 9.10533 9.28516 14.0074 9.28516 19.9759C9.28516 26.301 14.4019 31.4286 20.7137 31.4286C27.0256 31.4286 32.1423 26.301 32.1423 19.9759C32.1423 19.8168 32.1391 19.6585 32.1327 19.501Z' fill='#C2FD75'/></svg>"
   },
   {
@@ -907,7 +907,7 @@
     "name": "@lumiui",
     "homepage": "https://www.lumiui.dev",
     "url": "https://www.lumiui.dev/r/{name}.json",
-    "description": "Composable React components powered by Base UI and Tailwind CSS \u2014 Build fast, customize everything.",
+    "description": "Composable React components powered by Base UI and Tailwind CSS — Build fast, customize everything.",
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32' fill='var(--foreground)'><circle cx='16' cy='16' r='14'/></svg>"
   },
   {


### PR DESCRIPTION
## Add @jalco to the open source registry index

**Registry:** [@jalco](https://ui.justinlevine.me)
**URL pattern:** `https://ui.justinlevine.me/r/{name}.json`

### About

Jalco UI is a curated collection of GitHub-integrated, documentation, and developer-facing components. Self-contained, zero-dependency, and production-ready.

### Components

- **ActivityGraph** — GitHub-style contribution heatmap with auto-fit sizing and custom color scales
- **GitHubStarsButton** — Live star count button with multiple variants and icon styles
- **GitHubButtonGroup** — Grouped GitHub repo metrics (stars, forks, watchers, issues)
- **CodeBlock** — Syntax-highlighted code block with language icon, copy button, and collapsible overflow
- **CodeBlockCommand** — Multi-package-manager install command with tab switching
- **CodeLine** — Single-line code snippet with inline copy button
- **AiCopyButton** — Copy-to-clipboard button with AI-provider icon cycling
- **RequestViewer** — HTTP request display with method badge, URL, headers, and body
- **ApiRefTable** — Expandable prop reference table for component docs
- **TipJar** — Crypto tip jar with QR code, address copy, and wallet deep links

### Checklist

- [x] Registry is open source and publicly accessible
- [x] Valid JSON conforming to the registry schema
- [x] Flat registry structure (`/r/registry.json` and `/r/{name}.json`)
- [x] `files` array in registry.json does NOT include `content` property
- [x] Entry added to `apps/v4/registry/directory.json`