### PR TITLE
fix(carousel): increase hit area of nav buttons to prevent click miss…

### DIFF
--- a/apps/v4/registry/styles/style-lyra.css
+++ b/apps/v4/registry/styles/style-lyra.css
@@ -856,6 +856,14 @@
   .cn-pagination-next {
     @apply pr-1.5!;
   }
+  /* MARK: Carousel */
+  .cn-carousel-previous {
+    @apply after:content-[''] after:absolute after:-inset-4;
+  }
+
+  .cn-carousel-next {
+    @apply after:content-[''] after:absolute after:-inset-4;
+  }
 
   /* MARK: Popover */
   .cn-popover-content {

--- a/apps/v4/registry/styles/style-maia.css
+++ b/apps/v4/registry/styles/style-maia.css
@@ -267,11 +267,11 @@
 
   /* MARK: Carousel */
   .cn-carousel-previous {
-    @apply rounded-full;
+    @apply rounded-full after:content-[''] after:absolute after:-inset-4;
   }
 
   .cn-carousel-next {
-    @apply rounded-full;
+    @apply rounded-full after:content-[''] after:absolute after:-inset-4;
   }
 
   /* MARK: Chart */

--- a/apps/v4/registry/styles/style-mira.css
+++ b/apps/v4/registry/styles/style-mira.css
@@ -267,11 +267,11 @@
 
   /* MARK: Carousel */
   .cn-carousel-previous {
-    @apply rounded-full;
+    @apply rounded-full after:content-[''] after:absolute after:-inset-4;
   }
 
   .cn-carousel-next {
-    @apply rounded-full;
+    @apply rounded-full after:content-[''] after:absolute after:-inset-4;
   }
 
   /* MARK: Chart */

--- a/apps/v4/registry/styles/style-nova.css
+++ b/apps/v4/registry/styles/style-nova.css
@@ -267,11 +267,11 @@
 
   /* MARK: Carousel */
   .cn-carousel-previous {
-    @apply rounded-full;
+    @apply rounded-full after:content-[''] after:absolute after:-inset-4;
   }
 
   .cn-carousel-next {
-    @apply rounded-full;
+    @apply rounded-full after:content-[''] after:absolute after:-inset-4;
   }
 
   /* MARK: Chart */

--- a/apps/v4/registry/styles/style-vega.css
+++ b/apps/v4/registry/styles/style-vega.css
@@ -263,11 +263,11 @@
 
   /* MARK: Carousel */
   .cn-carousel-previous {
-    @apply rounded-full;
+    @apply rounded-full after:content-[''] after:absolute after:-inset-4;
   }
 
   .cn-carousel-next {
-    @apply rounded-full;
+    @apply rounded-full after:content-[''] after:absolute after:-inset-4;
   }
 
   /* MARK: Chart */


### PR DESCRIPTION
… during animation

The carousel navigation buttons (28px) inherit active:translate-y-px and transition-all from the base Button component. When clicking the top edge, the 1px downward shift during the 0.15s transition moves the button out from under the cursor before mouseup fires, causing the click event to fail.

This fix adds a transparent pseudo-element (after:absolute after:-inset-4) to the buttons. This increases the logical hit area by 16px in each direction, ensuring that the mouseup event still registers on the button even as it animates downward, thus preserving the visual feedback while fixing the functional bug.

Closes shadcn-ui/ui#10084