### PR TITLE
fix(cli): normalize package subpath dependencies

### DIFF
--- a/.changeset/healthy-paws-speak.md
+++ b/.changeset/healthy-paws-speak.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Normalize package subpath dependencies before installing registry components.

--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -8,6 +8,48 @@ import { spinner } from "@/src/utils/spinner"
 import { execa } from "execa"
 import prompts from "prompts"
 
+function normalizePackageDependencies(
+  dependencies: RegistryItem["dependencies"] = []
+) {
+  return Array.from(new Set(dependencies.map(normalizePackageDependency)))
+}
+
+function normalizePackageDependency(dependency: string) {
+  const trimmedDependency = dependency.trim()
+
+  if (
+    !trimmedDependency ||
+    shouldPreserveDependencySpecifier(trimmedDependency)
+  ) {
+    return dependency
+  }
+
+  const segments = trimmedDependency.split("/")
+
+  if (trimmedDependency.startsWith("@")) {
+    if (segments.length <= 2 || segments[1]?.includes("@")) {
+      return dependency
+    }
+
+    return `${segments[0]}/${segments[1]}`
+  }
+
+  if (segments.length <= 1 || segments[0]?.includes("@")) {
+    return dependency
+  }
+
+  return segments[0]
+}
+
+function shouldPreserveDependencySpecifier(dependency: string) {
+  return (
+    /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(dependency) ||
+    /^(?:\.{1,2}\/|~\/|\/)/.test(dependency) ||
+    dependency.includes("#") ||
+    dependency.includes("\\")
+  )
+}
+
 export async function updateDependencies(
   dependencies: RegistryItem["dependencies"],
   devDependencies: RegistryItem["devDependencies"],
@@ -16,8 +58,8 @@ export async function updateDependencies(
     silent?: boolean
   }
 ) {
-  dependencies = Array.from(new Set(dependencies))
-  devDependencies = Array.from(new Set(devDependencies))
+  dependencies = normalizePackageDependencies(dependencies)
+  devDependencies = normalizePackageDependencies(devDependencies)
 
   if (!dependencies?.length && !devDependencies?.length) {
     return

--- a/packages/shadcn/test/utils/updaters/update-dependencies.test.ts
+++ b/packages/shadcn/test/utils/updaters/update-dependencies.test.ts
@@ -118,6 +118,31 @@ describe("updateDependencies", () => {
       expectedArgs: ["install", "first"],
       expectedDevArgs: ["install", "-D", "second"],
     },
+    {
+      description: "normalizes package subpath dependencies before installing",
+      options: { silent: true },
+      dependencies: [
+        "react-aria-components/Button",
+        "react-aria-components/composeRenderProps",
+        "@scope/pkg/subpath",
+        "@scope/pkg/other",
+        "tailwind-variants",
+      ],
+      devDependencies: ["eslint/use-at-your-own-risk", "@types/react"],
+      config: {
+        resolvedPaths: {
+          cwd: path.resolve(__dirname, "../../fixtures/project-npm"),
+        },
+      },
+      expectedPackageManager: "npm",
+      expectedArgs: [
+        "install",
+        "react-aria-components",
+        "@scope/pkg",
+        "tailwind-variants",
+      ],
+      expectedDevArgs: ["install", "-D", "eslint", "@types/react"],
+    },
   ])(
     "$description",
     async ({


### PR DESCRIPTION
## Summary

- Normalize package subpath exports (for example `react-aria-components/Button`) to their owning package before installing registry dependencies.
- Add regression coverage for unscoped and scoped subpath dependencies.
- Add a patch changeset for `shadcn`.

Fixes #10535

## Test plan

- `pnpm --filter=shadcn exec vitest run test/utils/updaters/update-dependencies.test.ts`
- `pnpm --filter=shadcn test`
- `pnpm --filter=shadcn typecheck`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter=shadcn build`
- `pnpm --filter=shadcn exec prettier --check src/utils/updaters/update-dependencies.ts test/utils/updaters/update-dependencies.test.ts ../../.changeset/healthy-paws-speak.md`
- `git diff --check`
