### PR TITLE
fix(cli): preserve custom registry styles in Tailwind v4 projects

### DIFF
--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -19,6 +19,11 @@ export const DEFAULT_UTILS = "@/lib/utils"
 export const DEFAULT_TAILWIND_CSS = "app/globals.css"
 export const DEFAULT_TAILWIND_CONFIG = "tailwind.config.js"
 export const DEFAULT_TAILWIND_BASE_COLOR = "slate"
+const TAILWIND_V4_COMPATIBLE_STYLES = new Set([
+  "default",
+  "new-york",
+  "new-york-v4",
+])
 
 // TODO: Figure out if we want to support all cosmiconfig formats.
 // A simple components.json file would be nice.
@@ -315,7 +320,10 @@ export function findCommonRoot(cwd: string, resolvedPath: string) {
 // TODO: Cache this call.
 export async function getTargetStyleFromConfig(cwd: string, fallback: string) {
   const projectInfo = await getProjectInfo(cwd)
-  return projectInfo?.tailwindVersion === "v4" ? "new-york-v4" : fallback
+  return projectInfo?.tailwindVersion === "v4" &&
+    TAILWIND_V4_COMPATIBLE_STYLES.has(fallback)
+    ? "new-york-v4"
+    : fallback
 }
 
 export function getBase(style: string | undefined) {

--- a/packages/shadcn/test/utils/get-config.test.ts
+++ b/packages/shadcn/test/utils/get-config.test.ts
@@ -8,6 +8,7 @@ import {
   getBase,
   getConfig,
   getRawConfig,
+  getTargetStyleFromConfig,
   getWorkspaceConfig,
 } from "../../src/utils/get-config"
 import { getProjectConfig } from "../../src/utils/get-project-info"
@@ -119,7 +120,10 @@ test("get project config from generic package import prefix", async () => {
 })
 
 test("get project config from root package imports", async () => {
-  const cwd = path.resolve(__dirname, "../fixtures/frameworks/vite-root-imports")
+  const cwd = path.resolve(
+    __dirname,
+    "../fixtures/frameworks/vite-root-imports"
+  )
 
   expect(await getProjectConfig(cwd)).toEqual({
     $schema: "https://ui.shadcn.com/schema.json",
@@ -649,6 +653,28 @@ describe("getBase", () => {
 
   test("returns radix for undefined", () => {
     expect(getBase(undefined)).toBe("radix")
+  })
+})
+
+describe("getTargetStyleFromConfig", () => {
+  const tailwindV4Cwd = path.resolve(
+    __dirname,
+    "../fixtures/frameworks/vite-monorepo-imports/apps/web"
+  )
+
+  test.each(["default", "new-york", "new-york-v4"])(
+    "uses new-york-v4 for built-in %s style in Tailwind v4 projects",
+    async (style) => {
+      await expect(
+        getTargetStyleFromConfig(tailwindV4Cwd, style)
+      ).resolves.toBe("new-york-v4")
+    }
+  )
+
+  test("preserves custom registry styles in Tailwind v4 projects", async () => {
+    await expect(
+      getTargetStyleFromConfig(tailwindV4Cwd, "base-nova")
+    ).resolves.toBe("base-nova")
   })
 })
 


### PR DESCRIPTION
## Summary

Fixes #10496.

`getTargetStyleFromConfig()` currently maps every Tailwind v4 project to `new-york-v4`, regardless of the configured fallback style. That is useful for shadcn's legacy built-in styles, but it breaks third-party registries that use their own `{style}` identifiers such as `base-nova`.

This keeps the Tailwind v4 compatibility upgrade for `default`, `new-york`, and `new-york-v4`, while preserving custom registry styles unchanged.

## Validation

- `corepack pnpm --filter shadcn test -- get-config.test.ts -t getTargetStyleFromConfig`
- `corepack pnpm --filter shadcn typecheck`
- `corepack pnpm --filter shadcn build`
- `corepack pnpm exec prettier --check packages/shadcn/src/utils/get-config.ts packages/shadcn/test/utils/get-config.test.ts`
- `git diff --check`

I also ran `corepack pnpm --filter shadcn test -- get-config.test.ts`; it still fails on existing Windows fixture path/workspace assertions unrelated to this change, while the new focused assertions pass.