### PR TITLE
docs: add missing environment setup step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,14 @@ git checkout -b my-new-branch
 pnpm install
 ```
 
+### Set up environment variables
+
+Create a local environment file from the `.env.example` by executing the command below or manually rename `apps/v4/.env.example` to `.env`:
+
+```bash
+cp apps/v4/.env.example apps/v4/.env
+```
+
 ### Run a workspace
 
 You can use the `pnpm --filter=[WORKSPACE]` command to start the development process for a workspace.


### PR DESCRIPTION
## Problem
The `CONTRIBUTING.md` file doesn't mention setting up environment variables, causing new contributors to encounter an `Invalid URL` error when running `pnpm --filter=v4 dev` or `pnpm dev`.

## Solution
Added a "Set up environment variables" section after `pnpm install` that instructs users to copy `.env.example` to `.env`.

## Changes
- Added instructions to copy `.env.example` to `.env`
- Included both command-line and manual options