### PR TITLE
fix: add --skip-git flag to shadcn init

### DIFF
--- a/packages/shadcn/src/commands/init.ts
+++ b/packages/shadcn/src/commands/init.ts
@@ -73,6 +73,7 @@ export const initOptionsSchema = z.object({
   force: z.boolean(),
   reinstall: z.boolean().optional(),
   silent: z.boolean(),
+  skipGit: z.boolean().optional(),
   isNewProject: z.boolean().default(false),
   cssVariables: z.boolean().default(true),
   rtl: z.boolean().optional(),
@@ -127,6 +128,7 @@ export const init = new Command()
   .option("--no-rtl", "disable RTL support.")
   .option("--reinstall", "re-install existing UI components.")
   .option("--no-reinstall", "do not re-install existing UI components.")
+  .option("--skip-git", "skip git init and initial commit.")
   .action(async (components, opts) => {
     let componentsJsonBackupPath: string | undefined
     let reinstallComponents: string[] = []
@@ -633,7 +635,7 @@ export async function runInit(
     })
 
     // Run postInit for new projects (e.g. git init).
-    await selectedTemplate.postInit({ projectPath: options.cwd })
+    await selectedTemplate.postInit({ projectPath: options.cwd, skipGit: options.skipGit })
 
     return result
   }
@@ -772,7 +774,7 @@ export async function runInit(
 
   // Run postInit for new projects without a custom init (e.g. git init).
   if (selectedTemplate) {
-    await selectedTemplate.postInit({ projectPath: options.cwd })
+    await selectedTemplate.postInit({ projectPath: options.cwd, skipGit: options.skipGit })
   }
 
   return fullConfig

--- a/packages/shadcn/src/templates/create-template.ts
+++ b/packages/shadcn/src/templates/create-template.ts
@@ -40,7 +40,7 @@ export interface TemplateConfig {
   create: (options: TemplateOptions) => Promise<void>
   init?: (options: TemplateInitOptions) => Promise<Config>
   files?: RegistryItem["files"]
-  postInit?: (options: { projectPath: string }) => Promise<void>
+  postInit?: (options: { projectPath: string; skipGit?: boolean }) => Promise<void>
   // Monorepo overrides. When --monorepo is passed, these fields
   // are merged over the base template config.
   monorepo?: {
@@ -301,7 +301,16 @@ function defaultScaffold({
 
 // Initialize a git repository and create an initial commit.
 // Silently ignores failures (e.g. git not installed).
-async function defaultPostInit({ projectPath }: { projectPath: string }) {
+async function defaultPostInit({
+  projectPath,
+  skipGit,
+}: {
+  projectPath: string
+  skipGit?: boolean
+}) {
+  if (skipGit) {
+    return
+  }
   try {
     await execa("git", ["init"], { cwd: projectPath })
     await execa("git", ["add", "-A"], { cwd: projectPath })


### PR DESCRIPTION

## Description

Add a `--skip-git` option to `shadcn init` command to allow users to opt out of the automatic `git init && git commit` that happens after project creation.

## Problem

Running `npx shadcn@latest init` in an existing git repository silently runs `git add . && git commit -m "feat: initial commit"` at the end of initialization, without any prompt or CLI flag to opt out.

This is destructive for projects that:
- Enforce logical / atomic commits (e.g. conventional-commits + an "incremental commit" workflow)
- Want a single PR to contain a coherent series of small, reviewable commits rather than one giant "initial commit" lump
- Run `shadcn init` *after* already having other meaningful commits on the branch

## Solution

Add `--skip-git` flag to the init command that skips the automatic git initialization and commit.

## Usage

```bash
npx shadcn@latest init --skip-git
```

Fixes #10320
