### PR TITLE
fix(chart): add margins to radar chart examples to prevent label cutoff

### DIFF
--- a/apps/v4/registry/new-york-v4/charts/chart-radar-default.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-radar-default.tsx
@@ -50,7 +50,15 @@ export function ChartRadarDefault() {
           config={chartConfig}
           className="mx-auto aspect-square max-h-[250px]"
         >
-          <RadarChart data={chartData}>
+          <RadarChart
+            data={chartData}
+            margin={{
+              top: 10,
+              right: 10,
+              bottom: 10,
+              left: 10,
+            }}
+          >
             <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
             <PolarAngleAxis dataKey="month" />
             <PolarGrid />

--- a/apps/v4/registry/new-york-v4/charts/chart-radar-dots.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-radar-dots.tsx
@@ -50,7 +50,15 @@ export function ChartRadarDots() {
           config={chartConfig}
           className="mx-auto aspect-square max-h-[250px]"
         >
-          <RadarChart data={chartData}>
+          <RadarChart
+            data={chartData}
+            margin={{
+              top: 10,
+              right: 10,
+              bottom: 10,
+              left: 10,
+            }}
+          >
             <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
             <PolarAngleAxis dataKey="month" />
             <PolarGrid />

--- a/apps/v4/registry/new-york-v4/charts/chart-radar-grid-circle-fill.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-radar-grid-circle-fill.tsx
@@ -50,7 +50,15 @@ export function ChartRadarGridCircleFill() {
           config={chartConfig}
           className="mx-auto aspect-square max-h-[250px]"
         >
-          <RadarChart data={chartData}>
+          <RadarChart
+            data={chartData}
+            margin={{
+              top: 10,
+              right: 10,
+              bottom: 10,
+              left: 10,
+            }}
+          >
             <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
             <PolarGrid
               className="fill-(--color-desktop) opacity-20"

--- a/apps/v4/registry/new-york-v4/charts/chart-radar-grid-circle-no-lines.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-radar-grid-circle-no-lines.tsx
@@ -50,7 +50,15 @@ export function ChartRadarGridCircleNoLines() {
           config={chartConfig}
           className="mx-auto aspect-square max-h-[250px]"
         >
-          <RadarChart data={chartData}>
+          <RadarChart
+            data={chartData}
+            margin={{
+              top: 10,
+              right: 10,
+              bottom: 10,
+              left: 10,
+            }}
+          >
             <ChartTooltip
               cursor={false}
               content={<ChartTooltipContent hideLabel />}

--- a/apps/v4/registry/new-york-v4/charts/chart-radar-grid-circle.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-radar-grid-circle.tsx
@@ -50,7 +50,15 @@ export function ChartRadarGridCircle() {
           config={chartConfig}
           className="mx-auto aspect-square max-h-[250px]"
         >
-          <RadarChart data={chartData}>
+          <RadarChart
+            data={chartData}
+            margin={{
+              top: 10,
+              right: 10,
+              bottom: 10,
+              left: 10,
+            }}
+          >
             <ChartTooltip
               cursor={false}
               content={<ChartTooltipContent hideLabel />}

--- a/apps/v4/registry/new-york-v4/charts/chart-radar-grid-custom.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-radar-grid-custom.tsx
@@ -50,7 +50,15 @@ export function ChartRadarGridCustom() {
           config={chartConfig}
           className="mx-auto aspect-square max-h-[250px]"
         >
-          <RadarChart data={chartData}>
+          <RadarChart
+            data={chartData}
+            margin={{
+              top: 10,
+              right: 10,
+              bottom: 10,
+              left: 10,
+            }}
+          >
             <ChartTooltip
               cursor={false}
               content={<ChartTooltipContent hideLabel />}

--- a/apps/v4/registry/new-york-v4/charts/chart-radar-grid-fill.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-radar-grid-fill.tsx
@@ -50,7 +50,15 @@ export function ChartRadarGridFill() {
           config={chartConfig}
           className="mx-auto aspect-square max-h-[250px]"
         >
-          <RadarChart data={chartData}>
+          <RadarChart
+            data={chartData}
+            margin={{
+              top: 10,
+              right: 10,
+              bottom: 10,
+              left: 10,
+            }}
+          >
             <ChartTooltip
               cursor={false}
               content={<ChartTooltipContent hideLabel />}

--- a/apps/v4/registry/new-york-v4/charts/chart-radar-grid-none.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-radar-grid-none.tsx
@@ -50,7 +50,15 @@ export function ChartRadarGridNone() {
           config={chartConfig}
           className="mx-auto aspect-square max-h-[250px]"
         >
-          <RadarChart data={chartData}>
+          <RadarChart
+            data={chartData}
+            margin={{
+              top: 10,
+              right: 10,
+              bottom: 10,
+              left: 10,
+            }}
+          >
             <ChartTooltip
               cursor={false}
               content={<ChartTooltipContent hideLabel />}

--- a/apps/v4/registry/new-york-v4/charts/chart-radar-lines-only.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-radar-lines-only.tsx
@@ -54,7 +54,15 @@ export function ChartRadarLinesOnly() {
           config={chartConfig}
           className="mx-auto aspect-square max-h-[250px]"
         >
-          <RadarChart data={chartData}>
+          <RadarChart
+            data={chartData}
+            margin={{
+              top: 10,
+              right: 10,
+              bottom: 10,
+              left: 10,
+            }}
+          >
             <ChartTooltip
               cursor={false}
               content={<ChartTooltipContent indicator="line" />}

--- a/apps/v4/registry/new-york-v4/charts/chart-radar-multiple.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-radar-multiple.tsx
@@ -54,7 +54,15 @@ export function ChartRadarMultiple() {
           config={chartConfig}
           className="mx-auto aspect-square max-h-[250px]"
         >
-          <RadarChart data={chartData}>
+          <RadarChart
+            data={chartData}
+            margin={{
+              top: 10,
+              right: 10,
+              bottom: 10,
+              left: 10,
+            }}
+          >
             <ChartTooltip
               cursor={false}
               content={<ChartTooltipContent indicator="line" />}

--- a/apps/v4/registry/new-york-v4/charts/chart-radar-radius.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-radar-radius.tsx
@@ -60,7 +60,15 @@ export function ChartRadarRadius() {
           config={chartConfig}
           className="mx-auto aspect-square max-h-[250px]"
         >
-          <RadarChart data={chartData}>
+          <RadarChart
+            data={chartData}
+            margin={{
+              top: 10,
+              right: 10,
+              bottom: 10,
+              left: 10,
+            }}
+          >
             <ChartTooltip
               cursor={false}
               content={


### PR DESCRIPTION
## What

Added explicit margins to all radar chart examples that were missing them, preventing axis label text from being clipped.

## Why

All radar chart examples (except `chart-radar-icons`, `chart-radar-legend`, and `chart-radar-label-custom` which already had explicit margins) were using Recharts' default minimal margins. This caused PolarAngleAxis labels — especially longer month names like "February" — to be cut off at the container edges despite ample available space.

## How

Added `margin={{ top: 10, right: 10, bottom: 10, left: 10 }}` to the `<RadarChart>` component in 11 example files, matching the pattern already used in `chart-radar-label-custom.tsx`.

**Files changed (11):**
- `chart-radar-default.tsx`
- `chart-radar-dots.tsx`
- `chart-radar-multiple.tsx`
- `chart-radar-grid-none.tsx`
- `chart-radar-grid-fill.tsx`
- `chart-radar-radius.tsx`
- `chart-radar-lines-only.tsx`
- `chart-radar-grid-circle.tsx`
- `chart-radar-grid-circle-fill.tsx`
- `chart-radar-grid-circle-no-lines.tsx`
- `chart-radar-grid-custom.tsx`

## Testing

- Verified labels are fully visible in all radar chart variants
- The 3 files that already had explicit margins were left untouched

Closes #9948