### PR TITLE
fix(cli): install pnpm deps at workspace root

### DIFF
--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -1,3 +1,4 @@
+import path from "path"
 import { SHADCN_URL } from "@/src/registry/constants"
 import { RegistryItem } from "@/src/schema"
 import { Config } from "@/src/utils/get-config"
@@ -6,6 +7,7 @@ import { getPackageManager } from "@/src/utils/get-package-manager"
 import { logger } from "@/src/utils/logger"
 import { spinner } from "@/src/utils/spinner"
 import { execa } from "execa"
+import fs from "fs-extra"
 import prompts from "prompts"
 
 export async function updateDependencies(
@@ -124,15 +126,30 @@ async function installWithPackageManager(
     return installWithExpo(dependencies, devDependencies, cwd)
   }
 
+  const workspaceRootFlag =
+    packageManager === "pnpm" && isPnpmWorkspaceRoot(cwd)
+      ? ["--workspace-root"]
+      : []
+
   if (dependencies?.length) {
-    await execa(packageManager, ["add", ...dependencies], {
-      cwd,
-    })
+    await execa(
+      packageManager,
+      ["add", ...workspaceRootFlag, ...dependencies],
+      { cwd }
+    )
   }
 
   if (devDependencies?.length) {
-    await execa(packageManager, ["add", "-D", ...devDependencies], { cwd })
+    await execa(
+      packageManager,
+      ["add", ...workspaceRootFlag, "-D", ...devDependencies],
+      { cwd }
+    )
   }
+}
+
+function isPnpmWorkspaceRoot(cwd: string) {
+  return fs.existsSync(path.resolve(cwd, "pnpm-workspace.yaml"))
 }
 
 async function installWithNpm(

--- a/packages/shadcn/test/fixtures/project-pnpm-workspace-root/package.json
+++ b/packages/shadcn/test/fixtures/project-pnpm-workspace-root/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-cli-project-pnpm-workspace-root",
+  "version": "1.0.0",
+  "main": "index.js",
+  "author": "shadcn",
+  "license": "MIT"
+}

--- a/packages/shadcn/test/fixtures/project-pnpm-workspace-root/pnpm-lock.yaml
+++ b/packages/shadcn/test/fixtures/project-pnpm-workspace-root/pnpm-lock.yaml
@@ -1,0 +1,5 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/packages/shadcn/test/fixtures/project-pnpm-workspace-root/pnpm-workspace.yaml
+++ b/packages/shadcn/test/fixtures/project-pnpm-workspace-root/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - .

--- a/packages/shadcn/test/utils/updaters/update-dependencies.test.ts
+++ b/packages/shadcn/test/utils/updaters/update-dependencies.test.ts
@@ -105,6 +105,28 @@ describe("updateDependencies", () => {
       expectedDevArgs: ["add", "-D", "fourth"],
     },
     {
+      description: "pnpm uses workspace root flag at a workspace root",
+      dependencies: ["first", "second", "third"],
+      devDependencies: ["fourth"],
+      config: {
+        resolvedPaths: {
+          cwd: path.resolve(
+            __dirname,
+            "../../fixtures/project-pnpm-workspace-root"
+          ),
+        },
+      },
+      expectedPackageManager: "pnpm",
+      expectedArgs: [
+        "add",
+        "--workspace-root",
+        "first",
+        "second",
+        "third",
+      ],
+      expectedDevArgs: ["add", "--workspace-root", "-D", "fourth"],
+    },
+    {
       description: "deduplicates input dependencies",
       options: { silent: true },
       dependencies: ["first", "first"],


### PR DESCRIPTION
## Summary

Fixes #9178.

When a project has a `pnpm-workspace.yaml` at its package root, `pnpm add` treats that directory as a workspace root and refuses to add dependencies unless the command is explicit about targeting the workspace root. Next.js can create this shape for a single-package app, so `shadcn init` could fail during dependency installation with `ERR_PNPM_ADDING_TO_ROOT`.

This updates the dependency installer to pass `--workspace-root` only when the detected package manager is pnpm and the install cwd contains `pnpm-workspace.yaml`. Non-workspace pnpm projects and other package managers keep their existing command arguments.

## Testing

- `corepack pnpm --filter=shadcn exec vitest run test/utils/updaters/update-dependencies.test.ts`
- `corepack pnpm --filter=shadcn typecheck`
- `corepack pnpm --filter=shadcn exec prettier --check src/utils/updaters/update-dependencies.ts test/utils/updaters/update-dependencies.test.ts test/fixtures/project-pnpm-workspace-root/package.json`
- `corepack pnpm --filter=shadcn build`

Note: direct root ESLint is not runnable in this checkout because ESLint 9 does not find a flat `eslint.config.*` file for these package files.