### PR TITLE
fix(slider): add thumbLabels prop for multi-thumb accessibility

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/slider.tsx
+++ b/apps/v4/registry/new-york-v4/ui/slider.tsx
@@ -5,14 +5,19 @@ import * as SliderPrimitive from "@radix-ui/react-slider"
 
 import { cn } from "@/lib/utils"
 
+interface SliderProps extends React.ComponentProps<typeof SliderPrimitive.Root> {
+  thumbLabels?: string[]
+}
+
 function Slider({
   className,
   defaultValue,
   value,
   min = 0,
   max = 100,
+  thumbLabels,
   ...props
-}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+}: SliderProps) {
   const _values = React.useMemo(
     () =>
       Array.isArray(value)
@@ -53,6 +58,7 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
+          aria-label={thumbLabels?.[index]}
           className="border-primary bg-background ring-ring/20 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
         />
       ))}


### PR DESCRIPTION
## Summary
Add optional `thumbLabels` prop to the Slider component for accessible multi-thumb sliders.

## Problem
Multi-thumb sliders (e.g., price range filters) have no way to distinguish thumbs for screen readers. This violates WAI-ARIA requirements.

## Solution
- Added optional `thumbLabels?: string[]` prop
- Each thumb receives `aria-label={thumbLabels?.[index]}`
- Fully backward compatible

## Usage
```tsx
// Accessible range slider
<Slider defaultValue={[25, 75]} thumbLabels={["Minimum price", "Maximum price"]} />

// Regular slider - unchanged
<Slider defaultValue={[50]} />
```

Fixes #10221