### PR TITLE
Fix combobox multiselect disabled state

### DIFF
--- a/apps/v4/registry/bases/base/ui/combobox.tsx
+++ b/apps/v4/registry/bases/base/ui/combobox.tsx
@@ -238,8 +238,9 @@ function ComboboxChips({
   ComboboxPrimitive.Chips.Props) {
   return (
     <ComboboxPrimitive.Chips
+      render={<InputGroup />}
       data-slot="combobox-chips"
-      className={cn("cn-combobox-chips", className)}
+      className={cn("cn-combobox-chips h-auto min-h-8 flex-wrap gap-1", className)}
       {...props}
     />
   )
@@ -285,15 +286,14 @@ function ComboboxChip({
 
 function ComboboxChipsInput({
   className,
+  disabled = false,
   ...props
 }: ComboboxPrimitive.Input.Props) {
   return (
     <ComboboxPrimitive.Input
+      render={<InputGroupInput disabled={disabled} />}
       data-slot="combobox-chip-input"
-      className={cn(
-        "cn-combobox-chip-input min-w-16 flex-1 outline-none",
-        className
-      )}
+      className={cn("cn-combobox-chip-input min-w-16 flex-1", className)}
       {...props}
     />
   )

--- a/apps/v4/registry/bases/radix/ui/combobox.tsx
+++ b/apps/v4/registry/bases/radix/ui/combobox.tsx
@@ -240,8 +240,9 @@ function ComboboxChips({
   ComboboxPrimitive.Chips.Props) {
   return (
     <ComboboxPrimitive.Chips
+      render={<InputGroup />}
       data-slot="combobox-chips"
-      className={cn("cn-combobox-chips", className)}
+      className={cn("cn-combobox-chips h-auto min-h-8 flex-wrap gap-1", className)}
       {...props}
     />
   )
@@ -287,15 +288,14 @@ function ComboboxChip({
 
 function ComboboxChipsInput({
   className,
+  disabled = false,
   ...props
 }: ComboboxPrimitive.Input.Props) {
   return (
     <ComboboxPrimitive.Input
+      render={<InputGroupInput disabled={disabled} />}
       data-slot="combobox-chip-input"
-      className={cn(
-        "cn-combobox-chip-input min-w-16 flex-1 outline-none",
-        className
-      )}
+      className={cn("cn-combobox-chip-input min-w-16 flex-1", className)}
       {...props}
     />
   )

--- a/apps/v4/registry/new-york-v4/ui/combobox.tsx
+++ b/apps/v4/registry/new-york-v4/ui/combobox.tsx
@@ -231,11 +231,9 @@ function ComboboxChips({
   ComboboxPrimitive.Chips.Props) {
   return (
     <ComboboxPrimitive.Chips
+      render={<InputGroup />}
       data-slot="combobox-chips"
-      className={cn(
-        "flex min-h-9 flex-wrap items-center gap-1.5 rounded-md border border-input bg-transparent bg-clip-padding px-2.5 py-1.5 text-sm shadow-xs transition-[color,box-shadow] focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50 has-aria-invalid:border-destructive has-aria-invalid:ring-[3px] has-aria-invalid:ring-destructive/20 has-data-[slot=combobox-chip]:px-1.5 dark:bg-input/30 dark:has-aria-invalid:border-destructive/50 dark:has-aria-invalid:ring-destructive/40",
-        className
-      )}
+      className={cn("h-auto min-h-9 flex-wrap gap-1.5 px-2.5 py-1.5", className)}
       {...props}
     />
   )
@@ -274,13 +272,14 @@ function ComboboxChip({
 
 function ComboboxChipsInput({
   className,
-  children,
+  disabled = false,
   ...props
 }: ComboboxPrimitive.Input.Props) {
   return (
     <ComboboxPrimitive.Input
+      render={<InputGroupInput disabled={disabled} />}
       data-slot="combobox-chip-input"
-      className={cn("min-w-16 flex-1 outline-none", className)}
+      className={cn("min-w-16 flex-1", className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- fix the combobox multiselect disabled-state issue reported in shadcn-ui/ui#10565
- align the multiselect chips path with the shared input-group structure used by the single-select combobox
- apply the fix to the base, radix, and new-york-v4 registry combobox implementations

## Root cause
The multiselect combobox path used a bare chips/input structure instead of the shared `InputGroup` composition used by the single-select combobox. Because of that, disabled-state behavior and styling could diverge for multiselect.

## What changed
- render `ComboboxChips` through `InputGroup`
- render `ComboboxChipsInput` through `InputGroupInput`
- preserve the chips layout with the minimal supporting class updates needed after adopting the shared wrapper

