### PR TITLE
fix(docs): update Embla Carousel documentation URLs

### DIFF
--- a/apps/v4/content/docs/components/base/carousel.mdx
+++ b/apps/v4/content/docs/components/base/carousel.mdx
@@ -4,8 +4,8 @@ description: A carousel with motion and swipe built using Embla.
 base: base
 component: true
 links:
-  doc: https://www.embla-carousel.com/get-started/react
-  api: https://www.embla-carousel.com/api
+  doc: https://www.embla-carousel.com/docs/get-started/react
+  api: https://www.embla-carousel.com/docs/api
 ---
 
 <ComponentPreview
@@ -176,7 +176,7 @@ Use the `orientation` prop to set the orientation of the carousel.
 
 ## Options
 
-You can pass options to the carousel using the `opts` prop. See the [Embla Carousel docs](https://www.embla-carousel.com/api/options/) for more information.
+You can pass options to the carousel using the `opts` prop. See the [Embla Carousel docs](https://www.embla-carousel.com/docs/api/options) for more information.
 
 ```tsx showLineNumbers {2-5}
 <Carousel
@@ -268,7 +268,7 @@ export function Example() {
 }
 ```
 
-See the [Embla Carousel docs](https://www.embla-carousel.com/api/events/) for more information on using events.
+See the [Embla Carousel docs](https://www.embla-carousel.com/docs/api/events) for more information on using events.
 
 ## Plugins
 
@@ -332,4 +332,4 @@ The `direction` option accepts `"ltr"` or `"rtl"` and should match the `dir` pro
 
 ## API Reference
 
-See the [Embla Carousel docs](https://www.embla-carousel.com/api/) for more information on props and plugins.
+See the [Embla Carousel docs](https://www.embla-carousel.com/docs/api) for more information on props and plugins.

--- a/apps/v4/content/docs/components/radix/carousel.mdx
+++ b/apps/v4/content/docs/components/radix/carousel.mdx
@@ -4,8 +4,8 @@ description: A carousel with motion and swipe built using Embla.
 base: radix
 component: true
 links:
-  doc: https://www.embla-carousel.com/get-started/react
-  api: https://www.embla-carousel.com/api
+  doc: https://www.embla-carousel.com/docs/get-started/react
+  api: https://www.embla-carousel.com/docs/api
 ---
 
 <ComponentPreview
@@ -176,7 +176,7 @@ Use the `orientation` prop to set the orientation of the carousel.
 
 ## Options
 
-You can pass options to the carousel using the `opts` prop. See the [Embla Carousel docs](https://www.embla-carousel.com/api/options/) for more information.
+You can pass options to the carousel using the `opts` prop. See the [Embla Carousel docs](https://www.embla-carousel.com/docs/api/options) for more information.
 
 ```tsx showLineNumbers {2-5}
 <Carousel
@@ -268,7 +268,7 @@ export function Example() {
 }
 ```
 
-See the [Embla Carousel docs](https://www.embla-carousel.com/api/events/) for more information on using events.
+See the [Embla Carousel docs](https://www.embla-carousel.com/docs/api/events) for more information on using events.
 
 ## Plugins
 
@@ -332,4 +332,4 @@ The `direction` option accepts `"ltr"` or `"rtl"` and should match the `dir` pro
 
 ## API Reference
 
-See the [Embla Carousel docs](https://www.embla-carousel.com/api/) for more information on props and plugins.
+See the [Embla Carousel docs](https://www.embla-carousel.com/docs/api) for more information on props and plugins.

--- a/apps/v4/registry/bases/base/ui/_registry.ts
+++ b/apps/v4/registry/bases/base/ui/_registry.ts
@@ -212,7 +212,7 @@ export const ui: Registry["items"] = [
         docs: "https://ui.shadcn.com/docs/components/base/carousel",
         examples:
           "https://raw.githubusercontent.com/shadcn-ui/ui/refs/heads/main/apps/v4/registry/bases/base/examples/carousel-example.tsx",
-        api: "https://www.embla-carousel.com/get-started/react",
+        api: "https://www.embla-carousel.com/docs/get-started/react",
       },
     },
   },

--- a/apps/v4/registry/bases/radix/ui/_registry.ts
+++ b/apps/v4/registry/bases/radix/ui/_registry.ts
@@ -213,7 +213,7 @@ export const ui: Registry["items"] = [
         docs: "https://ui.shadcn.com/docs/components/radix/carousel",
         examples:
           "https://raw.githubusercontent.com/shadcn-ui/ui/refs/heads/main/apps/v4/registry/bases/radix/examples/carousel-example.tsx",
-        api: "https://www.embla-carousel.com/get-started/react",
+        api: "https://www.embla-carousel.com/docs/get-started/react",
       },
     },
   },


### PR DESCRIPTION
## Summary

Updates Embla Carousel links to the current documentation URL structure under `/docs/`, and normalizes trailing slashes on deep links.

## Changes

- **Docs (`base` / `radix` carousel):** Frontmatter `doc` / `api` links and inline references now use `https://www.embla-carousel.com/docs/...` (e.g. get-started, API, options, events).
- **Registry:** Carousel `api` metadata in `apps/v4/registry/bases/base/ui/_registry.ts` and `apps/v4/registry/bases/radix/ui/_registry.ts` points to `.../docs/get-started/react`.
