### PR TITLE
fix: restore scroll position when RTL component preview mounts

### DIFF
--- a/apps/v4/components/component-preview-tabs.tsx
+++ b/apps/v4/components/component-preview-tabs.tsx
@@ -45,11 +45,22 @@ export function ComponentPreviewTabs({
   direction?: "ltr" | "rtl"
   styleName?: string
 }) {
+  const previewRef = React.useRef<HTMLDivElement>(null)
+
   const [isMobileCodeVisible, setIsMobileCodeVisible] = React.useState(false)
   const base = styleName?.split("-")[0]
 
+  React.useEffect(() => {
+    if (direction !== "rtl") return
+    const scrollY = window.scrollY
+    requestAnimationFrame(() => {
+      window.scrollTo({ top: scrollY })
+    })
+  }, [direction])
+
   return (
     <div
+      ref={previewRef}
       data-slot="component-preview"
       className={cn(
         "group relative mt-4 mb-12 flex flex-col overflow-hidden rounded-xl border",


### PR DESCRIPTION
## What does this PR do?

Fixes the auto-scroll behavior on the Command component docs page when navigating to:
- `/docs/components/radix/command`
- `/docs/components/base/command`

## Root Cause

The RTL `ComponentPreview` renders a `LanguageSelector` which uses Base UI's `Select` component. Base UI Select internally renders a hidden input that receives focus on mount, causing the browser to scroll to its position (~4435px down the page).

## Fix

Capture `window.scrollY` before the RTL component mounts, then restore it after mount via `requestAnimationFrame`.

## How to test

1. Navigate to `/docs/components/radix/command`
2. Page should no longer auto-scroll to bottom on load

Closes #10394