### PR TITLE
fix(toggle-group): scope spacing=0 overrides to parent group for outline variant

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/toggle-group.tsx
+++ b/apps/v4/registry/new-york-v4/ui/toggle-group.tsx
@@ -70,7 +70,7 @@ function ToggleGroupItem({
           size: context.size || size,
         }),
         "w-auto min-w-0 shrink-0 px-3 focus:z-10 focus-visible:z-10",
-        "data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-md data-[spacing=0]:last:rounded-r-md data-[spacing=0]:data-[variant=outline]:border-l-0 data-[spacing=0]:data-[variant=outline]:first:border-l",
+        "group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:shadow-none group-data-[spacing=0]/toggle-group:first:rounded-l-md group-data-[spacing=0]/toggle-group:last:rounded-r-md group-data-[spacing=0]/toggle-group:data-[variant=outline]:border-l-0 group-data-[spacing=0]/toggle-group:data-[variant=outline]:first:border-l",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Fixes #10717.

With `<ToggleGroup variant="outline" spacing={0}>` (the default), the items in the new-york-v4 registry render as fully-separated rounded buttons instead of a segmented control: every item shows all four corners rounded, and the double-borders between adjacent items create a visible gap.

## Root cause

On `ToggleGroupItem`, the self-scoped `data-[spacing=0]:rounded-none` (and the sibling `data-[spacing=0]:` overrides) compete with `rounded-md` coming from the base `toggleVariants` at the same CSS specificity. The intended override doesn't win.

## Fix

Switch the overrides from the self-scoped `data-[spacing=0]:` selector to the parent-group-scoped `group-data-[spacing=0]/toggle-group:` selector. The latter generates `.group\/toggle-group[data-spacing="0"] &.rounded-none { ... }`, which has a higher selector specificity than the plain `.rounded-md` from `toggleVariants` — so the segmented styling now wins.

This is the same pattern already used by the radix-sera and radix-luma toggle-group variants in this repo ([`apps/v4/styles/radix-sera/ui/toggle-group.tsx`](apps/v4/styles/radix-sera/ui/toggle-group.tsx#L75), [`apps/v4/styles/radix-luma/ui/toggle-group.tsx`](apps/v4/styles/radix-luma/ui/toggle-group.tsx)). New-york-v4 was the outlier.

## Diff scope

One file, one line changed: [`apps/v4/registry/new-york-v4/ui/toggle-group.tsx`](apps/v4/registry/new-york-v4/ui/toggle-group.tsx#L73).

## Test plan

- [ ] `apps/v4/registry/new-york-v4/examples/toggle-group-outline.tsx` (the default outline demo, spacing=0) renders as a segmented control: shared border between adjacent items, only outer corners rounded
- [ ] `apps/v4/registry/new-york-v4/examples/toggle-group-spacing.tsx` (explicit spacing={2}) still renders as separated rounded buttons
- [ ] Other style variants (default, large, small, single, disabled, demo) unchanged