### PR TITLE
fix: prevent TypeError in ThemeHotkey when event.key is undefined

### DIFF
--- a/templates/next-app/components/theme-provider.tsx
+++ b/templates/next-app/components/theme-provider.tsx
@@ -47,7 +47,7 @@ function ThemeHotkey() {
         return
       }
 
-      if (event.key.toLowerCase() !== "d") {
+      if (event.key?.toLowerCase() !== "d") {
         return
       }
 

--- a/templates/next-monorepo/apps/web/components/theme-provider.tsx
+++ b/templates/next-monorepo/apps/web/components/theme-provider.tsx
@@ -47,7 +47,7 @@ function ThemeHotkey() {
         return
       }
 
-      if (event.key.toLowerCase() !== "d") {
+      if (event.key?.toLowerCase() !== "d") {
         return
       }
 

--- a/templates/vite-app/src/components/theme-provider.tsx
+++ b/templates/vite-app/src/components/theme-provider.tsx
@@ -153,7 +153,7 @@ export function ThemeProvider({
         return
       }
 
-      if (event.key.toLowerCase() !== "d") {
+      if (event.key?.toLowerCase() !== "d") {
         return
       }
 

--- a/templates/vite-monorepo/apps/web/src/components/theme-provider.tsx
+++ b/templates/vite-monorepo/apps/web/src/components/theme-provider.tsx
@@ -153,7 +153,7 @@ export function ThemeProvider({
         return
       }
 
-      if (event.key.toLowerCase() !== "d") {
+      if (event.key?.toLowerCase() !== "d") {
         return
       }
 


### PR DESCRIPTION
## Problem

The `ThemeHotkey` component in the generated `theme-provider.tsx` calls `event.key.toLowerCase()` without checking if `event.key` is defined. During browser autofill/autocomplete in Chrome and Edge, the browser fires synthetic keydown events where `event.key` is `undefined`, causing an uncaught TypeError:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at onKeyDown (theme-provider.tsx)
```

## Solution

Added optional chaining (`event.key?.toLowerCase()`) to safely handle synthetic events where `event.key` may be `undefined`. This fix is applied to all 4 template theme-provider files:

- `templates/next-app/components/theme-provider.tsx`
- `templates/next-monorepo/apps/web/components/theme-provider.tsx`
- `templates/vite-app/src/components/theme-provider.tsx`
- `templates/vite-monorepo/apps/web/src/components/theme-provider.tsx`

Note: The `apps/v4/components/theme-provider.tsx` file already handles this correctly by using `e.key === "d" || e.key === "D"` instead of calling `.toLowerCase()`.

## How to reproduce

1. Create a new Next.js project using `npx shadcn@latest init`
2. Add a plain `<input type="email" />` to any page
3. Save an autofill entry in Chrome or Edge for that field
4. Focus the input and select a suggestion from the browser autocomplete dropdown

**Before**: TypeError is thrown
**After**: Autofill completes normally, theme hotkey listener safely ignores the event

Fixes #10378