### PR TITLE
fix(hover-card-demo): remove unused Avatar imports for base-ui example

### DIFF
--- a/apps/v4/examples/base/hover-card-demo.tsx
+++ b/apps/v4/examples/base/hover-card-demo.tsx
@@ -1,4 +1,3 @@
-import { Avatar, AvatarFallback, AvatarImage } from "@/examples/base/ui/avatar"
 import { Button } from "@/examples/base/ui/button"
 import {
   HoverCard,


### PR DESCRIPTION
The Base UI hover card demo imports Avatar, AvatarFallback, AvatarImage but none of them are used in the JSX. This removes the unused import (or restores the Avatar usage to match the Radix demo).

pnpm registry:build -> the command changed the style (indentation) of apps/v4/registry/directory.json for 
`"name": "@sabraman"...`
I did not include it here to keep the PR as simple as possible.