### PR TITLE
fix: Carousel keyboard navigation for vertical orientation

### DIFF
--- a/apps/v4/registry/bases/base/ui/carousel.tsx
+++ b/apps/v4/registry/bases/base/ui/carousel.tsx
@@ -77,15 +77,17 @@ function Carousel({
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === "ArrowLeft") {
+      const prevKey = orientation === "vertical" ? "ArrowUp" : "ArrowLeft"
+      const nextKey = orientation === "vertical" ? "ArrowDown" : "ArrowRight"
+      if (event.key === prevKey) {
         event.preventDefault()
         scrollPrev()
-      } else if (event.key === "ArrowRight") {
+      } else if (event.key === nextKey) {
         event.preventDefault()
         scrollNext()
       }
     },
-    [scrollPrev, scrollNext]
+    [scrollPrev, scrollNext, orientation]
   )
 
   React.useEffect(() => {

--- a/apps/v4/registry/bases/radix/ui/carousel.tsx
+++ b/apps/v4/registry/bases/radix/ui/carousel.tsx
@@ -77,15 +77,17 @@ function Carousel({
 
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === "ArrowLeft") {
+      const prevKey = orientation === "vertical" ? "ArrowUp" : "ArrowLeft"
+      const nextKey = orientation === "vertical" ? "ArrowDown" : "ArrowRight"
+      if (event.key === prevKey) {
         event.preventDefault()
         scrollPrev()
-      } else if (event.key === "ArrowRight") {
+      } else if (event.key === nextKey) {
         event.preventDefault()
         scrollNext()
       }
     },
-    [scrollPrev, scrollNext]
+    [scrollPrev, scrollNext, orientation]
   )
 
   React.useEffect(() => {


### PR DESCRIPTION
## Bug

Fixes #10219

The Carousel component's `handleKeyDown` callback only handles `ArrowLeft` and `ArrowRight` keys, regardless of the carousel's orientation. When orientation is set to `"vertical"`, pressing `ArrowUp`/`ArrowDown` does nothing, and `ArrowLeft`/`ArrowRight` still triggers prev/next navigation, which is incorrect for a vertical layout.

## Fix

Updated `handleKeyDown` to check the `orientation` prop and select the appropriate key bindings:
- **Horizontal** (default): `ArrowLeft` for previous, `ArrowRight` for next
- **Vertical**: `ArrowUp` for previous, `ArrowDown` for next

Added `orientation` to the `useCallback` dependency array so the handler updates when orientation changes.

## Files changed

- `apps/v4/registry/bases/base/ui/carousel.tsx`
- `apps/v4/registry/bases/radix/ui/carousel.tsx`

Both the base and radix implementations have been updated with the same fix.