### PR TITLE
fix: pie chart custom label dark mode support

### DIFF
--- a/apps/v4/registry/new-york-v4/charts/chart-pie-label-custom.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-pie-label-custom.tsx
@@ -83,7 +83,7 @@ export function ChartPieLabelCustom() {
                     y={props.y}
                     textAnchor={props.textAnchor}
                     dominantBaseline={props.dominantBaseline}
-                    fill="var(--foreground)"
+                    className="fill-foreground"
                   >
                     {payload.visitors}
                   </text>


### PR DESCRIPTION
## What

Fixed the custom label in `chart-pie-label-custom` not being visible in dark mode.

## Why

The `<text>` element used `fill="var(--foreground)"` as an SVG attribute, which doesn't respond to dark mode theme changes. In dark mode, the label text remains dark-colored against the dark background, making it invisible.

## How

Replaced `fill="var(--foreground)"` with `className="fill-foreground"` (Tailwind utility class), which is the established pattern used by other chart label examples:
- `chart-bar-label.tsx`
- `chart-bar-label-custom.tsx`
- `chart-line-label.tsx`
- `chart-line-label-custom.tsx`

## Testing

- Verified the label renders correctly in both light and dark mode
- Consistent with the approach used across all other chart label examples

Closes #9703