### PR TITLE
fix: wrap base scroll area children in content

### DIFF
--- a/apps/v4/registry/bases/base/ui/scroll-area.tsx
+++ b/apps/v4/registry/bases/base/ui/scroll-area.tsx
@@ -20,7 +20,9 @@ function ScrollArea({
         data-slot="scroll-area-viewport"
         className="cn-scroll-area-viewport size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >
-        {children}
+        <ScrollAreaPrimitive.Content data-slot="scroll-area-content">
+          {children}
+        </ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />
       <ScrollAreaPrimitive.Corner />

--- a/apps/v4/styles/base-luma/ui/scroll-area.tsx
+++ b/apps/v4/styles/base-luma/ui/scroll-area.tsx
@@ -20,7 +20,9 @@ function ScrollArea({
         data-slot="scroll-area-viewport"
         className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >
-        {children}
+        <ScrollAreaPrimitive.Content data-slot="scroll-area-content">
+          {children}
+        </ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />
       <ScrollAreaPrimitive.Corner />

--- a/apps/v4/styles/base-lyra/ui/scroll-area.tsx
+++ b/apps/v4/styles/base-lyra/ui/scroll-area.tsx
@@ -20,7 +20,9 @@ function ScrollArea({
         data-slot="scroll-area-viewport"
         className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >
-        {children}
+        <ScrollAreaPrimitive.Content data-slot="scroll-area-content">
+          {children}
+        </ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />
       <ScrollAreaPrimitive.Corner />

--- a/apps/v4/styles/base-maia/ui/scroll-area.tsx
+++ b/apps/v4/styles/base-maia/ui/scroll-area.tsx
@@ -20,7 +20,9 @@ function ScrollArea({
         data-slot="scroll-area-viewport"
         className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >
-        {children}
+        <ScrollAreaPrimitive.Content data-slot="scroll-area-content">
+          {children}
+        </ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />
       <ScrollAreaPrimitive.Corner />

--- a/apps/v4/styles/base-mira/ui/scroll-area.tsx
+++ b/apps/v4/styles/base-mira/ui/scroll-area.tsx
@@ -20,7 +20,9 @@ function ScrollArea({
         data-slot="scroll-area-viewport"
         className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >
-        {children}
+        <ScrollAreaPrimitive.Content data-slot="scroll-area-content">
+          {children}
+        </ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />
       <ScrollAreaPrimitive.Corner />

--- a/apps/v4/styles/base-nova/ui-rtl/scroll-area.tsx
+++ b/apps/v4/styles/base-nova/ui-rtl/scroll-area.tsx
@@ -20,7 +20,9 @@ function ScrollArea({
         data-slot="scroll-area-viewport"
         className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >
-        {children}
+        <ScrollAreaPrimitive.Content data-slot="scroll-area-content">
+          {children}
+        </ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />
       <ScrollAreaPrimitive.Corner />

--- a/apps/v4/styles/base-nova/ui/scroll-area.tsx
+++ b/apps/v4/styles/base-nova/ui/scroll-area.tsx
@@ -20,7 +20,9 @@ function ScrollArea({
         data-slot="scroll-area-viewport"
         className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >
-        {children}
+        <ScrollAreaPrimitive.Content data-slot="scroll-area-content">
+          {children}
+        </ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />
       <ScrollAreaPrimitive.Corner />

--- a/apps/v4/styles/base-sera/ui/scroll-area.tsx
+++ b/apps/v4/styles/base-sera/ui/scroll-area.tsx
@@ -20,7 +20,9 @@ function ScrollArea({
         data-slot="scroll-area-viewport"
         className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >
-        {children}
+        <ScrollAreaPrimitive.Content data-slot="scroll-area-content">
+          {children}
+        </ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />
       <ScrollAreaPrimitive.Corner />

--- a/apps/v4/styles/base-vega/ui/scroll-area.tsx
+++ b/apps/v4/styles/base-vega/ui/scroll-area.tsx
@@ -20,7 +20,9 @@ function ScrollArea({
         data-slot="scroll-area-viewport"
         className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >
-        {children}
+        <ScrollAreaPrimitive.Content data-slot="scroll-area-content">
+          {children}
+        </ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />
       <ScrollAreaPrimitive.Corner />


### PR DESCRIPTION
Closes #10534

This wraps children with ScrollAreaPrimitive.Content for the Base UI-backed ScrollArea registry variants. Base UI attaches content resize observation through this part, so dynamic content size changes can recalculate scrollbar thumb sizing and visibility without requiring a scroll event.

Scope:
- Updated the base registry ScrollArea.
- Updated all base-* style ScrollArea variants, including RTL.
- Left Radix-backed ScrollArea variants unchanged because Radix ScrollArea does not expose a Content part.

Verification:
- Ran git diff --check.
- Confirmed all 9 @base-ui/react/scroll-area variants include ScrollAreaPrimitive.Content.
- Confirmed @base-ui/react@1.3.0 exports ScrollArea.Content from scroll-area/index.parts.d.ts.