### PR TITLE
fix(cli): fall back when package manager detection fails

### DIFF
--- a/packages/shadcn/src/utils/get-package-manager.test.ts
+++ b/packages/shadcn/src/utils/get-package-manager.test.ts
@@ -1,0 +1,61 @@
+import { detect } from "@antfu/ni"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { getPackageManager } from "./get-package-manager"
+
+vi.mock("@antfu/ni", () => ({
+  detect: vi.fn(),
+}))
+
+describe("getPackageManager", () => {
+  const originalUserAgent = process.env.npm_config_user_agent
+
+  beforeEach(() => {
+    vi.mocked(detect).mockReset()
+    delete process.env.npm_config_user_agent
+  })
+
+  afterEach(() => {
+    if (originalUserAgent === undefined) {
+      delete process.env.npm_config_user_agent
+    } else {
+      process.env.npm_config_user_agent = originalUserAgent
+    }
+  })
+
+  it("falls back to the user agent when detection fails in fallback mode", async () => {
+    vi.mocked(detect).mockRejectedValue(
+      Object.assign(
+        new Error("EACCES: permission denied, scandir '/data/data'"),
+        {
+          code: "EACCES",
+        }
+      )
+    )
+    process.env.npm_config_user_agent = "pnpm/10.33.4 npm/? node/?"
+
+    await expect(
+      getPackageManager("/data/data/com.termux/files/home", {
+        withFallback: true,
+      })
+    ).resolves.toBe("pnpm")
+  })
+
+  it("rethrows detection errors when fallback mode is disabled", async () => {
+    const error = new Error("EACCES: permission denied")
+    vi.mocked(detect).mockRejectedValue(error)
+
+    await expect(getPackageManager("/data/data")).rejects.toBe(error)
+  })
+
+  it("uses a detected package manager before falling back to the user agent", async () => {
+    vi.mocked(detect).mockResolvedValue("bun")
+    process.env.npm_config_user_agent = "npm/10.0.0 node/?"
+
+    await expect(
+      getPackageManager("/project", {
+        withFallback: true,
+      })
+    ).resolves.toBe("bun")
+  })
+})

--- a/packages/shadcn/src/utils/get-package-manager.ts
+++ b/packages/shadcn/src/utils/get-package-manager.ts
@@ -8,18 +8,25 @@ export async function getPackageManager(
     withFallback: false,
   }
 ): Promise<PackageManager> {
-  const packageManager = await detect({ programmatic: true, cwd: targetDir })
+  let packageManager: Awaited<ReturnType<typeof detect>> | undefined
+
+  try {
+    packageManager = await detect({ programmatic: true, cwd: targetDir })
+  } catch (error) {
+    if (!withFallback) {
+      throw error
+    }
+  }
 
   if (packageManager === "yarn@berry") return "yarn"
   if (packageManager === "pnpm@6") return "pnpm"
   if (packageManager === "bun") return "bun"
   if (packageManager === "deno") return "deno"
-  if (!withFallback) {
-    return packageManager ?? "npm"
+  if (packageManager) {
+    return packageManager
   }
 
-  // Fallback to user agent if not detected.
-  return getPackageManagerFromUserAgent() ?? "npm"
+  return withFallback ? (getPackageManagerFromUserAgent() ?? "npm") : "npm"
 }
 
 export function getPackageManagerFromUserAgent(


### PR DESCRIPTION
Fixes #10731.

## Summary
- catch package-manager detection failures when fallback mode is enabled
- fall back to the invoking package manager from `npm_config_user_agent` when detection hits an unreadable path
- preserve the existing behavior of rethrowing detection errors when fallback mode is disabled

## Validation
- `corepack pnpm --dir packages/shadcn exec vitest run src/utils/get-package-manager.test.ts`
- `corepack pnpm --dir packages/shadcn exec tsc --noEmit --pretty false`
- `corepack pnpm --filter=shadcn build`
- `node node_modules/prettier/bin/prettier.cjs --check packages/shadcn/src/utils/get-package-manager.ts packages/shadcn/src/utils/get-package-manager.test.ts`
- `corepack pnpm lint --filter=shadcn --filter=!v4 --filter=!tests` (no tasks configured for this scope)
- `git diff --check`

Note: Prettier emits an existing Tailwind stylesheet compatibility warning in this checkout, but it exits successfully and reports the files are formatted.