### PR TITLE
docs: fix broken link on /blocks page

### DIFF
--- a/apps/v4/app/(app)/blocks/layout.tsx
+++ b/apps/v4/app/(app)/blocks/layout.tsx
@@ -56,7 +56,7 @@ export default function BlocksLayout({
             <a href="#blocks">Browse Blocks</a>
           </Button>
           <Button asChild variant="ghost" size="sm">
-            <Link href="/docs/blocks">Add a block</Link>
+            <Link href="/blocks">Add a block</Link>
           </Button>
         </PageActions>
       </PageHeader>


### PR DESCRIPTION
## Summary

Fixes a broken link on the /blocks page where the "add a block" button was linking to a 404 page.

## Problem

The "add a block" button on https://ui.shadcn.com/blocks was linking to /docs/blocks which returns 404.

## Fix

Updated the link to point to the correct path /blocks.

Fixes shadcn-ui/ui#10079