### PR TITLE
fix(docs): update broken link of Embla Carousel docs

### DIFF
--- a/apps/v4/content/docs/components/base/carousel.mdx
+++ b/apps/v4/content/docs/components/base/carousel.mdx
@@ -332,4 +332,4 @@ The `direction` option accepts `"ltr"` or `"rtl"` and should match the `dir` pro
 
 ## API Reference
 
-See the [Embla Carousel docs](https://www.embla-carousel.com/api/) for more information on props and plugins.
+See the [Embla Carousel docs](https://www.embla-carousel.com/docs) for more information on props and plugins.

--- a/apps/v4/content/docs/components/radix/carousel.mdx
+++ b/apps/v4/content/docs/components/radix/carousel.mdx
@@ -332,4 +332,4 @@ The `direction` option accepts `"ltr"` or `"rtl"` and should match the `dir` pro
 
 ## API Reference
 
-See the [Embla Carousel docs](https://www.embla-carousel.com/api/) for more information on props and plugins.
+See the [Embla Carousel docs](https://www.embla-carousel.com/docs) for more information on props and plugins.


### PR DESCRIPTION
Fixes broken Embla Carousel docs link in carousel component documentation.

Updates URL from `/api` (404) to `/docs`.
