### PR TITLE
fix(v4): add cursor-pointer to button component

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/button.tsx
+++ b/apps/v4/registry/new-york-v4/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 cursor-pointer",
   {
     variants: {
       variant: {


### PR DESCRIPTION
This PR adds `cursor-pointer` to the base button variants in the v4 registry.

### Description
In Tailwind CSS v4, the default button cursor was changed to follow W3C standards (which prefer the default cursor for buttons). However, this has resulted in significant UX confusion for users of shadcn/ui who expect interactive elements to provide visual 'hand' pointer feedback.

This fix restores the `cursor-pointer` class to the base `buttonVariants`.

### Related Issues
Fixes #6843 (122+ 👍 from the community)

### Checklist
- [x] Verified in v4 registry
- [x] Preserves `disabled:pointer-events-none` behavior