### PR TITLE
fix: preserve customizer settings on style change

### DIFF
--- a/apps/v4/app/(app)/create/components/style-picker.tsx
+++ b/apps/v4/app/(app)/create/components/style-picker.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 
-import { PRESETS, type Style, type StyleName } from "@/registry/config"
+import { type Style, type StyleName } from "@/registry/config"
 import { LockButton } from "@/app/(app)/create/components/lock-button"
 import {
   Picker,
@@ -53,24 +53,7 @@ export function StylePicker({
           <PickerRadioGroup
             value={currentStyle?.name}
             onValueChange={(value) => {
-              const styleName = value as StyleName
-              const preset = PRESETS.find(
-                (p) => p.base === params.base && p.style === styleName
-              )
-              setParams({
-                style: styleName,
-                ...(preset && {
-                  baseColor: preset.baseColor,
-                  theme: preset.theme,
-                  chartColor: preset.chartColor,
-                  iconLibrary: preset.iconLibrary,
-                  font: preset.font,
-                  fontHeading: preset.fontHeading,
-                  menuAccent: preset.menuAccent,
-                  menuColor: preset.menuColor,
-                  radius: preset.radius,
-                }),
-              })
+              setParams({ style: value as StyleName })
             }}
           >
             <PickerGroup>


### PR DESCRIPTION
Preserve existing customizer selections when switching styles so style changes no longer reset font, colors, menu, icon library, or radius values.