### PR TITLE
fix(dialog,alert-dialog): fix centering regression in Chrome 147

### DIFF
--- a/apps/v4/registry/styles/style-luma.css
+++ b/apps/v4/registry/styles/style-luma.css
@@ -451,6 +451,7 @@
 
   .cn-alert-dialog-content {
     @apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/5 dark:ring-foreground/10 gap-6 rounded-4xl p-6 shadow-xl ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-md;
+    transform: translate(-50%, -50%);
   }
 
   .cn-alert-dialog-header {
@@ -674,6 +675,7 @@
 
   .cn-dialog-content {
     @apply bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/5 dark:ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-4xl p-6 text-sm shadow-xl ring-1 duration-100 sm:max-w-md;
+    transform: translate(-50%, -50%);
   }
 
   .cn-dialog-close {

--- a/apps/v4/registry/styles/style-lyra.css
+++ b/apps/v4/registry/styles/style-lyra.css
@@ -48,6 +48,7 @@
 
   .cn-alert-dialog-content {
     @apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-4 rounded-none p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm;
+    transform: translate(-50%, -50%);
   }
 
   .cn-alert-dialog-header {
@@ -429,6 +430,7 @@
 
   .cn-dialog-content {
     @apply bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-none p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-sm;
+    transform: translate(-50%, -50%);
   }
 
   .cn-dialog-close {

--- a/apps/v4/registry/styles/style-maia.css
+++ b/apps/v4/registry/styles/style-maia.css
@@ -27,6 +27,7 @@
 
   .cn-alert-dialog-content {
     @apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/5 gap-6 rounded-4xl p-6 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-md;
+    transform: translate(-50%, -50%);
   }
 
   .cn-alert-dialog-header {
@@ -450,6 +451,7 @@
 
   .cn-dialog-content {
     @apply bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/5 grid max-w-[calc(100%-2rem)] gap-6 rounded-4xl p-6 text-sm ring-1 duration-100 sm:max-w-md;
+    transform: translate(-50%, -50%);
   }
 
   .cn-dialog-close {

--- a/apps/v4/registry/styles/style-mira.css
+++ b/apps/v4/registry/styles/style-mira.css
@@ -27,6 +27,7 @@
 
   .cn-alert-dialog-content {
     @apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-3 rounded-xl p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-64 data-[size=default]:sm:max-w-sm;
+    transform: translate(-50%, -50%);
   }
 
   .cn-alert-dialog-header {
@@ -450,6 +451,7 @@
 
   .cn-dialog-content {
     @apply bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-sm;
+    transform: translate(-50%, -50%);
   }
 
   .cn-dialog-close {

--- a/apps/v4/registry/styles/style-nova.css
+++ b/apps/v4/registry/styles/style-nova.css
@@ -48,6 +48,7 @@
 
   .cn-alert-dialog-content {
     @apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-4 rounded-xl p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm;
+    transform: translate(-50%, -50%);
   }
 
   .cn-alert-dialog-header {
@@ -450,6 +451,7 @@
 
   .cn-dialog-content {
     @apply bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-sm ring-1 duration-100 sm:max-w-sm;
+    transform: translate(-50%, -50%);
   }
 
   .cn-dialog-close {

--- a/apps/v4/registry/styles/style-sera.css
+++ b/apps/v4/registry/styles/style-sera.css
@@ -48,6 +48,7 @@
 
   .cn-alert-dialog-content {
     @apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-6 rounded-none p-6 shadow-md ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-md;
+    transform: translate(-50%, -50%);
   }
 
   .cn-alert-dialog-header {
@@ -441,6 +442,7 @@
 
   .cn-dialog-content {
     @apply bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-none p-6 text-sm shadow-md ring-1 duration-100 sm:max-w-md;
+    transform: translate(-50%, -50%);
   }
 
   .cn-dialog-close {

--- a/apps/v4/registry/styles/style-vega.css
+++ b/apps/v4/registry/styles/style-vega.css
@@ -23,6 +23,7 @@
 
   .cn-alert-dialog-content {
     @apply data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-6 rounded-xl p-6 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg;
+    transform: translate(-50%, -50%);
   }
 
   .cn-alert-dialog-header {
@@ -446,6 +447,7 @@
 
   .cn-dialog-content {
     @apply bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-xl p-6 text-sm ring-1 duration-100 sm:max-w-md;
+    transform: translate(-50%, -50%);
   }
 
   .cn-dialog-close {


### PR DESCRIPTION
## Summary

Chrome 147 introduced a regression where `transform: translate()` used in combination with CSS variables (via Tailwind's `--tw-translate-x`/`--tw-translate-y` variables) is not applied correctly, causing Dialog and AlertDialog components to appear off-center.

This fix adds an explicit `transform: translate(-50%, -50%)` to the `.cn-dialog-content` and `.cn-alert-dialog-content` CSS rules across all 7 registry styles, ensuring correct centering regardless of how Chrome resolves the CSS variable transforms.

## Root cause

Dialog is positioned with `fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2`. Tailwind compiles this to CSS variables:

```css
--tw-translate-x: -50%;
--tw-translate-y: -50%;
translate: var(--tw-translate-x) var(--tw-translate-y);
```

Chrome 147 miscalculates the translate when combined with percentage positioning via CSS variables, shifting the dialog off-center. Using the explicit longhand `transform: translate(-50%, -50%)` avoids this issue.

## Changes

- **7 style files** modified (`apps/v4/registry/styles/style-{luma,lyra,maia,mira,nova,sera,vega}.css`)
- Added `transform: translate(-50%, -50%)` to `.cn-dialog-content`
- Added `transform: translate(-50%, -50%)` to `.cn-alert-dialog-content`

## Testing

Verified on Chrome 147.0.7727.117 (arm64) and confirmed Safari is unaffected.

## Fixes

Fixes shadcn-ui/ui#7507