### PR TITLE
docs: fix broken link on /blocks page

### DIFF
--- a/apps/v4/app/(app)/blocks/layout.tsx
+++ b/apps/v4/app/(app)/blocks/layout.tsx
@@ -56,7 +56,7 @@ export default function BlocksLayout({
             <a href="#blocks">Browse Blocks</a>
           </Button>
           <Button asChild variant="ghost" size="sm">
-            <Link href="/docs/blocks">Add a block</Link>
+            <Link href="/blocks">Add a block</Link>
           </Button>
         </PageActions>
       </PageHeader>


### PR DESCRIPTION
Fixes shadcn-ui/ui#10079

The 'add a block' button was linking to /docs/blocks which returns 404. Updated to link to the correct path /blocks.