### PR TITLE
fix: add null check for event.key in ThemeHotkey to prevent crash on browser autofill (fixes #10378)

### DIFF
--- a/apps/v4/app/(app)/create/lib/v0.ts
+++ b/apps/v4/app/(app)/create/lib/v0.ts
@@ -125,7 +125,7 @@ const themeProviderFile = registryItemFileSchema.parse({
             return
           }
 
-          if (event.key.toLowerCase() !== "d") {
+          if (!event.key || event.key.toLowerCase() !== "d") {
             return
           }
 

--- a/templates/next-app/components/theme-provider.tsx
+++ b/templates/next-app/components/theme-provider.tsx
@@ -47,7 +47,7 @@ function ThemeHotkey() {
         return
       }
 
-      if (event.key.toLowerCase() !== "d") {
+      if (!event.key || event.key.toLowerCase() !== "d") {
         return
       }
 

--- a/templates/next-monorepo/apps/web/components/theme-provider.tsx
+++ b/templates/next-monorepo/apps/web/components/theme-provider.tsx
@@ -47,7 +47,7 @@ function ThemeHotkey() {
         return
       }
 
-      if (event.key.toLowerCase() !== "d") {
+      if (!event.key || event.key.toLowerCase() !== "d") {
         return
       }
 

--- a/templates/vite-app/src/components/theme-provider.tsx
+++ b/templates/vite-app/src/components/theme-provider.tsx
@@ -153,7 +153,7 @@ export function ThemeProvider({
         return
       }
 
-      if (event.key.toLowerCase() !== "d") {
+      if (!event.key || event.key.toLowerCase() !== "d") {
         return
       }
 

--- a/templates/vite-monorepo/apps/web/src/components/theme-provider.tsx
+++ b/templates/vite-monorepo/apps/web/src/components/theme-provider.tsx
@@ -153,7 +153,7 @@ export function ThemeProvider({
         return
       }
 
-      if (event.key.toLowerCase() !== "d") {
+      if (!event.key || event.key.toLowerCase() !== "d") {
         return
       }
 


### PR DESCRIPTION
## Background

The default `theme-provider.tsx` generated by `npx shadcn@latest init` contains a `ThemeHotkey` component that listens for the `Ctrl+D` keyboard shortcut to toggle the theme. The listener calls `event.key.toLowerCase()` without checking if `event.key` is defined.

During browser autofill/autocomplete on Chrome and Edge, the browser fires a synthetic `keydown` event where `event.key` is `undefined`. This causes an uncaught `TypeError`:

```
Uncaught TypeError: Cannot read properties of undefined (reading toLowerCase)
    at onKeyDown (theme-provider.tsx)
```

## Solution

Add a null/undefined guard before accessing `event.key.toLowerCase()` in all affected files. This follows the same defensive pattern already used elsewhere in the handler (e.g., `event.defaultPrevented` check).

## Changes

- `templates/next-app/components/theme-provider.tsx`: Added `!event.key ||` guard
- `templates/next-monorepo/apps/web/components/theme-provider.tsx`: Added `!event.key ||` guard
- `templates/vite-app/src/components/theme-provider.tsx`: Added `!event.key ||` guard
- `templates/vite-monorepo/apps/web/src/components/theme-provider.tsx`: Added `!event.key ||` guard
- `apps/v4/app/(app)/create/lib/v0.ts`: Added `!event.key ||` guard

## Verification

1. Create a new Next.js project with `npx shadcn@latest init`
2. Add `<input type="email" />` to a page
3. Save an autofill entry in Chrome
4. Focus the input and select a suggestion from the browser autocomplete dropdown
5. Before fix: `TypeError` in console
6. After fix: Autofill completes normally, no errors

Closes #10378