### PR TITLE
fix: add color-scheme support for date inputs in dark mode

### DIFF
--- a/apps/v4/app/globals.css
+++ b/apps/v4/app/globals.css
@@ -200,6 +200,13 @@
   [data-lang="he"] {
     font-family: var(--font-he);
   }
+
+  .dark input[type="date"],
+  .dark input[type="datetime-local"],
+  .dark input[type="time"],
+  .dark input[type="month"] {
+    color-scheme: dark;
+  }
 }
 
 @utility border-grid {

--- a/packages/shadcn/src/tailwind.css
+++ b/packages/shadcn/src/tailwind.css
@@ -93,3 +93,14 @@
     display: none;
   }
 }
+
+/* Fix for iOS Safari: native date picker elements need explicit
+   color-scheme to render correctly in dark mode. */
+@layer base {
+  .dark input[type="date"],
+  .dark input[type="datetime-local"],
+  .dark input[type="time"],
+  .dark input[type="month"] {
+    color-scheme: dark;
+  }
+}


### PR DESCRIPTION
## Summary
- Added `color-scheme: dark` CSS rules for date, datetime-local, time, and month input types in dark mode
- iOS Safari requires explicit `color-scheme: dark` to properly style native date picker elements
- Applied in both the docs globals.css and the shadcn package tailwind.css

## Test plan
- [ ] Open a page with `<Input type="date" />` on iOS Safari
- [ ] Toggle dark mode
- [ ] Verify the native date picker respects dark mode styling
- [ ] Verify no regression on Chrome/Firefox desktop

Fixes #10106