### PR TITLE
fix: add tslib as explicit dependency to prevent pnpm monorepo hoisting issues

### DIFF
--- a/apps/v4/registry/new-york-v4/registry.ts
+++ b/apps/v4/registry/new-york-v4/registry.ts
@@ -22,7 +22,7 @@ const DEPRECATED_ITEMS = [
 // Shared between index and style for backward compatibility.
 const NEW_YORK_V4_STYLE = {
   type: "registry:style",
-  dependencies: ["class-variance-authority", "lucide-react", "radix-ui"],
+  dependencies: ["class-variance-authority", "lucide-react", "radix-ui", "tslib"],
   devDependencies: ["tw-animate-css", "shadcn"],
   registryDependencies: ["utils"],
   css: {


### PR DESCRIPTION
## Problem

When using `pnpm dlx shadcn@latest init --monorepo` in an astro monorepo, running `pnpm dev` fails with:

```
Error: Cannot find module 'tslib'
Require stack:
- /node_modules/react-remove-scroll/dist/es5/index.js
```

## Root Cause

 is a transitive dependency of  (used by radix-ui components). In pnpm monorepo setups, transitive dependencies aren't always hoisted properly, causing runtime errors.

## Solution

Add  as an explicit dependency in the base registry configuration. This ensures it's always installed and available, regardless of pnpm's hoisting behavior.

## Testing

- Added `tslib` to `NEW_YORK_V4_STYLE.dependencies`
- This will be installed for all new shadcn/ui projects
- Existing projects can add it manually if they encounter the issue

## Impact

- Minimal: `tslib` is already a transitive dependency, just making it explicit
- No breaking changes
- Fixes the monorepo hoisting issue

Fixes: #10286