### PR TITLE
fix(cli): inject pnpm.onlyBuiltDependencies to fix Vite template initialization crash

### DIFF
--- a/packages/shadcn/src/templates/create-template.ts
+++ b/packages/shadcn/src/templates/create-template.ts
@@ -270,24 +270,34 @@ function defaultScaffold({
       // Adapt workspace config and lockfiles for the target package manager.
       await adaptWorkspaceConfig(projectPath, packageManager)
 
+      // Write project name to the package.json and inject pnpm configuration.
+      const packageJsonPath = path.join(projectPath, "package.json")
+      if (fs.existsSync(packageJsonPath)) {
+        const packageJsonContent = await fs.readFile(packageJsonPath, "utf8")
+        const packageJson = JSON.parse(packageJsonContent)
+        packageJson.name = path.basename(projectPath)
+
+        if (packageManager === "pnpm") {
+          packageJson.pnpm = packageJson.pnpm || {}
+          packageJson.pnpm.onlyBuiltDependencies =
+            packageJson.pnpm.onlyBuiltDependencies || []
+          if (!packageJson.pnpm.onlyBuiltDependencies.includes("esbuild")) {
+            packageJson.pnpm.onlyBuiltDependencies.push("esbuild")
+          }
+        }
+
+        await fs.writeFile(
+          packageJsonPath,
+          JSON.stringify(packageJson, null, 2) + "\n"
+        )
+      }
+
       // Run install.
       const installArgs = getInstallArgs(packageManager)
       const args = ["install", ...installArgs]
       await execa(packageManager, args, {
         cwd: projectPath,
       })
-
-      // Write project name to the package.json.
-      const packageJsonPath = path.join(projectPath, "package.json")
-      if (fs.existsSync(packageJsonPath)) {
-        const packageJsonContent = await fs.readFile(packageJsonPath, "utf8")
-        const packageJson = JSON.parse(packageJsonContent)
-        packageJson.name = path.basename(projectPath)
-        await fs.writeFile(
-          packageJsonPath,
-          JSON.stringify(packageJson, null, 2) + "\n"
-        )
-      }
 
       createSpinner?.succeed(`Creating a new ${title} project.`)
     } catch (error) {


### PR DESCRIPTION
Resolves #10658.

### Description
When running shadcn init with the Vite template using modern pnpm, the initialization process fails during pnpm install with [ERR_PNPM_IGNORED_BUILDS]. This happens because esbuild requires a post-install build script, which pnpm blocks by default for security.

### Solution
This PR moves the package.json setup in create-template.ts to execute **before** pnpm install. It then automatically detects if the package manager is pnpm and injects "pnpm: { onlyBuiltDependencies: [esbuild] } into the package.json.

This signals to pnpm that the esbuild script is trusted, allowing the installation to succeed seamlessly out of the box without requiring manual .npmrc or pnpm-workspace.yaml overrides from the user.
