### PR TITLE
fix: remove resources capablities from mcp

### DIFF
--- a/packages/shadcn/src/mcp/index.ts
+++ b/packages/shadcn/src/mcp/index.ts
@@ -23,8 +23,7 @@ export const server = new Server(
     version: "1.0.0",
   },
   {
-    capabilities: {
-      resources: {},
+    capabilities: {      
       tools: {},
     },
   }


### PR DESCRIPTION
Removed resources declaration from capabilities. 

The MCP server doesn't support resources. Publishing this support causes some MCP clients to receive errors.