### PR TITLE
fix(a11y): add aria-label to data table filter inputs (#10397)

### DIFF
--- a/apps/v4/app/(app)/examples/tasks/components/data-table-toolbar.tsx
+++ b/apps/v4/app/(app)/examples/tasks/components/data-table-toolbar.tsx
@@ -24,6 +24,7 @@ export function DataTableToolbar<TData>({
       <div className="flex flex-1 items-center gap-2">
         <Input
           placeholder="Filter tasks..."
+          aria-label="Filter tasks"
           value={(table.getColumn("title")?.getFilterValue() as string) ?? ""}
           onChange={(event) =>
             table.getColumn("title")?.setFilterValue(event.target.value)

--- a/apps/v4/examples/base/data-table-demo.tsx
+++ b/apps/v4/examples/base/data-table-demo.tsx
@@ -205,6 +205,7 @@ export function DataTableDemo() {
       <div className="flex items-center py-4">
         <Input
           placeholder="Filter emails..."
+          aria-label="Filter emails"
           value={(table.getColumn("email")?.getFilterValue() as string) ?? ""}
           onChange={(event) =>
             table.getColumn("email")?.setFilterValue(event.target.value)

--- a/apps/v4/examples/radix/data-table-demo.tsx
+++ b/apps/v4/examples/radix/data-table-demo.tsx
@@ -203,6 +203,7 @@ export function DataTableDemo() {
       <div className="flex items-center py-4">
         <Input
           placeholder="Filter emails..."
+          aria-label="Filter emails"
           value={(table.getColumn("email")?.getFilterValue() as string) ?? ""}
           onChange={(event) =>
             table.getColumn("email")?.setFilterValue(event.target.value)


### PR DESCRIPTION
## Summary

Add `aria-label` to data table filter `<Input>` components across all example variants
(Radix, Base, and Tasks) to comply with **WCAG 2.1 Level A** (4.1.2 Name, Role, Value).

Placeholder text alone is not a valid accessible name. Screen readers would announce
"edit text" with no context that this is a filter control.

## Changes

| File | aria-label |
|------|------------|
| `apps/v4/examples/radix/data-table-demo.tsx` | `"Filter emails"` |
| `apps/v4/examples/base/data-table-demo.tsx` | `"Filter emails"` |
| `apps/v4/app/(app)/examples/tasks/components/data-table-toolbar.tsx` | `"Filter tasks"` |

## Testing

1. Inspect each data table filter input — confirm `aria-label` is present
2. Test with screen reader — confirm filter is announced correctly

Fixes shadcn-ui/ui#10397