### PR TITLE
feat(sidebar): add SidebarInsetFooter

### DIFF
--- a/apps/v4/content/docs/components/base/sidebar.mdx
+++ b/apps/v4/content/docs/components/base/sidebar.mdx
@@ -127,6 +127,7 @@ SidebarProvider
 │   ├── SidebarFooter
 │   └── SidebarRail
 ├── SidebarInset
+│   └── SidebarInsetFooter
 └── SidebarTrigger
 ```
 
@@ -141,6 +142,7 @@ SidebarProvider
 - **SidebarMenu** / **SidebarMenuItem** — Menu structure for links, badges, actions, and nested submenus.
 - **SidebarRail** — Resize handle for adjusting sidebar width when applicable.
 - **SidebarInset** — Wraps main content when using the `inset` variant.
+- **SidebarInsetFooter** — Pins a container (e.g. a chat prompt input) to the bottom of `SidebarInset`.
 - **SidebarTrigger** — Control that toggles the sidebar open or collapsed.
 
 <Image
@@ -232,6 +234,69 @@ The main `Sidebar` component used to render a collapsible sidebar.
     <main>{children}</main>
   </SidebarInset>
 </SidebarProvider>
+```
+
+### SidebarInsetFooter
+
+Use the `SidebarInsetFooter` component to pin a container to the bottom of `SidebarInset`. This is useful for persistent UI such as a chat prompt input, a cookie notice, or a toolbar.
+
+For the footer to stay visually pinned while the main content scrolls, the content above it should be allowed to grow and scroll (e.g. `flex-1 overflow-auto`).
+
+```tsx showLineNumbers
+<SidebarProvider>
+  <Sidebar />
+  <SidebarInset>
+    <div className="flex-1 overflow-auto">{children}</div>
+    <SidebarInsetFooter>
+      <form>{/* chat prompt, etc. */}</form>
+    </SidebarInsetFooter>
+  </SidebarInset>
+</SidebarProvider>
+```
+
+### Controlling a right sidebar from anywhere
+
+To render both a left and a right sidebar and toggle each one independently — including from a standalone button placed outside the right sidebar — nest a second `SidebarProvider` around the right `Sidebar` and use the controlled `open` / `onOpenChange` props. Each provider owns its own state, so any button that sets that state can act as a trigger.
+
+```tsx showLineNumbers
+"use client"
+
+import * as React from "react"
+
+export function Layout({ children }: { children: React.ReactNode }) {
+  const [rightOpen, setRightOpen] = React.useState(false)
+
+  return (
+    <SidebarProvider>
+      <Sidebar side="left">{/* ... */}</Sidebar>
+
+      <SidebarInset>
+        <header className="flex h-14 items-center gap-2 border-b px-4">
+          {/* Toggles the left sidebar via the nearest provider. */}
+          <SidebarTrigger />
+
+          {/* Standalone button that toggles the right sidebar. */}
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => setRightOpen((open) => !open)}
+            className="ml-auto"
+          >
+            <PanelRightIcon />
+            <span className="sr-only">Toggle right sidebar</span>
+          </Button>
+        </header>
+
+        <div className="flex-1 overflow-auto">{children}</div>
+      </SidebarInset>
+
+      {/* A second provider owns the right sidebar's state. */}
+      <SidebarProvider open={rightOpen} onOpenChange={setRightOpen}>
+        <Sidebar side="right">{/* ... */}</Sidebar>
+      </SidebarProvider>
+    </SidebarProvider>
+  )
+}
 ```
 
 ## useSidebar

--- a/apps/v4/content/docs/components/radix/sidebar.mdx
+++ b/apps/v4/content/docs/components/radix/sidebar.mdx
@@ -127,6 +127,7 @@ SidebarProvider
 │   ├── SidebarFooter
 │   └── SidebarRail
 ├── SidebarInset
