### PR TITLE
docs: add React Router usage example for DropdownMenuItem

### DIFF
--- a/apps/v4/content/docs/components/radix/dropdown-menu.mdx
+++ b/apps/v4/content/docs/components/radix/dropdown-menu.mdx
@@ -173,6 +173,24 @@ To enable RTL support in shadcn/ui, see the [RTL configuration guide](/docs/rtl)
   direction="rtl"
 />
 
+### Usage with React Router
+
+When using `DropdownMenuItem` with React Router's `Link` component,
+use the `asChild` prop to ensure the menu closes immediately after
+navigation and to preserve the `<a>` tag for SEO:
+```tsx
+import { Link } from "react-router-dom"
+
+<DropdownMenuItem asChild>
+  <Link to="/home">Home</Link>
+</DropdownMenuItem>
+\```
+
+Avoid placing `<Link>` inside `DropdownMenuItem` without `asChild` —
+this causes the menu to remain open after navigation,
+especially with lazy-loaded pages.
+```
+
 ## API Reference
 
 See the [Radix UI documentation](https://www.radix-ui.com/docs/primitives/components/dropdown-menu) for the full API reference.


### PR DESCRIPTION
## What does this PR do?

Adds a documentation example showing how to correctly use 
`DropdownMenuItem` with React Router's `Link` component.

## Problem

When placing `<Link>` inside `DropdownMenuItem` without `asChild`,
the menu doesn't close immediately after navigation — especially
with lazy-loaded pages.

## Solution

Use `asChild` prop on `DropdownMenuItem`:
```tsx
<DropdownMenuItem asChild>
  <Link to="/home">Home</Link>
</DropdownMenuItem>
```

This preserves the `<a>` tag for SEO and ensures correct 
closing behavior.

## Related issue

Fixes #НОМЕР_ISSUEЫ