### PR TITLE
Fix combobox horizontal scroll positioning

### DIFF
--- a/apps/v4/registry/bases/base/ui/combobox.tsx
+++ b/apps/v4/registry/bases/base/ui/combobox.tsx
@@ -105,11 +105,17 @@ function ComboboxContent({
   align = "start",
   alignOffset = 0,
   anchor,
+  collisionAvoidance = { align: "none" },
   ...props
 }: ComboboxPrimitive.Popup.Props &
   Pick<
     ComboboxPrimitive.Positioner.Props,
-    "side" | "align" | "sideOffset" | "alignOffset" | "anchor"
+    | "side"
+    | "align"
+    | "sideOffset"
+    | "alignOffset"
+    | "anchor"
+    | "collisionAvoidance"
   >) {
   return (
     <ComboboxPrimitive.Portal>
@@ -119,6 +125,7 @@ function ComboboxContent({
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
+        collisionAvoidance={collisionAvoidance}
         className="isolate z-50"
       >
         <ComboboxPrimitive.Popup

--- a/apps/v4/registry/bases/radix/ui/combobox.tsx
+++ b/apps/v4/registry/bases/radix/ui/combobox.tsx
@@ -107,11 +107,17 @@ function ComboboxContent({
   align = "start",
   alignOffset = 0,
   anchor,
+  collisionAvoidance = { align: "none" },
   ...props
 }: ComboboxPrimitive.Popup.Props &
   Pick<
     ComboboxPrimitive.Positioner.Props,
-    "side" | "align" | "sideOffset" | "alignOffset" | "anchor"
+    | "side"
+    | "align"
+    | "sideOffset"
+    | "alignOffset"
+    | "anchor"
+    | "collisionAvoidance"
   >) {
   return (
     <ComboboxPrimitive.Portal>
@@ -121,6 +127,7 @@ function ComboboxContent({
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
+        collisionAvoidance={collisionAvoidance}
         className="isolate z-50"
       >
         <ComboboxPrimitive.Popup


### PR DESCRIPTION
## Summary

Fixes #10631.

Fixes combobox popup positioning when a horizontally scrollable layout is scrolled sideways.

## What Changed

- Forwards `collisionAvoidance` from `ComboboxContent` to Base UI's `Combobox.Positioner`.
- Defaults combobox alignment collision handling to `{ align: "none" }` so the popup stays aligned with its anchor instead of shifting horizontally away from the trigger.

## Why

Base UI's default collision behavior can shift floating content along the alignment axis to keep it visible. In horizontally scrolled containers, that can make the combobox popup appear detached from the input. Centralizing this in the shadcn combobox wrapper means users get the fix automatically when using `ComboboxContent`, while still being able to override `collisionAvoidance` when needed.
