### PR TITLE
feature:add alias config hint for Vite installation

### DIFF
--- a/apps/v4/content/docs/installation/vite.mdx
+++ b/apps/v4/content/docs/installation/vite.mdx
@@ -25,6 +25,19 @@ npx shadcn@latest init -t vite
 npx shadcn@latest init -t vite --monorepo
 ```
 
+Make sure configure the path aliases in your `tsconfig.json` file.
+
+```json {3-6} title="tsconfig.json" showLineNumbers
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}
+```
+
 ### Add Components
 
 You can now start adding components to your project.


### PR DESCRIPTION
## What

Add a helpful message when no import alias in tsconfig.json for Vite projects, by add alias config hint for Vite installation.

## Why

Many users encounter issues when initializing shadcn-ui with Vite due to missing path alias configuration. The current error message lead us to https://ui.shadcn.com/docs/installation/vite, where does not provide actionable guidance.

This change improves developer experience by providing clear instructions on how to configure the required alias.

## Changes

- Add clear instructions for configuring: tsconfig.json paths

## Checklist

- [x] Code follows project structure
- [x] No breaking changes
- [x] Tested locally using `pnpm shadcn`