### PR TITLE
fix: Update import path for Button component in react-router-app template

### DIFF
--- a/templates/react-router-app/app/routes/home.tsx
+++ b/templates/react-router-app/app/routes/home.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/ui/button"
+import { Button } from "~/components/ui/button"
 
 export default function Home() {
   return (


### PR DESCRIPTION
### Summary

The React Router template currently uses `@` as an import alias, while the project configuration expects `~`.
This causes import resolution errors right after project initialization.

Screenshot:
<img width="1903" height="906" alt="Capture d’écran du 2026-03-17 02-15-05" src="https://github.com/user-attachments/assets/f87d95af-7fbb-487c-aa62-f1536648db69" />


This PR replaces the incorrect `@` alias with `~` to match the configured path alias.

### Changes

* Replaced `@` with `~` in the React Router template home.tsx component import.
