### PR TITLE
fix(carousel): prevent click suppression on nav buttons

### DIFF
--- a/apps/v4/styles/radix-nova/ui/carousel.tsx
+++ b/apps/v4/styles/radix-nova/ui/carousel.tsx
@@ -187,8 +187,8 @@ function CarouselPrevious({
       className={cn(
         "absolute touch-manipulation rounded-full",
         orientation === "horizontal"
-          ? "top-1/2 -left-12 -translate-y-1/2"
-          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+          ? "top-1/2 -left-12 -translate-y-1/2 active:not-aria-[haspopup]:-translate-y-[calc(50%-0.5px)]"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90 active:not-aria-[haspopup]:-translate-x-1/2 active:not-aria-[haspopup]:translate-y-[0.5px]",
         className
       )}
       disabled={!canScrollPrev}
@@ -217,8 +217,8 @@ function CarouselNext({
       className={cn(
         "absolute touch-manipulation rounded-full",
         orientation === "horizontal"
-          ? "top-1/2 -right-12 -translate-y-1/2"
-          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+          ? "top-1/2 -right-12 -translate-y-1/2 active:not-aria-[haspopup]:-translate-y-[calc(50%-0.5px)]"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90 active:not-aria-[haspopup]:-translate-x-1/2 active:not-aria-[haspopup]:translate-y-[0.5px]",
         className
       )}
       disabled={!canScrollNext}


### PR DESCRIPTION
## Summary

Fixes intermittent click loss on carousel navigation buttons: Fixes #10742.

## Root cause

The shared `Button` styles apply:

```css
active:not-aria-[haspopup]:translate-y-px
```

`CarouselPrevious` and `CarouselNext` are absolutely positioned and vertically centered using `-translate-y-1/2`.

When clicking near the top edge of the button, the active translate can move the button away from the cursor between `mousedown` and `mouseup`, causing the browser to suppress the `click` event.

This explains why:

* the press animation still appears
* `pointerdown` / `mousedown` fire consistently
* `click` intermittently fails
* clicks from the lower edge are more reliable

## Fix

Override the active translate behavior for carousel navigation buttons while preserving subtle press feedback.

This keeps the interaction responsive without removing the pressed-state feel entirely.
