### PR TITLE
fix(registry): add Accept: application/json header to fetchRegistry

### DIFF
--- a/packages/shadcn/src/registry/fetcher.ts
+++ b/packages/shadcn/src/registry/fetcher.ts
@@ -54,6 +54,7 @@ export async function fetchRegistry(
           const response = await fetch(url, {
             agent,
             headers: {
+              Accept: "application/json",
               ...headers,
             },
           })


### PR DESCRIPTION
When fetching from registry URLs, the CLI now sends an `Accept: application/json` header. This allows custom registries to use content negotiation to serve JSON to the CLI while serving HTML documentation to browsers at the same URL.

## Problem
When using `shadcn add` with a custom registry URL, the CLI doesn't send an Accept header. This prevents registries from using standard HTTP content negotiation to serve different content types based on the client.

## Solution
Add `Accept: application/json` header to the fetch request in `fetchRegistry`.

## Testing
- Verified the header is included in requests
- Allows registries to differentiate between CLI and browser requests

Fixes #10164