### PR TITLE
fix(dialog): add closeLabel prop for i18n support in DialogContent and DialogFooter (base-mira)

### DIFF
--- a/apps/v4/styles/base-mira/ui/dialog.tsx
+++ b/apps/v4/styles/base-mira/ui/dialog.tsx
@@ -43,9 +43,11 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  closeLabel = "Close",
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
+  closeLabel?: React.ReactNode
 }) {
   return (
     <DialogPortal>
@@ -71,7 +73,7 @@ function DialogContent({
             }
           >
             <XIcon />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">{closeLabel}</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Popup>
@@ -92,10 +94,12 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
 function DialogFooter({
   className,
   showCloseButton = false,
+  closeLabel = "Close",
   children,
   ...props
 }: React.ComponentProps<"div"> & {
   showCloseButton?: boolean
+  closeLabel?: React.ReactNode
 }) {
   return (
     <div
@@ -109,7 +113,7 @@ function DialogFooter({
       {children}
       {showCloseButton && (
         <DialogPrimitive.Close render={<Button variant="outline" />}>
-          Close
+          {closeLabel}
         </DialogPrimitive.Close>
       )}
     </div>


### PR DESCRIPTION
## Summary
Add an optional `closeLabel` prop (default: Close) to `DialogContent` and `DialogFooter` in the base-mira registry style. This enables localized applications to pass a translated string without forking the registry file.

## Problem
- DialogContent icon close button: hardcoded `<span className="sr-only">Close</span>` breaks screen-reader i18n
- DialogFooter close button: hardcoded visible "Close" text breaks UI i18n

## Fix
Both DialogContent and DialogFooter now accept an optional `closeLabel` prop:
```tsx
<DialogContent closeLabel={t("dialog.close")}>
<DialogFooter showCloseButton closeLabel={t("dialog.close")}>
```
Default is "Close" for backwards compatibility.

## Files changed
apps/v4/styles/base-mira/ui/dialog.tsx

## Related
- Shadcn-ui/ui#5712 (closed stale, same issue different style)
- Discovered via CodeRabbit review on kkzakaria/tranzit#18