### PR TITLE
Fix default Tailwind v4 registry fallback

### DIFF
--- a/packages/shadcn/src/registry/config.test.ts
+++ b/packages/shadcn/src/registry/config.test.ts
@@ -61,6 +61,22 @@ describe("configWithDefaults", () => {
     expect(result.style).toBe(FALLBACK_STYLE)
   })
 
+  it("should use FALLBACK_STYLE when style is default and tailwind.config is empty", () => {
+    const config = createConfig({
+      style: "default",
+      tailwind: {
+        config: "",
+        css: "app/globals.css",
+        baseColor: "slate",
+        cssVariables: true,
+      },
+    })
+
+    const result = configWithDefaults(config)
+
+    expect(result.style).toBe(FALLBACK_STYLE)
+  })
+
   it("should keep new-york style when tailwind.config is not empty", () => {
     const config = createConfig({
       style: "new-york",
@@ -77,11 +93,11 @@ describe("configWithDefaults", () => {
     expect(result.style).toBe("new-york")
   })
 
-  it("should preserve non-new-york styles regardless of tailwind config", () => {
+  it("should preserve legacy default style when tailwind.config is not empty", () => {
     const config1 = createConfig({
       style: "default",
       tailwind: {
-        config: "",
+        config: "tailwind.config.js",
         css: "app/globals.css",
         baseColor: "slate",
         cssVariables: true,
@@ -90,7 +106,9 @@ describe("configWithDefaults", () => {
 
     const result1 = configWithDefaults(config1)
     expect(result1.style).toBe("default")
+  })
 
+  it("should preserve custom styles regardless of tailwind config", () => {
     const config2 = createConfig({
       style: "miami",
       tailwind: {

--- a/packages/shadcn/src/registry/config.ts
+++ b/packages/shadcn/src/registry/config.ts
@@ -10,7 +10,10 @@ function resolveStyleFromConfig(config: DeepPartial<Config>) {
 
   // Check if we should use new-york-v4 for Tailwind v4.
   // We assume that if tailwind.config is empty, we're using Tailwind v4.
-  if (config.style === "new-york" && config.tailwind?.config === "") {
+  if (
+    (config.style === "default" || config.style === "new-york") &&
+    config.tailwind?.config === ""
+  ) {
     return FALLBACK_STYLE
   }
 


### PR DESCRIPTION
## Summary

- Treat legacy `default` style with an empty Tailwind config the same as `new-york`, resolving it to the Tailwind v4 fallback style.
- Add coverage so `default` falls back only for Tailwind v4 configless projects, while legacy config-file projects and custom styles are preserved.

This addresses the `styles/default/combobox.json` 404 path reported in #10065 without changing legacy `default` projects that still have a Tailwind config file.

## Test plan

- `corepack pnpm exec vitest run packages/shadcn/src/registry/config.test.ts`
- `corepack pnpm --filter shadcn typecheck`
- `corepack pnpm exec prettier --check packages/shadcn/src/registry/config.ts packages/shadcn/src/registry/config.test.ts`
- `corepack pnpm --filter shadcn build`
- `git diff --check`

Notes:
- `corepack pnpm exec eslint packages/shadcn/src/registry/config.ts packages/shadcn/src/registry/config.test.ts` is currently blocked locally because the repo has legacy `.eslintrc.json` config while the installed ESLint 9 CLI expects `eslint.config.*`.
- `corepack pnpm --filter shadcn test` has existing Windows-specific path snapshot/local-file failures outside this change; the targeted registry config test passed.