### PR TITLE
fix(docs): correct styleName references in radix combobox and chart docs

### DIFF
--- a/apps/v4/content/docs/components/radix/chart.mdx
+++ b/apps/v4/content/docs/components/radix/chart.mdx
@@ -595,7 +595,7 @@ This prop adds keyboard access and screen reader support to your charts.
 To enable RTL support in shadcn/ui, see the [RTL configuration guide](/docs/rtl).
 
 <ComponentPreview
-  styleName="base-nova"
+  styleName="radix-nova"
   name="chart-rtl"
   direction="rtl"
   previewClassName="h-92"

--- a/apps/v4/content/docs/components/radix/combobox.mdx
+++ b/apps/v4/content/docs/components/radix/combobox.mdx
@@ -9,7 +9,7 @@ links:
 ---
 
 <ComponentPreview
-  styleName="base-nova"
+  styleName="radix-nova"
   name="combobox-demo"
   description="A combobox with a list of frameworks."
 />
@@ -44,7 +44,7 @@ npm install @base-ui/react
 <ComponentSource
   name="combobox"
   title="components/ui/combobox.tsx"
-  styleName="base-nova"
+  styleName="radix-nova"
 />
 
 <Step>Update the import paths to match your project setup.</Step>
@@ -256,55 +256,55 @@ export function ExampleComboboxMultiple() {
 
 A simple combobox with a list of frameworks.
 
-<ComponentPreview styleName="base-nova" name="combobox-basic" />
+<ComponentPreview styleName="radix-nova" name="combobox-basic" />
 
 ### Multiple
 
 A combobox with multiple selection using `multiple` and `ComboboxChips`.
 
-<ComponentPreview styleName="base-nova" name="combobox-multiple" />
+<ComponentPreview styleName="radix-nova" name="combobox-multiple" />
 
 ### Clear Button
 
 Use the `showClear` prop to show a clear button.
 
-<ComponentPreview styleName="base-nova" name="combobox-clear" />
+<ComponentPreview styleName="radix-nova" name="combobox-clear" />
 
 ### Groups
 
 Use `ComboboxGroup` and `ComboboxSeparator` to group items.
 
-<ComponentPreview styleName="base-nova" name="combobox-groups" />
+<ComponentPreview styleName="radix-nova" name="combobox-groups" />
 
 ### Custom Items
 
 You can render a custom component inside `ComboboxItem`.
 
-<ComponentPreview styleName="base-nova" name="combobox-custom" />
+<ComponentPreview styleName="radix-nova" name="combobox-custom" />
 
 ### Invalid
 
 Use the `aria-invalid` prop to make the combobox invalid.
 
-<ComponentPreview styleName="base-nova" name="combobox-invalid" />
+<ComponentPreview styleName="radix-nova" name="combobox-invalid" />
 
 ### Disabled
 
 Use the `disabled` prop to disable the combobox.
 
-<ComponentPreview styleName="base-nova" name="combobox-disabled" />
+<ComponentPreview styleName="radix-nova" name="combobox-disabled" />
 
 ### Auto Highlight
 
 Use the `autoHighlight` prop to automatically highlight the first item on filter.
 
-<ComponentPreview styleName="base-nova" name="combobox-auto-highlight" />
+<ComponentPreview styleName="radix-nova" name="combobox-auto-highlight" />
 
 ### Popup
 
 You can trigger the combobox from a button or any other component by using the `render` prop. Move the `ComboboxInput` inside the `ComboboxContent`.
 
-<ComponentPreview styleName="base-nova" name="combobox-popup" />
+<ComponentPreview styleName="radix-nova" name="combobox-popup" />
 
 ### Input Group
 


### PR DESCRIPTION
Fixes #10674

In the Radix UI documentation pages, several `ComponentPreview` and `ComponentSource` blocks were incorrectly using `styleName="base-nova"` instead of `styleName="radix-nova"`. This meant users browsing the Radix style docs were seeing Base UI style previews instead of the Radix UI equivalents.

## Changes

- `apps/v4/content/docs/components/radix/combobox.mdx`: Updated 11 style preview references from `base-nova` → `radix-nova`
- `apps/v4/content/docs/components/radix/chart.mdx`: Updated the RTL section preview from `base-nova` → `radix-nova`