+│   └── SidebarInsetFooter
 └── SidebarTrigger
 ```
 
@@ -141,6 +142,7 @@ SidebarProvider
 - **SidebarMenu** / **SidebarMenuItem** — Menu structure for links, badges, actions, and nested submenus.
 - **SidebarRail** — Resize handle for adjusting sidebar width when applicable.
 - **SidebarInset** — Wraps main content when using the `inset` variant.
+- **SidebarInsetFooter** — Pins a container (e.g. a chat prompt input) to the bottom of `SidebarInset`.
 - **SidebarTrigger** — Control that toggles the sidebar open or collapsed.
 
 <Image
@@ -232,6 +234,69 @@ The main `Sidebar` component used to render a collapsible sidebar.
     <main>{children}</main>
   </SidebarInset>
 </SidebarProvider>
+```
+
+### SidebarInsetFooter
+
+Use the `SidebarInsetFooter` component to pin a container to the bottom of `SidebarInset`. This is useful for persistent UI such as a chat prompt input, a cookie notice, or a toolbar.
+
+For the footer to stay visually pinned while the main content scrolls, the content above it should be allowed to grow and scroll (e.g. `flex-1 overflow-auto`).
+
+```tsx showLineNumbers
+<SidebarProvider>
+  <Sidebar />
+  <SidebarInset>
+    <div className="flex-1 overflow-auto">{children}</div>
+    <SidebarInsetFooter>
+      <form>{/* chat prompt, etc. */}</form>
+    </SidebarInsetFooter>
+  </SidebarInset>
+</SidebarProvider>
+```
+
+### Controlling a right sidebar from anywhere
+
+To render both a left and a right sidebar and toggle each one independently — including from a standalone button placed outside the right sidebar — nest a second `SidebarProvider` around the right `Sidebar` and use the controlled `open` / `onOpenChange` props. Each provider owns its own state, so any button that sets that state can act as a trigger.
+
+```tsx showLineNumbers
+"use client"
+
+import * as React from "react"
+
+export function Layout({ children }: { children: React.ReactNode }) {
+  const [rightOpen, setRightOpen] = React.useState(false)
+
+  return (
+    <SidebarProvider>
+      <Sidebar side="left">{/* ... */}</Sidebar>
+
+      <SidebarInset>
+        <header className="flex h-14 items-center gap-2 border-b px-4">
+          {/* Toggles the left sidebar via the nearest provider. */}
+          <SidebarTrigger />
+
+          {/* Standalone button that toggles the right sidebar. */}
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => setRightOpen((open) => !open)}
+            className="ml-auto"
+          >
+            <PanelRightIcon />
+            <span className="sr-only">Toggle right sidebar</span>
+          </Button>
+        </header>
+
+        <div className="flex-1 overflow-auto">{children}</div>
+      </SidebarInset>
+
+      {/* A second provider owns the right sidebar's state. */}
+      <SidebarProvider open={rightOpen} onOpenChange={setRightOpen}>
+        <Sidebar side="right">{/* ... */}</Sidebar>
+      </SidebarProvider>
+    </SidebarProvider>
+  )
+}
 ```
 
 ## useSidebar

--- a/apps/v4/registry/bases/base/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/base/ui/sidebar.tsx
@@ -322,6 +322,20 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
   )
 }
 
