### PR TITLE
fix(cli): scope transformCssVars to only transform class name strings

### DIFF
--- a/packages/shadcn/src/utils/transformers/transform-css-vars.ts
+++ b/packages/shadcn/src/utils/transformers/transform-css-vars.ts
@@ -1,7 +1,21 @@
 import { registryBaseColorSchema } from "@/src/schema"
 import { Transformer } from "@/src/utils/transformers"
-import { ScriptKind, SyntaxKind } from "ts-morph"
+import { SyntaxKind, type StringLiteral } from "ts-morph"
 import { z } from "zod"
+
+function applyColorMappingToStringLiteral(
+  node: StringLiteral,
+  inlineColors: z.infer<typeof registryBaseColorSchema>["inlineColors"]
+) {
+  const raw = node.getLiteralText()
+  const mapped = applyColorMapping(raw, inlineColors).trim()
+  if (mapped !== raw) {
+    node.setLiteralValue(mapped)
+  }
+}
+
+// Class name utility function names that accept class strings as arguments.
+const CLASS_UTIL_FUNCTIONS = ["cn", "clsx", "cva"]
 
 export const transformCssVars: Transformer = async ({
   sourceFile,
@@ -13,91 +27,123 @@ export const transformCssVars: Transformer = async ({
     return sourceFile
   }
 
-  // Find jsx attributes with the name className.
-  // const openingElements = sourceFile.getDescendantsOfKind(SyntaxKind.JsxElement)
-  // console.log(openingElements)
-  // const jsxAttributes = sourceFile
-  //   .getDescendantsOfKind(SyntaxKind.JsxAttribute)
-  //   .filter((node) => node.getName() === "className")
+  const inlineColors = baseColor.inlineColors
 
-  // for (const jsxAttribute of jsxAttributes) {
-  //   const value = jsxAttribute.getInitializer()?.getText()
-  //   if (value) {
-  //     const valueWithColorMapping = applyColorMapping(
-  //       value.replace(/"/g, ""),
-  //       baseColor.inlineColors
-  //     )
-  //     jsxAttribute.setInitializer(`"${valueWithColorMapping}"`)
-  //   }
-  // }
-  sourceFile.getDescendantsOfKind(SyntaxKind.StringLiteral).forEach((node) => {
-    const raw = node.getLiteralText()
-    const mapped = applyColorMapping(raw, baseColor.inlineColors).trim()
-    if (mapped !== raw) {
-      node.setLiteralValue(mapped)
+  // Transform cva() calls: cva(base, { variants: { ... } })
+  sourceFile
+    .getDescendantsOfKind(SyntaxKind.CallExpression)
+    .filter((node) => node.getExpression().getText() === "cva")
+    .forEach((node) => {
+      // cva(base, ...)
+      const firstArg = node.getArguments()[0]
+      if (firstArg?.isKind(SyntaxKind.StringLiteral)) {
+        applyColorMappingToStringLiteral(firstArg, inlineColors)
+      }
+
+      // cva(..., { variants: { ... } })
+      const secondArg = node.getArguments()[1]
+      if (secondArg?.isKind(SyntaxKind.ObjectLiteralExpression)) {
+        secondArg
+          .getDescendantsOfKind(SyntaxKind.PropertyAssignment)
+          .find((node) => node.getName() === "variants")
+          ?.getDescendantsOfKind(SyntaxKind.PropertyAssignment)
+          .forEach((node) => {
+            node
+              .getDescendantsOfKind(SyntaxKind.PropertyAssignment)
+              .forEach((node) => {
+                const classNames = node.getInitializerIfKind(
+                  SyntaxKind.StringLiteral
+                )
+                if (classNames) {
+                  applyColorMappingToStringLiteral(classNames, inlineColors)
+                }
+              })
+          })
+      }
+    })
+
+  // Transform className and classNames JSX attributes.
+  sourceFile.getDescendantsOfKind(SyntaxKind.JsxAttribute).forEach((node) => {
+    const attrName = node.getNameNode().getText()
+
+    if (attrName === "className") {
+      // className="..."
+      const initializer = node.getInitializer()
+      if (initializer?.isKind(SyntaxKind.StringLiteral)) {
+        applyColorMappingToStringLiteral(initializer, inlineColors)
+      }
+
+      // className={...}
+      if (initializer?.isKind(SyntaxKind.JsxExpression)) {
+        // Find calls to cn(), clsx(), etc.
+        initializer
+          .getDescendantsOfKind(SyntaxKind.CallExpression)
+          .filter((node) =>
+            CLASS_UTIL_FUNCTIONS.includes(node.getExpression().getText())
+          )
+          .forEach((callExpression) => {
+            callExpression.getArguments().forEach((arg) => {
+              if (arg.isKind(SyntaxKind.StringLiteral)) {
+                applyColorMappingToStringLiteral(arg, inlineColors)
+              }
+
+              if (
+                arg.isKind(SyntaxKind.ConditionalExpression) ||
+                arg.isKind(SyntaxKind.BinaryExpression)
+              ) {
+                arg
+                  .getChildrenOfKind(SyntaxKind.StringLiteral)
+                  .forEach((node) => {
+                    applyColorMappingToStringLiteral(node, inlineColors)
+                  })
+              }
+            })
+          })
+      }
+    }
+
+    // classNames={...} (object form, e.g. classNames={{ root: cn("...") }})
+    if (attrName === "classNames") {
+      if (node.getInitializer()?.isKind(SyntaxKind.JsxExpression)) {
+        node
+          .getDescendantsOfKind(SyntaxKind.PropertyAssignment)
+          .forEach((prop) => {
+            if (prop.getInitializer()?.isKind(SyntaxKind.CallExpression)) {
+              const callExpression = prop.getInitializerIfKind(
+                SyntaxKind.CallExpression
+              )
+              if (callExpression) {
+                callExpression.getArguments().forEach((arg) => {
+                  if (arg.isKind(SyntaxKind.StringLiteral)) {
+                    applyColorMappingToStringLiteral(arg, inlineColors)
+                  }
+
+                  if (arg.isKind(SyntaxKind.ConditionalExpression)) {
+                    arg
+                      .getChildrenOfKind(SyntaxKind.StringLiteral)
+                      .forEach((node) => {
+                        applyColorMappingToStringLiteral(node, inlineColors)
+                      })
+                  }
+                })
+              }
+            }
+
+            if (prop.getInitializer()?.isKind(SyntaxKind.StringLiteral)) {
+              const classNames = prop.getInitializerIfKind(
+                SyntaxKind.StringLiteral
+              )
+              if (classNames) {
+                applyColorMappingToStringLiteral(classNames, inlineColors)
+              }
+            }
+          })
+      }
     }
   })
 
   return sourceFile
 }
-
-// export default function transformer(file: FileInfo, api: API) {
-//   const j = api.jscodeshift.withParser("tsx")
-
-//   // Replace bg-background with "bg-white dark:bg-slate-950"
-//   const $j = j(file.source)
-//   return $j
-//     .find(j.JSXAttribute, {
-//       name: {
-//         name: "className",
-//       },
-//     })
-//     .forEach((path) => {
-//       const { node } = path
-//       if (node?.value?.type) {
-//         if (node.value.type === "StringLiteral") {
-//           node.value.value = applyColorMapping(node.value.value)
-//           console.log(node.value.value)
-//         }
-
-//         if (
-//           node.value.type === "JSXExpressionContainer" &&
-//           node.value.expression.type === "CallExpression"
-//         ) {
-//           const callee = node.value.expression.callee
-//           if (callee.type === "Identifier" && callee.name === "cn") {
-//             node.value.expression.arguments.forEach((arg) => {
-//               if (arg.type === "StringLiteral") {
-//                 arg.value = applyColorMapping(arg.value)
-//               }
-
-//               if (
-//                 arg.type === "LogicalExpression" &&
-//                 arg.right.type === "StringLiteral"
-//               ) {
-//                 arg.right.value = applyColorMapping(arg.right.value)
-//               }
-//             })
-//           }
-//         }
-//       }
-//     })
-//     .toSource()
-// }
-
-// // export function splitClassName(input: string): (string | null)[] {
-// //   const parts = input.split(":")
-// //   const classNames = parts.map((part) => {
-// //     const match = part.match(/^\[?(.+)\]$/)
-// //     if (match) {
-// //       return match[1]
-// //     } else {
-// //       return null
-// //     }
-// //   })
-
-// //   return classNames
-// // }
 
 // Splits a className into [variant, name, alpha].
 // eg. hover:bg-primary-100 -> [hover, bg-primary, 100]

--- a/packages/shadcn/test/utils/transform-css-vars.test.ts
+++ b/packages/shadcn/test/utils/transform-css-vars.test.ts
@@ -3,6 +3,115 @@ import { expect, test } from "vitest"
 import { transform } from "../../src/utils/transformers"
 import stone from "../fixtures/colors/stone.json"
 
+test("should not transform non-class string literals", async () => {
+  const result = await transform({
+    filename: "test.ts",
+    raw: `import * as React from "react"
+export function SpaceBug() {
+  const parts = ["a", "b"];
+  const value = parts.join(" ");
+  return <div className="bg-background">{value}</div>;
+}
+`,
+    config: {
+      tsx: true,
+      tailwind: {
+        baseColor: "stone",
+        cssVariables: false,
+      },
+      aliases: {
+        components: "@/components",
+        utils: "@/lib/utils",
+      },
+    },
+    baseColor: stone,
+  })
+
+  // The join(" ") should be preserved — not corrupted to join("")
+  expect(result).toContain('join(" ")')
+  // But className should still be transformed
+  expect(result).toContain("bg-white")
+})
+
+test("should not transform template literals or non-class strings", async () => {
+  const result = await transform({
+    filename: "test.ts",
+    raw: `import * as React from "react"
+export function Foo() {
+  const sep = " | ";
+  const msg = "Hello World";
+  const id = "bg-primary";
+  return <div className="bg-background text-foreground" data-testid="my-component">{msg}</div>;
+}
+`,
+    config: {
+      tsx: true,
+      tailwind: {
+        baseColor: "stone",
+        cssVariables: false,
+      },
+      aliases: {
+        components: "@/components",
+        utils: "@/lib/utils",
+      },
+    },
+    baseColor: stone,
+  })
+
+  // Non-class strings should be preserved
+  expect(result).toContain('" | "')
+  expect(result).toContain('"Hello World"')
+  // Strings in variables that look like class names should NOT be transformed
+  // because they're not in a className attribute or class utility call
+  expect(result).toContain('"bg-primary"')
+  // data-testid should not be transformed
+  expect(result).toContain('"my-component"')
+  // But className should be transformed
+  expect(result).toContain("bg-white")
+})
+
+test("should transform clsx() and cva() calls", async () => {
+  const result = await transform({
+    filename: "test.ts",
+    raw: `import * as React from "react"
+import { clsx } from "clsx"
+import { cva } from "class-variance-authority"
+
+const buttonVariants = cva("bg-primary text-primary-foreground", {
+  variants: {
+    variant: {
+      default: "bg-primary text-primary-foreground",
+      outline: "border border-input bg-background",
+    },
+  },
+});
+
+export function Foo() {
+  return <div className={clsx("bg-background", true && "text-foreground")}>foo</div>;
+}
+`,
+    config: {
+      tsx: true,
+      tailwind: {
+        baseColor: "stone",
+        cssVariables: false,
+      },
+      aliases: {
+        components: "@/components",
+        utils: "@/lib/utils",
+      },
+    },
+    baseColor: stone,
+  })
+
+  // cva base should be transformed
+  expect(result).toContain("bg-stone-900")
+  // cva variants should be transformed
+  expect(result).toContain("bg-stone-50")
+  // clsx args inside className should be transformed
+  expect(result).toContain("bg-white")
+})
+
 test("transform css vars", async () => {
   expect(
     await transform({


### PR DESCRIPTION
## Description

The `transformCssVars` transformer in the CLI was walking **all** `StringLiteral` AST nodes and applying `applyColorMapping` indiscriminately. This caused non-class strings to be corrupted when `tailwind.cssVariables` was `false`.

For example, `parts.join(" ")` would become `parts.join("")` because `applyColorMapping` splits on spaces, joins them back, and trims — destroying whitespace-only or space-separated non-class strings.

Fixes #9972

## Root Cause

In `packages/shadcn/src/utils/transformers/transform-css-vars.ts`, the transformer used:

```typescript
sourceFile.getDescendantsOfKind(SyntaxKind.StringLiteral).forEach((node) => {
  const raw = node.getLiteralText()
  const mapped = applyColorMapping(raw, baseColor.inlineColors).trim()
  if (mapped !== raw) {
    node.setLiteralValue(mapped)
  }
})
```

This processes every string in the file, not just CSS class names.

## Fix

Replaced the blanket string literal walk with scoped traversal that only transforms strings in:

1. **`className` JSX attributes** — both direct strings (`className="bg-background"`) and expression containers (`className={cn("bg-background", ...)}`)
2. **`cn()`/`clsx()` calls** within className expressions — including conditional/binary expressions
3. **`cva()` calls** — base string argument and variant string values
4. **`classNames` JSX attributes** — object form with utility function calls or direct strings

This mirrors the scoping approach already used by `transformTwPrefixes` in the same codebase.

Also removed stale commented-out code from the original jscodeshift implementation.

## Tests

Added 3 new test cases covering the bug and the scoped behavior:

- **Non-class strings preserved**: `join(" ")`, `" | "`, `"Hello World"` are untouched
- **Class-like strings in variables ignored**: `"bg-primary"` in a `const` is not transformed
- **`clsx()` and `cva()` calls transformed**: base strings and variant values are correctly mapped

All 1204 existing tests continue to pass.