### PR TITLE
fix(v4): forward refs in Button asChild variants

### DIFF
--- a/apps/v4/registry/bases/radix/ui/button.test.tsx
+++ b/apps/v4/registry/bases/radix/ui/button.test.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import { Button } from "./button"
+
+describe("radix button", () => {
+  it("is a forwardRef component", () => {
+    expect(Button.$$typeof).toBe(Symbol.for("react.forward_ref"))
+  })
+
+  it("renders an asChild child without wrapping", () => {
+    const html = renderToStaticMarkup(
+      <Button asChild>
+        <span>Action</span>
+      </Button>
+    )
+
+    expect(html).toMatch(/^<span\b[^>]*>Action<\/span>$/)
+    expect(html).not.toContain("<button")
+  })
+})

--- a/apps/v4/registry/bases/radix/ui/button.tsx
+++ b/apps/v4/registry/bases/radix/ui/button.tsx
@@ -34,20 +34,26 @@ const buttonVariants = cva(
   }
 )
 
-function Button({
-  className,
-  variant = "default",
-  size = "default",
-  asChild = false,
-  ...props
-}: React.ComponentProps<"button"> &
+type ButtonProps = React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean
-  }) {
+  }
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  {
+    className,
+    variant = "default",
+    size = "default",
+    asChild = false,
+    ...props
+  },
+  ref
+) {
   const Comp = asChild ? Slot.Root : "button"
 
   return (
     <Comp
+      ref={ref}
       data-slot="button"
       data-variant={variant}
       data-size={size}
@@ -55,6 +61,8 @@ function Button({
       {...props}
     />
   )
-}
+})
+
+Button.displayName = "Button"
 
 export { Button, buttonVariants }

--- a/apps/v4/registry/new-york-v4/ui/button.test.tsx
+++ b/apps/v4/registry/new-york-v4/ui/button.test.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import { Button } from "./button"
+
+describe("new-york Button", () => {
+  it("is a forwardRef component", () => {
+    expect(Button.$$typeof).toBe(Symbol.for("react.forward_ref"))
+  })
+
+  it("renders an asChild child without wrapping", () => {
+    const html = renderToStaticMarkup(
+      <Button asChild>
+        <span>Action</span>
+      </Button>
+    )
+
+    expect(html).toMatch(/^<span\b[^>]*>Action<\/span>$/)
+    expect(html).not.toContain("<button")
+  })
+})

--- a/apps/v4/registry/new-york-v4/ui/button.tsx
+++ b/apps/v4/registry/new-york-v4/ui/button.tsx
@@ -38,20 +38,26 @@ const buttonVariants = cva(
   }
 )
 
-function Button({
-  className,
-  variant = "default",
-  size = "default",
-  asChild = false,
-  ...props
-}: React.ComponentProps<"button"> &
+type ButtonProps = React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean
-  }) {
+  }
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  {
+    className,
+    variant = "default",
+    size = "default",
+    asChild = false,
+    ...props
+  },
+  ref
+) {
   const Comp = asChild ? Slot.Root : "button"
 
   return (
     <Comp
+      ref={ref}
       data-slot="button"
       data-variant={variant}
       data-size={size}
@@ -59,6 +65,8 @@ function Button({
       {...props}
     />
   )
-}
+})
+
+Button.displayName = "Button"
 
 export { Button, buttonVariants }


### PR DESCRIPTION
## Summary

Fixes #8930.

- Convert both v4 registry `Button` variants to `React.forwardRef` components.
- Forward the ref through `Slot.Root` when `asChild` is used, preserving composition with Tooltip and other slot-based primitives.
- Add SSR-focused tests that verify `Button asChild` renders only the child element and does not wrap it in a nested `<button>`.

## Validation

- `corepack pnpm vitest run apps/v4/registry/new-york-v4/ui/button.test.tsx apps/v4/registry/bases/radix/ui/button.test.tsx`
- `corepack pnpm --filter=v4 typecheck`
- `corepack pnpm --filter=v4 lint`
- `corepack pnpm --filter=v4 validate:registries`
- `corepack pnpm --filter=shadcn build`
- `git diff --check origin/main...HEAD`

## Notes

- `corepack pnpm --filter=v4 build` could not complete in my local Windows environment because the script invokes bare `pnpm` and this machine only exposes pnpm through Corepack. Attempting the registry step manually with `tsx` also fails before this change is exercised because the script expects Bun's JSX runtime and Bun is not installed locally.