### PR TITLE
fix(cli): allow apply in monorepo UI workspaces without framework config

### DIFF
--- a/.changeset/apply-monorepo-packages-ui.md
+++ b/.changeset/apply-monorepo-packages-ui.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+fix `apply` failing with "could not detect a supported framework" when targeting a monorepo workspace (e.g. `packages/ui`) that has a valid `components.json` but no framework config

--- a/packages/shadcn/src/preflights/preflight-init.test.ts
+++ b/packages/shadcn/src/preflights/preflight-init.test.ts
@@ -1,0 +1,127 @@
+import path from "path"
+import fs from "fs-extra"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { preFlightInit } from "./preflight-init"
+
+let tmpDir: string
+
+beforeEach(async () => {
+  tmpDir = path.join(
+    await fs.realpath(require("os").tmpdir()),
+    `shadcn-preflight-init-test-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2)}`
+  )
+  await fs.ensureDir(tmpDir)
+})
+
+afterEach(async () => {
+  await fs.remove(tmpDir)
+})
+
+describe("preFlightInit", () => {
+  it("should not error on missing framework when existingConfig is provided", async () => {
+    // Simulate a shadcn monorepo UI workspace: a package.json with
+    // tailwind and an import alias but no framework config. This mirrors
+    // `packages/ui` in a shadcn-generated monorepo where the UI library
+    // is a sibling of the app workspace (e.g. `apps/web`).
+    await fs.writeJson(path.join(tmpDir, "package.json"), {
+      name: "@acme/ui",
+      dependencies: {
+        tailwindcss: "^4.0.0",
+      },
+    })
+    await fs.writeFile(
+      path.join(tmpDir, "styles.css"),
+      `@import "tailwindcss";\n`
+    )
+    await fs.writeJson(path.join(tmpDir, "tsconfig.json"), {
+      compilerOptions: {
+        paths: {
+          "@acme/ui/*": ["./src/*"],
+        },
+      },
+    })
+
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never)
+
+    const result = await preFlightInit({
+      cwd: tmpDir,
+      yes: true,
+      defaults: false,
+      // Force bypasses the components.json-exists check — apply uses
+      // a backup file to side-step that, but for the test this is equivalent.
+      force: true,
+      silent: true,
+      isNewProject: false,
+      cssVariables: true,
+      installStyleIndex: true,
+      existingConfig: {
+        $schema: "https://ui.shadcn.com/schema.json",
+        style: "new-york",
+        tailwind: {
+          config: "",
+          css: "styles.css",
+          baseColor: "neutral",
+          cssVariables: true,
+          prefix: "",
+        },
+        aliases: {
+          components: "@acme/ui/components",
+          ui: "@acme/ui/components/ui",
+          hooks: "@acme/ui/hooks",
+          lib: "@acme/ui/lib",
+          utils: "@acme/ui/lib/utils",
+        },
+      },
+    })
+
+    expect(exitSpy).not.toHaveBeenCalled()
+    expect(result.errors).toEqual({})
+    expect(result.projectInfo).toBeTruthy()
+
+    exitSpy.mockRestore()
+  })
+
+  it("should error on missing framework when no existingConfig is provided", async () => {
+    await fs.writeJson(path.join(tmpDir, "package.json"), {
+      name: "@acme/ui",
+      dependencies: {
+        tailwindcss: "^4.0.0",
+      },
+    })
+    await fs.writeFile(
+      path.join(tmpDir, "styles.css"),
+      `@import "tailwindcss";\n`
+    )
+    await fs.writeJson(path.join(tmpDir, "tsconfig.json"), {
+      compilerOptions: {
+        paths: {
+          "@acme/ui/*": ["./src/*"],
+        },
+      },
+    })
+
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never)
+
+    await preFlightInit({
+      cwd: tmpDir,
+      yes: true,
+      defaults: false,
+      force: true,
+      silent: true,
+      isNewProject: false,
+      cssVariables: true,
+      installStyleIndex: true,
+    })
+
+    expect(exitSpy).toHaveBeenCalledWith(1)
+
+    exitSpy.mockRestore()
+  })
+})

