### PR TITLE
docs(templates): update correct instruction when add components to monorepo

### DIFF
--- a/templates/astro-monorepo/README.md
+++ b/templates/astro-monorepo/README.md
@@ -12,8 +12,10 @@ This is a monorepo template for Astro with React, TypeScript, and shadcn/ui.
 To add components, run the following command from the root:
 
 ```bash
-npx shadcn@latest add button -c apps/web
+npx shadcn@latest add button -c packages/ui
 ```
+
+This will place the ui components in the `packages/ui/src/components` directory.
 
 ## Using components
 

--- a/templates/next-monorepo/README.md
+++ b/templates/next-monorepo/README.md
@@ -4,10 +4,10 @@ This is a Next.js monorepo template with shadcn/ui.
 
 ## Adding components
 
-To add components to your app, run the following command at the root of your `web` app:
+To add components to your app, run the following command at the root of your monorepo:
 
 ```bash
-pnpm dlx shadcn@latest add button -c apps/web
+pnpm dlx shadcn@latest add button -c packages/ui
 ```
 
 This will place the ui components in the `packages/ui/src/components` directory.

--- a/templates/react-router-monorepo/README.md
+++ b/templates/react-router-monorepo/README.md
@@ -4,10 +4,10 @@ This is a React Router monorepo template with shadcn/ui.
 
 ## Adding components
 
-To add components to your app, run the following command at the root of your `web` app:
+To add components to your app, run the following command at the root of your monorepo:
 
 ```bash
-pnpm dlx shadcn@latest add button -c apps/web
+pnpm dlx shadcn@latest add button -c packages/ui
 ```
 
 This will place the ui components in the `packages/ui/src/components` directory.

--- a/templates/start-monorepo/README.md
+++ b/templates/start-monorepo/README.md
@@ -4,10 +4,10 @@ This is a TanStack Start monorepo template with shadcn/ui.
 
 ## Adding components
 
-To add components to your app, run the following command at the root of your `web` app:
+To add components to your app, run the following command at the root of your monorepo:
 
 ```bash
-pnpm dlx shadcn@latest add button -c apps/web
+pnpm dlx shadcn@latest add button -c packages/ui
 ```
 
 This will place the ui components in the `packages/ui/src/components` directory.

--- a/templates/vite-monorepo/README.md
+++ b/templates/vite-monorepo/README.md
@@ -4,10 +4,10 @@ This is a Vite monorepo template with shadcn/ui.
 
 ## Adding components
 
-To add components to your app, run the following command at the root of your `web` app:
+To add components to your app, run the following command at the root of your monorepo:
 
 ```bash
-pnpm dlx shadcn@latest add button -c apps/web
+pnpm dlx shadcn@latest add button -c packages/ui
 ```
 
 This will place the ui components in the `packages/ui/src/components` directory.


### PR DESCRIPTION
This pull request includes a small change to these files: 
- templates/astro-monorepo/README.md
- templates/next-monorepo/README.md
- templates/react-router-monorepo/README.md
- templates/start-monorepo/README.md
- templates/vite-monorepo/README.md

The change corrects the add components instruction, place the ui components in `packages/ui`, do not miss leading the starter messed the apps directory.
