### PR TITLE
fix(blocks): allow vertical page scroll

### DIFF
--- a/apps/v4/app/globals.css
+++ b/apps/v4/app/globals.css
@@ -172,7 +172,7 @@
     @apply bg-selection text-selection-foreground;
   }
   html {
-    @apply overscroll-y-none;
+    @apply overscroll-x-none;
   }
   body {
     font-synthesis-weight: none;
@@ -183,7 +183,7 @@
   }
 
   [data-slot="layout"] {
-    @apply overscroll-none;
+    @apply overscroll-x-none;
   }
 
   @supports (font: -apple-system-body) and (-webkit-appearance: none) {

--- a/apps/v4/app/layout.tsx
+++ b/apps/v4/app/layout.tsx
@@ -92,7 +92,7 @@ export default function RootLayout({
       </head>
       <body
         className={cn(
-          "group/body overscroll-none antialiased [--footer-height:calc(var(--spacing)*14)] [--header-height:calc(var(--spacing)*14)] xl:[--footer-height:calc(var(--spacing)*24)]"
+          "group/body overscroll-x-none antialiased [--footer-height:calc(var(--spacing)*14)] [--header-height:calc(var(--spacing)*14)] xl:[--footer-height:calc(var(--spacing)*24)]"
         )}
       >
         <ThemeProvider>


### PR DESCRIPTION
## Summary

- Allow vertical scroll chaining on the app shell so wheel gestures over block preview iframes can continue scrolling the blocks page.
- Keep horizontal overscroll suppressed at the root/layout level.

## Test Plan

- `pnpm check`