+function SidebarInsetFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-inset-footer"
+      data-sidebar="inset-footer"
+      className={cn("cn-sidebar-inset-footer flex flex-col", className)}
+      {...props}
+    />
+  )
+}
+
 function SidebarInput({
   className,
   ...props
@@ -712,6 +726,7 @@ export {
   SidebarHeader,
   SidebarInput,
   SidebarInset,
+  SidebarInsetFooter,
   SidebarMenu,
   SidebarMenuAction,
   SidebarMenuBadge,

--- a/apps/v4/registry/bases/radix/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/radix/ui/sidebar.tsx
@@ -321,6 +321,20 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
   )
 }
 
+function SidebarInsetFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-inset-footer"
+      data-sidebar="inset-footer"
+      className={cn("cn-sidebar-inset-footer flex flex-col", className)}
+      {...props}
+    />
+  )
+}
+
 function SidebarInput({
   className,
   ...props
@@ -691,6 +705,7 @@ export {
   SidebarHeader,
   SidebarInput,
   SidebarInset,
+  SidebarInsetFooter,
   SidebarMenu,
   SidebarMenuAction,
   SidebarMenuBadge,

--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -318,6 +318,20 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
   )
 }
 
+function SidebarInsetFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-inset-footer"
+      data-sidebar="inset-footer"
+      className={cn("flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
 function SidebarInput({
   className,
   ...props
@@ -709,6 +723,7 @@ export {
   SidebarHeader,
   SidebarInput,
   SidebarInset,
+  SidebarInsetFooter,
   SidebarMenu,
   SidebarMenuAction,
   SidebarMenuBadge,


### PR DESCRIPTION
## Summary

Closes #10427

Adds a new `SidebarInsetFooter` primitive so consumers can pin a persistent container to the bottom of `SidebarInset`, mirroring how `SidebarFooter` works inside `Sidebar`. The motivating use case in the issue is a chat prompt input; the same pattern is useful for cookie notices, action toolbars, status bars, etc.

## What's added

- `SidebarInsetFooter` component in the three canonical sources:
  - `apps/v4/registry/bases/base/ui/sidebar.tsx`
  - `apps/v4/registry/bases/radix/ui/sidebar.tsx`
  - `apps/v4/registry/new-york-v4/ui/sidebar.tsx`
- Exported alphabetically (between `SidebarInset` and `SidebarMenu`).
- Uses `data-slot="sidebar-inset-footer"` and `data-sidebar="inset-footer"` to stay consistent with the existing attribute conventions used elsewhere in the component.
- In the `base` / `radix` variants it carries a `cn-sidebar-inset-footer` class hook so theme authors can attach their own styles without changing the component. No CSS rules are added to the theme files in this PR — the component works out of the box with the sensible `flex flex-col` default and themes can opt-in later if they want variant-specific styling.
- In `new-york-v4` it uses inline Tailwind (`flex flex-col gap-2 p-4`) to match the styling approach already used by the other inset-side elements in that variant.

## Docs

- Added `SidebarInsetFooter` to the composition tree and the structure bullet list.
- Added a dedicated `### SidebarInsetFooter` section with a usage example showing how to combine it with a scrollable content container so the footer stays visually pinned.
- Applied to both `components/base/sidebar.mdx` and `components/radix/sidebar.mdx`.

## Addressing the follow-up comment on #10427 (and why it's intentionally kept out of this PR's code changes)

The issue author left a follow-up comment asking for a standalone button that can control a **right** sidebar panel (not just the left), linking [#5651](https://github.com/shadcn-ui/ui/issues/5651) and [#8868](https://github.com/shadcn-ui/ui/issues/8868) as prior history.

I deliberately did **not** add a code-level API for this in this PR. The reasoning:

1. **#8868 was already declined by the maintainer.** On Nov 25 2025, @shadcn commented on that exact request:
   > "I looked into this but the implementation became too complex for single-sidebar, which accounts for 90% of cases."
   Any new `sidebarId` / multi-sidebar-context / "cross-provider trigger" API I could introduce here would be the same design that has already been rejected. Shipping it under this PR would almost certainly result in that part being reverted during review and, at worst, drag the uncontroversial footer addition down with it.

2. **#5651 is closed** (self-closed by the OP) with the canonical community pattern being **nested `SidebarProvider`s**, one per sidebar — i.e. the problem is already solvable with today's API.

3. **Scope discipline.** Bundling a rejected-direction architectural change with a clean additive component change is the fastest way to turn a mergeable PR into an unmergeable one. Keeping this PR strictly to `SidebarInsetFooter` keeps its review surface small and its chance of landing high.

**What I did do instead** is add a short **docs-only** subsection — `### Controlling a right sidebar from anywhere` — under `SidebarInset` in both sidebar MDX files. It demonstrates that the use case the commenter describes is already achievable on `main` today: nest a second `SidebarProvider` around the right `Sidebar`, hoist its state via the existing `open` / `onOpenChange` props, and use any `Button` as a standalone trigger. No new runtime API is introduced — the example uses props that already exist, so the documentation is immediately accurate and doesn't commit the project to a design that was previously declined.

If reviewers prefer, I'm happy to split the docs subsection out into a separate follow-up PR so this one is literally only the `SidebarInsetFooter` component.

## Usage example

```tsx
<SidebarProvider>
  <Sidebar />
  <SidebarInset>
    <div className="flex-1 overflow-auto">{children}</div>
    <SidebarInsetFooter>
      <form>{/* chat prompt, etc. */}</form>
    </SidebarInsetFooter>
  </SidebarInset>
</SidebarProvider>