### PR TITLE
fix: upgrade basic-ftp to 5.2.0 (CVE-2026-27699)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@typescript-eslint/eslint-plugin": "^8.49.0",
     "@typescript-eslint/parser": "^8.49.0",
     "autoprefixer": "^10.4.14",
+    "basic-ftp": "5.2.1",
     "chokidar": "^4.0.3",
     "concurrently": "^8.0.1",
     "cross-env": "^7.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.14
         version: 10.4.21(postcss@8.5.6)
+      basic-ftp:
+        specifier: 5.2.1
+        version: 5.2.1
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -3989,10 +3992,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.0.5:
-    resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
+  basic-ftp@5.2.1:
+    resolution: {integrity: sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -11743,7 +11745,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.0: {}
 
-  basic-ftp@5.0.5: {}
+  basic-ftp@5.2.1: {}
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -13479,7 +13481,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.0.5
+      basic-ftp: 5.2.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
Upgrade basic-ftp from 5.0.5 to 5.2.0 to fix CVE-2026-27699.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-27699 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-27699` |
| **File** | `pnpm-lock.yaml` |

**Description**: basic-ftp: basic-ftp: File overwrite due to path traversal

## Changes
- `package.json`
- `pnpm-lock.yaml`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
