### PR TITLE
fix(registry): register missing Next.js form examples

### DIFF
--- a/apps/v4/registry/__index__.tsx
+++ b/apps/v4/registry/__index__.tsx
@@ -4888,6 +4888,44 @@ export const Index: Record<string, Record<string, any>> = {
       categories: undefined,
       meta: undefined,
     },
+    "form-next-demo": {
+      name: "form-next-demo",
+      title: "undefined",
+      description: "",
+      type: "registry:example",
+      registryDependencies: ["field","input","textarea","button","card","spinner"],
+      files: [{
+        path: "registry/new-york-v4/examples/form-next-demo.tsx",
+        type: "registry:example",
+        target: ""
+      }],
+      component: React.lazy(async () => {
+        const mod = await import("@/registry/new-york-v4/examples/form-next-demo.tsx")
+        const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+        return { default: mod.default || mod[exportName] }
+      }),
+      categories: undefined,
+      meta: undefined,
+    },
+    "form-next-complex": {
+      name: "form-next-complex",
+      title: "undefined",
+      description: "",
+      type: "registry:example",
+      registryDependencies: ["field","input","textarea","button","card","spinner","checkbox","dialog","radio-group","select","switch"],
+      files: [{
+        path: "registry/new-york-v4/examples/form-next-complex.tsx",
+        type: "registry:example",
+        target: ""
+      }],
+      component: React.lazy(async () => {
+        const mod = await import("@/registry/new-york-v4/examples/form-next-complex.tsx")
+        const exportName = Object.keys(mod).find(key => typeof mod[key] === 'function' || typeof mod[key] === 'object') || item.name
+        return { default: mod.default || mod[exportName] }
+      }),
+      categories: undefined,
+      meta: undefined,
+    },
     "form-rhf-demo": {
       name: "form-rhf-demo",
       title: "undefined",

--- a/apps/v4/registry/new-york-v4/examples/_registry.ts
+++ b/apps/v4/registry/new-york-v4/examples/_registry.ts
@@ -951,6 +951,40 @@ export const examples: Registry["items"] = [
     ],
   },
   {
+    name: "form-next-demo",
+    type: "registry:example",
+    registryDependencies: ["field", "input", "textarea", "button", "card", "spinner"],
+    files: [
+      {
+        path: "examples/form-next-demo.tsx",
+        type: "registry:example",
+      },
+    ],
+  },
+  {
+    name: "form-next-complex",
+    type: "registry:example",
+    registryDependencies: [
+      "field",
+      "input",
+      "textarea",
+      "button",
+      "card",
+      "spinner",
+      "checkbox",
+      "dialog",
+      "radio-group",
+      "select",
+      "switch",
+    ],
+    files: [
+      {
+        path: "examples/form-next-complex.tsx",
+        type: "registry:example",
+      },
+    ],
+  },
+  {
     name: "form-rhf-demo",
     type: "registry:example",
     registryDependencies: ["field", "input", "input-group", "button", "card"],


### PR DESCRIPTION
## Summary
- register the missing `form-next-demo` and `form-next-complex` examples in the new-york-v4 example registry source
- update the generated runtime registry index so `ComponentPreview` can resolve both docs previews again

## Testing
- git diff --check

Closes #9969
