### PR TITLE
fix: Add Base UI compat selector to data-selected variant

### DIFF
--- a/packages/shadcn/src/tailwind.css
+++ b/packages/shadcn/src/tailwind.css
@@ -54,7 +54,8 @@
 }
 
 @custom-variant data-selected {
-  &:where([data-selected="true"]) {
+  &:where([data-selected="true"]),
+  &:where([data-selected]:not([data-selected="false"])) {
     @slot;
   }
 }


### PR DESCRIPTION
The `data-selected` variant only matches `[data-selected="true"]`. Base UI sets `data-selected=""` (presence pattern), so the variant doesn't work with Base UI components like `SelectItem` and `ComboboxItem`.

Adds the same `[data-selected]:not([data-selected="false"])` fallback already used by `data-disabled`, `data-active`, `data-open`, `data-checked`, and `data-closed`.