### PR TITLE
docs(rtl): fix TanStack Start root route example

### DIFF
--- a/apps/v4/content/docs/rtl/start.mdx
+++ b/apps/v4/content/docs/rtl/start.mdx
@@ -37,18 +37,20 @@ Add the `dir="rtl"` and `lang="ar"` attributes to the `html` tag. Update `lang="
 
 Then wrap your app with the `DirectionProvider` component with the `direction="rtl"` prop in your `__root.tsx`:
 
-```tsx title="src/routes/__root.tsx" showLineNumbers {1,9,14-16}
+```tsx title="src/routes/__root.tsx" showLineNumbers {3,11,16}
+import { createRootRoute, HeadContent, Scripts } from "@tanstack/react-router"
+
 import { DirectionProvider } from "@/components/ui/direction"
 
 export const Route = createRootRoute({
-  component: RootComponent,
+  shellComponent: RootDocument,
 })
 
-function RootComponent() {
+function RootDocument({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ar" dir="rtl">
       <head>
-        <Meta />
+        <HeadContent />
       </head>
       <body>
         <DirectionProvider direction="rtl">{children}</DirectionProvider>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation fix.

## What is the current behavior?

The `Add DirectionProvider` step on [docs/rtl/start](https://ui.shadcn.com/docs/rtl/start) shows a `src/routes/__root.tsx` snippet that does not compile and does not match the current TanStack Start API used by the `start-app` / `start-monorepo` templates in this repo:

- `createRootRoute`, `HeadContent`, and `Scripts` are referenced without being imported.
- The route is registered with `component: RootComponent`, but `RootComponent` takes no props and then references an undefined `{children}` identifier inside the `<DirectionProvider>`.
- The head renders `<Meta />`, which is not exported from `@tanstack/react-router`; TanStack Start exposes `HeadContent` for head metadata.

Users copying this snippet into a fresh TanStack Start project hit a TypeScript error (`Cannot find name 'children'`) and a runtime import error for `<Meta />`.

## What is the new behavior?

The snippet is updated to match `templates/start-app/src/routes/__root.tsx`:

- Add the missing `createRootRoute`, `HeadContent`, `Scripts` imports from `@tanstack/react-router`.
- Switch to `shellComponent: RootDocument` and rename the function to `RootDocument`.
- Destructure `{ children }: { children: React.ReactNode }` on `RootDocument` so `<DirectionProvider>` receives a defined value.
- Replace `<Meta />` with `<HeadContent />`.
- Refresh the highlighted line numbers to point at the RTL-relevant lines (`DirectionProvider` import, `<html dir="rtl">`, and the `<DirectionProvider direction="rtl">` wrapper).

Only `apps/v4/content/docs/rtl/start.mdx` is touched; no changeset is needed since the `v4` docs app is listed under `ignore` in `.changeset/config.json`.