### PR TITLE
fix: scope transformCssVars to only process className strings

### DIFF
--- a/packages/shadcn/src/utils/transformers/transform-css-vars.ts
+++ b/packages/shadcn/src/utils/transformers/transform-css-vars.ts
@@ -1,7 +1,31 @@
 import { registryBaseColorSchema } from "@/src/schema"
 import { Transformer } from "@/src/utils/transformers"
-import { ScriptKind, SyntaxKind } from "ts-morph"
+import { Node, ScriptKind, SyntaxKind } from "ts-morph"
 import { z } from "zod"
+
+function isInClassNameContext(node: Node): boolean {
+  let current = node.getParent()
+  while (current) {
+    const kind = current.getKind()
+    if (kind === SyntaxKind.JsxAttribute) {
+      const nameNode = current.getFirstChildByKind(SyntaxKind.Identifier)
+      if (nameNode?.getText() === "className") {
+        return true
+      }
+    }
+    if (kind === SyntaxKind.CallExpression) {
+      const callee = current.getChildAtIndex(0)
+      if (
+        callee?.getKind() === SyntaxKind.Identifier &&
+        ["cn", "clsx", "cva"].includes(callee.getText())
+      ) {
+        return true
+      }
+    }
+    current = current.getParent()
+  }
+  return false
+}
 
 export const transformCssVars: Transformer = async ({
   sourceFile,
@@ -31,6 +55,7 @@ export const transformCssVars: Transformer = async ({
   //   }
   // }
   sourceFile.getDescendantsOfKind(SyntaxKind.StringLiteral).forEach((node) => {
+    if (!isInClassNameContext(node)) return
     const raw = node.getLiteralText()
     const mapped = applyColorMapping(raw, baseColor.inlineColors).trim()
     if (mapped !== raw) {

--- a/packages/shadcn/test/utils/transform-css-vars.test.ts
+++ b/packages/shadcn/test/utils/transform-css-vars.test.ts
@@ -3,6 +3,33 @@ import { expect, test } from "vitest"
 import { transform } from "../../src/utils/transformers"
 import stone from "../fixtures/colors/stone.json"
 
+test("transform css vars preserves non-className strings", async () => {
+  const result = await transform({
+    filename: "test.ts",
+    raw: `import * as React from "react"
+export function Foo({ items }: { items: string[] }) {
+	return <div className="bg-background text-primary-foreground">{items.join(' ')}</div>
+}`,
+    config: {
+      tsx: true,
+      tailwind: {
+        baseColor: "stone",
+        cssVariables: false,
+      },
+      aliases: {
+        components: "@/components",
+        utils: "@/lib/utils",
+      },
+    },
+    baseColor: stone,
+  })
+  // Non-className strings like join(' ') should be preserved.
+  expect(result).toContain("join(' ')")
+  // className strings should still be transformed.
+  expect(result).not.toContain("bg-background")
+  expect(result).toContain("bg-white")
+})
+
 test("transform css vars", async () => {
   expect(
     await transform({


### PR DESCRIPTION
Fixes #9972

## Problem

`transformCssVars` walks ALL `StringLiteral` AST nodes and applies `applyColorMapping()` when `tailwind.cssVariables` is `false`. Since `applyColorMapping()` splits on spaces, deduplicates, and trims, a single space like in `join(' ')` becomes an empty string `join('')`.

## Fix

Added an `isInClassNameContext()` guard that walks up the AST from each `StringLiteral` to check if it's inside:
1. A `className` JSX attribute, or
2. A `cn()`/`clsx()`/`cva()` call expression

Only applies `applyColorMapping` when the guard returns true. Non-className strings like `join(' ')` are left untouched.

## Test Plan

- Added test case with a component containing `join(' ')` alongside className attributes with `cssVariables: false`
- Verified className strings still get color-mapped correctly
- Verified non-className strings are preserved unchanged
- All existing tests pass (1228/1228)