### PR TITLE
fix(datePicker) : Prevent Natural Language Date-Picker from closing on month/year click

### DIFF
--- a/apps/v4/examples/base/date-picker-natural-language.tsx
+++ b/apps/v4/examples/base/date-picker-natural-language.tsx
@@ -78,6 +78,7 @@ export function DatePickerNaturalLanguage() {
               className="w-auto overflow-hidden p-0"
               align="end"
               sideOffset={8}
+              onClick={(e) => e.stopPropagation()}
             >
               <Calendar
                 mode="single"

--- a/apps/v4/examples/radix/date-picker-natural-language.tsx
+++ b/apps/v4/examples/radix/date-picker-natural-language.tsx
@@ -76,6 +76,7 @@ export function DatePickerNaturalLanguage() {
               className="w-auto overflow-hidden p-0"
               align="end"
               sideOffset={8}
+              onClick={(e) => e.stopPropagation()}
             >
               <Calendar
                 mode="single"


### PR DESCRIPTION
## Summary

- Added `onClick={(e) => e.stopPropagation()}` to `PopoverContent` in `examples/radix/date-picker-natural-language.tsx` and `examples/base/date-picker-natural-language.tsx`

## Problem

In the Natural Language DatePicker, clicking the **month or year dropdown** (`captionLayout="dropdown"`) inside the calendar immediately closes the popover no selection is made.

Keyboard interaction is unaffected; only mouse clicks on the dropdowns trigger the close.

**Root cause : two layered behaviors that interact:**

1. React portals propagate synthetic events through the **React component tree**, not the DOM tree. `PopoverContent` renders in a portal, but it is logically a child of `InputGroupAddon` in the React tree.

2. `InputGroupAddon` has a click handler that calls `.focus()` on the sibling `<input>` whenever a click originates from a non-button element:

```tsx
// input-group.tsx: InputGroupAddon
onClick={(e) => {
  if ((e.target as HTMLElement).closest("button")) return
  e.currentTarget.parentElement?.querySelector("input")?.focus()
}}
```

When the user clicks the native `<select>` (month/year dropdown) inside the calendar:
- The React synthetic `onClick` bubbles up through the portal to `InputGroupAddon`
- `e.target` is a `<select>`, not a `button`, the guard does not fire
- `InputGroupAddon` focuses the `InputGroupInput` (which is **outside** the portal)
- Radix's `DismissableLayer` detects focus moved outside the popover content
- Radix fires `onFocusOutside` -> calls `onOpenChange(false)` -> popover closes

This issue was reported in **#10714**.

## Fix

```tsx
// examples/radix/date-picker-natural-language.tsx
// examples/base/date-picker-natural-language.tsx
<PopoverContent
  className="w-auto overflow-hidden p-0"
  align="end"
  sideOffset={8}
  onClick={(e) => e.stopPropagation()}   // added
>
```

Stopping propagation on `PopoverContent` prevents the portal's click events from reaching `InputGroupAddon`, breaking the chain that caused the accidental focus and subsequent dismiss.

Fixes #10714

## Files Changed

- `apps/v4/examples/radix/date-picker-natural-language.tsx`
- `apps/v4/examples/base/date-picker-natural-language.tsx`

## Test Plan

- [x] Reproduced bug: clicking month/year dropdown in the Natural Language DatePicker immediately closed the popover
- [x] Verified fix: clicking month and year dropdowns navigates the calendar without closing the popover
- [x] Verified date selection still works and closes the popover correctly
- [x] Verified backdrop / outside click still closes the popover
- [x] Verified Escape key still closes the popover
- [x] Verified natural language text input still parses and updates the date
- [x] Both `radix` and `base` variants fixed
