### PR TITLE
fix waveform card footer

### DIFF
--- a/apps/v4/registry/bases/base/blocks/preview/cards/live-waveform.tsx
+++ b/apps/v4/registry/bases/base/blocks/preview/cards/live-waveform.tsx
@@ -528,7 +528,7 @@ export function LiveWaveformCard() {
           historySize={120}
         />
       </CardContent>
-      <CardFooter className="gap-2">
+      <CardFooter className="grid gap-2">
         <Button
           size="sm"
           variant={active ? "default" : "outline"}

--- a/apps/v4/registry/bases/radix/blocks/preview/cards/live-waveform.tsx
+++ b/apps/v4/registry/bases/radix/blocks/preview/cards/live-waveform.tsx
@@ -528,7 +528,7 @@ export function LiveWaveformCard() {
           historySize={120}
         />
       </CardContent>
-      <CardFooter className="gap-2">
+      <CardFooter className="grid gap-2">
         <Button
           size="sm"
           variant={active ? "default" : "outline"}


### PR DESCRIPTION
It doesn't seem like these three buttons can fit in a single row on most screens :)

Before:
<img width="460" height="469" alt="image" src="https://github.com/user-attachments/assets/9134ab8a-1d84-448c-b638-b74fa77d930e" />

After:
<img width="460" height="585" alt="image" src="https://github.com/user-attachments/assets/0cdfd304-c23d-4067-8225-7e1411b1800c" />
