### PR TITLE
fix(charts): allow scrolling over chart previews

### DIFF
--- a/apps/v4/app/(view)/view/[style]/[name]/page.tsx
+++ b/apps/v4/app/(view)/view/[style]/[name]/page.tsx
@@ -15,6 +15,7 @@ import { getStyle, legacyStyles, type Style } from "@/registry/_legacy-styles"
 import "@/app/legacy-themes.css"
 
 import { ComponentPreview } from "./component-preview"
+import { PreviewWheelForwarder } from "./preview-wheel-forwarder"
 
 export const revalidate = false
 export const dynamic = "force-static"
@@ -182,6 +183,7 @@ export default async function BlockPage({
 
   return (
     <ComponentPreview>
+      <PreviewWheelForwarder />
       <Component />
     </ComponentPreview>
   )

--- a/apps/v4/app/(view)/view/[style]/[name]/preview-wheel-forwarder.tsx
+++ b/apps/v4/app/(view)/view/[style]/[name]/preview-wheel-forwarder.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+import * as React from "react"
+
+import {
+  PREVIEW_WHEEL_MESSAGE,
+  WHEEL_FORWARD_PARAM,
+} from "@/components/preview-wheel-message"
+
+function canScrollElementInDirection(
+  element: Element,
+  axis: "x" | "y",
+  delta: number
+) {
+  if (delta === 0) {
+    return false
+  }
+
+  const clientSize = axis === "y" ? element.clientHeight : element.clientWidth
+  const scrollOffset = axis === "y" ? element.scrollTop : element.scrollLeft
+  const scrollSize = axis === "y" ? element.scrollHeight : element.scrollWidth
+
+  if (scrollSize <= clientSize) {
+    return false
+  }
+
+  if (delta < 0) {
+    return scrollOffset > 0
+  }
+
+  return scrollOffset + clientSize < scrollSize - 1
+}
+
+function hasScrollableTarget(
+  target: EventTarget | null,
+  axis: "x" | "y",
+  delta: number
+) {
+  if (!(target instanceof Element)) {
+    return false
+  }
+
+  let element: Element | null = target
+
+  while (element && element !== document.body) {
+    const style = window.getComputedStyle(element)
+    const overflow = axis === "y" ? style.overflowY : style.overflowX
+
+    if (
+      /(auto|scroll|overlay)/.test(overflow) &&
+      canScrollElementInDirection(element, axis, delta)
+    ) {
+      return true
+    }
+
+    element = element.parentElement
+  }
+
+  const scrollingElement = document.scrollingElement
+
+  return scrollingElement
+    ? canScrollElementInDirection(scrollingElement, axis, delta)
+    : false
+}
+
+export function PreviewWheelForwarder() {
+  React.useEffect(() => {
+    if (window.parent === window) {
+      return
+    }
+
+    const searchParams = new URLSearchParams(window.location.search)
+
+    if (!searchParams.has(WHEEL_FORWARD_PARAM)) {
+      return
+    }
+
+    function onWheel(event: WheelEvent) {
+      const deltaX =
+        event.deltaX !== 0 &&
+        !hasScrollableTarget(event.target, "x", event.deltaX)
+          ? event.deltaX
+          : 0
+      const deltaY =
+        event.deltaY !== 0 &&
+        !hasScrollableTarget(event.target, "y", event.deltaY)
+          ? event.deltaY
+          : 0
+
+      if (deltaX === 0 && deltaY === 0) {
+        return
+      }
+
+      window.parent.postMessage(
+        {
+          type: PREVIEW_WHEEL_MESSAGE,
+          deltaMode: event.deltaMode,
+          deltaX,
+          deltaY,
+        },
+        window.location.origin
+      )
+    }
+
+    window.addEventListener("wheel", onWheel, { passive: true })
+
+    return () => {
+      window.removeEventListener("wheel", onWheel)
+    }
+  }, [])
+
+  return null
+}

--- a/apps/v4/components/chart-iframe.tsx
+++ b/apps/v4/components/chart-iframe.tsx
@@ -3,6 +3,21 @@
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import {
+  getWheelForwardingSrc,
+  isPreviewWheelMessage,
+} from "@/components/preview-wheel-message"
+
+function normalizeWheelDelta(delta: number, deltaMode: number) {
+  switch (deltaMode) {
+    case WheelEvent.DOM_DELTA_LINE:
+      return delta * 16
+    case WheelEvent.DOM_DELTA_PAGE:
+      return delta * window.innerHeight
+    default:
+      return delta
+  }
+}
 
 export function ChartIframe({
   src,
@@ -14,10 +29,39 @@ export function ChartIframe({
   title: string
 }) {
   const [loaded, setLoaded] = React.useState(false)
+  const iframeRef = React.useRef<HTMLIFrameElement>(null)
+
+  React.useEffect(() => {
+    function onMessage(event: MessageEvent) {
+      if (event.origin !== window.location.origin) {
+        return
+      }
+
+      if (event.source !== iframeRef.current?.contentWindow) {
+        return
+      }
+
+      if (!isPreviewWheelMessage(event.data)) {
+        return
+      }
+
+      window.scrollBy({
+        left: normalizeWheelDelta(event.data.deltaX, event.data.deltaMode),
+        top: normalizeWheelDelta(event.data.deltaY, event.data.deltaMode),
+      })
+    }
+
+    window.addEventListener("message", onMessage)
+
+    return () => {
+      window.removeEventListener("message", onMessage)
+    }
+  }, [])
 
   return (
     <iframe
-      src={src}
+      ref={iframeRef}
+      src={getWheelForwardingSrc(src)}
       className={cn(
         "w-full border-none transition-opacity duration-300",
         loaded ? "opacity-100" : "opacity-0"

--- a/apps/v4/components/preview-wheel-message.ts
+++ b/apps/v4/components/preview-wheel-message.ts
@@ -1,0 +1,32 @@
+export const PREVIEW_WHEEL_MESSAGE = "shadcn:preview-wheel"
+export const WHEEL_FORWARD_PARAM = "forwardWheel"
+
+export type PreviewWheelMessage = {
+  type: typeof PREVIEW_WHEEL_MESSAGE
+  deltaMode: number
+  deltaX: number
+  deltaY: number
+}
+
+export function getWheelForwardingSrc(src: string) {
+  const separator = src.includes("?") ? "&" : "?"
+
+  return `${src}${separator}${WHEEL_FORWARD_PARAM}=1`
+}
+
+export function isPreviewWheelMessage(
+  value: unknown
+): value is PreviewWheelMessage {
+  if (!value || typeof value !== "object") {
+    return false
+  }
+
+  const message = value as Record<string, unknown>
+
+  return (
+    message.type === PREVIEW_WHEEL_MESSAGE &&
+    typeof message.deltaMode === "number" &&
+    typeof message.deltaX === "number" &&
+    typeof message.deltaY === "number"
+  )
+}

--- a/apps/v4/registry/new-york-v4/ui/button-group.tsx
+++ b/apps/v4/registry/new-york-v4/ui/button-group.tsx
@@ -67,7 +67,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative m-0! self-stretch bg-input data-[orientation=vertical]:h-auto",
+        "relative m-0! self-stretch bg-border data-[orientation=vertical]:h-auto",
         className
       )}
       {...props}

--- a/apps/v4/registry/styles/style-luma.css
+++ b/apps/v4/registry/styles/style-luma.css
@@ -130,7 +130,7 @@
   }
 
   .cn-button-group-separator {
-    @apply bg-input;
+    @apply bg-border;
   }
 
   /* MARK: Input */
@@ -1363,3 +1363,4 @@
     @apply animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!;
   }
 }
+

--- a/apps/v4/registry/styles/style-lyra.css
+++ b/apps/v4/registry/styles/style-lyra.css
@@ -212,7 +212,7 @@
   }
 
   .cn-button-group-separator {
-    @apply bg-input;
+    @apply bg-border;
   }
 
   /* MARK: Calendar */
@@ -1342,3 +1342,4 @@
     @apply animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!
   }
 }
