### PR TITLE
fix(cli): use Phosphor SSR imports for RSC

### DIFF
--- a/.changeset/calm-icons-serve.md
+++ b/.changeset/calm-icons-serve.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Use the Phosphor SSR entrypoint when transforming icons in React Server Component files.

--- a/packages/shadcn/src/icons/libraries.ts
+++ b/packages/shadcn/src/icons/libraries.ts
@@ -29,6 +29,7 @@ export const iconLibraries = {
     title: "Phosphor Icons",
     packages: ["@phosphor-icons/react"],
     import: "import { ICON } from '@phosphor-icons/react'",
+    rscImport: "import { ICON } from '@phosphor-icons/react/ssr'",
     usage: "<ICON strokeWidth={2} />",
     export: "@phosphor-icons/react",
   },

--- a/packages/shadcn/src/utils/transformers/transform-icons.test.ts
+++ b/packages/shadcn/src/utils/transformers/transform-icons.test.ts
@@ -279,6 +279,70 @@ export function Component() {
     })
   })
 
+  describe("phosphor library", () => {
+    test("uses the SSR entrypoint for server component files", async () => {
+      expect(
+        await transform(
+          {
+            filename: "test.tsx",
+            raw: `import * as React from "react"
+import { IconPlaceholder } from "@/app/(create)/create/components/icon-placeholder"
+
+export function Component() {
+  return <div><IconPlaceholder phosphor="CaretRightIcon" /></div>
+}`,
+            config: {
+              ...testConfig,
+              rsc: true,
+              iconLibrary: "phosphor",
+            },
+          },
+          [transformIcons]
+        )
+      ).toMatchInlineSnapshot(`
+        "import * as React from "react"
+        import { CaretRightIcon } from "@phosphor-icons/react/ssr"
+
+        export function Component() {
+          return <div><CaretRightIcon /></div>
+        }"
+      `)
+    })
+
+    test("keeps the client entrypoint for use client files", async () => {
+      expect(
+        await transform(
+          {
+            filename: "test.tsx",
+            raw: `"use client"
+
+import * as React from "react"
+import { IconPlaceholder } from "@/app/(create)/create/components/icon-placeholder"
+
+export function Component() {
+  return <div><IconPlaceholder phosphor="CaretRightIcon" /></div>
+}`,
+            config: {
+              ...testConfig,
+              rsc: true,
+              iconLibrary: "phosphor",
+            },
+          },
+          [transformIcons]
+        )
+      ).toMatchInlineSnapshot(`
+        ""use client"
+
+        import * as React from "react"
+        import { CaretRightIcon } from "@phosphor-icons/react"
+
+        export function Component() {
+          return <div><CaretRightIcon /></div>
+        }"
+      `)
+    })
+  })
+
   describe("hugeicons library", () => {
     test("transforms IconPlaceholder to HugeiconsIcon wrapper", async () => {
       expect(

--- a/packages/shadcn/src/utils/transformers/transform-icons.ts
+++ b/packages/shadcn/src/utils/transformers/transform-icons.ts
@@ -2,6 +2,8 @@ import { iconLibraries, type IconLibraryName } from "@/src/icons/libraries"
 import { Transformer } from "@/src/utils/transformers"
 import { SourceFile, SyntaxKind } from "ts-morph"
 
+const useClientDirectiveRegex = /^["']use client["'];?$/
+
 export const transformIcons: Transformer = async ({ sourceFile, config }) => {
   const iconLibrary = config.iconLibrary
 
@@ -163,7 +165,13 @@ export const transformIcons: Transformer = async ({ sourceFile, config }) => {
   }
 
   if (transformedIcons.length > 0) {
-    const importStatements = libraryConfig.import.split("\n")
+    const importTemplate =
+      config.rsc &&
+      !_hasUseClientDirective(sourceFile) &&
+      "rscImport" in libraryConfig
+        ? libraryConfig.rscImport
+        : libraryConfig.import
+    const importStatements = importTemplate.split("\n")
     const addedImports = []
 
     for (const importStmt of importStatements) {
@@ -207,4 +215,9 @@ function _useSemicolon(sourceFile: SourceFile) {
   return (
     sourceFile.getImportDeclarations()?.[0]?.getText().endsWith(";") ?? false
   )
+}
+
+function _hasUseClientDirective(sourceFile: SourceFile) {
+  const first = sourceFile.getFirstChildByKind(SyntaxKind.ExpressionStatement)
+  return first ? useClientDirectiveRegex.test(first.getText()) : false
 }


### PR DESCRIPTION
## Summary
- Use Phosphor's SSR entrypoint when icon placeholders are transformed in React Server Component files.
- Preserve the regular Phosphor client entrypoint for files with `"use client"`.

Fixes #10503

## Test plan
- `pnpm --filter=shadcn test -- src/utils/transformers/transform-icons.test.ts`
- `pnpm --filter=shadcn typecheck`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter=shadcn build`
- `pnpm --filter=shadcn format:check`
- `pnpm exec prettier --check .changeset/calm-icons-serve.md packages/shadcn/src/icons/libraries.ts packages/shadcn/src/utils/transformers/transform-icons.ts packages/shadcn/src/utils/transformers/transform-icons.test.ts`
- `git diff --check`
