### PR TITLE
fix(calendar): add locale prop with fallback for formatMonthDropdown

### DIFF
--- a/apps/v4/content/docs/components/base/calendar.mdx
+++ b/apps/v4/content/docs/components/base/calendar.mdx
@@ -312,11 +312,11 @@ Pass the `locale` prop to the `DayPicker` component:
       showOutsideDays={showOutsideDays}
       className={cn(...)}
       captionLayout={captionLayout}
-+     locale={locale}
+      locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
 -         date.toLocaleString("default", { month: "short" }),
-+         date.toLocaleString(locale?.code, { month: "short" }),
++         date.toLocaleString(locale?.code ?? "default", { month: "short" }),
         ...formatters,
       }}
 ```

--- a/apps/v4/content/docs/components/radix/calendar.mdx
+++ b/apps/v4/content/docs/components/radix/calendar.mdx
@@ -312,11 +312,11 @@ Pass the `locale` prop to the `DayPicker` component:
       showOutsideDays={showOutsideDays}
       className={cn(...)}
       captionLayout={captionLayout}
-+     locale={locale}
+      locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
 -         date.toLocaleString("default", { month: "short" }),
-+         date.toLocaleString(locale?.code, { month: "short" }),
++         date.toLocaleString(locale?.code ?? "default", { month: "short" }),
         ...formatters,
       }}
 ```

--- a/apps/v4/registry/bases/base/ui/calendar.tsx
+++ b/apps/v4/registry/bases/base/ui/calendar.tsx
@@ -40,7 +40,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString(locale?.code ?? "default", { month: "short" }),
         ...formatters,
       }}
       classNames={{

--- a/apps/v4/registry/bases/radix/ui/calendar.tsx
+++ b/apps/v4/registry/bases/radix/ui/calendar.tsx
@@ -1,16 +1,17 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import {
-  DayPicker,
-  getDefaultClassNames,
-  type DayButton,
-  type Locale,
-} from "react-day-picker"
+import * as React from "react";
+import { DayPicker, getDefaultClassNames, type DayButton, type Locale } from "react-day-picker";
 
-import { cn } from "@/registry/bases/radix/lib/utils"
-import { Button, buttonVariants } from "@/registry/bases/radix/ui/button"
-import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
+
+
+import { cn } from "@/registry/bases/radix/lib/utils";
+import { Button, buttonVariants } from "@/registry/bases/radix/ui/button";
+import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder";
+
+
+
+
 
 function Calendar({
   className,
@@ -40,7 +41,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString(locale?.code ?? "default", { month: "short" }),
         ...formatters,
       }}
       classNames={{

--- a/apps/v4/registry/new-york-v4/ui/calendar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/calendar.tsx
@@ -22,6 +22,7 @@ function Calendar({
   captionLayout = "label",
   buttonVariant = "ghost",
   formatters,
+  locale,
   components,
   ...props
 }: React.ComponentProps<typeof DayPicker> & {
@@ -41,7 +42,7 @@ function Calendar({
       captionLayout={captionLayout}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString("default", { month: "short" }),
+          date.toLocaleString(locale?.code ?? "default", { month: "short" }),
         ...formatters,
       }}
       classNames={{


### PR DESCRIPTION
## Summary
- Added `locale` prop to Calendar component to change month/day localization
- Fixed `formatMonthDropdown` to use `locale?.code ?? "default"` fallback when locale is undefined
- Updated changelog documentation in base and radix calendar docs