### PR TITLE
fix(v4): improve destructive alert contrast for WCAG AA compliance

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/alert.tsx
+++ b/apps/v4/registry/new-york-v4/ui/alert.tsx
@@ -10,7 +10,7 @@ const alertVariants = cva(
       variant: {
         default: "bg-card text-card-foreground",
         destructive:
-          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current",
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive [&>svg]:text-current",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
This PR improves the color contrast of the destructive alert description in the v4 registry.

### Description
The current implementation uses `text-destructive/90`, which results in a contrast ratio of approximately `4.49:1` against a white background (`#ffffff`). This falls just below the WCAG AA requirement of `4.5:1` for normal text.

Removing the `90%` opacity restores the contrast to approximately `4.76:1`, ensuring accessibility compliance by default.

### Related Issues
Fixes #10431

### Checklist
- [x] Verified contrast ratio math
- [x] Applies to `new-york-v4` registry