### PR TITLE
fix(theme-provider): guard against undefined event.key during browser autofill

### DIFF
--- a/templates/next-app/components/theme-provider.tsx
+++ b/templates/next-app/components/theme-provider.tsx
@@ -47,7 +47,7 @@ function ThemeHotkey() {
         return
       }
 
-      if (event.key.toLowerCase() !== "d") {
+      if (event.key?.toLowerCase() !== "d") {
         return
       }
 

--- a/templates/next-monorepo/apps/web/components/theme-provider.tsx
+++ b/templates/next-monorepo/apps/web/components/theme-provider.tsx
@@ -47,7 +47,7 @@ function ThemeHotkey() {
         return
       }
 
-      if (event.key.toLowerCase() !== "d") {
+      if (event.key?.toLowerCase() !== "d") {
         return
       }
 

--- a/templates/vite-app/src/components/theme-provider.tsx
+++ b/templates/vite-app/src/components/theme-provider.tsx
@@ -153,7 +153,7 @@ export function ThemeProvider({
         return
       }
 
-      if (event.key.toLowerCase() !== "d") {
+      if (event.key?.toLowerCase() !== "d") {
         return
       }
 

--- a/templates/vite-monorepo/apps/web/src/components/theme-provider.tsx
+++ b/templates/vite-monorepo/apps/web/src/components/theme-provider.tsx
@@ -153,7 +153,7 @@ export function ThemeProvider({
         return
       }
 
-      if (event.key.toLowerCase() !== "d") {
+      if (event.key?.toLowerCase() !== "d") {
         return
       }
 


### PR DESCRIPTION
## What

When Chrome or Edge autofills a form field (email, password, etc.), the browser fires a synthetic `keydown` event where `event.key` is `undefined`. The `ThemeHotkey` listener calls `event.key.toLowerCase()` unconditionally, which throws:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'toLowerCase')
```

This crashes the page for any user who triggers browser autocomplete on a form that lives alongside the generated `theme-provider`.

## Why

The `KeyboardEvent.key` property is typed as `string` in TypeScript's `lib.dom.d.ts`, but browsers are not spec-compliant in all synthetic/autofill paths — Chrome and Edge both omit the `key` value on certain injected keyboard events.

## Fix

Add optional chaining (`?.`) so that `undefined` short-circuits to `undefined !== "d"` → `true`, and the handler returns early without touching the theme:

```diff
- if (event.key.toLowerCase() !== "d") {
+ if (event.key?.toLowerCase() !== "d") {
```

Applied to all four project templates:

- `templates/next-app/components/theme-provider.tsx`
- `templates/next-monorepo/apps/web/components/theme-provider.tsx`
- `templates/vite-app/src/components/theme-provider.tsx`
- `templates/vite-monorepo/apps/web/src/components/theme-provider.tsx`

Closes #10378