### PR TITLE
templates package.json changes

### DIFF
--- a/templates/next-app/package.json
+++ b/templates/next-app/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "next": "16.1.7",
+    "next": "16.2.6",
     "next-themes": "^0.4.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
@@ -24,11 +24,11 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "eslint": "^9.39.4",
-    "eslint-config-next": "16.1.7",
+    "eslint-config-next": "16.2.6",
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "postcss": "^8",
-    "tailwindcss": "^4.2.1",
+    "tailwindcss": "^4",
     "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
- New Next js provide verions next v16.2.6 and eslint-config-next v16.2.6 it only for update with starter kit for next js 