### PR TITLE
fix(shadcn): preserve existing dependency specifiers

### DIFF
--- a/.changeset/sweet-rabbits-remember.md
+++ b/.changeset/sweet-rabbits-remember.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Preserve existing package dependency specifiers when adding registry items.

--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -19,6 +19,10 @@ export async function updateDependencies(
   dependencies = Array.from(new Set(dependencies))
   devDependencies = Array.from(new Set(devDependencies))
 
+  const packageInfo = getPackageInfo(config.resolvedPaths.cwd, false)
+  dependencies = filterMissingDependencies(dependencies, packageInfo)
+  devDependencies = filterMissingDependencies(devDependencies, packageInfo)
+
   if (!dependencies?.length && !devDependencies?.length) {
     return
   }
@@ -72,6 +76,45 @@ export async function updateDependencies(
   )
 
   dependenciesSpinner?.succeed()
+}
+
+function filterMissingDependencies(
+  dependencies: string[],
+  packageInfo: ReturnType<typeof getPackageInfo>
+) {
+  const existingDependencies = new Set([
+    ...Object.keys(packageInfo?.dependencies ?? {}),
+    ...Object.keys(packageInfo?.devDependencies ?? {}),
+    ...Object.keys(packageInfo?.optionalDependencies ?? {}),
+    ...Object.keys(packageInfo?.peerDependencies ?? {}),
+  ])
+
+  return dependencies.filter(
+    (dependency) =>
+      hasExplicitDependencySpecifier(dependency) ||
+      !existingDependencies.has(getDependencyName(dependency))
+  )
+}
+
+function hasExplicitDependencySpecifier(dependency: string) {
+  if (dependency.startsWith("npm:")) {
+    return hasExplicitDependencySpecifier(dependency.slice(4))
+  }
+
+  const packageName = getDependencyName(dependency)
+  return dependency.charAt(packageName.length) === "@"
+}
+
+function getDependencyName(dependency: string) {
+  if (dependency.startsWith("npm:")) {
+    return getDependencyName(dependency.slice(4))
+  }
+
+  if (dependency.startsWith("@")) {
+    return dependency.match(/^(@[^/]+\/[^@/]+)/)?.[1] ?? dependency
+  }
+
+  return dependency.split("@")[0].split("/")[0]
 }
 
 function shouldPromptForNpmFlag(config: Config) {

--- a/packages/shadcn/test/fixtures/project-pnpm-existing-deps/package.json
+++ b/packages/shadcn/test/fixtures/project-pnpm-existing-deps/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "test-cli-project-pnpm-existing-deps",
+  "version": "1.0.0",
+  "main": "index.js",
+  "author": "shadcn",
+  "license": "MIT",
+  "dependencies": {
+    "@base-ui/react": "^1.4.1",
+    "class-variance-authority": "^0.7.1",
+    "recharts": "^2.15.4"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.2.1"
+  }
+}

--- a/packages/shadcn/test/fixtures/project-pnpm-existing-deps/pnpm-lock.yaml
+++ b/packages/shadcn/test/fixtures/project-pnpm-existing-deps/pnpm-lock.yaml
@@ -1,0 +1,5 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/packages/shadcn/test/utils/updaters/update-dependencies.test.ts
+++ b/packages/shadcn/test/utils/updaters/update-dependencies.test.ts
@@ -154,4 +154,33 @@ describe("updateDependencies", () => {
       )
     }
   )
+
+  test("skips unversioned dependencies already declared in package.json", async () => {
+    const cwd = path.resolve(
+      __dirname,
+      "../../fixtures/project-pnpm-existing-deps"
+    )
+
+    await updateDependencies(
+      [
+        "@base-ui/react",
+        "class-variance-authority",
+        "react-is",
+        "recharts@3.8.0",
+      ],
+      ["@tailwindcss/postcss", "typescript"],
+      { resolvedPaths: { cwd } },
+      { silent: true }
+    )
+
+    expect(execa).toHaveBeenCalledTimes(2)
+    expect(execa).toHaveBeenCalledWith(
+      "pnpm",
+      ["add", "react-is", "recharts@3.8.0"],
+      { cwd }
+    )
+    expect(execa).toHaveBeenCalledWith("pnpm", ["add", "-D", "typescript"], {
+      cwd,
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Skip reinstalling unversioned registry dependencies that are already declared in `package.json`.
- Keep explicit version specs (for example `recharts@3.8.0`) installable so registry-required versions still apply.
- Add regression coverage for the idempotent dependency update path.

Fixes #10525

## Test plan

- `pnpm --filter=shadcn exec vitest run test/utils/updaters/update-dependencies.test.ts`
- `pnpm --filter=shadcn typecheck`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter=shadcn build`
- `pnpm exec prettier --check packages/shadcn/src/utils/updaters/update-dependencies.ts packages/shadcn/test/utils/updaters/update-dependencies.test.ts packages/shadcn/test/fixtures/project-pnpm-existing-deps/package.json .changeset/sweet-rabbits-remember.md`
- `git diff --check`
