### PR TITLE
fix(cli): support tailwind v4 and tsconfig references (#10135)

### DIFF
--- a/.changeset/hip-turkeys-sleep.md
+++ b/.changeset/hip-turkeys-sleep.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+fix(cli): support tailwind v4 and tsconfig references (fixes #10135)

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -107,6 +107,7 @@
     "prompts": "^2.4.2",
     "recast": "^0.23.11",
     "stringify-object": "^5.0.0",
+    "strip-json-comments": "^5.0.3",
     "tailwind-merge": "^3.0.1",
     "ts-morph": "^26.0.0",
     "tsconfig-paths": "^4.2.0",

--- a/packages/shadcn/src/utils/get-project-info.ts
+++ b/packages/shadcn/src/utils/get-project-info.ts
@@ -8,6 +8,7 @@ import { Config, getConfig, resolveConfigPaths } from "@/src/utils/get-config"
 import { getPackageInfo } from "@/src/utils/get-package-info"
 import fg from "fast-glob"
 import fs from "fs-extra"
+import stripJsonComments from "strip-json-comments"
 import { loadConfig } from "tsconfig-paths"
 import { z } from "zod"
 
@@ -226,10 +227,47 @@ export async function getTailwindVersion(
     return "v4"
   }
 
-  if (
-    !packageInfo?.dependencies?.tailwindcss &&
-    !packageInfo?.devDependencies?.tailwindcss
-  ) {
+  // Check for Tailwind v4 ecosystem packages
+  const tailwindV4Packages = [
+    "@tailwindcss/vite",
+    "@tailwindcss/postcss",
+    "@tailwindcss/cli",
+  ]
+
+  const hasV4Package = tailwindV4Packages.some(
+    (pkg) =>
+      packageInfo?.dependencies?.[pkg] || packageInfo?.devDependencies?.[pkg]
+  )
+
+  if (hasV4Package) {
+    return "v4"
+  }
+
+  // Check if tailwindcss is installed
+  const hasTailwindcss =
+    packageInfo?.dependencies?.tailwindcss ||
+    packageInfo?.devDependencies?.tailwindcss
+
+  if (!hasTailwindcss) {
+    // Fallback: Check vite.config.ts for @tailwindcss/vite plugin
+    const viteConfigFiles = await fg.glob("vite.config.*", {
+      cwd,
+      deep: 1,
+      ignore: PROJECT_SHARED_IGNORE,
+    })
+
+    if (viteConfigFiles.length > 0) {
+      const viteConfigPath = path.resolve(cwd, viteConfigFiles[0])
+      try {
+        const contents = await fs.readFile(viteConfigPath, "utf8")
+        if (contents.includes("@tailwindcss/vite")) {
+          return "v4"
+        }
+      } catch {
+        // Ignore read errors
+      }
+    }
+
     return null
   }
 
@@ -302,26 +340,72 @@ export async function getTsConfigAliasPrefix(cwd: string) {
   const tsConfig = await loadConfig(cwd)
 
   if (
-    tsConfig?.resultType === "failed" ||
-    !Object.entries(tsConfig?.paths).length
+    tsConfig?.resultType !== "failed" &&
+    Object.entries(tsConfig?.paths || {}).length
   ) {
-    return null
+    return extractAliasPrefixFromPaths(tsConfig.paths)
   }
 
-  // This assume that the first alias is the prefix.
-  for (const [alias, paths] of Object.entries(tsConfig.paths)) {
+  // Fallback: parse references array from root tsconfig.json
+  const rootConfigPath = path.resolve(cwd, "tsconfig.json")
+  if (await fs.pathExists(rootConfigPath)) {
+    try {
+      const rootConfig = await readTsConfigFile(rootConfigPath)
+      if (rootConfig?.references?.length) {
+        for (const ref of rootConfig.references) {
+          const refPathValue = ref.path
+          const refPath = path.resolve(cwd, refPathValue)
+          // Handle both file and directory references
+          const configPath = refPathValue.endsWith(".json")
+            ? refPath
+            : path.join(refPath, "tsconfig.json")
+
+          if (await fs.pathExists(configPath)) {
+            const refConfig = await readTsConfigFile(configPath)
+            const paths = refConfig?.compilerOptions?.paths
+            if (paths && Object.keys(paths).length) {
+              return extractAliasPrefixFromPaths(paths)
+            }
+          }
+        }
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  return null
+}
+
+// Helper to read tsconfig with comment stripping
+async function readTsConfigFile(filePath: string) {
+  const contents = await fs.readFile(filePath, "utf8")
+
+  try {
+    return JSON.parse(stripJsonComments(contents))
+  } catch {
+    return null
+  }
+}
+
+// Helper to extract alias prefix from paths object
+function extractAliasPrefixFromPaths(
+  paths: Record<string, string[]>
+): string | null {
+  // This assumes that the first matching alias is the prefix.
+  for (const [alias, pathValues] of Object.entries(paths)) {
     if (
-      paths.includes("./*") ||
-      paths.includes("./src/*") ||
-      paths.includes("./app/*") ||
-      paths.includes("./resources/js/*") // Laravel.
+      pathValues.includes("./*") ||
+      pathValues.includes("./src/*") ||
+      pathValues.includes("./app/*") ||
+      pathValues.includes("./resources/js/*") // Laravel.
     ) {
       return alias.replace(/\/\*$/, "") ?? null
     }
   }
 
   // Use the first alias as the prefix.
-  return Object.keys(tsConfig?.paths)?.[0].replace(/\/\*$/, "") ?? null
+  return Object.keys(paths)?.[0]?.replace(/\/\*$/, "") ?? null
 }
 
 export async function isTypeScriptProject(cwd: string) {

--- a/packages/shadcn/test/fixtures/frameworks/vite-v4-config-only/package.json
+++ b/packages/shadcn/test/fixtures/frameworks/vite-v4-config-only/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "vite-v4-config-only",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.28",
+    "@types/react-dom": "^18.2.13",
+    "@vitejs/plugin-react": "^4.1.0",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/packages/shadcn/test/fixtures/frameworks/vite-v4-config-only/src/index.css
+++ b/packages/shadcn/test/fixtures/frameworks/vite-v4-config-only/src/index.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/packages/shadcn/test/fixtures/frameworks/vite-v4-config-only/src/main.tsx
+++ b/packages/shadcn/test/fixtures/frameworks/vite-v4-config-only/src/main.tsx
@@ -1,0 +1,9 @@
+import React from "react"
+import ReactDOM from "react-dom/client"
+import "./index.css"
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <div>Hello World</div>
+  </React.StrictMode>
+)

--- a/packages/shadcn/test/fixtures/frameworks/vite-v4-config-only/tsconfig.json
+++ b/packages/shadcn/test/fixtures/frameworks/vite-v4-config-only/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/shadcn/test/fixtures/frameworks/vite-v4-config-only/vite.config.ts
+++ b/packages/shadcn/test/fixtures/frameworks/vite-v4-config-only/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+import tailwindcss from "@tailwindcss/vite"
+import path from "path"
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+})

--- a/packages/shadcn/test/fixtures/frameworks/vite-v4-references/package.json
+++ b/packages/shadcn/test/fixtures/frameworks/vite-v4-references/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "vite-v4-references",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.0.0",
+    "@types/react": "^18.2.28",
+    "@types/react-dom": "^18.2.13",
+    "@vitejs/plugin-react": "^4.1.0",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/packages/shadcn/test/fixtures/frameworks/vite-v4-references/src/index.css
+++ b/packages/shadcn/test/fixtures/frameworks/vite-v4-references/src/index.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/packages/shadcn/test/fixtures/frameworks/vite-v4-references/src/main.tsx
+++ b/packages/shadcn/test/fixtures/frameworks/vite-v4-references/src/main.tsx
@@ -1,0 +1,9 @@
+import React from "react"
+import ReactDOM from "react-dom/client"
+import "./index.css"
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <div>Hello World</div>
+  </React.StrictMode>
+)

--- a/packages/shadcn/test/fixtures/frameworks/vite-v4-references/src/vite-env.d.ts
+++ b/packages/shadcn/test/fixtures/frameworks/vite-v4-references/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/shadcn/test/fixtures/frameworks/vite-v4-references/tsconfig.app.json
+++ b/packages/shadcn/test/fixtures/frameworks/vite-v4-references/tsconfig.app.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/shadcn/test/fixtures/frameworks/vite-v4-references/tsconfig.json
+++ b/packages/shadcn/test/fixtures/frameworks/vite-v4-references/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/packages/shadcn/test/fixtures/frameworks/vite-v4-references/tsconfig.node.json
+++ b/packages/shadcn/test/fixtures/frameworks/vite-v4-references/tsconfig.node.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/packages/shadcn/test/fixtures/frameworks/vite-v4-references/vite.config.ts
+++ b/packages/shadcn/test/fixtures/frameworks/vite-v4-references/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+import tailwindcss from "@tailwindcss/vite"
+import path from "path"
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+})

--- a/packages/shadcn/test/utils/get-project-info.test.ts
+++ b/packages/shadcn/test/utils/get-project-info.test.ts
@@ -146,6 +146,34 @@ describe("get project info", async () => {
         aliasPrefix: null,
       },
     },
+    {
+      name: "vite-v4-references",
+      type: {
+        framework: FRAMEWORKS["vite"],
+        isSrcDir: true,
+        isRSC: false,
+        isTsx: true,
+        tailwindConfigFile: null,
+        tailwindCssFile: "src/index.css",
+        tailwindVersion: "v4",
+        frameworkVersion: null,
+        aliasPrefix: "@",
+      },
+    },
+    {
+      name: "vite-v4-config-only",
+      type: {
+        framework: FRAMEWORKS["vite"],
+        isSrcDir: true,
+        isRSC: false,
+        isTsx: true,
+        tailwindConfigFile: null,
+        tailwindCssFile: "src/index.css",
+        tailwindVersion: "v4",
+        frameworkVersion: null,
+        aliasPrefix: "@",
+      },
+    },
   ])(`getProjectType($name) -> $type`, async ({ name, type }) => {
     expect(
       await getProjectInfo(

--- a/packages/shadcn/test/utils/get-ts-config-alias-prefix.test.ts
+++ b/packages/shadcn/test/utils/get-ts-config-alias-prefix.test.ts
@@ -29,6 +29,10 @@ describe("get ts config alias prefix", async () => {
       name: "next-app-custom-alias",
       prefix: "@custom-alias",
     },
+    {
+      name: "vite-v4-references",
+      prefix: "@",
+    },
   ])(`getTsConfigAliasPrefix($name) -> $prefix`, async ({ name, prefix }) => {
     expect(
       await getTsConfigAliasPrefix(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -443,6 +443,9 @@ importers:
       stringify-object:
         specifier: ^5.0.0
         version: 5.0.0
+      strip-json-comments:
+        specifier: ^5.0.3
+        version: 5.0.3
       tailwind-merge:
         specifier: ^3.0.1
         version: 3.3.1
@@ -7214,6 +7217,10 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
 
   style-to-js@1.1.17:
     resolution: {integrity: sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==}
@@ -15576,6 +15583,8 @@ snapshots:
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-json-comments@5.0.3: {}
 
   style-to-js@1.1.17:
     dependencies:


### PR DESCRIPTION
This is my first time submitting a PR for an open source project so please give feedback if needed. 
1. The Problem
The init command currently fails preflight checks in modern development environments using:

Tailwind v4: Where the configuration is handled by the @tailwindcss/vite plugin rather than a legacy tailwind.config.js file.

TSConfig Project References: Where the root tsconfig.json acts as a "Solution" file and the actual path aliases live in referenced files like tsconfig.app.json.

2. The Solution
I have updated the CLI logic in packages/shadcn to be "modern-stack aware":

Enhanced Tailwind Detection: The getTailwindVersion utility now checks for v4 ecosystem packages (@tailwindcss/vite, @tailwindcss/postcss, @tailwindcss/cli) and falls back to scanning vite.config.ts for the Tailwind plugin.

Reference-Aware TSConfig Parsing: The getTsConfigAliasPrefix utility now recursively follows the references array in the root tsconfig.json to locate path aliases in sub-configs.

Comment Stripping: Added a robust readTsConfigFile helper to handle standard JSONC (JSON with comments) often found in TypeScript configurations.

3. Verification & Testing
To ensure zero regressions and verify the fix:

New Fixture:  Created vite-v4-references and vite-v4-config-only test fixtures to cover both package.json and 
  vite.config.ts detection paths.

Automated Tests: Added new Vitest cases to get-project-info.test.ts and get-ts-config-alias-prefix.test.ts.

Changeset: Included a patch changeset for the shadcn package.