### PR TITLE
fix(hooks): use useSyncExternalStore in useIsMobile

### DIFF
--- a/apps/v4/hooks/use-mobile.ts
+++ b/apps/v4/hooks/use-mobile.ts
@@ -1,17 +1,19 @@
 import * as React from "react"
 
-export function useIsMobile(mobileBreakpoint = 768) {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+export function useIsMobile(mobileBreakpoint = 768): boolean {
+  const subscribe = React.useCallback(
+    (callback: () => void) => {
+      const mql = window.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`)
+      mql.addEventListener("change", callback)
+      return () => mql.removeEventListener("change", callback)
+    },
+    [mobileBreakpoint]
+  )
 
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < mobileBreakpoint)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < mobileBreakpoint)
-    return () => mql.removeEventListener("change", onChange)
-  }, [mobileBreakpoint])
+  const getSnapshot = React.useCallback(
+    () => window.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`).matches,
+    [mobileBreakpoint]
+  )
 
-  return !!isMobile
+  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)
 }

--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -447,7 +447,7 @@
     "name": "@ncdai",
     "homepage": "https://chanhdai.com/components",
     "url": "https://chanhdai.com/r/{name}.json",
-    "description": "A collection of reusable components."
+    "description": "Pixel-perfect, uniquely crafted."
   },
   {
     "name": "@nteract",

--- a/apps/v4/public/r/styles/base-luma/use-mobile.json
+++ b/apps/v4/public/r/styles/base-luma/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-luma/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_QUERY)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-lyra/use-mobile.json
+++ b/apps/v4/public/r/styles/base-lyra/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-lyra/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_QUERY)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-maia/use-mobile.json
+++ b/apps/v4/public/r/styles/base-maia/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-maia/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_QUERY)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-mira/use-mobile.json
+++ b/apps/v4/public/r/styles/base-mira/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-mira/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_QUERY)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-nova/use-mobile.json
+++ b/apps/v4/public/r/styles/base-nova/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-nova/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_QUERY)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-sera/use-mobile.json
+++ b/apps/v4/public/r/styles/base-sera/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-sera/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_QUERY)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-vega/use-mobile.json
+++ b/apps/v4/public/r/styles/base-vega/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-vega/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_QUERY)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/new-york-v4/use-mobile.json
+++ b/apps/v4/public/r/styles/new-york-v4/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/new-york-v4/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_QUERY)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-luma/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-luma/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-luma/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_QUERY)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-lyra/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-lyra/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-lyra/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_QUERY)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-maia/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-maia/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-maia/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_QUERY)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-mira/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-mira/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-mira/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_QUERY)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-nova/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-nova/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-nova/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_QUERY)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-sera/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-sera/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-sera/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_QUERY)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-vega/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-vega/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-vega/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_QUERY)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/registry/bases/base/hooks/use-mobile.ts
+++ b/apps/v4/registry/bases/base/hooks/use-mobile.ts
@@ -1,19 +1,22 @@
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
+const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+
+function subscribe(callback: () => void) {
+  const mql = window.matchMedia(MOBILE_QUERY)
+  mql.addEventListener("change", callback)
+  return () => mql.removeEventListener("change", callback)
+}
+
+function getSnapshot() {
+  return window.matchMedia(MOBILE_QUERY).matches
+}
+
+function getServerSnapshot() {
+  return false
+}
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }

--- a/apps/v4/registry/bases/radix/hooks/use-mobile.ts
+++ b/apps/v4/registry/bases/radix/hooks/use-mobile.ts
@@ -1,19 +1,22 @@
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
+const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+
+function subscribe(callback: () => void) {
+  const mql = window.matchMedia(MOBILE_QUERY)
+  mql.addEventListener("change", callback)
+  return () => mql.removeEventListener("change", callback)
+}
+
+function getSnapshot() {
+  return window.matchMedia(MOBILE_QUERY).matches
+}
+
+function getServerSnapshot() {
+  return false
+}
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }

--- a/apps/v4/registry/new-york-v4/hooks/use-mobile.ts
+++ b/apps/v4/registry/new-york-v4/hooks/use-mobile.ts
@@ -1,19 +1,22 @@
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
+const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+
+function subscribe(callback: () => void) {
+  const mql = window.matchMedia(MOBILE_QUERY)
+  mql.addEventListener("change", callback)
+  return () => mql.removeEventListener("change", callback)
+}
+
+function getSnapshot() {
+  return window.matchMedia(MOBILE_QUERY).matches
+}
+
+function getServerSnapshot() {
+  return false
+}
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }


### PR DESCRIPTION
Hit this on a Next 16 app after bumping `eslint-config-next` to 16.2.6:

```
src/hooks/use-mobile.ts
  14:5  error  Calling setState synchronously within an effect can trigger cascading renders  react-hooks/set-state-in-effect
```

The new `react-hooks/set-state-in-effect` rule (shipped in 16.2.5+) flags the `setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)` call inside the effect. Same thing also blows up under the React 19 Compiler.

Refs #8739. PR #8741 attempts a fix but still calls `setIsMobile(mql.matches)` inside the effect, so the lint rule still fires.

Switched the hook to `useSyncExternalStore`, which is what React 19 wants you to use for mirroring a browser API into state:

```ts
function subscribe(callback: () => void) {
  const mql = window.matchMedia(MOBILE_QUERY)
  mql.addEventListener("change", callback)
  return () => mql.removeEventListener("change", callback)
}

function getSnapshot() {
  return window.matchMedia(MOBILE_QUERY).matches
}

export function useIsMobile() {
  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)
}
```

Side benefit: returns a real boolean on first client render instead of the `undefined` flicker the old version had.