### PR TITLE
fix(create): prebuild example preview routes

### DIFF
--- a/apps/v4/app/(create)/preview/[base]/[name]/page.tsx
+++ b/apps/v4/app/(create)/preview/[base]/[name]/page.tsx
@@ -13,13 +13,15 @@ import { DarkModeScript } from "@/app/(app)/create/components/mode-switcher"
 import { OpenPresetScript } from "@/app/(app)/create/components/open-preset"
 import { PreviewStyle } from "@/app/(app)/create/components/preview-style"
 import { RandomizeScript } from "@/app/(app)/create/components/random-button"
-import { getBaseComponent, getBaseItem } from "@/app/(app)/create/lib/api"
+import {
+  getBaseComponent,
+  getBaseItem,
+  getItemsForBase,
+} from "@/app/(app)/create/lib/api"
 
 export const revalidate = false
 export const dynamic = "force-static"
 export const dynamicParams = true
-
-const STATIC_PREVIEW_ITEMS = ["preview", "preview-02"] as const
 
 function PreventScrollOnFocusScript() {
   return (
@@ -94,12 +96,18 @@ export async function generateMetadata({
 }
 
 export async function generateStaticParams() {
-  return BASES.flatMap((base) =>
-    STATIC_PREVIEW_ITEMS.map((name) => ({
-      base: base.name,
-      name,
-    }))
+  const params = await Promise.all(
+    BASES.map(async (base) => {
+      const items = await getItemsForBase(base.name)
+
+      return items.map((item) => ({
+        base: base.name,
+        name: item.name,
+      }))
+    })
   )
+
+  return params.flat()
 }
 
 export default async function BlockPage({


### PR DESCRIPTION
Fixes #10720.

## Summary
- generate `/preview/[base]/[name]` static params from the allowed registry items for each base
- remove the hard-coded list that only prebuilt `preview` and `preview-02`
- lets builder navigation load example preview routes like `/preview/radix/accordion-example` in production builds

## Validation
- `corepack pnpm --filter=shadcn build`
- `corepack pnpm --filter=v4 typecheck`
- `corepack pnpm --filter=v4 lint`
- `node ../../node_modules/prettier/bin/prettier.cjs --check 'app/(create)/preview/[base]/[name]/page.tsx'` from `apps/v4`
- `node ../../node_modules/eslint/bin/eslint.js 'app/(create)/preview/[base]/[name]/page.tsx'` from `apps/v4`
- `NEXT_PUBLIC_APP_URL=http://localhost:4000 NEXT_PUBLIC_V0_URL=https://v0.dev corepack pnpm --filter=v4 exec next build`
- `git diff --check`

Note: `corepack pnpm --filter=v4 build` could not run as-is on this Windows machine because the package script requires `bun`, which is not installed here. I ran `next build` directly after the registry output was already present and `packages/shadcn` was built.