### PR TITLE
ci: fix signed commits permissions

### DIFF
--- a/.github/workflows/signed-commits.yml
+++ b/.github/workflows/signed-commits.yml
@@ -9,8 +9,7 @@ on:
       - ready_for_review
 
 permissions:
-  issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   signed-commits:


### PR DESCRIPTION
Updates the signed commits workflow permission so it can comment on pull requests.