### PR TITLE
fix(select): add shrink-0 to base-luma SelectContent

### DIFF
--- a/apps/v4/styles/base-luma/ui/select.tsx
+++ b/apps/v4/styles/base-luma/ui/select.tsx
@@ -85,6 +85,7 @@ function SelectContent({
           data-align-trigger={alignItemWithTrigger}
           className={cn(
             "cn-menu-target cn-menu-translucent relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-3xl bg-popover text-popover-foreground shadow-lg ring-1 ring-foreground/5 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            "shrink-0",
             className
           )}
           {...props}


### PR DESCRIPTION
Hey! 👋

This PR fixes the horizontal misalignment of the Select popup in the base-luma style.

## The Problem

The Select popup in base-luma style was horizontally misaligned with the trigger, showing a ~6px gap on the right edge. This was caused by the popup being compressed by flexbox.

## The Solution

Added `shrink-0` class to the SelectContent popup to prevent it from being compressed by flexbox, ensuring proper alignment with the trigger.

## What Changed

- Added `shrink-0` class to `apps/v4/styles/base-luma/ui/select.tsx`

## Testing

- Verified the fix resolves the alignment issue on https://ui.shadcn.com/create?preset=b2D0wqNxT&base=base
- No visual regression on other base styles (nova, sera, maia, mira)

Fixes #10543