### PR TITLE
feat(registry): add Wensity

### DIFF
--- a/apps/v4/public/r/registries.json
+++ b/apps/v4/public/r/registries.json
@@ -1156,5 +1156,11 @@
     "homepage": "https://www.turbopills.com/ui/docs",
     "url": "https://ui.turbopills.com/r/{name}.json",
     "description": "Beautiful, accessible, and customizable React components for your telehealth applications."
+  },
+  {
+    "name": "@wensity",
+    "homepage": "https://wensity.com",
+    "url": "https://raw.githubusercontent.com/ksparth12/wensity-shadcn-registry/main/{name}.json",
+    "description": "Motion-rich React components for AI interfaces, SaaS blocks, and cinematic interactions. Free Wensity components only."
   }
 ]

--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1350,5 +1350,12 @@
     "url": "https://ui.turbopills.com/r/{name}.json",
     "description": "Beautiful, accessible, and customizable React components for your telehealth applications.",
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' version='1.0' width='597.000000pt' height='525.000000pt' viewBox='0 0 597.000000 525.000000' preserveAspectRatio='xMidYMid meet'><g transform='translate(0.000000,525.000000) scale(0.100000,-0.100000)' fill='var(--foreground, currentColor)' stroke='none'><path d='M1816 5223 l-1809 -3 6 -108 c24 -383 241 -748 579 -969 113 -74 205   -118 338 -162 178 -58 237 -64 678 -70 l404 -6 14 33 c56 136 213 367 364 538   283 320 747 605 1163 716 48 12 87 26 87 30 0 5 -3 7 -7 6 -5 -2 -822 -4   -1817 -5z'/><path d='M4630 5209 c-983 -101 -1863 -612 -2297 -1334 -249 -414 -394 -925   -462 -1625 -28 -287 -29 -310 -19 -304 4 3 8 12 8 20 0 19 87 192 163 324 413   718 1068 1274 1797 1522 228 78 466 118 703 118 506 0 811 110 1079 389 135   139 217 274 283 462 43 123 60 208 70 342 l7 97 -623 -1 c-343 -1 -662 -6   -709 -10z'/><path d='M3876 3584 c-339 -138 -733 -410 -1041 -719 -347 -347 -596 -694   -840 -1170 -188 -367 -356 -851 -435 -1250 -31 -157 -60 -344 -60 -389 l0 -39   183 7 c224 8 336 20 497 52 676 135 1179 580 1326 1174 19 74 56 257 83 405   94 515 222 1211 256 1390 50 268 97 545 93 555 -2 4 -29 -2 -62 -16z'/></g></svg>"
+  },
+  {
+    "name": "@wensity",
+    "homepage": "https://wensity.com",
+    "url": "https://raw.githubusercontent.com/ksparth12/wensity-shadcn-registry/main/{name}.json",
+    "description": "Motion-rich React components for AI interfaces, SaaS blocks, and cinematic interactions. Free Wensity components only.",
+    "logo": "<svg width='512' height='512' viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'><rect width='512' height='512' rx='112' fill='var(--foreground)'/><path d='M112 152h58l36 160 43-160h49l43 160 36-160h58l-62 208h-62l-38-141-38 141h-62L112 152Z' fill='var(--background)'/></svg>"
   }
 ]


### PR DESCRIPTION
Adds the @wensity community registry to the public registry index.\n\nRegistry: https://github.com/ksparth12/wensity-shadcn-registry\nHomepage: https://wensity.com\nURL template: https://raw.githubusercontent.com/ksparth12/wensity-shadcn-registry/main/{name}.json\n\nThe public registry contains only free Wensity components. Pro components are intentionally excluded and remain available through Wensity's authenticated CLI.\n\nValidation run:\n- pnpm registry:build\n- pnpm validate:registries