--- a/packages/shadcn/src/preflights/preflight-init.ts
+++ b/packages/shadcn/src/preflights/preflight-init.ts
@@ -65,7 +65,17 @@ export async function preFlightInit(
   const projectInfo = await getProjectInfo(options.cwd, {
     configCssFile: typeof tailwind?.css === "string" ? tailwind.css : undefined,
   })
-  if (!projectInfo || projectInfo?.framework.name === "manual") {
+  // When an existing components.json is already present (re-init or the
+  // `apply` command), the project has been configured for shadcn. This is
+  // common for UI-library workspaces in monorepos (e.g. `packages/ui`) which
+  // don't ship their own framework config. Trust the existing config and
+  // skip the framework check rather than failing with
+  // UNSUPPORTED_FRAMEWORK.
+  const hasExistingConfig = Boolean(options.existingConfig)
+  if (
+    !hasExistingConfig &&
+    (!projectInfo || projectInfo?.framework.name === "manual")
+  ) {
     errors[ERRORS.UNSUPPORTED_FRAMEWORK] = true
     frameworkSpinner?.fail()
 
@@ -93,15 +103,19 @@ export async function preFlightInit(
     logger.break()
     process.exit(1)
   }
-  frameworkSpinner?.succeed(
-    `Verifying framework. Found ${highlighter.info(
-      projectInfo.framework.label
-    )}.`
-  )
+  if (projectInfo && projectInfo.framework.name !== "manual") {
+    frameworkSpinner?.succeed(
+      `Verifying framework. Found ${highlighter.info(
+        projectInfo.framework.label
+      )}.`
+    )
+  } else {
+    frameworkSpinner?.succeed(`Verifying framework.`)
+  }
 
   let tailwindSpinnerMessage = "Validating Tailwind CSS."
 
-  if (projectInfo.tailwindVersion === "v4") {
+  if (projectInfo?.tailwindVersion === "v4") {
     tailwindSpinnerMessage = `Validating Tailwind CSS. Found ${highlighter.info(
       "v4"
     )}.`
@@ -111,18 +125,18 @@ export async function preFlightInit(
     silent: options.silent,
   }).start()
   if (
-    projectInfo.tailwindVersion === "v3" &&
+    projectInfo?.tailwindVersion === "v3" &&
     (!projectInfo?.tailwindConfigFile || !projectInfo?.tailwindCssFile)
   ) {
     errors[ERRORS.TAILWIND_NOT_CONFIGURED] = true
     tailwindSpinner?.fail()
   } else if (
-    projectInfo.tailwindVersion === "v4" &&
+    projectInfo?.tailwindVersion === "v4" &&
     !projectInfo?.tailwindCssFile
   ) {
     errors[ERRORS.TAILWIND_NOT_CONFIGURED] = true
     tailwindSpinner?.fail()
-  } else if (!projectInfo.tailwindVersion) {
+  } else if (!projectInfo?.tailwindVersion) {
     errors[ERRORS.TAILWIND_NOT_CONFIGURED] = true
     tailwindSpinner?.fail()
   } else {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix.

## What is the current behavior?
Closes #10411

Running `shadcn apply -c packages/ui` (or `bunx shadcn@latest apply --preset … -c packages/ui`) from a shadcn-generated monorepo fails with:

```
We could not detect a supported framework at /.../packages/ui.
Visit https://ui.shadcn.com/docs/installation/manual to manually configure your project.
Once configured, you can use the cli to add components.
```

The target `packages/ui` has a valid `components.json` (it was scaffolded by `shadcn init` itself), but it has no framework config file (`next.config.*`, `vite.config.*`, etc.) because the UI library workspace intentionally doesn't ship one — those live in `apps/web`. `preFlightInit` then flags the workspace with `UNSUPPORTED_FRAMEWORK` and exits.

## What is the new behavior?
`preFlightInit` now treats a provided `options.existingConfig` as proof the project has already been configured for shadcn, and skips the framework detection error in that case. The tailwind-CSS and import-alias checks continue to run normally, so misconfigured projects are still caught.

Practical effects:

- `shadcn apply --preset … -c packages/ui` now proceeds past preflight and applies the preset.
- Any re-init on a project that already has a `components.json` no longer fails with `UNSUPPORTED_FRAMEWORK` if the framework can't be auto-detected.
- First-time `init` behaviour is unchanged — without `existingConfig` the original monorepo detection + error message still apply.

## Additional context
- A regression test was added at `packages/shadcn/src/preflights/preflight-init.test.ts` covering both the new branch (existingConfig present, no framework -> no error) and the pre-existing branch (no existingConfig, no framework -> exits with error).
- A patch changeset was added for `shadcn`.