### PR TITLE
fix(cli): emit arbitrary values for raw CSS colors when cssVariables is false

### DIFF
--- a/packages/shadcn/src/utils/transformers/transform-css-vars.ts
+++ b/packages/shadcn/src/utils/transformers/transform-css-vars.ts
@@ -147,6 +147,21 @@ export function splitClassName(className: string): (string | null)[] {
 
 const PREFIXES = ["bg-", "text-", "border-", "ring-offset-", "ring-"]
 
+// Raw CSS color values (e.g. `oklch(0.205 0 0)`, `#fff`, `rgb(0 0 0)`) cannot
+// be appended to a utility prefix directly because Tailwind only accepts
+// palette tokens (e.g. `stone-900`) in that position. Detect them so they can
+// be emitted as arbitrary values instead (e.g. `bg-[oklch(0.205_0_0)]`).
+function isRawCssColor(value: string) {
+  return /[\s()#]/.test(value)
+}
+
+function formatColorUtility(prefix: string, color: string) {
+  if (isRawCssColor(color)) {
+    return `${prefix}[${color.replace(/\s+/g, "_")}]`
+  }
+  return `${prefix}${color}`
+}
+
 export function applyColorMapping(
   input: string,
   mapping: z.infer<typeof registryBaseColorSchema>["inlineColors"]
@@ -173,13 +188,13 @@ export function applyColorMapping(
     const needle = value?.replace(prefix, "")
     if (needle && needle in mapping.light) {
       lightMode.add(
-        [variant, `${prefix}${mapping.light[needle]}`]
+        [variant, formatColorUtility(prefix, mapping.light[needle])]
           .filter(Boolean)
           .join(":") + (modifier ? `/${modifier}` : "")
       )
 
       darkMode.add(
-        ["dark", variant, `${prefix}${mapping.dark[needle]}`]
+        ["dark", variant, formatColorUtility(prefix, mapping.dark[needle])]
           .filter(Boolean)
           .join(":") + (modifier ? `/${modifier}` : "")
       )

--- a/packages/shadcn/test/utils/apply-color-mapping.test.ts
+++ b/packages/shadcn/test/utils/apply-color-mapping.test.ts
@@ -82,3 +82,70 @@ describe("apply color mapping", async () => {
     expect(applyColorMapping(input, baseColor.inlineColors)).toBe(output)
   })
 })
+
+// Ensure base colors that use raw CSS color values (oklch, rgb, hsl, hex) are
+// emitted as Tailwind arbitrary values instead of being concatenated directly
+// after the utility prefix. See: https://github.com/shadcn-ui/ui/issues/10429
+describe("apply color mapping with raw CSS color values", async () => {
+  const oklchColors = {
+    light: {
+      background: "oklch(1 0 0)",
+      foreground: "oklch(0.145 0 0)",
+      primary: "oklch(0.205 0 0)",
+      "primary-foreground": "oklch(0.985 0 0)",
+      muted: "oklch(0.97 0 0)",
+      "accent-foreground": "oklch(0.205 0 0)",
+      border: "oklch(0.922 0 0)",
+      ring: "oklch(0.708 0 0)",
+      destructive: "oklch(0.577 0.245 27.325)",
+    },
+    dark: {
+      background: "oklch(0.145 0 0)",
+      foreground: "oklch(0.985 0 0)",
+      primary: "oklch(0.922 0 0)",
+      "primary-foreground": "oklch(0.205 0 0)",
+      muted: "oklch(0.269 0 0)",
+      "accent-foreground": "oklch(0.985 0 0)",
+      border: "oklch(1 0 0 / 10%)",
+      ring: "oklch(0.556 0 0)",
+      destructive: "oklch(0.704 0.191 22.216)",
+    },
+  }
+
+  test.each([
+    {
+      input: "bg-primary text-primary-foreground",
+      output:
+        "bg-[oklch(0.205_0_0)] text-[oklch(0.985_0_0)] dark:bg-[oklch(0.922_0_0)] dark:text-[oklch(0.205_0_0)]",
+    },
+    {
+      input: "bg-background text-foreground",
+      output:
+        "bg-[oklch(1_0_0)] text-[oklch(0.145_0_0)] dark:bg-[oklch(0.145_0_0)] dark:text-[oklch(0.985_0_0)]",
+    },
+    {
+      input: "hover:bg-muted sm:focus:text-accent-foreground",
+      output:
+        "hover:bg-[oklch(0.97_0_0)] sm:focus:text-[oklch(0.205_0_0)] dark:hover:bg-[oklch(0.269_0_0)] dark:sm:focus:text-[oklch(0.985_0_0)]",
+    },
+    {
+      input: "bg-primary/80",
+      output: "bg-[oklch(0.205_0_0)]/80 dark:bg-[oklch(0.922_0_0)]/80",
+    },
+    {
+      input: "ring-ring border-border",
+      output:
+        "ring-[oklch(0.708_0_0)] border-[oklch(0.922_0_0)] dark:ring-[oklch(0.556_0_0)] dark:border-[oklch(1_0_0_/_10%)]",
+    },
+    {
+      input: "text-destructive",
+      output:
+        "text-[oklch(0.577_0.245_27.325)] dark:text-[oklch(0.704_0.191_22.216)]",
+    },
+  ])(
+    `applyColorMapping($input) -> $output`,
+    ({ input, output }) => {
+      expect(applyColorMapping(input, oklchColors)).toBe(output)
+    }
+  )
+})


### PR DESCRIPTION
## Summary

When `tailwind.cssVariables: false` (or `--no-css-variables` on `shadcn init`), the CLI rewrites utility classes like `bg-primary` using each base color's `inlineColors` map. The current implementation concatenates the Tailwind utility prefix with the raw value from that map:

```ts
`${prefix}${mapping.light[needle]}`
```

This worked when `inlineColors` held palette tokens (e.g. `stone-900`). The production color data in `apps/v4/public/r/colors/*.json` now stores raw OKLCH color functions such as `oklch(0.205 0 0)` and `oklch(1 0 0 / 10%)`, so the concatenation produces invalid classes like:

```
bg-oklch(0.205 0 0)
border-oklch(0.922 0 0)
dark:ring-oklch(0.556 0 0)/50
```

Tailwind cannot parse these, which is why generated components end up unstyled when users opt out of CSS variables.

## What this PR does

Adds a small `formatColorUtility(prefix, color)` helper in `transform-css-vars.ts` that:

- Detects **raw CSS color values** (whitespace, parentheses, or `#`) and emits them as Tailwind arbitrary values with spaces replaced by underscores, e.g. `bg-[oklch(0.205_0_0)]`.
- Leaves **palette tokens** like `stone-900` and **named colors** like `white` / `transparent` untouched, preserving existing behavior for color fixtures that still use that form.

This is applied to both the light and dark output paths inside `applyColorMapping`, and works correctly with:

- variants (`hover:`, `sm:focus:`, `dark:`, `aria-invalid:`, etc.)
- alpha modifiers (`/80`, `/20`) — the modifier is appended after the arbitrary-value bracket (`bg-[oklch(0.205_0_0)]/80`)
- values with a baked-in alpha channel, e.g. `oklch(1 0 0 / 10%)` — the slash sits inside the brackets and is treated literally
- compound OKLCH colors, e.g. `oklch(0.577 0.245 27.325)` for destructive

### Sample output after the fix

| Before (invalid) | After (valid) |
|---|---|
| `bg-oklch(0.205 0 0)` | `bg-[oklch(0.205_0_0)]` |
| `border-oklch(0.922 0 0)` | `border-[oklch(0.922_0_0)]` |
| `dark:ring-oklch(0.556 0 0)/50` | `dark:ring-[oklch(0.556_0_0)]/50` |
| `dark:border-oklch(1 0 0 / 10%)` | `dark:border-[oklch(1_0_0_/_10%)]` |
| `bg-oklch(0.577 0.245 27.325)/10` | `bg-[oklch(0.577_0.245_27.325)]/10` |

Palette-based output (e.g. `bg-stone-900`, `bg-white`) is unchanged.

## Out of scope

While investigating I noticed the generated output in the issue also contains artifacts like `dark:dark:aria-invalid:...` and `dark:dark:border-oklch(...)` — the transformer unconditionally prepends `dark:` even when the source class already starts with `dark:`. That's a separate, pre-existing bug in the same file and not what #10429 is reporting, so I've left it for a follow-up PR to keep this change minimal and reviewable.

## Tests

- Added a new `describe("apply color mapping with raw CSS color values")` block in `packages/shadcn/test/utils/apply-color-mapping.test.ts` covering OKLCH base colors across the affected prefixes (`bg-`, `text-`, `border-`, `ring-`), variants, alpha modifiers, and values with baked-in alpha.
- Existing snapshot tests in `test/utils/transform-css-vars.test.ts` (which use the `stone` fixture with palette tokens) still pass — no regression for palette-based inline colors.
- `tsc --noEmit` passes.

## Files changed

- `packages/shadcn/src/utils/transformers/transform-css-vars.ts`
- `packages/shadcn/test/utils/apply-color-mapping.test.ts`

No generated files, no docs, no `styles/**`, no `public/r/**`.

Fixes #10429