### PR TITLE
docs(drawer): add `asChild` on DrawerClose in Usage example

### DIFF
--- a/apps/v4/content/docs/components/base/drawer.mdx
+++ b/apps/v4/content/docs/components/base/drawer.mdx
@@ -80,7 +80,7 @@ import {
     </DrawerHeader>
     <DrawerFooter>
       <Button>Submit</Button>
-      <DrawerClose>
+      <DrawerClose asChild>
         <Button variant="outline">Cancel</Button>
       </DrawerClose>
     </DrawerFooter>

--- a/apps/v4/content/docs/components/radix/drawer.mdx
+++ b/apps/v4/content/docs/components/radix/drawer.mdx
@@ -80,7 +80,7 @@ import {
     </DrawerHeader>
     <DrawerFooter>
       <Button>Submit</Button>
-      <DrawerClose>
+      <DrawerClose asChild>
         <Button variant="outline">Cancel</Button>
       </DrawerClose>
     </DrawerFooter>


### PR DESCRIPTION
## Summary

The Drawer Usage example wraps a `<Button>` inside a `<DrawerClose>` without `asChild`:

```tsx
<DrawerClose>
  <Button variant="outline">Cancel</Button>
</DrawerClose>
```

Because `DrawerClose` renders a `<button>` by default and `Button` also renders a `<button>`, copy-pasting the example produces a nested `<button><button>` tree and React raises a hydration error:

> In HTML, `<button>` cannot be a descendant of `<button>`. This will cause a hydration error.

Adding `asChild` delegates rendering to the child so only one `<button>` ends up in the DOM — matching the pattern already used by `DialogClose`, `AlertDialogCancel`, and other Radix primitives elsewhere in the docs.

Fix applied to both the Radix and Base variants of the drawer doc:
- `apps/v4/content/docs/components/radix/drawer.mdx`
- `apps/v4/content/docs/components/base/drawer.mdx`

Fixes #6205

## Test plan

- [x] Both doc files updated identically
- [x] Pattern matches `asChild` usage already present in sibling close-button docs
- [ ] Docs site renders the updated example without hydration warning (not run locally; two-char MDX edit)