### PR TITLE
fix: send Accept header for registry fetches

### DIFF
--- a/packages/shadcn/src/registry/fetcher.test.ts
+++ b/packages/shadcn/src/registry/fetcher.test.ts
@@ -75,6 +75,27 @@ describe("fetchRegistry", () => {
     })
   })
 
+  it("should send Accept: application/json when fetching external URLs", async () => {
+    server.use(
+      http.get("https://external.com/accept.json", ({ request }) => {
+        expect(request.headers.get("accept")).toBe("application/json")
+
+        return HttpResponse.json({
+          name: "accept",
+          type: "registry:ui",
+        })
+      })
+    )
+
+    const result = await fetchRegistry(["https://external.com/accept.json"])
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      name: "accept",
+      type: "registry:ui",
+    })
+  })
+
   it("should use cache when enabled", async () => {
     // First fetch - should hit the server
     const result1 = await fetchRegistry(["test.json"], { useCache: true })

--- a/packages/shadcn/src/registry/fetcher.ts
+++ b/packages/shadcn/src/registry/fetcher.ts
@@ -54,6 +54,7 @@ export async function fetchRegistry(
           const response = await fetch(url, {
             agent,
             headers: {
+              accept: "application/json",
               ...headers,
             },
           })


### PR DESCRIPTION
## Summary
- send `Accept: application/json` for remote registry fetches
- keep existing registry auth headers intact
- add a regression test covering direct external registry URLs

## Testing
- `pnpm --filter shadcn exec vitest run src/registry/fetcher.test.ts`

Fixes #10164