### PR TITLE
fix: pnpm test crash on pnpm version mismatch

### DIFF
--- a/templates/astro-monorepo/package.json
+++ b/templates/astro-monorepo/package.json
@@ -16,7 +16,7 @@
     "turbo": "^2.8.17",
     "typescript": "5.9.3"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@9.0.6",
   "engines": {
     "node": ">=20"
   }

--- a/templates/next-monorepo/package.json
+++ b/templates/next-monorepo/package.json
@@ -17,7 +17,7 @@
     "turbo": "^2.8.17",
     "typescript": "5.9.3"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@9.0.6",
   "engines": {
     "node": ">=20"
   }

--- a/templates/react-router-monorepo/package.json
+++ b/templates/react-router-monorepo/package.json
@@ -14,7 +14,7 @@
     "turbo": "^2.8.17",
     "typescript": "5.9.3"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@9.0.6",
   "engines": {
     "node": ">=20"
   }

--- a/templates/start-monorepo/package.json
+++ b/templates/start-monorepo/package.json
@@ -15,7 +15,7 @@
     "turbo": "^2.8.17",
     "typescript": "5.9.3"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@9.0.6",
   "engines": {
     "node": ">=20"
   }

--- a/templates/vite-monorepo/package.json
+++ b/templates/vite-monorepo/package.json
@@ -15,7 +15,7 @@
     "turbo": "^2.8.17",
     "typescript": "5.9.3"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@9.0.6",
   "engines": {
     "node": ">=20"
   }


### PR DESCRIPTION
While I was working on #9444, I realized that the CI on main was broken, for example, with the latest test run:  https://github.com/shadcn-ui/ui/actions/runs/23505907275/job/68413571644.

The error message says:

>     '\\u2009ERR_PNPM_BAD_PM_VERSION\\u2009 This project is configured to use v9.15.9 of pnpm. Your current pnpm is v9.0.6\n' +

The regression seems to have been introduced in #10076.

This can be tested with `pnpm turbo run test --filter=tests -- -t "should create a monorepo with preset"`.