### PR TITLE
fix(base-mira): forward orientation prop to TabsPrimitive.Root

### DIFF
--- a/apps/v4/styles/base-mira/ui/tabs.tsx
+++ b/apps/v4/styles/base-mira/ui/tabs.tsx
@@ -14,6 +14,7 @@ function Tabs({
     <TabsPrimitive.Root
       data-slot="tabs"
       data-orientation={orientation}
+      orientation={orientation}
       className={cn(
         "group/tabs flex gap-2 data-horizontal:flex-col",
         className


### PR DESCRIPTION
## Summary

Fixes #10592

This PR fixes a critical accessibility bug in the `base-mira` Tabs component where the `orientation` prop is not forwarded to `TabsPrimitive.Root`, breaking keyboard navigation for vertical tabs.

## Problem

The `Tabs` wrapper in `base-mira` destructures `orientation` from props but never forwards it to `TabsPrimitive.Root`. The value is only used for the `data-orientation` attribute (styling), so Base UI's internal keyboard-navigation handling for vertical tabs never receives the orientation.

**Result:** `orientation="vertical"` renders correctly visually but loses Up/Down arrow-key navigation.

## Impact

Base UI's `Tabs.Root` uses the `orientation` prop internally to:
- Set ARIA `aria-orientation` on the tablist
- Configure arrow-key keyboard navigation (Up/Down for vertical, Left/Right for horizontal)
- Adjust focus-management semantics

Without forwarding, consumers setting `<Tabs orientation="vertical">` get the correct visual layout (via the `group-data-vertical/tabs:*` Tailwind variants) but **the keyboard navigation stays in horizontal mode**. This is a latent accessibility regression for any vertical tabs deployment.

## Reproduction

```tsx
<Tabs orientation="vertical">
  <TabsList>
    <TabsTrigger value="a">A</TabsTrigger>
    <TabsTrigger value="b">B</TabsTrigger>
    <TabsTrigger value="c">C</TabsTrigger>
  </TabsList>
  <TabsContent value="a">…</TabsContent>
  <TabsContent value="b">…</TabsContent>
  <TabsContent value="c">…</TabsContent>
</Tabs>
```

Focus the first trigger and press the arrow keys.
- **Expected:** Up/Down navigates between A/B/C
- **Actual:** Only Left/Right navigate (horizontal default)

You can also inspect the rendered DOM: `<div role="tablist">` will not have `aria-orientation="vertical"`.

## Solution

Pass `orientation` through to `TabsPrimitive.Root` alongside the `data-orientation` attribute:

```tsx
<TabsPrimitive.Root
  data-slot="tabs"
  data-orientation={orientation}
  orientation={orientation}  // ← Added
  className={cn(
    "group/tabs flex gap-2 data-horizontal:flex-col",
    className
  )}
  {...props}
/>
```

This is a one-line, behavior-preserving fix: horizontal stays the default, vertical now works end-to-end (visual + keyboard + ARIA).

## Changes

- `apps/v4/styles/base-mira/ui/tabs.tsx`
  - Add `orientation={orientation}` prop to `TabsPrimitive.Root`

## Testing

- Visual layout remains unchanged for both horizontal and vertical tabs
- Keyboard navigation now works correctly for vertical tabs (Up/Down arrows)
- ARIA attributes are correctly set (`aria-orientation="vertical"`)

## Environment

- shadcn registry style: `base-mira`
- `@base-ui/react`: `1.4.1`
- React: `19.2.5`
- Next.js: `16.1.7`