### PR TITLE
feat(components): add keepMounted prop to DialogContent

### DIFF
--- a/.changeset/dialog-keep-mounted.md
+++ b/.changeset/dialog-keep-mounted.md
@@ -1,0 +1,5 @@
+---
+"v4": patch
+---
+
+Added `keepMounted` prop to `DialogContent` to allow passing it to the underlying `DialogPortal`.

--- a/apps/v4/content/docs/components/base/dialog.mdx
+++ b/apps/v4/content/docs/components/base/dialog.mdx
@@ -85,6 +85,14 @@ import {
 </Dialog>
 ```
 
+### Keep Mounted
+
+Use the `keepMounted` prop to keep the dialog in the DOM when it is closed.
+
+```tsx
+<DialogContent keepMounted>...</DialogContent>
+```
+
 ## Composition
 
 Use the following composition to build a `Dialog`:

--- a/apps/v4/registry/bases/base/ui/dialog.tsx
+++ b/apps/v4/registry/bases/base/ui/dialog.tsx
@@ -40,12 +40,14 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  keepMounted = false,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
+  keepMounted?: boolean
 }) {
   return (
-    <DialogPortal>
+    <DialogPortal keepMounted={keepMounted}>
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"

--- a/apps/v4/styles/base-luma/ui/dialog.tsx
+++ b/apps/v4/styles/base-luma/ui/dialog.tsx
@@ -43,12 +43,14 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  keepMounted = false,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
+  keepMounted?: boolean
 }) {
   return (
-    <DialogPortal>
+    <DialogPortal keepMounted={keepMounted}>
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"

--- a/apps/v4/styles/base-lyra/ui/dialog.tsx
+++ b/apps/v4/styles/base-lyra/ui/dialog.tsx
@@ -43,12 +43,14 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  keepMounted = false,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
+  keepMounted?: boolean
 }) {
   return (
-    <DialogPortal>
+    <DialogPortal keepMounted={keepMounted}>
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"

--- a/apps/v4/styles/base-maia/ui/dialog.tsx
+++ b/apps/v4/styles/base-maia/ui/dialog.tsx
@@ -43,12 +43,14 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  keepMounted = false,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
+  keepMounted?: boolean
 }) {
   return (
-    <DialogPortal>
+    <DialogPortal keepMounted={keepMounted}>
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"

--- a/apps/v4/styles/base-mira/ui/dialog.tsx
+++ b/apps/v4/styles/base-mira/ui/dialog.tsx
@@ -43,12 +43,14 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  keepMounted = false,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
+  keepMounted?: boolean
 }) {
   return (
-    <DialogPortal>
+    <DialogPortal keepMounted={keepMounted}>
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"

--- a/apps/v4/styles/base-nova/ui-rtl/dialog.tsx
+++ b/apps/v4/styles/base-nova/ui-rtl/dialog.tsx
@@ -43,12 +43,14 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  keepMounted = false,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
+  keepMounted?: boolean
 }) {
   return (
-    <DialogPortal>
+    <DialogPortal keepMounted={keepMounted}>
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"

--- a/apps/v4/styles/base-nova/ui/dialog.tsx
+++ b/apps/v4/styles/base-nova/ui/dialog.tsx
@@ -43,12 +43,14 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  keepMounted = false,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
+  keepMounted?: boolean
 }) {
   return (
-    <DialogPortal>
+    <DialogPortal keepMounted={keepMounted}>
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"

--- a/apps/v4/styles/base-sera/ui/dialog.tsx
+++ b/apps/v4/styles/base-sera/ui/dialog.tsx
@@ -43,12 +43,14 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  keepMounted = false,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
+  keepMounted?: boolean
 }) {
   return (
-    <DialogPortal>
+    <DialogPortal keepMounted={keepMounted}>
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"

--- a/apps/v4/styles/base-vega/ui/dialog.tsx
+++ b/apps/v4/styles/base-vega/ui/dialog.tsx
@@ -43,12 +43,14 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  keepMounted = false,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
+  keepMounted?: boolean
 }) {
   return (
-    <DialogPortal>
+    <DialogPortal keepMounted={keepMounted}>
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"


### PR DESCRIPTION
## Summary
Adds a `keepMounted` prop to `DialogContent`, passing it through to `DialogPortal`.

## Problem
In Base UI dialogs, the content is unmounted when closed, which causes issues in scenarios where the DOM needs to persist (e.g. state reset, animations, or integrations relying on mounted elements).

## Solution
Expose a `keepMounted` prop on `DialogContent` so consumers can control this behavior.

## Notes
- Applied consistently across base-* styles
- Added example usage in docs

Related to #10483