### PR TITLE
fix(shadcn): remap Geist font variables in existing next apps

### DIFF
--- a/packages/shadcn/src/utils/updaters/update-fonts.test.ts
+++ b/packages/shadcn/src/utils/updaters/update-fonts.test.ts
@@ -1,6 +1,13 @@
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises"
+import os from "os"
+import path from "path"
 import { describe, expect, it, vi } from "vitest"
 
-import { massageTreeForFonts, transformLayoutFonts } from "./update-fonts"
+import {
+  findLayoutFile,
+  massageTreeForFonts,
+  transformLayoutFonts,
+} from "./update-fonts"
 
 const mockConfig = {
   style: "new-york",
@@ -30,6 +37,77 @@ const mockConfig = {
     ui: "/test/components/ui",
   },
 } as any
+
+describe("findLayoutFile", () => {
+  it("should find app/layout.js in a javascript next app", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "find-layout-file-"))
+
+    try {
+      await mkdir(path.join(cwd, "app"), { recursive: true })
+      await writeFile(
+        path.join(cwd, "app/layout.js"),
+        "export default function RootLayout({ children }) { return <html>{children}</html> }"
+      )
+
+      const result = await findLayoutFile(
+        { resolvedPaths: { cwd } } as any,
+        { isSrcDir: false, isTsx: false } as any
+      )
+
+      expect(result).toBe(path.join(cwd, "app/layout.js"))
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it("should prefer src/app/layout.js in a javascript src project", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "find-layout-file-"))
+
+    try {
+      await mkdir(path.join(cwd, "src/app"), { recursive: true })
+      await mkdir(path.join(cwd, "app"), { recursive: true })
+
+      await writeFile(
+        path.join(cwd, "src/app/layout.js"),
+        "export default function RootLayout({ children }) { return <html>{children}</html> }"
+      )
+      await writeFile(
+        path.join(cwd, "app/layout.js"),
+        "export default function LegacyLayout({ children }) { return <html>{children}</html> }"
+      )
+
+      const result = await findLayoutFile(
+        { resolvedPaths: { cwd } } as any,
+        { isSrcDir: true, isTsx: false } as any
+      )
+
+      expect(result).toBe(path.join(cwd, "src/app/layout.js"))
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it("should fall back to layout.jsx in a javascript next app", async () => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "find-layout-file-"))
+
+    try {
+      await mkdir(path.join(cwd, "app"), { recursive: true })
+      await writeFile(
+        path.join(cwd, "app/layout.jsx"),
+        "export default function RootLayout({ children }) { return <html>{children}</html> }"
+      )
+
+      const result = await findLayoutFile(
+        { resolvedPaths: { cwd } } as any,
+        { isSrcDir: false, isTsx: false } as any
+      )
+
+      expect(result).toBe(path.join(cwd, "app/layout.jsx"))
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+})
 
 describe("transformLayoutFonts", () => {
   it("should add a single Google font to empty layout", async () => {
@@ -565,7 +643,7 @@ export default function RootLayout({
     `)
   })
 
-  it("should skip Geist font if already imported (create-next-app scenario)", async () => {
+  it("should remap create-next-app Geist variable to root font token", async () => {
     // This simulates a fresh create-next-app project with Geist already set up.
     const input = `
 import type { Metadata } from "next";
@@ -619,8 +697,17 @@ export default function RootLayout({
 
     const result = await transformLayoutFonts(input, fonts, mockConfig)
 
-    // Geist is already imported, so the layout should remain unchanged.
-    expect(result).toBe(input)
+    expect(result).toContain(
+      `const geist = Geist({subsets:['latin'],variable:'--font-sans'})`
+    )
+    expect(result).toContain(`import { cn } from "@/lib/utils";`)
+    expect(result).toContain(
+      `<html lang="en" className={cn("font-sans", geist.variable)}>`
+    )
+    expect(result).toContain(
+      "${geist.variable} ${geistMono.variable} antialiased"
+    )
+    expect(result).not.toContain("--font-geist-sans")
   })
 
   it("should add to existing next/font/google import", async () => {

--- a/packages/shadcn/src/utils/updaters/update-fonts.ts
+++ b/packages/shadcn/src/utils/updaters/update-fonts.ts
@@ -169,12 +169,13 @@ export async function findLayoutFile(
 ): Promise<string | null> {
   const cwd = config.resolvedPaths.cwd
   const isSrcDir = projectInfo.isSrcDir
-  const isTsx = projectInfo.isTsx
-  const ext = isTsx ? "tsx" : "jsx"
-
+  const possibleExtensions = projectInfo.isTsx ? ["tsx"] : ["js", "jsx"]
   const possiblePaths = isSrcDir
-    ? [`src/app/layout.${ext}`, `app/layout.${ext}`]
-    : [`app/layout.${ext}`]
+    ? possibleExtensions.flatMap((ext) => [
+        `src/app/layout.${ext}`,
+        `app/layout.${ext}`,
+      ])
+    : possibleExtensions.map((ext) => `app/layout.${ext}`)
 
   for (const relativePath of possiblePaths) {
     const fullPath = path.join(cwd, relativePath)
@@ -218,14 +219,10 @@ export async function transformLayoutFonts(
       const moduleSpecifier = decl.getModuleSpecifierValue()
       return moduleSpecifier === "next/font/google"
     })
-    let hasExistingImport = false
 
     if (existingImport) {
       const namedImports = existingImport.getNamedImports()
-      hasExistingImport = namedImports.some(
-        (imp) => imp.getName() === importName
-      )
-      if (!hasExistingImport) {
+      if (!namedImports.some((imp) => imp.getName() === importName)) {
         existingImport.addNamedImport(importName)
       }
     } else {
@@ -242,20 +239,25 @@ export async function transformLayoutFonts(
     const fontOptions = buildFontOptions(font)
 
     // Check if variable declaration already exists with same variable CSS property.
-    const existingVarDecl = findFontVariableDeclaration(
+    let existingVarDecl = findFontVariableDeclaration(
       sourceFile,
       font.font.variable
     )
-    let resolvedVarName = varName
 
-    if (
-      hasExistingImport &&
-      !existingVarDecl &&
-      isRootFontVariable(font.font.variable) &&
-      !hasHeadingFontDeclaration(sourceFile, importName)
-    ) {
-      continue
+    // For root variables, also match existing declarations by import name.
+    // This allows us to remap create-next-app defaults like --font-geist-sans
+    // to --font-sans instead of silently skipping updates.
+    if (!existingVarDecl && isRootFontVariable(font.font.variable)) {
+      existingVarDecl = findFontVariableDeclarationByImport(
+        sourceFile,
+        importName,
+        {
+          excludeVariables: ["--font-heading"],
+        }
+      )
     }
+
+    let resolvedVarName = varName
 
     if (existingVarDecl) {
       // Replace the initializer of the existing declaration.
@@ -407,10 +409,14 @@ function findFontVariableDeclaration(
   return null
 }
 
-function hasHeadingFontDeclaration(
+function findFontVariableDeclarationByImport(
   sourceFile: ReturnType<Project["createSourceFile"]>,
-  importName: string
+  importName: string,
+  options?: {
+    excludeVariables?: string[]
+  }
 ) {
+  const excludedVariables = new Set(options?.excludeVariables ?? [])
   const variableStatements = sourceFile.getVariableStatements()
 
   for (const statement of variableStatements) {
@@ -426,14 +432,21 @@ function hasHeadingFontDeclaration(
       const args = callExpr.getArguments()
       if (!args.length) continue
 
-      const argText = args[0].getText()
-      if (argText.includes(`variable:`) && argText.includes("--font-heading")) {
-        return true
+      const variable = getVariableOption(args[0].getText())
+      if (variable && excludedVariables.has(variable)) {
+        continue
       }
+
+      return declaration
     }
   }
 
-  return false
+  return null
+}
+
+function getVariableOption(argText: string) {
+  const match = argText.match(/variable\s*:\s*['"]([^'"]+)['"]/)
+  return match?.[1] ?? null
 }
 
 function findInsertPosition(

--- a/packages/tests/src/tests/init.test.ts
+++ b/packages/tests/src/tests/init.test.ts
@@ -193,6 +193,40 @@ describe("shadcn init - custom style", async () => {
           },
         },
       },
+      {
+        name: "font-geist",
+        type: "registry:font",
+        font: {
+          family: "'Geist Variable', sans-serif",
+          provider: "google",
+          import: "Geist",
+          variable: "--font-sans",
+          subsets: ["latin"],
+          dependency: "@fontsource-variable/geist",
+        },
+      },
+      {
+        name: "font-geist-mono",
+        type: "registry:font",
+        font: {
+          family: "'Geist Mono Variable', monospace",
+          provider: "google",
+          import: "Geist_Mono",
+          variable: "--font-mono",
+          subsets: ["latin"],
+          dependency: "@fontsource-variable/geist-mono",
+        },
+      },
+      {
+        name: "style-font-remap",
+        type: "registry:style",
+        registryDependencies: [
+          "http://localhost:4445/r/font-geist.json",
+          "http://localhost:4445/r/font-geist-mono.json",
+        ],
+        cssVars: {},
+        files: [],
+      },
     ],
     {
       port: 4445,
@@ -205,6 +239,75 @@ describe("shadcn init - custom style", async () => {
 
   afterAll(async () => {
     await customRegistry.stop()
+  })
+
+  it("should remap existing Geist variables when a style installs root font tokens", async () => {
+    const fixturePath = await createFixtureTestDirectory("next-app")
+
+    await Promise.all([
+      fs.writeFile(
+        path.join(fixturePath, "app/layout.tsx"),
+        `import { Geist, Geist_Mono } from "next/font/google"
+import "./globals.css"
+
+const geistSans = Geist({ subsets: ["latin"], variable: "--font-geist-sans" })
+const geistMono = Geist_Mono({ subsets: ["latin"], variable: "--font-geist-mono" })
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en" className={\`\${geistSans.variable} \${geistMono.variable}\`}>
+      <body>{children}</body>
+    </html>
+  )
+}
+`,
+        "utf-8"
+      ),
+      fs.writeFile(
+        path.join(fixturePath, "app/globals.css"),
+        `@import "tailwindcss";
+
+@theme inline {
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
+}
+`,
+        "utf-8"
+      ),
+    ])
+
+    await npxShadcn(fixturePath, [
+      "init",
+      "http://localhost:4445/r/style-font-remap.json",
+    ])
+
+    const layoutContent = await fs.readFile(
+      path.join(fixturePath, "app/layout.tsx"),
+      "utf-8"
+    )
+    const cssContent = await fs.readFile(
+      path.join(fixturePath, "app/globals.css"),
+      "utf-8"
+    )
+
+    expect(layoutContent).toMatch(/variable:\s*["']--font-sans["']/)
+    expect(layoutContent).toContain(`font-sans`)
+    expect(layoutContent).not.toContain(`--font-geist-sans`)
+    expect(
+      cssHasProperties(cssContent, [
+        {
+          selector: "@theme inline",
+          properties: {
+            "--font-sans": "var(--font-sans)",
+            "--font-mono": "var(--font-mono)",
+          },
+        },
+      ])
+    ).toBe(true)
   })
 
   it("should init with style that extends shadcn", async () => {


### PR DESCRIPTION
## Summary

This fixes a font update edge case in `shadcn init` for existing Next.js apps that already use Geist font variables.

When the target app already uses `Geist` with variables such as `--font-geist-sans`, the font updater could leave the existing layout declaration unchanged while the installed registry font expects the root token `--font-sans`.

## Reproduction

1. Create a Next.js app that uses the App Router and `next/font/google` with Geist variables.
2. Run `shadcn init` in that existing project with a style or preset that installs root font tokens.
3. Observe that `globals.css` expects `--font-sans`, while the existing layout can still keep `--font-geist-sans`.

This reproduces with the current Geist-based Next.js setup and with Geist-based presets such as:

`npx shadcn@latest init --preset b1D0dxmF --base base --template next`

## Fix

- remap existing Geist declarations to the expected root font tokens instead of skipping them
- detect existing root font declarations by import name when needed
- support existing Next.js app router layout files in TypeScript and JavaScript projects
- keep the heading-font exclusion in place

## Testing

- `pnpm --filter shadcn build`
- `pnpm --filter shadcn test -- src/utils/updaters/update-fonts.test.ts`
- `pnpm --filter tests typecheck`

Also verified locally against fresh Next.js apps covering:
- TypeScript App Router
- JavaScript App Router
- `app/` and `src/app/`
- custom import alias