### PR TITLE
fix: type mismatch on EmptyDescription

### DIFF
--- a/apps/v4/examples/base/ui-rtl/empty.tsx
+++ b/apps/v4/examples/base/ui-rtl/empty.tsx
@@ -64,7 +64,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/examples/base/ui/empty.tsx
+++ b/apps/v4/examples/base/ui/empty.tsx
@@ -64,7 +64,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/examples/radix/ui-rtl/empty.tsx
+++ b/apps/v4/examples/radix/ui-rtl/empty.tsx
@@ -64,7 +64,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/examples/radix/ui/empty.tsx
+++ b/apps/v4/examples/radix/ui/empty.tsx
@@ -64,7 +64,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/registry/bases/base/ui/empty.tsx
+++ b/apps/v4/registry/bases/base/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/registry/bases/radix/ui/empty.tsx
+++ b/apps/v4/registry/bases/radix/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/registry/new-york-v4/ui/empty.tsx
+++ b/apps/v4/registry/new-york-v4/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/deprecated/www/registry/default/ui/empty.tsx
+++ b/deprecated/www/registry/default/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/deprecated/www/registry/new-york/ui/empty.tsx
+++ b/deprecated/www/registry/new-york/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"


### PR DESCRIPTION
`EmptyDescription` accepts `React.ComponentProps<'p'>` but renders a `<div>`