### PR TITLE
fix(field): change FieldSeparator background to inherit from parent (#10376)

### DIFF
--- a/apps/v4/styles/base-luma/ui/field.tsx
+++ b/apps/v4/styles/base-luma/ui/field.tsx
@@ -163,7 +163,7 @@ function FieldSeparator({
       <Separator className="absolute inset-0 top-1/2" />
       {children && (
         <span
-          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          className="relative mx-auto block w-fit bg-inherit px-2 text-muted-foreground"
           data-slot="field-separator-content"
         >
           {children}

--- a/apps/v4/styles/base-lyra/ui/field.tsx
+++ b/apps/v4/styles/base-lyra/ui/field.tsx
@@ -163,7 +163,7 @@ function FieldSeparator({
       <Separator className="absolute inset-0 top-1/2" />
       {children && (
         <span
-          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          className="relative mx-auto block w-fit bg-inherit px-2 text-muted-foreground"
           data-slot="field-separator-content"
         >
           {children}

--- a/apps/v4/styles/base-maia/ui/field.tsx
+++ b/apps/v4/styles/base-maia/ui/field.tsx
@@ -163,7 +163,7 @@ function FieldSeparator({
       <Separator className="absolute inset-0 top-1/2" />
       {children && (
         <span
-          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          className="relative mx-auto block w-fit bg-inherit px-2 text-muted-foreground"
           data-slot="field-separator-content"
         >
           {children}

--- a/apps/v4/styles/base-mira/ui/field.tsx
+++ b/apps/v4/styles/base-mira/ui/field.tsx
@@ -163,7 +163,7 @@ function FieldSeparator({
       <Separator className="absolute inset-0 top-1/2" />
       {children && (
         <span
-          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          className="relative mx-auto block w-fit bg-inherit px-2 text-muted-foreground"
           data-slot="field-separator-content"
         >
           {children}

--- a/apps/v4/styles/base-nova/ui-rtl/field.tsx
+++ b/apps/v4/styles/base-nova/ui-rtl/field.tsx
@@ -163,7 +163,7 @@ function FieldSeparator({
       <Separator className="absolute inset-0 top-1/2" />
       {children && (
         <span
-          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          className="relative mx-auto block w-fit bg-inherit px-2 text-muted-foreground"
           data-slot="field-separator-content"
         >
           {children}

--- a/apps/v4/styles/base-nova/ui/field.tsx
+++ b/apps/v4/styles/base-nova/ui/field.tsx
@@ -163,7 +163,7 @@ function FieldSeparator({
       <Separator className="absolute inset-0 top-1/2" />
       {children && (
         <span
-          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          className="relative mx-auto block w-fit bg-inherit px-2 text-muted-foreground"
           data-slot="field-separator-content"
         >
           {children}

--- a/apps/v4/styles/base-vega/ui/field.tsx
+++ b/apps/v4/styles/base-vega/ui/field.tsx
@@ -163,7 +163,7 @@ function FieldSeparator({
       <Separator className="absolute inset-0 top-1/2" />
       {children && (
         <span
-          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          className="relative mx-auto block w-fit bg-inherit px-2 text-muted-foreground"
           data-slot="field-separator-content"
         >
           {children}

--- a/apps/v4/styles/radix-luma/ui/field.tsx
+++ b/apps/v4/styles/radix-luma/ui/field.tsx
@@ -163,7 +163,7 @@ function FieldSeparator({
       <Separator className="absolute inset-0 top-1/2" />
       {children && (
         <span
-          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          className="relative mx-auto block w-fit bg-inherit px-2 text-muted-foreground"
           data-slot="field-separator-content"
         >
           {children}

--- a/apps/v4/styles/radix-lyra/ui/field.tsx
+++ b/apps/v4/styles/radix-lyra/ui/field.tsx
@@ -163,7 +163,7 @@ function FieldSeparator({
       <Separator className="absolute inset-0 top-1/2" />
       {children && (
         <span
-          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          className="relative mx-auto block w-fit bg-inherit px-2 text-muted-foreground"
           data-slot="field-separator-content"
         >
           {children}

--- a/apps/v4/styles/radix-maia/ui/field.tsx
+++ b/apps/v4/styles/radix-maia/ui/field.tsx
@@ -163,7 +163,7 @@ function FieldSeparator({
       <Separator className="absolute inset-0 top-1/2" />
       {children && (
         <span
-          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          className="relative mx-auto block w-fit bg-inherit px-2 text-muted-foreground"
           data-slot="field-separator-content"
         >
           {children}

--- a/apps/v4/styles/radix-mira/ui/field.tsx
+++ b/apps/v4/styles/radix-mira/ui/field.tsx
@@ -163,7 +163,7 @@ function FieldSeparator({
       <Separator className="absolute inset-0 top-1/2" />
       {children && (
         <span
-          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          className="relative mx-auto block w-fit bg-inherit px-2 text-muted-foreground"
           data-slot="field-separator-content"
         >
           {children}

--- a/apps/v4/styles/radix-nova/ui-rtl/field.tsx
+++ b/apps/v4/styles/radix-nova/ui-rtl/field.tsx
@@ -163,7 +163,7 @@ function FieldSeparator({
       <Separator className="absolute inset-0 top-1/2" />
       {children && (
         <span
-          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          className="relative mx-auto block w-fit bg-inherit px-2 text-muted-foreground"
           data-slot="field-separator-content"
         >
           {children}

--- a/apps/v4/styles/radix-nova/ui/field.tsx
+++ b/apps/v4/styles/radix-nova/ui/field.tsx
@@ -163,7 +163,7 @@ function FieldSeparator({
       <Separator className="absolute inset-0 top-1/2" />
       {children && (
         <span
-          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          className="relative mx-auto block w-fit bg-inherit px-2 text-muted-foreground"
           data-slot="field-separator-content"
         >
           {children}

--- a/apps/v4/styles/radix-vega/ui/field.tsx
+++ b/apps/v4/styles/radix-vega/ui/field.tsx
@@ -163,7 +163,7 @@ function FieldSeparator({
       <Separator className="absolute inset-0 top-1/2" />
       {children && (
         <span
-          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          className="relative mx-auto block w-fit bg-inherit px-2 text-muted-foreground"
           data-slot="field-separator-content"
         >
           {children}


### PR DESCRIPTION
## Problem

The `FieldSeparator` component has a hardcoded `bg-background` class on the separator text span. This causes visual issues when the component is used inside containers with different backgrounds (like cards which use `bg-card`), especially in dark mode.

**Reproduction:**
1. Add a `Card` component
2. Add a `FieldSeparator` with text inside the card
3. Switch to dark mode
4. The separator text background doesn't match the card background

## Solution

Changed `bg-background` to `bg-inherit` so the separator text background automatically matches its parent container's background.

### Changes
- Updated all `field.tsx` files across all style variants (radix-*, base-*)
- Changed line 166: `bg-background` → `bg-inherit`

## Testing

The separator text now correctly inherits the background from:
- Cards (`bg-card`)
- Dialogs (`bg-popover`)
- Any custom background containers

## Related

Fixes #10376

---

Submitted by: [@mrlexcoder](https://github.com/mrlexcoder)