### PR TITLE
fix: guard against undefined event.key in ThemeHotkey (fixes #10378)

### DIFF
--- a/templates/next-app/components/theme-provider.tsx
+++ b/templates/next-app/components/theme-provider.tsx
@@ -47,7 +47,7 @@ function ThemeHotkey() {
         return
       }
 
-      if (event.key.toLowerCase() !== "d") {
+      if (!event.key || event.key.toLowerCase() !== "d") {
         return
       }
 

--- a/templates/next-monorepo/apps/web/components/theme-provider.tsx
+++ b/templates/next-monorepo/apps/web/components/theme-provider.tsx
@@ -47,7 +47,7 @@ function ThemeHotkey() {
         return
       }
 
-      if (event.key.toLowerCase() !== "d") {
+      if (!event.key || event.key.toLowerCase() !== "d") {
         return
       }
 

--- a/templates/vite-app/src/components/theme-provider.tsx
+++ b/templates/vite-app/src/components/theme-provider.tsx
@@ -153,7 +153,7 @@ export function ThemeProvider({
         return
       }
 
-      if (event.key.toLowerCase() !== "d") {
+      if (!event.key || event.key.toLowerCase() !== "d") {
         return
       }
 

--- a/templates/vite-monorepo/apps/web/src/components/theme-provider.tsx
+++ b/templates/vite-monorepo/apps/web/src/components/theme-provider.tsx
@@ -153,7 +153,7 @@ export function ThemeProvider({
         return
       }
 
-      if (event.key.toLowerCase() !== "d") {
+      if (!event.key || event.key.toLowerCase() !== "d") {
         return
       }
 


### PR DESCRIPTION
## Background

The ThemeHotkey component in the generated theme-provider.tsx template attaches a global keydown listener. During browser autofill/autocomplete on Chrome and Edge, a synthetic keydown event is fired where event.key is undefined. The listener calls event.key.toLowerCase() without a null-check, causing an uncaught TypeError.

## Solution

Add a guard that checks event.key is truthy before calling .toLowerCase().

## Changes

- templates/next-app/components/theme-provider.tsx — Added !event.key || guard
- templates/next-monorepo/apps/web/components/theme-provider.tsx — Same guard
- templates/vite-app/src/components/theme-provider.tsx — Same guard
- templates/vite-monorepo/apps/web/src/components/theme-provider.tsx — Same guard

## Verification

1. Create a new Next.js project using npx shadcn@latest init
2. Add an input type=email to a page
3. Save an autofill entry in Chrome/Edge
4. Focus the input and select a suggestion from browser autocomplete
5. Previously: TypeError: Cannot read properties of undefined (reading toLowerCase)
6. Now: Autofill completes without error