### PR TITLE
fix(carousel): add vertical keyboard nav and aria-live announcements

### DIFF
--- a/apps/v4/registry/bases/base/ui/carousel.tsx
+++ b/apps/v4/registry/bases/base/ui/carousel.tsx
@@ -49,6 +49,7 @@ function Carousel({
   plugins,
   className,
   children,
+  "aria-label": ariaLabel,
   ...props
 }: React.ComponentProps<"div"> & CarouselProps) {
   const [carouselRef, api] = useEmblaCarousel(
@@ -60,11 +61,15 @@ function Carousel({
   )
   const [canScrollPrev, setCanScrollPrev] = React.useState(false)
   const [canScrollNext, setCanScrollNext] = React.useState(false)
+  const [currentSlide, setCurrentSlide] = React.useState(0)
+  const [slideCount, setSlideCount] = React.useState(0)
 
   const onSelect = React.useCallback((api: CarouselApi) => {
     if (!api) return
     setCanScrollPrev(api.canScrollPrev())
     setCanScrollNext(api.canScrollNext())
+    setCurrentSlide(api.selectedScrollSnap() + 1)
+    setSlideCount(api.scrollSnapList().length)
   }, [])
 
   const scrollPrev = React.useCallback(() => {
@@ -77,15 +82,18 @@ function Carousel({
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === "ArrowLeft") {
+      const prevKey = orientation === "vertical" ? "ArrowUp" : "ArrowLeft"
+      const nextKey = orientation === "vertical" ? "ArrowDown" : "ArrowRight"
+
+      if (event.key === prevKey) {
         event.preventDefault()
         scrollPrev()
-      } else if (event.key === "ArrowRight") {
+      } else if (event.key === nextKey) {
         event.preventDefault()
         scrollNext()
       }
     },
-    [scrollPrev, scrollNext]
+    [orientation, scrollPrev, scrollNext]
   )
 
   React.useEffect(() => {
@@ -100,6 +108,7 @@ function Carousel({
     api.on("select", onSelect)
 
     return () => {
+      api?.off("reInit", onSelect)
       api?.off("select", onSelect)
     }
   }, [api, onSelect])
@@ -123,10 +132,20 @@ function Carousel({
         className={cn("relative", className)}
         role="region"
         aria-roledescription="carousel"
+        aria-label={ariaLabel}
         data-slot="carousel"
         {...props}
       >
         {children}
+        <span
+          aria-live="polite"
+          aria-atomic="true"
+          className="sr-only"
+        >
+          {slideCount > 0
+            ? `Slide ${currentSlide} of ${slideCount}`
+            : ""}
+        </span>
       </div>
     </CarouselContext.Provider>
   )

--- a/apps/v4/registry/bases/radix/ui/carousel.tsx
+++ b/apps/v4/registry/bases/radix/ui/carousel.tsx
@@ -49,6 +49,7 @@ function Carousel({
   plugins,
   className,
   children,
+  "aria-label": ariaLabel,
   ...props
 }: React.ComponentProps<"div"> & CarouselProps) {
   const [carouselRef, api] = useEmblaCarousel(
@@ -60,11 +61,15 @@ function Carousel({
   )
   const [canScrollPrev, setCanScrollPrev] = React.useState(false)
   const [canScrollNext, setCanScrollNext] = React.useState(false)
+  const [currentSlide, setCurrentSlide] = React.useState(0)
+  const [slideCount, setSlideCount] = React.useState(0)
 
   const onSelect = React.useCallback((api: CarouselApi) => {
     if (!api) return
     setCanScrollPrev(api.canScrollPrev())
     setCanScrollNext(api.canScrollNext())
+    setCurrentSlide(api.selectedScrollSnap() + 1)
+    setSlideCount(api.scrollSnapList().length)
   }, [])
 
   const scrollPrev = React.useCallback(() => {
@@ -77,15 +82,18 @@ function Carousel({
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === "ArrowLeft") {
+      const prevKey = orientation === "vertical" ? "ArrowUp" : "ArrowLeft"
+      const nextKey = orientation === "vertical" ? "ArrowDown" : "ArrowRight"
+
+      if (event.key === prevKey) {
         event.preventDefault()
         scrollPrev()
-      } else if (event.key === "ArrowRight") {
+      } else if (event.key === nextKey) {
         event.preventDefault()
         scrollNext()
       }
     },
-    [scrollPrev, scrollNext]
+    [orientation, scrollPrev, scrollNext]
   )
 
   React.useEffect(() => {
@@ -100,6 +108,7 @@ function Carousel({
     api.on("select", onSelect)
 
     return () => {
+      api?.off("reInit", onSelect)
       api?.off("select", onSelect)
     }
   }, [api, onSelect])
@@ -123,10 +132,20 @@ function Carousel({
         className={cn("relative", className)}
         role="region"
         aria-roledescription="carousel"
+        aria-label={ariaLabel}
         data-slot="carousel"
         {...props}
       >
         {children}
+        <span
+          aria-live="polite"
+          aria-atomic="true"
+          className="sr-only"
+        >
+          {slideCount > 0
+            ? `Slide ${currentSlide} of ${slideCount}`
+            : ""}
+        </span>
       </div>
     </CarouselContext.Provider>
   )

--- a/apps/v4/registry/new-york-v4/ui/carousel.tsx
+++ b/apps/v4/registry/new-york-v4/ui/carousel.tsx
@@ -49,6 +49,7 @@ function Carousel({
   plugins,
   className,
   children,
+  "aria-label": ariaLabel,
   ...props
 }: React.ComponentProps<"div"> & CarouselProps) {
   const [carouselRef, api] = useEmblaCarousel(
@@ -60,11 +61,15 @@ function Carousel({
   )
   const [canScrollPrev, setCanScrollPrev] = React.useState(false)
   const [canScrollNext, setCanScrollNext] = React.useState(false)
+  const [currentSlide, setCurrentSlide] = React.useState(0)
+  const [slideCount, setSlideCount] = React.useState(0)
 
   const onSelect = React.useCallback((api: CarouselApi) => {
     if (!api) return
     setCanScrollPrev(api.canScrollPrev())
     setCanScrollNext(api.canScrollNext())
+    setCurrentSlide(api.selectedScrollSnap() + 1)
+    setSlideCount(api.scrollSnapList().length)
   }, [])
 
   const scrollPrev = React.useCallback(() => {
@@ -77,15 +82,18 @@ function Carousel({
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === "ArrowLeft") {
+      const prevKey = orientation === "vertical" ? "ArrowUp" : "ArrowLeft"
+      const nextKey = orientation === "vertical" ? "ArrowDown" : "ArrowRight"
+
+      if (event.key === prevKey) {
         event.preventDefault()
         scrollPrev()
-      } else if (event.key === "ArrowRight") {
+      } else if (event.key === nextKey) {
         event.preventDefault()
         scrollNext()
       }
     },
-    [scrollPrev, scrollNext]
+    [orientation, scrollPrev, scrollNext]
   )
 
   React.useEffect(() => {
@@ -100,6 +108,7 @@ function Carousel({
     api.on("select", onSelect)
 
     return () => {
+      api?.off("reInit", onSelect)
       api?.off("select", onSelect)
     }
   }, [api, onSelect])
@@ -123,10 +132,20 @@ function Carousel({
         className={cn("relative", className)}
         role="region"
         aria-roledescription="carousel"
+        aria-label={ariaLabel}
         data-slot="carousel"
         {...props}
       >
         {children}
+        <span
+          aria-live="polite"
+          aria-atomic="true"
+          className="sr-only"
+        >
+          {slideCount > 0
+            ? `Slide ${currentSlide} of ${slideCount}`
+            : ""}
+        </span>
       </div>
     </CarouselContext.Provider>
   )


### PR DESCRIPTION
## What

Two accessibility improvements for the Carousel component:

1. **Vertical keyboard navigation** — ArrowUp/ArrowDown now work when `orientation="vertical"`
2. **Screen reader announcements** — Added `aria-live` region that announces current slide position

## Why

### Keyboard navigation (#10219)
The `handleKeyDown` handler only listened for `ArrowLeft`/`ArrowRight`, making vertical carousels inaccessible via keyboard. Per [WAI-ARIA Carousel Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/carousel/), directional keys should match the carousel orientation.

### Screen reader support (#10220)
The carousel `role="region"` had no mechanism to announce slide changes. Screen reader users had no way to know which slide they were on or how many slides existed.

## How

### Keyboard fix
Replaced hardcoded arrow key strings with orientation-aware variables:
```ts
const prevKey = orientation === "vertical" ? "ArrowUp" : "ArrowLeft"
const nextKey = orientation === "vertical" ? "ArrowDown" : "ArrowRight"
```
Added `orientation` to the `useCallback` dependency array.

### Aria-live region
- Added `currentSlide` and `slideCount` state, updated in `onSelect`
- Added a visually-hidden `<span aria-live="polite" aria-atomic="true">` that announces "Slide X of Y"
- Added optional `aria-label` prop forwarded to the `role="region"` container
- Fixed missing `api?.off("reInit", onSelect)` in useEffect cleanup

### Files changed (3)
All three carousel variants updated consistently:
- `apps/v4/registry/bases/base/ui/carousel.tsx`
- `apps/v4/registry/bases/radix/ui/carousel.tsx`
- `apps/v4/registry/new-york-v4/ui/carousel.tsx`

## Testing

- Verified ArrowUp/ArrowDown navigates vertical carousels
- Verified ArrowLeft/ArrowRight still works for horizontal (default)
- Verified aria-live region updates on slide change
- No breaking changes — `aria-label` is optional, keyboard behavior is backward-compatible

Closes #10219
Closes #10220