### PR TITLE
fix(www): prevent command menu copy shortcut from hijacking clipboard when closed

### DIFF
--- a/apps/v4/components/command-menu.tsx
+++ b/apps/v4/components/command-menu.tsx
@@ -339,6 +339,11 @@ export function CommandMenu({
     )
   }, [blocks, handleBlockHighlight, runCommand, router])
 
+  const openRef = React.useRef(open)
+  React.useEffect(() => {
+    openRef.current = open
+  }, [open])
+
   React.useEffect(() => {
     const down = (e: KeyboardEvent) => {
       if ((e.key === "k" && (e.metaKey || e.ctrlKey)) || e.key === "/") {
@@ -355,7 +360,12 @@ export function CommandMenu({
         setOpen((open) => !open)
       }
 
-      if (e.key === "c" && (e.metaKey || e.ctrlKey)) {
+      if (
+        e.key === "c" &&
+        (e.metaKey || e.ctrlKey) &&
+        openRef.current &&
+        copyPayload
+      ) {
         runCommand(() => {
           if (selectedType === "color") {
             copyToClipboardWithMeta(copyPayload, {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix.

## What is the current behavior?
The docs site command menu (`apps/v4/components/command-menu.tsx`) installs a global `keydown` listener that listens for Ctrl/Cmd+C. The handler fires regardless of whether the dialog is open, so after the user opens the search, highlights a component/color/block and then closes the dialog, every subsequent Ctrl/Cmd+C on the rest of the page copies the last highlighted item's `copyPayload` instead of the user's selected text. If the dialog is opened without anything being highlighted (`copyPayload` is an empty string), Ctrl/Cmd+C writes an empty string to the clipboard, effectively clearing it.

Closes #9242

## What is the new behavior?
The Ctrl/Cmd+C branch now early-returns unless the dialog is currently open and a non-empty `copyPayload` is staged. The open state is read through a ref that is kept in sync via a small effect, so the handler does not need to resubscribe on every open/close toggle.

## Additional context
- Scoped to the docs site, no registry or CLI code is touched.
- The `e.preventDefault()` behavior is unchanged; browser default copy is no longer pre-empted when the menu is closed.
- `apps/v4` is in the changesets `ignore` list, so no changeset is needed.