### PR TITLE
fix(ui): move aria-hidden from ellipsis parent to decorative icon

### DIFF
--- a/apps/v4/registry/bases/base/ui/breadcrumb.tsx
+++ b/apps/v4/registry/bases/base/ui/breadcrumb.tsx
@@ -107,7 +107,6 @@ function BreadcrumbEllipsis({
     <span
       data-slot="breadcrumb-ellipsis"
       role="presentation"
-      aria-hidden="true"
       className={cn(
         "cn-breadcrumb-ellipsis flex items-center justify-center",
         className
@@ -115,6 +114,7 @@ function BreadcrumbEllipsis({
       {...props}
     >
       <IconPlaceholder
+        aria-hidden="true"
         lucide="MoreHorizontalIcon"
         tabler="IconDots"
         hugeicons="MoreHorizontalCircle01Icon"

--- a/apps/v4/registry/bases/base/ui/pagination.tsx
+++ b/apps/v4/registry/bases/base/ui/pagination.tsx
@@ -125,7 +125,6 @@ function PaginationEllipsis({
 }: React.ComponentProps<"span">) {
   return (
     <span
-      aria-hidden
       data-slot="pagination-ellipsis"
       className={cn(
         "cn-pagination-ellipsis flex items-center justify-center",
@@ -134,6 +133,7 @@ function PaginationEllipsis({
       {...props}
     >
       <IconPlaceholder
+        aria-hidden="true"
         lucide="MoreHorizontalIcon"
         tabler="IconDots"
         hugeicons="MoreHorizontalCircle01Icon"

--- a/apps/v4/registry/bases/radix/ui/breadcrumb.tsx
+++ b/apps/v4/registry/bases/radix/ui/breadcrumb.tsx
@@ -104,7 +104,6 @@ function BreadcrumbEllipsis({
     <span
       data-slot="breadcrumb-ellipsis"
       role="presentation"
-      aria-hidden="true"
       className={cn(
         "cn-breadcrumb-ellipsis flex items-center justify-center",
         className
@@ -112,6 +111,7 @@ function BreadcrumbEllipsis({
       {...props}
     >
       <IconPlaceholder
+        aria-hidden="true"
         lucide="MoreHorizontalIcon"
         tabler="IconDots"
         hugeicons="MoreHorizontalCircle01Icon"

--- a/apps/v4/registry/bases/radix/ui/pagination.tsx
+++ b/apps/v4/registry/bases/radix/ui/pagination.tsx
@@ -124,7 +124,6 @@ function PaginationEllipsis({
 }: React.ComponentProps<"span">) {
   return (
     <span
-      aria-hidden
       data-slot="pagination-ellipsis"
       className={cn(
         "cn-pagination-ellipsis flex items-center justify-center",
@@ -133,6 +132,7 @@ function PaginationEllipsis({
       {...props}
     >
       <IconPlaceholder
+        aria-hidden="true"
         lucide="MoreHorizontalIcon"
         tabler="IconDots"
         hugeicons="MoreHorizontalCircle01Icon"

--- a/apps/v4/registry/new-york-v4/ui/breadcrumb.tsx
+++ b/apps/v4/registry/new-york-v4/ui/breadcrumb.tsx
@@ -88,11 +88,10 @@ function BreadcrumbEllipsis({
     <span
       data-slot="breadcrumb-ellipsis"
       role="presentation"
-      aria-hidden="true"
       className={cn("flex size-9 items-center justify-center", className)}
       {...props}
     >
-      <MoreHorizontal className="size-4" />
+      <MoreHorizontal aria-hidden="true" className="size-4" />
       <span className="sr-only">More</span>
     </span>
   )

--- a/apps/v4/registry/new-york-v4/ui/pagination.tsx
+++ b/apps/v4/registry/new-york-v4/ui/pagination.tsx
@@ -105,12 +105,11 @@ function PaginationEllipsis({
 }: React.ComponentProps<"span">) {
   return (
     <span
-      aria-hidden
       data-slot="pagination-ellipsis"
       className={cn("flex size-9 items-center justify-center", className)}
       {...props}
     >
-      <MoreHorizontalIcon className="size-4" />
+      <MoreHorizontalIcon aria-hidden="true" className="size-4" />
       <span className="sr-only">More pages</span>
     </span>
   )


### PR DESCRIPTION
This PR fixes a systemic accessibility bug where aria-hidden="true" was incorrectly applied to parent containers of ellipsis components (in Pagination and Breadcrumb), which also contained sr-only labels.

As per the W3C WAI-ARIA and MDN specifications, aria-hidden="true" on a parent hides all of its descendants from the accessibility tree, including those styled with sr-only. This makes the "More" or "More pages" labels invisible to screen reader users.

This fix moves aria-hidden="true" from the parent ellipsis container specifically to the decorative icon, ensuring the labels remain perceivable.

Related Issues
Fixes shadcn-ui#8074

Files Modified
registry/new-york-v4/ui/pagination.tsx
registry/new-york-v4/ui/breadcrumb.tsx
registry/bases/radix/ui/pagination.tsx
registry/bases/radix/ui/breadcrumb.tsx
registry/bases/base/ui/pagination.tsx
registry/bases/base/ui/breadcrumb.tsx

Verification
Verified consistent implementation across all three registry styles (base, radix, new-york-v4).
Confirmed decorative icons are still hidden while text labels remain accessible.
