### PR TITLE
fix(registry): include all 33 card sub-components in preview block

### DIFF
--- a/apps/v4/registry/bases/base/blocks/_registry.ts
+++ b/apps/v4/registry/bases/base/blocks/_registry.ts
@@ -39,6 +39,138 @@ export const blocks: Registry["items"] = [
         path: "blocks/preview/index.tsx",
         type: "registry:block",
       },
+      {
+        path: "blocks/preview/cards/activate-agent-dialog.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/analytics-card.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/anomaly-alert.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/assign-issue.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/bar-chart-card.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/bar-visualizer.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/book-appointment.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/codespaces-card.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/contributions-activity.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/contributors.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/environment-variables.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/feedback-form.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/file-upload.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/github-profile.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/icon-preview-grid.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/invite-team.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/invoice.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/live-waveform.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/no-team-members.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/not-found.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/observability-card.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/pie-chart-card.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/report-bug.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/shipping-address.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/shortcuts.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/skeleton-loading.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/sleep-report.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/style-overview.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/typography-specimen.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/ui-elements.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/usage-card.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/visitors.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/weekly-fitness-summary.tsx",
+        type: "registry:component",
+      },
     ],
   },
   {

--- a/apps/v4/registry/bases/radix/blocks/_registry.ts
+++ b/apps/v4/registry/bases/radix/blocks/_registry.ts
@@ -38,6 +38,138 @@ export const blocks: Registry["items"] = [
         path: "blocks/preview/index.tsx",
         type: "registry:block",
       },
+      {
+        path: "blocks/preview/cards/activate-agent-dialog.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/analytics-card.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/anomaly-alert.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/assign-issue.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/bar-chart-card.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/bar-visualizer.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/book-appointment.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/codespaces-card.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/contributions-activity.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/contributors.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/environment-variables.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/feedback-form.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/file-upload.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/github-profile.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/icon-preview-grid.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/invite-team.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/invoice.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/live-waveform.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/no-team-members.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/not-found.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/observability-card.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/pie-chart-card.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/report-bug.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/shipping-address.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/shortcuts.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/skeleton-loading.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/sleep-report.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/style-overview.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/typography-specimen.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/ui-elements.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/usage-card.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/visitors.tsx",
+        type: "registry:component",
+      },
+      {
+        path: "blocks/preview/cards/weekly-fitness-summary.tsx",
+        type: "registry:component",
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Fixes #10284

## Problem

When running `npx shadcn add preview`, only `blocks/preview/index.tsx` was installed. The 33 card components under `blocks/preview/cards/` were missing from the registry `files` array, so all card imports in `index.tsx` fail immediately after install:

```
Cannot find module '@/components/blocks/preview/cards/analytics-card'
```

## Root Cause

The `preview` block definition in `_registry.ts` only listed `index.tsx` in the `files` array. The `cards/` directory has 33 sub-components that `index.tsx` imports but they were never included.

## Fix

Added all 33 card files as `registry:component` entries in the `files` array for both the `base` and `radix` registry variants.

**Files added:** activate-agent-dialog, analytics-card, anomaly-alert, assign-issue, bar-chart-card, bar-visualizer, book-appointment, codespaces-card, contributions-activity, contributors, environment-variables, feedback-form, file-upload, github-profile, icon-preview-grid, invite-team, invoice, live-waveform, no-team-members, not-found, observability-card, pie-chart-card, report-bug, shipping-address, shortcuts, skeleton-loading, sleep-report, style-overview, typography-specimen, ui-elements, usage-card, visitors, weekly-fitness-summary