### PR TITLE
fix(cli): skip installed bare dependencies

### DIFF
--- a/packages/shadcn/src/utils/updaters/update-dependencies.test.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.test.ts
@@ -1,0 +1,109 @@
+import os from "node:os"
+import path from "node:path"
+import fs from "fs-extra"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { updateDependencies } from "./update-dependencies"
+
+const execaMock = vi.hoisted(() => vi.fn())
+
+vi.mock("execa", () => ({
+  execa: execaMock,
+}))
+
+vi.mock("@/src/utils/get-package-manager", () => ({
+  getPackageManager: vi.fn().mockResolvedValue("pnpm"),
+}))
+
+vi.mock("@/src/utils/spinner", () => ({
+  spinner: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn(),
+    fail: vi.fn(),
+    stopAndPersist: vi.fn(),
+  })),
+}))
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  execaMock.mockClear()
+
+  for (const dir of tempDirs.splice(0)) {
+    await fs.remove(dir)
+  }
+})
+
+describe("updateDependencies", () => {
+  it("skips bare dependency requests already present in package.json", async () => {
+    const cwd = await createTempProject({
+      dependencies: {
+        "@base-ui/react": "^1.4.1",
+        "class-variance-authority": "^0.7.1",
+      },
+      devDependencies: {
+        "@tailwindcss/postcss": "^4.2.1",
+      },
+    })
+
+    await updateDependencies(
+      [
+        "@base-ui/react",
+        "class-variance-authority",
+        "react-is",
+        "recharts@3.8.0",
+      ],
+      ["@tailwindcss/postcss"],
+      createConfig(cwd),
+      { silent: true }
+    )
+
+    expect(execaMock).toHaveBeenCalledTimes(1)
+    expect(execaMock).toHaveBeenCalledWith(
+      "pnpm",
+      ["add", "react-is", "recharts@3.8.0"],
+      { cwd }
+    )
+  })
+
+  it("prefers explicit package specs over duplicate bare requests", async () => {
+    const cwd = await createTempProject({
+      dependencies: {},
+      devDependencies: {},
+    })
+
+    await updateDependencies(
+      ["recharts", "recharts@3.8.0", "@base-ui/react", "@base-ui/react@1.4.1"],
+      [],
+      createConfig(cwd),
+      { silent: true }
+    )
+
+    expect(execaMock).toHaveBeenCalledTimes(1)
+    expect(execaMock).toHaveBeenCalledWith(
+      "pnpm",
+      ["add", "recharts@3.8.0", "@base-ui/react@1.4.1"],
+      { cwd }
+    )
+  })
+})
+
+async function createTempProject(packageJson: {
+  dependencies: Record<string, string>
+  devDependencies: Record<string, string>
+}) {
+  const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "shadcn-deps-"))
+  tempDirs.push(cwd)
+
+  await fs.writeJson(path.join(cwd, "package.json"), packageJson)
+
+  return cwd
+}
+
+function createConfig(cwd: string) {
+  return {
+    resolvedPaths: {
+      cwd,
+    },
+  } as any
+}

--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -16,8 +16,9 @@ export async function updateDependencies(
     silent?: boolean
   }
 ) {
-  dependencies = Array.from(new Set(dependencies))
-  devDependencies = Array.from(new Set(devDependencies))
+  const packageInfo = getPackageInfo(config.resolvedPaths.cwd, false)
+  dependencies = normalizeDependencyRequests(dependencies, packageInfo)
+  devDependencies = normalizeDependencyRequests(devDependencies, packageInfo)
 
   if (!dependencies?.length && !devDependencies?.length) {
     return
@@ -72,6 +73,72 @@ export async function updateDependencies(
   )
 
   dependenciesSpinner?.succeed()
+}
+
+function normalizeDependencyRequests(
+  dependencies: RegistryItem["dependencies"] = [],
+  packageInfo: ReturnType<typeof getPackageInfo>
+) {
+  const installedDependencies = new Set([
+    ...Object.keys(packageInfo?.dependencies ?? {}),
+    ...Object.keys(packageInfo?.devDependencies ?? {}),
+    ...Object.keys(packageInfo?.optionalDependencies ?? {}),
+    ...Object.keys(packageInfo?.peerDependencies ?? {}),
+  ])
+  const installRequests = new Map<
+    string,
+    { dependency: string; hasSpecifier: boolean }
+  >()
+
+  for (const dependency of dependencies) {
+    const packageRequest = parsePackageRequest(dependency)
+
+    if (!packageRequest) {
+      installRequests.set(dependency, {
+        dependency,
+        hasSpecifier: true,
+      })
+      continue
+    }
+
+    if (
+      !packageRequest.hasSpecifier &&
+      installedDependencies.has(packageRequest.name)
+    ) {
+      continue
+    }
+
+    const existing = installRequests.get(packageRequest.name)
+    if (!existing || (!existing.hasSpecifier && packageRequest.hasSpecifier)) {
+      installRequests.set(packageRequest.name, {
+        dependency,
+        hasSpecifier: packageRequest.hasSpecifier,
+      })
+    }
+  }
+
+  return Array.from(installRequests.values()).map(
+    ({ dependency }) => dependency
+  )
+}
+
+function parsePackageRequest(dependency: string) {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(dependency)) {
+    return null
+  }
+
+  const match = dependency.startsWith("@")
+    ? dependency.match(/^(@[^/]+\/[^@/]+)(@.+)?$/)
+    : dependency.match(/^([^@/]+)(@.+)?$/)
+
+  if (!match) {
+    return null
+  }
+
+  return {
+    name: match[1],
+    hasSpecifier: Boolean(match[2]),
+  }
 }
 
 function shouldPromptForNpmFlag(config: Config) {


### PR DESCRIPTION
Fixes #10525.

## Summary
- skip package-manager installs for bare registry dependency requests when that package is already present in package.json
- keep explicit registry specs like `recharts@3.8.0` installable so pinned registry requirements can still update intentionally
- dedupe duplicate package requests by package name, preferring explicit specs over bare requests

## Tests
- `corepack pnpm --filter=shadcn exec vitest run src/utils/updaters/update-dependencies.test.ts`
- `corepack pnpm --filter=shadcn typecheck`
- `corepack pnpm --filter=shadcn build`
- `corepack pnpm --filter=shadcn exec prettier --check src/utils/updaters/update-dependencies.ts src/utils/updaters/update-dependencies.test.ts`
- `$env:ESLINT_USE_FLAT_CONFIG='false'; corepack pnpm exec eslint packages/shadcn/src/utils/updaters/update-dependencies.ts packages/shadcn/src/utils/updaters/update-dependencies.test.ts`
- `git diff --check`
