### PR TITLE
fix(components): equality check for uniqueErrors length

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/field.tsx
+++ b/apps/v4/registry/new-york-v4/ui/field.tsx
@@ -204,7 +204,7 @@ function FieldError({
       ...new Map(errors.map((error) => [error?.message, error])).values(),
     ]
 
-    if (uniqueErrors?.length == 1) {
+    if (uniqueErrors?.length === 1) {
       return uniqueErrors[0]?.message
     }
 


### PR DESCRIPTION
## Summary

Replaced loose equality (`==`) with strict equality (`===`) when checking `uniqueErrors.length`.

## Why

Using strict equality avoids implicit type coercion and keeps comparisons predictable and consistent with modern JavaScript/TypeScript best practices.

## Changes

Before:
```ts
    if (uniqueErrors?.length == 1) {
      return uniqueErrors[0]?.message;
    }
```

After:
```ts
    if (uniqueErrors?.length === 1) {
      return uniqueErrors[0]?.message;
    }
```