### PR TITLE
feat(registry): add @stepper registry

### DIFF
--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -1101,6 +1101,12 @@
     "name": "@evilbuttons",
     "homepage": "https://evilbuttons.radiumcoders.com/docs",
     "url": "https://evilbuttons.radiumcoders.com/r/{name}.json",
-    "description": "A shadcn/ui registry featuring a collection of animated buttons built with Motion. Each component is designed to add punchy, interactive feedback to your UI with minimal setup."  
+    "description": "A shadcn/ui registry featuring a collection of animated buttons built with Motion. Each component is designed to add punchy, interactive feedback to your UI with minimal setup."
+  },
+  {
+    "name": "@stepper",
+    "homepage": "https://francozeta-stepper.vercel.app",
+    "url": "https://francozeta-stepper.vercel.app/{name}.json",
+    "description": "A modern, accessible and composable Stepper component for React and Tailwind CSS. Built for shadcn/ui-style workflows with registry-first distribution."
   }
 ]

--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1287,5 +1287,12 @@
     "url": "https://evilbuttons.radiumcoders.com/r/{name}.json",
     "description": "A shadcn/ui registry featuring a collection of animated buttons built with Motion. Each component is designed to add punchy, interactive feedback to your UI with minimal setup.",  
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 270 270' fill='var(--foreground)'><circle cx='135' cy='135' r='135' fill='black'/><path d='M161.057 161.35L186.181 221.846L164.141 231.05L139.018 170.853L102.75 207.419V52.945L211.663 161.281L161.057 161.35Z' fill='white'/><path d='M160.5 64.8521C158.1 81.2521 135.5 84.5187 126 83.3521C130.167 92.0187 140.8 112.352 156 112.352C175 112.352 163.5 44.3521 160.5 64.8521Z' fill='white' stroke='white'/><path d='M71.1794 99.9477C83.9367 110.529 102.918 97.8346 109.197 90.6108C111.9 99.8395 117.603 122.065 106.307 132.236C92.1875 144.949 55.2328 86.7206 71.1794 99.9477Z' fill='white' stroke='white'/><circle cx='121' cy='122' r='5' fill='black'/><circle cx='141' cy='112' r='5' fill='black'/></svg>"
+  },
+  {
+    "name": "@stepper",
+    "homepage": "https://francozeta-stepper.vercel.app",
+    "url": "https://francozeta-stepper.vercel.app/{name}.json",
+    "description": "A modern, accessible and composable Stepper component for React and Tailwind CSS. Built for shadcn/ui-style workflows with registry-first distribution.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256' fill='currentColor'><path d='M139 32a7 7 0 0 1 14 0v104.6c0 18.3-8.8 35.4-23.7 46L55.8 235H22l93.4-66.6A30.2 30.2 0 0 0 128 143.8V32h11Z'/><path d='M160 42c14.2-5.8 27.9 11.3 50 6.6-8.6 12.4-21.8 18-36.2 16.1-5.8-.8-10-2.5-13.8-4.2V42Z'/><path d='M163 82.8 210 99v105c0 18.2-14.8 33-33 33h-74.7l43.7-31.2c15.6-11.1 24.9-29.1 24.9-48.2V103.8L163 101V82.8Zm20 59.2a7 7 0 0 1 14 0v24h-14v-24Z'/><path d='M84 87.5 122 77v50H66V99.8l18-4.9v-7.4Zm-31 43.5h71v22H53a7 7 0 0 1-7-7v-8a7 7 0 0 1 7-7Zm-32 33h77v22H21a7 7 0 0 1-7-7v-8a7 7 0 0 1 7-7Zm-10 33h62v22H11a7 7 0 0 1-7-7v-8a7 7 0 0 1 7-7Z'/><circle cx='42' cy='116' r='13'/></svg>"
   }
 ]


### PR DESCRIPTION
## What

Adds `@stepper` to the shadcn registry directory and generated public registry index.

## Why

Stepper is an open-source, shadcn/ui-style Stepper primitive with registry-first distribution.

Registry homepage: https://francozeta-stepper.vercel.app

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter=shadcn build`
- `pnpm dlx bun run ./scripts/build-registry.mts`
- `pnpm lint:fix`
- `pnpm format:write -- --loglevel silent`
- `pnpm --filter=v4 validate:registries`
- `git diff --check`
- Checked `https://francozeta-stepper.vercel.app/registry.json`, `/stepper.json`, and `/stepper-demo.json`
- `pnpm dlx shadcn@latest view https://francozeta-stepper.vercel.app/stepper.json`

Note: the local machine did not have `bun` on PATH, so I ran the registry generator through `pnpm dlx bun`.