### PR TITLE
fix(cli): normalize versioned package manager detection

### DIFF
--- a/packages/shadcn/src/utils/get-package-manager.ts
+++ b/packages/shadcn/src/utils/get-package-manager.ts
@@ -1,37 +1,39 @@
 import { detect } from "@antfu/ni"
 
+function normalizePackageManager(packageManager?: string | null) {
+  if (!packageManager) {
+    return null
+  }
+
+  if (packageManager.startsWith("yarn")) return "yarn"
+  if (packageManager.startsWith("pnpm")) return "pnpm"
+  if (packageManager.startsWith("bun")) return "bun"
+  if (packageManager.startsWith("deno")) return "deno"
+  if (packageManager.startsWith("npm")) return "npm"
+
+  return null
+}
+
 export async function getPackageManager(
   targetDir: string,
   { withFallback }: { withFallback?: boolean } = {
     withFallback: false,
   }
 ): Promise<"yarn" | "pnpm" | "bun" | "npm" | "deno"> {
-  const packageManager = await detect({ programmatic: true, cwd: targetDir })
+  const packageManager = normalizePackageManager(
+    await detect({ programmatic: true, cwd: targetDir })
+  )
 
-  if (packageManager === "yarn@berry") return "yarn"
-  if (packageManager === "pnpm@6") return "pnpm"
-  if (packageManager === "bun") return "bun"
-  if (packageManager === "deno") return "deno"
+  if (packageManager) {
+    return packageManager
+  }
+
   if (!withFallback) {
-    return packageManager ?? "npm"
+    return "npm"
   }
 
   // Fallback to user agent if not detected.
-  const userAgent = process.env.npm_config_user_agent || ""
-
-  if (userAgent.startsWith("yarn")) {
-    return "yarn"
-  }
-
-  if (userAgent.startsWith("pnpm")) {
-    return "pnpm"
-  }
-
-  if (userAgent.startsWith("bun")) {
-    return "bun"
-  }
-
-  return "npm"
+  return normalizePackageManager(process.env.npm_config_user_agent) ?? "npm"
 }
 
 export async function getPackageRunner(cwd: string) {

--- a/packages/shadcn/test/utils/get-package-manager.test.ts
+++ b/packages/shadcn/test/utils/get-package-manager.test.ts
@@ -1,9 +1,16 @@
 import path from "path"
-import { expect, test } from "vitest"
+import { afterEach, expect, test, vi } from "vitest"
 
-import { getPackageManager } from "../../src/utils/get-package-manager"
+afterEach(() => {
+  vi.resetModules()
+  vi.doUnmock("@antfu/ni")
+})
 
 test("get package manager", async () => {
+  const { getPackageManager } = await import(
+    "../../src/utils/get-package-manager"
+  )
+
   expect(
     await getPackageManager(path.resolve(__dirname, "../fixtures/project-yarn"))
   ).toBe("yarn")
@@ -29,4 +36,22 @@ test("get package manager", async () => {
   expect(
     await getPackageManager(path.resolve(__dirname, "../fixtures/next"))
   ).toBe("pnpm")
+})
+
+test("normalizes versioned package manager results", async () => {
+  vi.doMock("@antfu/ni", () => ({
+    detect: vi
+      .fn()
+      .mockResolvedValueOnce("pnpm@9.15.0")
+      .mockResolvedValueOnce("pnpm@9.15.0")
+      .mockResolvedValueOnce("yarn@1.22.22"),
+  }))
+
+  const { getPackageManager, getPackageRunner } = await import(
+    "../../src/utils/get-package-manager"
+  )
+
+  expect(await getPackageManager("/test")).toBe("pnpm")
+  expect(await getPackageRunner("/test")).toBe("pnpm dlx")
+  expect(await getPackageManager("/test")).toBe("yarn")
 })


### PR DESCRIPTION

**Repo:** shadcn-ui/ui (⭐ 83000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +50/-23

## What
Normalize version-suffixed package manager identifiers returned by `@antfu/ni` in the CLI utility that detects the current package manager. The patch replaces a couple of hard-coded special cases with a shared normalizer and adds a focused test that covers versioned `pnpm` and `yarn` results, including the `getPackageRunner()` path.

## Why
The previous logic only special-cased `pnpm@6` and `yarn@berry`. If detection returned values such as `pnpm@9.15.0` or `yarn@1.22.22`, the utility could leak those raw strings through a function typed to return plain package manager names, and `getPackageRunner()` would fall back to `npx` instead of `pnpm dlx`. This change makes the CLI robust across versioned detector outputs with minimal surface area.

## Testing
Verified `git diff --check` passes. Attempted to run `pnpm --filter=shadcn exec vitest run test/utils/get-package-manager.test.ts`, but the sandbox blocked `pnpm exec` because it tried to write to `/Users/bojun/Library/pnpm/.tools/...` outside the workspace.

## Risk
Low / the change is isolated to package manager normalization logic and adds regression coverage for the affected cases.