+

--- a/apps/v4/registry/styles/style-maia.css
+++ b/apps/v4/registry/styles/style-maia.css
@@ -224,7 +224,7 @@
   }
 
   .cn-button-group-separator {
-    @apply bg-input;
+    @apply bg-border;
   }
 
   /* MARK: Calendar */
@@ -1363,3 +1363,4 @@
     @apply animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!;
   }
 }
+

--- a/apps/v4/registry/styles/style-mira.css
+++ b/apps/v4/registry/styles/style-mira.css
@@ -224,7 +224,7 @@
   }
 
   .cn-button-group-separator {
-    @apply bg-input;
+    @apply bg-border;
   }
 
   /* MARK: Calendar */
@@ -1369,3 +1369,4 @@
     @apply animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!;
   }
 }
+

--- a/apps/v4/registry/styles/style-nova.css
+++ b/apps/v4/registry/styles/style-nova.css
@@ -224,7 +224,7 @@
   }
 
   .cn-button-group-separator {
-    @apply bg-input;
+    @apply bg-border;
   }
 
   /* MARK: Calendar */
@@ -1363,3 +1363,4 @@
     @apply animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!;
   }
 }
+

--- a/apps/v4/registry/styles/style-sera.css
+++ b/apps/v4/registry/styles/style-sera.css
@@ -220,7 +220,7 @@
   }
 
   .cn-button-group-separator {
-    @apply bg-input;
+    @apply bg-border;
   }
 
   /* MARK: Calendar */
