### PR TITLE
fix(calendar): resolve TypeScript error for locale.code access

### DIFF
--- a/apps/v4/styles/base-luma/ui/calendar.tsx
+++ b/apps/v4/styles/base-luma/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -208,7 +208,7 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/base-lyra/ui/calendar.tsx
+++ b/apps/v4/styles/base-lyra/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -208,7 +208,7 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/base-maia/ui/calendar.tsx
+++ b/apps/v4/styles/base-maia/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -208,7 +208,7 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/base-mira/ui/calendar.tsx
+++ b/apps/v4/styles/base-mira/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -208,7 +208,7 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/base-nova/ui-rtl/calendar.tsx
+++ b/apps/v4/styles/base-nova/ui-rtl/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -208,7 +208,7 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/base-nova/ui/calendar.tsx
+++ b/apps/v4/styles/base-nova/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -208,7 +208,7 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/base-sera/ui/calendar.tsx
+++ b/apps/v4/styles/base-sera/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -208,7 +208,7 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/base-vega/ui/calendar.tsx
+++ b/apps/v4/styles/base-vega/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -208,7 +208,7 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/radix-luma/ui/calendar.tsx
+++ b/apps/v4/styles/radix-luma/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -209,7 +209,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/radix-lyra/ui/calendar.tsx
+++ b/apps/v4/styles/radix-lyra/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -209,7 +209,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/radix-maia/ui/calendar.tsx
+++ b/apps/v4/styles/radix-maia/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -209,7 +209,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/radix-mira/ui/calendar.tsx
+++ b/apps/v4/styles/radix-mira/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -209,7 +209,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/radix-nova/ui-rtl/calendar.tsx
+++ b/apps/v4/styles/radix-nova/ui-rtl/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -209,7 +209,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/radix-nova/ui/calendar.tsx
+++ b/apps/v4/styles/radix-nova/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -209,7 +209,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/radix-sera/ui/calendar.tsx
+++ b/apps/v4/styles/radix-sera/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -209,7 +209,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/radix-vega/ui/calendar.tsx
+++ b/apps/v4/styles/radix-vega/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -209,7 +209,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&


### PR DESCRIPTION
## What

All `base-*` and `radix-*` calendar variants access `locale?.code` in two places:

1. `formatMonthDropdown` formatter — `date.toLocaleString(locale?.code, { month: "short" })`
2. `data-day` attribute — `day.date.toLocaleDateString(locale?.code)`

The `Locale` type re-exported from `react-day-picker` is typed as `DayPickerLocale` which does not declare a `code` property, causing a TypeScript error: `Property 'code' does not exist on type 'DayPickerLocale'`.

## Fix

Add a minimal inline type assertion `(locale as { code?: string })` at both call sites in all 16 affected files. The underlying date-fns `Locale` object does carry `code` at runtime — only the type was too narrow.

No behavior change.

Fixes #10709