### PR TITLE
fix(templates): add notFoundComponent to start root route

### DIFF
--- a/templates/start-app/src/routes/__root.tsx
+++ b/templates/start-app/src/routes/__root.tsx
@@ -25,6 +25,12 @@ export const Route = createRootRoute({
       },
     ],
   }),
+  notFoundComponent: () => (
+    <main className="container mx-auto p-4 pt-16">
+      <h1>404</h1>
+      <p>The requested page could not be found.</p>
+    </main>
+  ),
   shellComponent: RootDocument,
 })
 

--- a/templates/start-monorepo/apps/web/src/routes/__root.tsx
+++ b/templates/start-monorepo/apps/web/src/routes/__root.tsx
@@ -23,6 +23,12 @@ export const Route = createRootRoute({
       },
     ],
   }),
+  notFoundComponent: () => (
+    <main className="container mx-auto p-4 pt-16">
+      <h1>404</h1>
+      <p>The requested page could not be found.</p>
+    </main>
+  ),
   shellComponent: RootDocument,
 })
 


### PR DESCRIPTION
Silence the TanStack Router warning that prints on first load in fresh `start-app` and `start-monorepo` projects. Neither template sets a not-found handler, so the warning fires from phantom requests hitting routes that do not exist (`/favicon.ico`, Chrome DevTools' `/.well-known/appspecific/com.chrome.devtools.json`).

Repro:

```bash
bunx --bun shadcn@latest init --preset b1VlJDbU --base base --template start
cd start-app && bun run dev
```

Fires on vite ready:

```
Warning: A notFoundError was encountered on the route with ID "__root__", but a notFoundComponent option was not configured, nor was a router level defaultNotFoundComponent configured.
```

The warning is emitted from `packages/react-router/src/renderRouteNotFound.tsx` in TanStack Router when neither `notFoundComponent` nor `defaultNotFoundComponent` is configured. TanStack's own migration guide for not-found handling configures `notFoundComponent` on the root route, so that is where the fix lives.

The JSX shape matches the 404 `ErrorBoundary` pattern shared by `templates/react-router-app/app/root.tsx` and `templates/react-router-monorepo/apps/web/app/root.tsx` (same `container mx-auto p-4 pt-16` wrapper, same "404" heading, same "The requested page could not be found." copy). Those two templates are the only 404 precedent across shadcn's ten, so copying the pattern keeps the suite consistent.

- `templates/start-app/src/routes/__root.tsx`: add `notFoundComponent` on the root route
- `templates/start-monorepo/apps/web/src/routes/__root.tsx`: same
