### PR TITLE
fix(calendar): guard locale.code access with type assertion for react-day-picker compat

### DIFF
--- a/apps/v4/content/docs/components/base/calendar.mdx
+++ b/apps/v4/content/docs/components/base/calendar.mdx
@@ -316,7 +316,10 @@ Pass the `locale` prop to the `DayPicker` component:
       formatters={{
         formatMonthDropdown: (date) =>
 -         date.toLocaleString("default", { month: "short" }),
-+         date.toLocaleString(locale?.code, { month: "short" }),
++         date.toLocaleString(
++           (locale as { code?: string } | undefined)?.code,
++           { month: "short" }
++         ),
         ...formatters,
       }}
 ```
@@ -338,14 +341,16 @@ Update the `CalendarDayButton` component signature and pass `locale`:
 
 <Step>Update date formatting in CalendarDayButton.</Step>
 
-Use `locale?.code` in the date formatting:
+Use `(locale as { code?: string } | undefined)?.code` in the date formatting:
 
 ```diff
     <Button
       variant="ghost"
       size="icon"
 -     data-day={day.date.toLocaleDateString()}
-+     data-day={day.date.toLocaleDateString(locale?.code)}
++     data-day={day.date.toLocaleDateString(
++       (locale as { code?: string } | undefined)?.code
++     )}
       ...
     />
 ```

--- a/apps/v4/content/docs/components/radix/calendar.mdx
+++ b/apps/v4/content/docs/components/radix/calendar.mdx
@@ -316,7 +316,10 @@ Pass the `locale` prop to the `DayPicker` component:
       formatters={{
         formatMonthDropdown: (date) =>
 -         date.toLocaleString("default", { month: "short" }),
-+         date.toLocaleString(locale?.code, { month: "short" }),
++         date.toLocaleString(
++           (locale as { code?: string } | undefined)?.code,
++           { month: "short" }
++         ),
         ...formatters,
       }}
 ```
@@ -338,14 +341,16 @@ Update the `CalendarDayButton` component signature and pass `locale`:
 
 <Step>Update date formatting in CalendarDayButton.</Step>
 
-Use `locale?.code` in the date formatting:
+Use `(locale as { code?: string } | undefined)?.code` in the date formatting:
 
 ```diff
     <Button
       variant="ghost"
       size="icon"
 -     data-day={day.date.toLocaleDateString()}
-+     data-day={day.date.toLocaleDateString(locale?.code)}
++     data-day={day.date.toLocaleDateString(
++       (locale as { code?: string } | undefined)?.code
++     )}
       ...
     />
 ```

--- a/apps/v4/registry/bases/base/ui/calendar.tsx
+++ b/apps/v4/registry/bases/base/ui/calendar.tsx
@@ -40,7 +40,10 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString(
+            (locale as { code?: string } | undefined)?.code,
+            { month: "short" }
+          ),
         ...formatters,
       }}
       classNames={{
@@ -222,7 +225,9 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString(
+        (locale as { code?: string } | undefined)?.code
+      )}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/registry/bases/radix/ui/calendar.tsx
+++ b/apps/v4/registry/bases/radix/ui/calendar.tsx
@@ -40,7 +40,10 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString(
+            (locale as { code?: string } | undefined)?.code,
+            { month: "short" }
+          ),
         ...formatters,
       }}
       classNames={{
@@ -223,7 +226,9 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString(
+        (locale as { code?: string } | undefined)?.code
+      )}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/base-luma/ui/calendar.tsx
+++ b/apps/v4/styles/base-luma/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -208,7 +208,7 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/base-lyra/ui/calendar.tsx
+++ b/apps/v4/styles/base-lyra/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -208,7 +208,7 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/base-maia/ui/calendar.tsx
+++ b/apps/v4/styles/base-maia/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -208,7 +208,7 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/base-mira/ui/calendar.tsx
+++ b/apps/v4/styles/base-mira/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -208,7 +208,7 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/base-nova/ui-rtl/calendar.tsx
+++ b/apps/v4/styles/base-nova/ui-rtl/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -208,7 +208,7 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/base-nova/ui/calendar.tsx
+++ b/apps/v4/styles/base-nova/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -208,7 +208,7 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/base-sera/ui/calendar.tsx
+++ b/apps/v4/styles/base-sera/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -208,7 +208,7 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/base-vega/ui/calendar.tsx
+++ b/apps/v4/styles/base-vega/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -208,7 +208,7 @@ function CalendarDayButton({
     <Button
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/radix-luma/ui/calendar.tsx
+++ b/apps/v4/styles/radix-luma/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -209,7 +209,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/radix-lyra/ui/calendar.tsx
+++ b/apps/v4/styles/radix-lyra/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -209,7 +209,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/radix-maia/ui/calendar.tsx
+++ b/apps/v4/styles/radix-maia/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -209,7 +209,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/radix-mira/ui/calendar.tsx
+++ b/apps/v4/styles/radix-mira/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -209,7 +209,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/radix-nova/ui-rtl/calendar.tsx
+++ b/apps/v4/styles/radix-nova/ui-rtl/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -209,7 +209,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/radix-nova/ui/calendar.tsx
+++ b/apps/v4/styles/radix-nova/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -209,7 +209,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/radix-sera/ui/calendar.tsx
+++ b/apps/v4/styles/radix-sera/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -209,7 +209,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/apps/v4/styles/radix-vega/ui/calendar.tsx
+++ b/apps/v4/styles/radix-vega/ui/calendar.tsx
@@ -44,7 +44,7 @@ function Calendar({
       locale={locale}
       formatters={{
         formatMonthDropdown: (date) =>
-          date.toLocaleString(locale?.code, { month: "short" }),
+          date.toLocaleString((locale as { code?: string })?.code, { month: "short" }),
         ...formatters,
       }}
       classNames={{
@@ -209,7 +209,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-day={day.date.toLocaleDateString((locale as { code?: string })?.code)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&


### PR DESCRIPTION
Fixes #10709

`DayPickerLocale` (introduced in react-day-picker 9.12.0) doesn't expose `code` as a known property at the type level when accessed through `Partial<Locale>`, even though the underlying `date-fns` Locale carries it at runtime.

The fix adds a minimal inline type assertion so TypeScript stops erroring when `locale?.code` is read in `formatMonthDropdown` and `data-day`.

Changed:
- `locale?.code` → `(locale as { code?: string } | undefined)?.code`

Applied to both `registry/bases/base` and `registry/bases/radix` calendar source files, along with the corresponding documentation examples.

Running `pnpm registry:build` will regenerate the `public/r/` JSON artifacts from the fixed registry sources.