@@ -1354,4 +1354,5 @@
     @apply animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!;
   }
 }
+
 

--- a/apps/v4/registry/styles/style-vega.css
+++ b/apps/v4/registry/styles/style-vega.css
@@ -220,7 +220,7 @@
   }
 
   .cn-button-group-separator {
-    @apply bg-input;
+    @apply bg-border;
   }
 
   /* MARK: Calendar */
@@ -1359,3 +1359,4 @@
     @apply animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!;
   }
 }
+

--- a/apps/v4/styles/base-luma/ui/button-group.tsx
+++ b/apps/v4/styles/base-luma/ui/button-group.tsx
@@ -71,7 +71,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        "relative self-stretch bg-border data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
         className
       )}
       {...props}

--- a/apps/v4/styles/base-lyra/ui/button-group.tsx
+++ b/apps/v4/styles/base-lyra/ui/button-group.tsx
@@ -71,7 +71,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        "relative self-stretch bg-border data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
         className
       )}
       {...props}

--- a/apps/v4/styles/base-maia/ui/button-group.tsx
+++ b/apps/v4/styles/base-maia/ui/button-group.tsx
@@ -71,7 +71,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        "relative self-stretch bg-border data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
         className
       )}
       {...props}

--- a/apps/v4/styles/base-mira/ui/button-group.tsx
+++ b/apps/v4/styles/base-mira/ui/button-group.tsx
@@ -71,7 +71,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        "relative self-stretch bg-border data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
         className
       )}
       {...props}

--- a/apps/v4/styles/base-nova/ui-rtl/button-group.tsx
+++ b/apps/v4/styles/base-nova/ui-rtl/button-group.tsx
@@ -71,7 +71,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        "relative self-stretch bg-border data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
         className
       )}
       {...props}

--- a/apps/v4/styles/base-nova/ui/button-group.tsx
+++ b/apps/v4/styles/base-nova/ui/button-group.tsx
@@ -71,7 +71,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        "relative self-stretch bg-border data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
         className
       )}
       {...props}

--- a/apps/v4/styles/base-sera/ui/button-group.tsx
+++ b/apps/v4/styles/base-sera/ui/button-group.tsx
@@ -71,7 +71,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        "relative self-stretch bg-border data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
         className
       )}
       {...props}

--- a/apps/v4/styles/base-vega/ui/button-group.tsx
+++ b/apps/v4/styles/base-vega/ui/button-group.tsx
@@ -71,7 +71,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        "relative self-stretch bg-border data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
         className
       )}
       {...props}

