### PR TITLE
fix(cli): substitute ${configDir} template variable in tsconfig paths

### DIFF
--- a/packages/shadcn/src/registry/utils.ts
+++ b/packages/shadcn/src/registry/utils.ts
@@ -8,13 +8,12 @@ import {
 } from "@/src/schema"
 import { Config } from "@/src/utils/get-config"
 import { getProjectInfo, ProjectInfo } from "@/src/utils/get-project-info"
-import { resolveImport } from "@/src/utils/resolve-import"
+import { loadTsConfig, resolveImport } from "@/src/utils/resolve-import"
 import {
   findCommonRoot,
   resolveFilePath,
 } from "@/src/utils/updaters/update-files"
 import { Project, ScriptKind } from "ts-morph"
-import { loadConfig } from "tsconfig-paths"
 import { z } from "zod"
 
 const FILE_EXTENSIONS_FOR_LOOKUP = [".tsx", ".ts", ".jsx", ".js", ".css"]
@@ -96,7 +95,7 @@ export async function recursivelyResolveFileImports(
   const sourceFile = project.createSourceFile(tempFile, content, {
     scriptKind: ScriptKind.TSX,
   })
-  const tsConfig = await loadConfig(config.resolvedPaths.cwd)
+  const tsConfig = await loadTsConfig(config.resolvedPaths.cwd)
   if (tsConfig.resultType === "failed") {
     return { dependencies: [], files: [] }
   }

--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -7,10 +7,9 @@ import {
 } from "@/src/schema"
 import { getProjectInfo } from "@/src/utils/get-project-info"
 import { highlighter } from "@/src/utils/highlighter"
-import { resolveImport } from "@/src/utils/resolve-import"
+import { loadTsConfig, resolveImport } from "@/src/utils/resolve-import"
 import { cosmiconfig } from "cosmiconfig"
 import fg from "fast-glob"
-import { loadConfig } from "tsconfig-paths"
 import { z } from "zod"
 
 export const DEFAULT_STYLE = "default"
@@ -54,7 +53,7 @@ export async function resolveConfigPaths(
   }
 
   // Read tsconfig.json.
-  const tsConfig = await loadConfig(cwd)
+  const tsConfig = await loadTsConfig(cwd)
 
   if (tsConfig.resultType === "failed") {
     throw new Error(

--- a/packages/shadcn/src/utils/get-project-info.ts
+++ b/packages/shadcn/src/utils/get-project-info.ts
@@ -6,9 +6,9 @@ import { rawConfigSchema } from "@/src/schema"
 import { Framework, FRAMEWORKS } from "@/src/utils/frameworks"
 import { Config, getConfig, resolveConfigPaths } from "@/src/utils/get-config"
 import { getPackageInfo } from "@/src/utils/get-package-info"
+import { loadTsConfig } from "@/src/utils/resolve-import"
 import fg from "fast-glob"
 import fs from "fs-extra"
-import { loadConfig } from "tsconfig-paths"
 import { z } from "zod"
 
 export type TailwindVersion = "v3" | "v4" | null
@@ -299,7 +299,7 @@ export async function getTailwindConfigFile(cwd: string) {
 }
 
 export async function getTsConfigAliasPrefix(cwd: string) {
-  const tsConfig = await loadConfig(cwd)
+  const tsConfig = await loadTsConfig(cwd)
 
   if (
     tsConfig?.resultType === "failed" ||

--- a/packages/shadcn/src/utils/resolve-import.ts
+++ b/packages/shadcn/src/utils/resolve-import.ts
@@ -1,4 +1,10 @@
-import { createMatchPath, type ConfigLoaderSuccessResult } from "tsconfig-paths"
+import path from "path"
+import {
+  createMatchPath,
+  loadConfig as loadTsConfigPaths,
+  type ConfigLoaderResult,
+  type ConfigLoaderSuccessResult,
+} from "tsconfig-paths"
 
 export async function resolveImport(
   importPath: string,
@@ -10,4 +16,78 @@ export async function resolveImport(
     () => true,
     [".ts", ".tsx", ".jsx", ".js", ".css"]
   )
+}
+
+/**
+ * Wrapper around `tsconfig-paths#loadConfig` that substitutes TypeScript's
+ * `${configDir}` template variable in `baseUrl` and `paths` with the directory
+ * of the resolved tsconfig file.
+ *
+ * TypeScript 5.5 introduced `${configDir}` for path mapping in extendable
+ * tsconfigs (common in monorepos). `tsconfig-paths` (v4) does not substitute
+ * this token, so without this wrapper paths like `"${configDir}/src/*"` are
+ * passed through literally and the CLI ends up writing components to a folder
+ * literally named `${configDir}`.
+ *
+ * See: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#the-configdir-template-variable-for-configuration-files
+ */
+export function loadTsConfig(cwd?: string): ConfigLoaderResult {
+  const result = loadTsConfigPaths(cwd)
+  return substituteConfigDir(result)
+}
+
+export function substituteConfigDir(
+  result: ConfigLoaderResult
+): ConfigLoaderResult {
+  if (result.resultType !== "success") {
+    return result
+  }
+
+  if (!containsConfigDir(result.baseUrl) && !pathsContainConfigDir(result.paths)) {
+    return result
+  }
+
+  const configDir = path.dirname(result.configFileAbsolutePath)
+
+  const substitutedBaseUrl = result.baseUrl
+    ? replaceConfigDir(result.baseUrl, configDir)
+    : result.baseUrl
+
+  const substitutedPaths = Object.fromEntries(
+    Object.entries(result.paths).map(([alias, values]) => [
+      alias,
+      values.map((value) => replaceConfigDir(value, configDir)),
+    ])
+  )
+
+  // Recompute absoluteBaseUrl when baseUrl contained `${configDir}`, otherwise
+  // `tsconfig-paths` has already produced a correct value.
+  const absoluteBaseUrl =
+    result.baseUrl && containsConfigDir(result.baseUrl) && substitutedBaseUrl
+      ? path.resolve(configDir, substitutedBaseUrl)
+      : result.absoluteBaseUrl
+
+  return {
+    ...result,
+    baseUrl: substitutedBaseUrl,
+    absoluteBaseUrl,
+    paths: substitutedPaths,
+  }
+}
+
+function containsConfigDir(value: string | undefined): boolean {
+  return typeof value === "string" && value.includes("${configDir}")
+}
+
+function pathsContainConfigDir(paths: Record<string, string[]>): boolean {
+  for (const values of Object.values(paths)) {
+    for (const value of values) {
+      if (containsConfigDir(value)) return true
+    }
+  }
+  return false
+}
+
+function replaceConfigDir(value: string, configDir: string): string {
+  return value.replace(/\$\{configDir\}/g, configDir)
 }

--- a/packages/shadcn/src/utils/updaters/update-files.ts
+++ b/packages/shadcn/src/utils/updaters/update-files.ts
@@ -15,7 +15,7 @@ import { Config } from "@/src/utils/get-config"
 import { getProjectInfo, ProjectInfo } from "@/src/utils/get-project-info"
 import { highlighter } from "@/src/utils/highlighter"
 import { logger } from "@/src/utils/logger"
-import { resolveImport } from "@/src/utils/resolve-import"
+import { loadTsConfig, resolveImport } from "@/src/utils/resolve-import"
 import { spinner } from "@/src/utils/spinner"
 import { transform } from "@/src/utils/transformers"
 import { transformAsChild } from "@/src/utils/transformers/transform-aschild"
@@ -31,7 +31,6 @@ import { transformRtl } from "@/src/utils/transformers/transform-rtl"
 import { transformTwPrefixes } from "@/src/utils/transformers/transform-tw-prefix"
 import prompts from "prompts"
 import { Project, ScriptKind } from "ts-morph"
-import { loadConfig } from "tsconfig-paths"
 import { z } from "zod"
 
 export async function updateFiles(
@@ -524,7 +523,7 @@ async function resolveImports(filePaths: string[], config: Config) {
     compilerOptions: {},
   })
   const projectInfo = await getProjectInfo(config.resolvedPaths.cwd)
-  const tsConfig = loadConfig(config.resolvedPaths.cwd)
+  const tsConfig = loadTsConfig(config.resolvedPaths.cwd)
   const updatedFiles = []
 
   if (!projectInfo || tsConfig.resultType === "failed") {

--- a/packages/shadcn/test/fixtures/with-config-dir/tsconfig.json
+++ b/packages/shadcn/test/fixtures/with-config-dir/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "baseUrl": "${configDir}",
+    "paths": {
+      "@/*": ["${configDir}/src/*"],
+      "~/components/*": ["${configDir}/src/components/*"],
+      "~/lib": ["${configDir}/src/lib"]
+    }
+  }
+}

--- a/packages/shadcn/test/utils/resolve-import.test.ts
+++ b/packages/shadcn/test/utils/resolve-import.test.ts
@@ -1,8 +1,12 @@
 import path from "path"
 import { loadConfig, type ConfigLoaderSuccessResult } from "tsconfig-paths"
-import { expect, test } from "vitest"
+import { describe, expect, test } from "vitest"
 
-import { resolveImport } from "../../src/utils/resolve-import"
+import {
+  loadTsConfig,
+  resolveImport,
+  substituteConfigDir,
+} from "../../src/utils/resolve-import"
 
 test("resolve import", async () => {
   expect(
@@ -77,5 +81,106 @@ test("resolve import without base url", async () => {
   )
   expect(await resolveImport("foo/bar", config)).toEqual(
     path.resolve(cwd, "foo/bar")
+  )
+})
+
+// Ensures the TypeScript 5.5 `${configDir}` template variable is substituted
+// when resolving tsconfig paths. Without this, the CLI creates components at
+// literal `${configDir}/src/components/ui` paths in monorepos that rely on
+// `${configDir}` in a shared base tsconfig.
+// See: https://github.com/shadcn-ui/ui/issues/10428
+describe("substituteConfigDir", () => {
+  test("returns the input unchanged when no ${configDir} tokens exist", () => {
+    const input: ConfigLoaderSuccessResult = {
+      resultType: "success",
+      configFileAbsolutePath: "/Users/shadcn/project/tsconfig.json",
+      baseUrl: ".",
+      absoluteBaseUrl: "/Users/shadcn/project",
+      paths: {
+        "@/*": ["./src/*"],
+      },
+    }
+
+    const result = substituteConfigDir(input)
+
+    expect(result).toBe(input)
+  })
+
+  test("substitutes ${configDir} in baseUrl and paths, recomputes absoluteBaseUrl", () => {
+    const configDir = "/Users/shadcn/project"
+    const input: ConfigLoaderSuccessResult = {
+      resultType: "success",
+      configFileAbsolutePath: path.join(configDir, "tsconfig.json"),
+      baseUrl: "${configDir}",
+      absoluteBaseUrl: path.join(configDir, "${configDir}"),
+      paths: {
+        "@/*": ["${configDir}/src/*"],
+        "~/components/*": ["${configDir}/src/components/*"],
+        "~/lib": ["${configDir}/src/lib"],
+      },
+    }
+
+    const result = substituteConfigDir(input) as ConfigLoaderSuccessResult
+
+    expect(result.baseUrl).toBe(configDir)
+    expect(result.absoluteBaseUrl).toBe(configDir)
+    expect(result.paths).toEqual({
+      "@/*": [`${configDir}/src/*`],
+      "~/components/*": [`${configDir}/src/components/*`],
+      "~/lib": [`${configDir}/src/lib`],
+    })
+  })
+
+  test("leaves absoluteBaseUrl intact when only paths reference ${configDir}", () => {
+    const configDir = "/Users/shadcn/project"
+    const input: ConfigLoaderSuccessResult = {
+      resultType: "success",
+      configFileAbsolutePath: path.join(configDir, "tsconfig.json"),
+      baseUrl: ".",
+      absoluteBaseUrl: configDir,
+      paths: {
+        "@/*": ["${configDir}/src/*"],
+      },
+    }
+
+    const result = substituteConfigDir(input) as ConfigLoaderSuccessResult
+
+    expect(result.baseUrl).toBe(".")
+    expect(result.absoluteBaseUrl).toBe(configDir)
+    expect(result.paths).toEqual({
+      "@/*": [`${configDir}/src/*`],
+    })
+  })
+
+  test("passes through failure results untouched", () => {
+    const failure = {
+      resultType: "failed" as const,
+      message: "could not load",
+    }
+
+    expect(substituteConfigDir(failure)).toBe(failure)
+  })
+})
+
+test("resolve import with ${configDir} in tsconfig", async () => {
+  const cwd = path.resolve(__dirname, "../fixtures/with-config-dir")
+  const config = loadTsConfig(cwd) as ConfigLoaderSuccessResult
+
+  expect(config.resultType).toBe("success")
+  expect(config.absoluteBaseUrl).toBe(cwd)
+  expect(config.paths).toEqual({
+    "@/*": [path.join(cwd, "src/*")],
+    "~/components/*": [path.join(cwd, "src/components/*")],
+    "~/lib": [path.join(cwd, "src/lib")],
+  })
+
+  expect(await resolveImport("@/components/ui", config)).toEqual(
+    path.resolve(cwd, "src/components/ui")
+  )
+  expect(await resolveImport("~/components/button", config)).toEqual(
+    path.resolve(cwd, "src/components/button")
+  )
+  expect(await resolveImport("~/lib", config)).toEqual(
+    path.resolve(cwd, "src/lib")
   )
 })


### PR DESCRIPTION
## Summary

Closes #10428

TypeScript 5.5 introduced the [`${configDir}` template variable](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#the-configdir-template-variable-for-configuration-files), which is commonly used in monorepos so a shared base `tsconfig.json` can define portable `baseUrl` / `paths` that resolve correctly in every extending project.

The CLI reads the user's `tsconfig.json` via `tsconfig-paths@4.2.0`, which does not substitute `${configDir}`. As a result, values like `"${configDir}/src/*"` were passed through literally to the path resolver, and `shadcn add` would happily write components to a folder named `${configDir}` on disk.

## Fix

- Add `loadTsConfig` / `substituteConfigDir` helpers in `packages/shadcn/src/utils/resolve-import.ts` that wrap `tsconfig-paths`'s `loadConfig` and replace every `${configDir}` occurrence in `baseUrl` and `paths` with `path.dirname(configFileAbsolutePath)` — matching TypeScript's semantics (the directory of the config at the end of the extends chain).
- When `baseUrl` itself contained `${configDir}`, `absoluteBaseUrl` is recomputed so `createMatchPath` gets a real filesystem path. Otherwise it's left untouched.
- Early-return the original result when no token is present, so the fix is a no-op for every existing project.
- Point the CLI's four internal `loadConfig` call sites at the new wrapper:
  - `src/utils/get-config.ts`
  - `src/utils/get-project-info.ts`
  - `src/registry/utils.ts`
  - `src/utils/updaters/update-files.ts`

## Before / after

Given a monorepo base config like:

```jsonc
// tsconfig.json
{
  "compilerOptions": {
    "baseUrl": "${configDir}",
    "paths": {
      "@/*": ["${configDir}/src/*"]
    }
  }
}