### PR TITLE
fix(registry): normalize package subpath dependencies

### DIFF
--- a/packages/shadcn/src/registry/resolver.test.ts
+++ b/packages/shadcn/src/registry/resolver.test.ts
@@ -387,6 +387,85 @@ describe("resolveRegistryItemsFromRegistries", () => {
   })
 })
 
+describe("resolveRegistryTree - dependency normalization", async () => {
+  const dependencyRegistry = await createRegistryServer(
+    [
+      {
+        name: "tailwind-button",
+        type: "registry:ui",
+        dependencies: [
+          "react-aria-components/Button",
+          "react-aria-components/Dialog",
+          "react-aria/chain",
+          "react",
+          "tailwind-variants",
+        ],
+        devDependencies: ["@scope/tool/cli", "@scope/tool"],
+        files: [
+          {
+            path: "ui/button.tsx",
+            content: "export const Button = () => <button />",
+            type: "registry:ui",
+          },
+        ],
+      },
+    ],
+    { port: 4461 }
+  )
+
+  beforeAll(async () => {
+    await dependencyRegistry.start()
+  })
+
+  afterAll(async () => {
+    await dependencyRegistry.stop()
+  })
+
+  test("should collapse package subpath dependencies before installation", async () => {
+    const config = {
+      style: "default",
+      rsc: false,
+      tsx: false,
+      aliases: {
+        components: "./components",
+        utils: "./lib/utils",
+        ui: "./components/ui",
+      },
+      tailwind: {
+        baseColor: "neutral",
+        css: "globals.css",
+        cssVariables: false,
+      },
+      registries: {
+        "@normalize": "http://localhost:4461/r/{name}.json",
+      },
+      resolvedPaths: {
+        cwd: process.cwd(),
+        tailwindConfig: "./tailwind.config.js",
+        tailwindCss: "./globals.css",
+        utils: "./lib/utils",
+        components: "./components",
+        lib: "./lib",
+        hooks: "./hooks",
+        ui: "./components/ui",
+      },
+    }
+
+    const result = await resolveRegistryTree(
+      ["@normalize/tailwind-button"],
+      config
+    )
+
+    expect(result?.dependencies).toEqual([
+      "react-aria-components",
+      "react-aria",
+      "react",
+      "tailwind-variants",
+    ])
+    expect(result?.devDependencies).toEqual(["@scope/tool"])
+  })
+})
+
 describe("resolveRegistryItems with URL dependencies", () => {
   it("should resolve URL dependencies from local files", async () => {
     const dependencyUrl = "https://example.com/dependency.json"

--- a/packages/shadcn/src/registry/resolver.ts
+++ b/packages/shadcn/src/registry/resolver.ts
@@ -19,6 +19,7 @@ import {
   deduplicateFilesByTarget,
   isLocalFile,
   isUrl,
+  normalizeRegistryDependencies,
 } from "@/src/registry/utils"
 import {
   RegistryFontItem,
@@ -344,9 +345,13 @@ export async function resolveRegistryTree(
     }))
 
   const parsed = registryResolvedItemsTreeSchema.parse({
-    dependencies: deepmerge.all(payload.map((item) => item.dependencies ?? [])),
-    devDependencies: deepmerge.all(
-      payload.map((item) => item.devDependencies ?? [])
+    dependencies: normalizeRegistryDependencies(
+      deepmerge.all(payload.map((item) => item.dependencies ?? [])) as string[]
+    ),
+    devDependencies: normalizeRegistryDependencies(
+      deepmerge.all(
+        payload.map((item) => item.devDependencies ?? [])
+      ) as string[]
     ),
     files: deduplicatedFiles,
     tailwind,

--- a/packages/shadcn/src/registry/utils.test.ts
+++ b/packages/shadcn/src/registry/utils.test.ts
@@ -7,9 +7,11 @@ import {
   canDeduplicateFiles,
   deduplicateFilesByTarget,
   getDependencyFromModuleSpecifier,
+  getPackageNameFromSpecifier,
   isLocalFile,
   isUniversalRegistryItem,
   isUrl,
+  normalizeRegistryDependencies,
 } from "./utils"
 
 describe("getDependencyFromModuleSpecifier", () => {
@@ -82,6 +84,43 @@ describe("getDependencyFromModuleSpecifier", () => {
     expect(getDependencyFromModuleSpecifier("@types/react/dom")).toBe(
       "@types/react"
     )
+  })
+})
+
+describe("getPackageNameFromSpecifier", () => {
+  it.each([
+    ["react-aria-components/Button", "react-aria-components"],
+    ["react-aria-components/composeRenderProps", "react-aria-components"],
+    ["react-aria/chain", "react-aria"],
+    ["@scope/package/subpath", "@scope/package"],
+    ["@scope/package", "@scope/package"],
+    ["zod@^3.20.0", "zod@^3.20.0"],
+  ])("should normalize package subpath specifier %s", (input, expected) => {
+    expect(getPackageNameFromSpecifier(input)).toBe(expected)
+  })
+
+  it.each([
+    "https://example.com/package.tgz",
+    "git+ssh://git@github.com/acme/package.git",
+    "github:acme/package",
+    "file:../package.tgz",
+    "npm:@scope/package@1.0.0",
+  ])("should preserve protocol dependency spec %s", (input) => {
+    expect(getPackageNameFromSpecifier(input)).toBe(input)
+  })
+})
+
+describe("normalizeRegistryDependencies", () => {
+  it("should normalize package subpaths and deduplicate matching packages", () => {
+    expect(
+      normalizeRegistryDependencies([
+        "react-aria-components/Button",
+        "react-aria-components/Dialog",
+        "react-aria/chain",
+        "react-aria",
+        "tailwind-variants",
+      ])
+    ).toEqual(["react-aria-components", "react-aria", "tailwind-variants"])
   })
 })
 

--- a/packages/shadcn/src/registry/utils.ts
+++ b/packages/shadcn/src/registry/utils.ts
@@ -26,6 +26,7 @@ const DEPENDENCY_SKIP_LIST = [
   /^(react|react-dom|next)(\/.*)?$/, // Matches react, react-dom, next and their submodules
   /^(node|jsr|npm):.*$/, // Matches node:, jsr:, and npm: prefixed modules
 ]
+const DEPENDENCY_SPECIFIER_PROTOCOL = /^[a-z][a-z0-9+.-]*:/i
 
 const project = new Project({
   compilerOptions: {},
@@ -41,22 +42,41 @@ export function getDependencyFromModuleSpecifier(
     return null
   }
 
-  // If the module specifier does not start with `@` and has a /, add the dependency first part only.
+  return getPackageNameFromSpecifier(moduleSpecifier)
+}
+
+// This returns the installable package name from a package or subpath import
+// specifier. Protocol-backed dependency specs are preserved as-is.
+export function getPackageNameFromSpecifier(specifier: string): string {
+  if (
+    DEPENDENCY_SPECIFIER_PROTOCOL.test(specifier) ||
+    specifier.startsWith(".")
+  ) {
+    return specifier
+  }
+
+  // If the specifier does not start with `@` and has a /, add the dependency first part only.
   // E.g. `foo/bar` -> `foo`
-  if (!moduleSpecifier.startsWith("@") && moduleSpecifier.includes("/")) {
-    moduleSpecifier = moduleSpecifier.split("/")[0]
+  if (!specifier.startsWith("@") && specifier.includes("/")) {
+    specifier = specifier.split("/")[0]
   }
 
   // For scoped packages, we want to keep the first two parts
   // E.g. `@types/react/dom` -> `@types/react`
-  if (moduleSpecifier.startsWith("@")) {
-    const parts = moduleSpecifier.split("/")
+  if (specifier.startsWith("@")) {
+    const parts = specifier.split("/")
     if (parts.length > 2) {
-      moduleSpecifier = parts.slice(0, 2).join("/")
+      specifier = parts.slice(0, 2).join("/")
     }
   }
 
-  return moduleSpecifier
+  return specifier
+}
+
+export function normalizeRegistryDependencies(
+  dependencies: string[] = []
+): string[] {
+  return Array.from(new Set(dependencies.map(getPackageNameFromSpecifier)))
 }
 
 export async function recursivelyResolveFileImports(


### PR DESCRIPTION
Fixes #10535.

## What changed

- Normalize registry dependency entries that are package subpath imports before they are passed to package managers.
- Preserve protocol-backed dependency specs such as `https:`, `git+ssh:`, `github:`, `file:`, and `npm:`.
- Add unit coverage for package subpath normalization and resolver-level dependency merging.

## Why

Third-party registry items can list import specifiers such as `react-aria-components/Button` or `react-aria/chain` in `dependencies`. Package managers treat these as GitHub shorthand dependencies, so installs like `shadcn add @react-aria/tailwind` fail before all files are written.

## Validation

- `corepack pnpm --filter=shadcn exec vitest run src/registry/utils.test.ts`
- `corepack pnpm --filter=shadcn exec vitest run src/registry/resolver.test.ts -t "dependency normalization"`
- `corepack pnpm --filter=shadcn exec vitest run src/registry/utils.test.ts src/registry/resolver.test.ts -t "getPackageNameFromSpecifier|normalizeRegistryDependencies|dependency normalization"`
- `corepack pnpm --filter=shadcn typecheck`
- `corepack pnpm --filter=shadcn build`
- `corepack pnpm exec prettier --check src/registry/utils.ts src/registry/resolver.ts src/registry/utils.test.ts src/registry/resolver.test.ts`
- `ESLINT_USE_FLAT_CONFIG=false corepack pnpm exec eslint packages/shadcn/src/registry/utils.ts packages/shadcn/src/registry/resolver.ts packages/shadcn/src/registry/utils.test.ts packages/shadcn/src/registry/resolver.test.ts`
- `git diff --check`
