### PR TITLE
docs: add missing asChild prop to DrawerClose usage example

### DIFF
--- a/apps/v4/content/docs/components/base/drawer.mdx
+++ b/apps/v4/content/docs/components/base/drawer.mdx
@@ -80,7 +80,7 @@ import {
     </DrawerHeader>
     <DrawerFooter>
       <Button>Submit</Button>
-      <DrawerClose>
+      <DrawerClose asChild>
         <Button variant="outline">Cancel</Button>
       </DrawerClose>
     </DrawerFooter>

--- a/apps/v4/content/docs/components/radix/drawer.mdx
+++ b/apps/v4/content/docs/components/radix/drawer.mdx
@@ -80,7 +80,7 @@ import {
     </DrawerHeader>
     <DrawerFooter>
       <Button>Submit</Button>
-      <DrawerClose>
+      <DrawerClose asChild>
         <Button variant="outline">Cancel</Button>
       </DrawerClose>
     </DrawerFooter>


### PR DESCRIPTION
## Summary
- Adds missing `asChild` prop to `<DrawerClose>` in the Drawer usage code examples
- Without `asChild`, `DrawerClose` renders as a `<button>`, causing nested `<button>` elements when wrapping a `<Button>` component
- This causes HTML validation errors and hydration issues in Next.js

Fixes #6205