### PR TITLE
feat(components): add Text component with variant and size props

### DIFF
--- a/apps/v4/content/docs/components/base/meta.json
+++ b/apps/v4/content/docs/components/base/meta.json
@@ -56,6 +56,7 @@
     "table",
     "tabs",
     "textarea",
+    "text",
     "toast",
     "toggle",
     "toggle-group",

--- a/apps/v4/content/docs/components/base/text.mdx
+++ b/apps/v4/content/docs/components/base/text.mdx
@@ -1,0 +1,83 @@
+---
+title: Text
+description: A typographic primitive for rendering text with semantic variants and size scales.
+base: base
+component: true
+---
+
+<ComponentPreview styleName="base-nova" name="text-demo" />
+
+## Installation
+
+<CodeTabs>
+
+<TabsList>
+  <TabsTrigger value="cli">Command</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add text
+```
+
+</TabsContent>
+
+<TabsContent value="manual">
+
+<Steps className="mb-0 pt-2">
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<ComponentSource
+  name="text"
+  title="components/ui/text.tsx"
+  styleName="base-nova"
+/>
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</CodeTabs>
+
+## Usage
+
+```tsx
+import { Text } from "@/components/ui/text"
+```
+
+```tsx
+<Text variant="muted" size="sm">Helper text</Text>
+```
+
+## Examples
+
+### Sizes
+
+Use the `size` prop to control the font size and line height.
+
+<ComponentPreview styleName="base-nova" name="text-demo" />
+
+### As Child
+
+Use `asChild` to render `Text` styles on a different element such as `h1`, `span`, or `label`.
+
+```tsx
+<Text variant="primary" size="xl" asChild>
+  <h1>Page Title</h1>
+</Text>
+```
+
+## API Reference
+
+### Text
+
+| Prop        | Type                                                                                    | Default     |
+| ----------- | --------------------------------------------------------------------------------------- | ----------- |
+| `variant`   | `"default" \| "primary" \| "secondary" \| "destructive" \| "muted" \| "accent"`        | `"default"` |
+| `size`      | `"xs" \| "sm" \| "default" \| "lg" \| "xl"`                                            | `"default"` |
+| `asChild`   | `boolean`                                                                               | `false`     |
+| `className` | `string`                                                                                | -           |

--- a/apps/v4/registry/new-york-v4/examples/_registry.ts
+++ b/apps/v4/registry/new-york-v4/examples/_registry.ts
@@ -2211,6 +2211,17 @@ export const examples: Registry["items"] = [
     ],
   },
   {
+    name: "text-demo",
+    type: "registry:example",
+    registryDependencies: ["text"],
+    files: [
+      {
+        path: "examples/text-demo.tsx",
+        type: "registry:example",
+      },
+    ],
+  },
+  {
     name: "toast-demo",
     type: "registry:example",
     registryDependencies: ["toast"],

--- a/apps/v4/registry/new-york-v4/examples/text-demo.tsx
+++ b/apps/v4/registry/new-york-v4/examples/text-demo.tsx
@@ -1,0 +1,23 @@
+import { Text } from "@/registry/new-york-v4/ui/text"
+
+export default function TextDemo() {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <Text size="xl">Extra Large</Text>
+        <Text size="lg">Large</Text>
+        <Text>Default</Text>
+        <Text size="sm">Small</Text>
+        <Text size="xs">Extra Small</Text>
+      </div>
+      <div className="flex flex-col gap-1">
+        <Text variant="default">Default variant</Text>
+        <Text variant="primary">Primary variant</Text>
+        <Text variant="secondary">Secondary variant</Text>
+        <Text variant="muted">Muted variant</Text>
+        <Text variant="destructive">Destructive variant</Text>
+        <Text variant="accent">Accent variant</Text>
+      </div>
+    </div>
+  )
+}

--- a/apps/v4/registry/new-york-v4/ui/_registry.ts
+++ b/apps/v4/registry/new-york-v4/ui/_registry.ts
@@ -604,6 +604,17 @@ export const ui: Registry["items"] = [
     ],
   },
   {
+    name: "text",
+    type: "registry:ui",
+    dependencies: ["radix-ui"],
+    files: [
+      {
+        path: "ui/text.tsx",
+        type: "registry:ui",
+      },
+    ],
+  },
+  {
     name: "toast",
     type: "registry:ui",
     dependencies: ["radix-ui"],

--- a/apps/v4/registry/new-york-v4/ui/text.tsx
+++ b/apps/v4/registry/new-york-v4/ui/text.tsx
@@ -1,0 +1,54 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const textVariants = cva("", {
+  variants: {
+    variant: {
+      default: "text-foreground",
+      primary: "text-primary",
+      secondary: "text-secondary-foreground",
+      destructive: "text-destructive",
+      muted: "text-muted-foreground",
+      accent: "text-accent-foreground",
+    },
+    size: {
+      xs: "text-xs leading-tight",
+      sm: "text-sm leading-snug",
+      default: "text-base leading-normal",
+      lg: "text-lg leading-relaxed",
+      xl: "text-xl leading-relaxed",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+    size: "default",
+  },
+})
+
+function Text({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"p"> &
+  VariantProps<typeof textVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot.Root : "p"
+
+  return (
+    <Comp
+      data-slot="text"
+      data-variant={variant}
+      data-size={size}
+      className={cn(textVariants({ variant, size }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Text, textVariants }


### PR DESCRIPTION
## Summary

Adds a **`Text`** primitive to the v4 **New York** registry for consistent typography using **CVA** variants. It maps semantic color variants and size scales to Tailwind utilities, renders as a `<p>` by default, and supports **`asChild`** via Radix **`Slot.Root`** so styles can apply to headings, spans, labels, etc.

## Changes

- **`apps/v4/registry/new-york-v4/ui/text.tsx`** — `Text` component and exported `textVariants`
  - **Variants:** `default`, `primary`, `secondary`, `destructive`, `muted`, `accent`
  - **Sizes:** `xs`, `sm`, `default`, `lg`, `xl`
- **Registry** — `text` in `ui/_registry.ts` (dependency: `radix-ui`); **`text-demo`** example wired in `examples/_registry.ts`
- **Docs** — `apps/v4/content/docs/components/base/text.mdx` (install, usage, examples, API); **`text`** listed in base `meta.json`

## Installation (for consumers)

```bash
npx shadcn@latest add text