### PR TITLE
fix(drawer): disable repositionInputs by default to fix mobile keyboa…

### DIFF
--- a/apps/v4/registry/bases/base/ui/drawer.tsx
+++ b/apps/v4/registry/bases/base/ui/drawer.tsx
@@ -6,9 +6,16 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/registry/bases/base/lib/utils"
 
 function Drawer({
+  repositionInputs = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  )
 }
 
 function DrawerTrigger({

--- a/apps/v4/registry/bases/radix/ui/drawer.tsx
+++ b/apps/v4/registry/bases/radix/ui/drawer.tsx
@@ -6,9 +6,16 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/registry/bases/radix/lib/utils"
 
 function Drawer({
+  repositionInputs = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  )
 }
 
 function DrawerTrigger({

--- a/apps/v4/styles/base-luma/ui/drawer.tsx
+++ b/apps/v4/styles/base-luma/ui/drawer.tsx
@@ -6,9 +6,16 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/lib/utils"
 
 function Drawer({
+  repositionInputs = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  )
 }
 
 function DrawerTrigger({

--- a/apps/v4/styles/base-lyra/ui/drawer.tsx
+++ b/apps/v4/styles/base-lyra/ui/drawer.tsx
@@ -6,9 +6,16 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/lib/utils"
 
 function Drawer({
+  repositionInputs = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  )
 }
 
 function DrawerTrigger({

--- a/apps/v4/styles/base-maia/ui/drawer.tsx
+++ b/apps/v4/styles/base-maia/ui/drawer.tsx
@@ -6,9 +6,16 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/lib/utils"
 
 function Drawer({
+  repositionInputs = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  )
 }
 
 function DrawerTrigger({

--- a/apps/v4/styles/base-mira/ui/drawer.tsx
+++ b/apps/v4/styles/base-mira/ui/drawer.tsx
@@ -6,9 +6,16 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/lib/utils"
 
 function Drawer({
+  repositionInputs = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  )
 }
 
 function DrawerTrigger({

--- a/apps/v4/styles/base-nova/ui/drawer.tsx
+++ b/apps/v4/styles/base-nova/ui/drawer.tsx
@@ -6,9 +6,16 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/lib/utils"
 
 function Drawer({
+  repositionInputs = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  )
 }
 
 function DrawerTrigger({

--- a/apps/v4/styles/base-sera/ui/drawer.tsx
+++ b/apps/v4/styles/base-sera/ui/drawer.tsx
@@ -6,9 +6,16 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/lib/utils"
 
 function Drawer({
+  repositionInputs = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  )
 }
 
 function DrawerTrigger({

--- a/apps/v4/styles/base-vega/ui/drawer.tsx
+++ b/apps/v4/styles/base-vega/ui/drawer.tsx
@@ -6,9 +6,16 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/lib/utils"
 
 function Drawer({
+  repositionInputs = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  )
 }
 
 function DrawerTrigger({

--- a/apps/v4/styles/radix-luma/ui/drawer.tsx
+++ b/apps/v4/styles/radix-luma/ui/drawer.tsx
@@ -6,9 +6,16 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/lib/utils"
 
 function Drawer({
+  repositionInputs = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  )
 }
 
 function DrawerTrigger({

--- a/apps/v4/styles/radix-lyra/ui/drawer.tsx
+++ b/apps/v4/styles/radix-lyra/ui/drawer.tsx
@@ -6,9 +6,16 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/lib/utils"
 
 function Drawer({
+  repositionInputs = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  )
 }
 
 function DrawerTrigger({

--- a/apps/v4/styles/radix-maia/ui/drawer.tsx
+++ b/apps/v4/styles/radix-maia/ui/drawer.tsx
@@ -6,9 +6,16 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/lib/utils"
 
 function Drawer({
+  repositionInputs = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  )
 }
 
 function DrawerTrigger({

--- a/apps/v4/styles/radix-mira/ui/drawer.tsx
+++ b/apps/v4/styles/radix-mira/ui/drawer.tsx
@@ -6,9 +6,16 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/lib/utils"
 
 function Drawer({
+  repositionInputs = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  )
 }
 
 function DrawerTrigger({

--- a/apps/v4/styles/radix-nova/ui/drawer.tsx
+++ b/apps/v4/styles/radix-nova/ui/drawer.tsx
@@ -6,9 +6,16 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/lib/utils"
 
 function Drawer({
+  repositionInputs = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  )
 }
 
 function DrawerTrigger({

--- a/apps/v4/styles/radix-sera/ui/drawer.tsx
+++ b/apps/v4/styles/radix-sera/ui/drawer.tsx
@@ -6,9 +6,16 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/lib/utils"
 
 function Drawer({
+  repositionInputs = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  )
 }
 
 function DrawerTrigger({

--- a/apps/v4/styles/radix-vega/ui/drawer.tsx
+++ b/apps/v4/styles/radix-vega/ui/drawer.tsx
@@ -6,9 +6,16 @@ import { Drawer as DrawerPrimitive } from "vaul"
 import { cn } from "@/lib/utils"
 
 function Drawer({
+  repositionInputs = false,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={repositionInputs}
+      {...props}
+    />
+  )
 }
 
 function DrawerTrigger({


### PR DESCRIPTION
This PR fixes #[10574](https://github.com/shadcn-ui/ui/issues/10574)  issue where the Drawer component fails to reset its layout correctly after the keyboard is dismissed on mobile devices. This results in a large vertical gap in the layout.

The issue stems from vaul's automatic `repositionInputs` logic failing to reset correctly in some environments. By exposing the `repositionInputs` prop and setting it to `false` by default, we provide a more stable default experience while allowing users to opt-in if needed.

**Changes:**

Added `repositionInputs` prop to Drawer component.
Set` repositionInputs={false}` as the default.
Updated all 16 variants of drawer.tsx across registries and styles for consistency.

Fixes: #10574