### PR TITLE
fix: pnpm test crash on init

### DIFF
--- a/packages/tests/src/tests/init.test.ts
+++ b/packages/tests/src/tests/init.test.ts
@@ -600,7 +600,7 @@ describe("shadcn init - next-monorepo", () => {
     // Build a custom init URL with specific options.
     const registryUrl = process.env.REGISTRY_URL || "http://localhost:4000/r"
     const baseUrl = registryUrl.replace(/\/r\/?$/, "")
-    const initUrl = `${baseUrl}/init?base=radix&style=nova&baseColor=zinc&theme=zinc&iconLibrary=lucide&font=inter&rtl=false&menuAccent=subtle&menuColor=default&radius=default&template=next`
+    const initUrl = `${baseUrl}/init?base=radix&style=nova&baseColor=zinc&chartColor=zinc&theme=zinc&iconLibrary=lucide&font=inter&rtl=false&menuAccent=subtle&menuColor=default&radius=default&template=next`
 
     const result = await npxShadcn(
       testBaseDir,


### PR DESCRIPTION
While I was working on #9444, I realized that the CI on main was broken, for example, with the latest test run:  https://github.com/shadcn-ui/ui/actions/runs/23505907275/job/68413571644.

Before: http://ui.shadcn.com/init?base=radix&style=nova&baseColor=zinc&theme=zinc&iconLibrary=lucide&font=inter&rtl=false&menuAccent=subtle&menuColor=default&radius=default&template=next
After: https://ui.shadcn.com/init?base=radix&style=nova&baseColor=zinc&chartColor=zinc&theme=zinc&iconLibrary=lucide&font=inter&rtl=false&menuAccent=subtle&menuColor=default&radius=default&template=next

This can be tested with `pnpm turbo run test --filter=tests -- -t "should create a monorepo with preset url"`.