### PR TITLE
chore: add changeset for monorepo package manager fix

### DIFF
--- a/.changeset/sharp-bushes-joke.md
+++ b/.changeset/sharp-bushes-joke.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+ensure monorepo respect package manager


### PR DESCRIPTION
## Summary
- Adds the missing changeset for #9962 (fix: monorepo templates ignore the user's package manager)

🤖 Generated with [Claude Code](https://claude.com/claude-code)