### PR TITLE
fix(a11y): add aria-label to Data Table filter inputs

### DIFF
--- a/apps/v4/app/(app)/examples/tasks/components/data-table-toolbar.tsx
+++ b/apps/v4/app/(app)/examples/tasks/components/data-table-toolbar.tsx
@@ -23,6 +23,7 @@ export function DataTableToolbar<TData>({
     <div className="flex items-center justify-between">
       <div className="flex flex-1 items-center gap-2">
         <Input
+          aria-label="Filter tasks"
           placeholder="Filter tasks..."
           value={(table.getColumn("title")?.getFilterValue() as string) ?? ""}
           onChange={(event) =>

--- a/apps/v4/examples/base/data-table-demo.tsx
+++ b/apps/v4/examples/base/data-table-demo.tsx
@@ -204,6 +204,7 @@ export function DataTableDemo() {
     <div className="w-full">
       <div className="flex items-center py-4">
         <Input
+          aria-label="Filter emails"
           placeholder="Filter emails..."
           value={(table.getColumn("email")?.getFilterValue() as string) ?? ""}
           onChange={(event) =>

--- a/apps/v4/examples/radix/data-table-demo.tsx
+++ b/apps/v4/examples/radix/data-table-demo.tsx
@@ -202,6 +202,7 @@ export function DataTableDemo() {
     <div className="w-full">
       <div className="flex items-center py-4">
         <Input
+          aria-label="Filter emails"
           placeholder="Filter emails..."
           value={(table.getColumn("email")?.getFilterValue() as string) ?? ""}
           onChange={(event) =>


### PR DESCRIPTION
## Description

Adds missing `aria-label` attributes to filter inputs in all Data Table example variants (Radix, Base, and Tasks) to fix a WCAG 2.1 SC 4.1.2 violation.

## Issue

Fixes #10397

## Changes

1. **`apps/v4/examples/radix/data-table-demo.tsx`** — Added `aria-label="Filter emails"` to the filter input
2. **`apps/v4/examples/base/data-table-demo.tsx`** — Added `aria-label="Filter emails"` to the filter input
3. **`apps/v4/app/(app)/examples/tasks/components/data-table-toolbar.tsx`** — Added `aria-label="Filter tasks"` to the filter input

## Why this matters

Since developers copy these examples directly into their projects, missing accessible labels propagate to thousands of production applications. Adding `aria-label` ensures screen reader users understand the purpose of these filter inputs.

## Testing

- Verified all three files have the `aria-label` attribute added
- The fix is minimal and non-breaking — only adds an accessibility attribute
- No functional changes to the component behavior