### PR TITLE
refactor(bar-visualizer): remove unnecessary useMemo for volumeBands selection

### DIFF
--- a/apps/v4/registry/bases/radix/blocks/preview/cards/bar-visualizer.tsx
+++ b/apps/v4/registry/bases/radix/blocks/preview/cards/bar-visualizer.tsx
@@ -360,10 +360,7 @@ const BarVisualizerComponent = React.forwardRef<
       }
     }, [demo, state, barCount])
 
-    const volumeBands = useMemo(
-      () => (demo ? fakeVolumeBands : realVolumeBands),
-      [demo, fakeVolumeBands, realVolumeBands]
-    )
+    const volumeBands = demo ? fakeVolumeBands : realVolumeBands
 
     const highlightedIndices = useBarAnimator(
       state,


### PR DESCRIPTION
refactor(bar-visualizer): remove unnecessary useMemo for volumeBands selection

The memoized value was a plain ternary returning one of its own
dependencies unchanged, providing no referential stability or
computation savings. Replace with a direct inline expression.