### PR TITLE
fix: add base-ui keyword to match GitHub topic

### DIFF
--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -23,6 +23,7 @@
     "ui",
     "tailwind",
     "radix-ui",
+    "base-ui",
     "shadcn"
   ],
   "type": "module",


### PR DESCRIPTION
This is about having https://github.com/shadcn-ui/ui

<img width="253" height="449" alt="SCR-20260406-bkny" src="https://github.com/user-attachments/assets/a47d81ed-ce99-4c5b-a6a3-7026476faa23" />

synced with https://www.npmjs.com/package/shadcn#user-content-keywords

<img width="496" height="147" alt="SCR-20260406-bkws" src="https://github.com/user-attachments/assets/e20af44f-69c7-464f-9fa7-9647937cc185" />

I assume the two are meant to be kept in sync.