### PR TITLE
fix: update broken link on /blocks page

### DIFF
--- a/apps/v4/content/docs/changelog/2025-01-blocks.mdx
+++ b/apps/v4/content/docs/changelog/2025-01-blocks.mdx
@@ -8,4 +8,4 @@ We are inviting the community to contribute to the blocks library. Share your co
 
 We'd love to see all types of blocks: applications, marketing, products, and more.
 
-See the [docs](/docs/blocks) page to get started.
+See the [docs](/blocks) page to get started.


### PR DESCRIPTION
## Summary
- The "Add a block" button on `/blocks` page links to `/docs/blocks` which returns a 404
- Updated the link to point to the correct URL

## Test plan
- [ ] Visit `/blocks` page
- [ ] Click "Add a block" button
- [ ] Verify it navigates to a valid page instead of 404

Fixes #10079