### PR TITLE
fix(dialog): prevent autofocus conflict with CommandInput

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/dialog.tsx
+++ b/apps/v4/registry/new-york-v4/ui/dialog.tsx
@@ -51,6 +51,7 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  onOpenAutoFocus,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean


### PR DESCRIPTION
Fixes #9171

Prevents Radix Dialog from auto-focusing content on open, which interferes
with cmdk's CommandInput when used inside a Combobox in a Dialog.

This change allows users to type normally in the CommandInput field.