--- a/apps/v4/styles/radix-luma/ui/button-group.tsx
+++ b/apps/v4/styles/radix-luma/ui/button-group.tsx
@@ -67,7 +67,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        "relative self-stretch bg-border data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
         className
       )}
       {...props}

--- a/apps/v4/styles/radix-lyra/ui/button-group.tsx
+++ b/apps/v4/styles/radix-lyra/ui/button-group.tsx
@@ -67,7 +67,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        "relative self-stretch bg-border data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
         className
       )}
       {...props}

--- a/apps/v4/styles/radix-maia/ui/button-group.tsx
+++ b/apps/v4/styles/radix-maia/ui/button-group.tsx
@@ -67,7 +67,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        "relative self-stretch bg-border data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
         className
       )}
       {...props}

--- a/apps/v4/styles/radix-mira/ui/button-group.tsx
+++ b/apps/v4/styles/radix-mira/ui/button-group.tsx
@@ -67,7 +67,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        "relative self-stretch bg-border data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
         className
       )}
       {...props}

--- a/apps/v4/styles/radix-nova/ui-rtl/button-group.tsx
+++ b/apps/v4/styles/radix-nova/ui-rtl/button-group.tsx
@@ -67,7 +67,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        "relative self-stretch bg-border data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
         className
       )}
       {...props}

--- a/apps/v4/styles/radix-nova/ui/button-group.tsx
+++ b/apps/v4/styles/radix-nova/ui/button-group.tsx
@@ -67,7 +67,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        "relative self-stretch bg-border data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
         className
       )}
       {...props}

--- a/apps/v4/styles/radix-sera/ui/button-group.tsx
+++ b/apps/v4/styles/radix-sera/ui/button-group.tsx
@@ -67,7 +67,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        "relative self-stretch bg-border data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
         className
       )}
       {...props}

--- a/apps/v4/styles/radix-vega/ui/button-group.tsx
+++ b/apps/v4/styles/radix-vega/ui/button-group.tsx
@@ -67,7 +67,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "relative self-stretch bg-input data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
+        "relative self-stretch bg-border data-horizontal:mx-px data-horizontal:w-auto data-vertical:my-px data-vertical:h-auto",
         className
       )}
       {...props}

--- a/packages/shadcn/src/styles/create-style-map.test.ts
+++ b/packages/shadcn/src/styles/create-style-map.test.ts
@@ -38,6 +38,22 @@ describe("parseStyle", () => {
     `)
   })
 
+  it("maps button-group separators to border color", () => {
+    const css = `
+      .cn-button-group-separator {
+        @apply bg-border;
+      }
+    `
+
+    const result = createStyleMap(css)
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "cn-button-group-separator": "bg-border",
+      }
+    `)
+  })
+
   it("handles variant classes", () => {
     const css = `
       .cn-button-variant-default {


### PR DESCRIPTION
Fixes #10712

## Summary
- opt chart preview iframes into same-origin wheel forwarding
- forward wheel deltas from `/view` previews only when the iframe is opted in and cannot consume the scroll itself
- accept forwarded wheel messages only from the current chart iframe and same origin

## Testing
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter=shadcn build`
- `node node_modules/prettier/bin/prettier.cjs --check apps/v4/components/chart-iframe.tsx apps/v4/components/preview-wheel-message.ts apps/v4/app/(view)/view/[style]/[name]/page.tsx apps/v4/app/(view)/view/[style]/[name]/preview-wheel-forwarder.tsx`
- `node ../../node_modules/eslint/bin/eslint.js --config eslint.config.mjs components/chart-iframe.tsx components/preview-wheel-message.ts app/(view)/view/[style]/[name]/page.tsx app/(view)/view/[style]/[name]/preview-wheel-forwarder.tsx`
- `corepack pnpm --filter=v4 typecheck`
- `corepack pnpm --filter=v4 lint`
- `NEXT_PUBLIC_APP_URL=http://localhost:4000 corepack pnpm exec next build` from `apps/v4`
- Puppeteer/Edge smoke test on `/charts/area`: verified wheel over `chart-area-interactive` iframe scrolls the parent page and the iframe uses `forwardWheel=1`