### PR TITLE
fix: make migrate rtl idempotent

### DIFF
--- a/packages/shadcn/src/migrations/migrate-rtl.test.ts
+++ b/packages/shadcn/src/migrations/migrate-rtl.test.ts
@@ -121,5 +121,57 @@ export function Component() {
       expect(result).toContain("size-4")
       expect(result).not.toContain("cn-rtl-flip")
     })
+
+    it("should be idempotent for translate-x classes", async () => {
+      const input = `
+import * as React from "react"
+
+export function Component() {
+  return <div className="-translate-x-1/2">content</div>
+}`
+
+      const firstPass = await transformDirection(input, true)
+      const secondPass = await transformDirection(firstPass, true)
+      expect(secondPass).toBe(firstPass)
+    })
+
+    it("should be idempotent for space-x classes", async () => {
+      const input = `
+import * as React from "react"
+
+export function Component() {
+  return <div className="space-x-4">content</div>
+}`
+
+      const firstPass = await transformDirection(input, true)
+      const secondPass = await transformDirection(firstPass, true)
+      expect(secondPass).toBe(firstPass)
+    })
+
+    it("should be idempotent for cursor swap classes", async () => {
+      const input = `
+import * as React from "react"
+
+export function Component() {
+  return <div className="cursor-e-resize">content</div>
+}`
+
+      const firstPass = await transformDirection(input, true)
+      const secondPass = await transformDirection(firstPass, true)
+      expect(secondPass).toBe(firstPass)
+    })
+
+    it("should be idempotent for direct replacement classes", async () => {
+      const input = `
+import * as React from "react"
+
+export function Component() {
+  return <div className="ml-2 mr-4 text-left pl-4">content</div>
+}`
+
+      const firstPass = await transformDirection(input, true)
+      const secondPass = await transformDirection(firstPass, true)
+      expect(secondPass).toBe(firstPass)
+    })
   })
 })

--- a/packages/shadcn/src/utils/transformers/transform-rtl.ts
+++ b/packages/shadcn/src/utils/transformers/transform-rtl.ts
@@ -139,6 +139,8 @@ function transformStringLiteralNode(node: {
 }
 
 export function applyRtlMapping(input: string) {
+  const existingClasses = new Set(input.split(" "))
+
   return input
     .split(" ")
     .flatMap((className) => {
@@ -164,6 +166,10 @@ export function applyRtlMapping(input: string) {
           const rtlClass = variant
             ? `rtl:${variant}:${rtlValue}${modifier ? `/${modifier}` : ""}`
             : `rtl:${rtlValue}${modifier ? `/${modifier}` : ""}`
+          // Skip if the rtl: class already exists (idempotency).
+          if (existingClasses.has(rtlClass)) {
+            return [className]
+          }
           return [className, rtlClass]
         }
       }
@@ -174,6 +180,10 @@ export function applyRtlMapping(input: string) {
           const rtlClass = variant
             ? `rtl:${variant}:${reverseClass}`
             : `rtl:${reverseClass}`
+          // Skip if the rtl: class already exists (idempotency).
+          if (existingClasses.has(rtlClass)) {
+            return [className]
+          }
           return [className, rtlClass]
         }
       }
@@ -184,6 +194,10 @@ export function applyRtlMapping(input: string) {
           const rtlClass = variant
             ? `rtl:${variant}:${swapped}`
             : `rtl:${swapped}`
+          // Skip if the rtl: class already exists (idempotency).
+          if (existingClasses.has(rtlClass)) {
+            return [className]
+          }
           return [className, rtlClass]
         }
       }


### PR DESCRIPTION
Fixes #9734

### Problem

Running `shadcn migrate rtl` more than once duplicates every `rtl:` variant class. For example, `space-x-4` becomes `space-x-4 rtl:space-x-reverse` on the first run, then `space-x-4 rtl:space-x-reverse rtl:space-x-reverse` on the second, and so on for `translate-x`, `divide-x`, and cursor swap classes.

### Root cause

`applyRtlMapping` in `transform-rtl.ts` has three "additive" code paths that append an `rtl:*` class next to the original physical class (translate-x, space-x/divide-x reverse, cursor swap). While individual classes starting with `rtl:` are already skipped, the original physical class (e.g. `space-x-4`) still matches on every run and generates a new duplicate.

### Fix

Before processing, collect all existing classes into a `Set`. In each additive code path, check if the `rtl:` class already exists before emitting it. This makes the transform idempotent — running it N times produces the same output as running it once.

### Tests

Added four idempotency test cases that run `transformDirection` twice and assert `secondPass === firstPass` for:
- translate-x classes
- space-x classes
- cursor swap classes
- direct replacement classes (ml, mr, pl, text-left)

All 12 tests pass.