### PR TITLE
fix(form): set aria-describedby only when FormDescription is rendered

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/form.tsx
+++ b/apps/v4/registry/new-york-v4/ui/form.tsx
@@ -53,7 +53,7 @@ const useFormField = () => {
     throw new Error("useFormField should be used within <FormField>")
   }
 
-  const { id } = itemContext
+  const { id, hasDescription } = itemContext
 
   return {
     id,
@@ -61,12 +61,15 @@ const useFormField = () => {
     formItemId: `${id}-form-item`,
     formDescriptionId: `${id}-form-item-description`,
     formMessageId: `${id}-form-item-message`,
+    hasDescription,
     ...fieldState,
   }
 }
 
 type FormItemContextValue = {
   id: string
+  hasDescription: boolean
+  setHasDescription: (value: boolean) => void
 }
 
 const FormItemContext = React.createContext<FormItemContextValue>(
@@ -75,9 +78,10 @@ const FormItemContext = React.createContext<FormItemContextValue>(
 
 function FormItem({ className, ...props }: React.ComponentProps<"div">) {
   const id = React.useId()
+  const [hasDescription, setHasDescription] = React.useState(false)
 
   return (
-    <FormItemContext.Provider value={{ id }}>
+    <FormItemContext.Provider value={{ id, hasDescription, setHasDescription }}>
       <div
         data-slot="form-item"
         className={cn("grid gap-2", className)}
@@ -105,17 +109,26 @@ function FormLabel({
 }
 
 function FormControl({ ...props }: React.ComponentProps<typeof Slot.Root>) {
-  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+  const {
+    error,
+    formItemId,
+    formDescriptionId,
+    formMessageId,
+    hasDescription,
+  } = useFormField()
+
+  const ariaDescribedBy = [
+    hasDescription ? formDescriptionId : "",
+    error ? formMessageId : "",
+  ]
+    .filter(Boolean)
+    .join(" ")
 
   return (
     <Slot.Root
       data-slot="form-control"
       id={formItemId}
-      aria-describedby={
-        !error
-          ? `${formDescriptionId}`
-          : `${formDescriptionId} ${formMessageId}`
-      }
+      aria-describedby={ariaDescribedBy || undefined}
       aria-invalid={!!error}
       {...props}
     />
@@ -124,6 +137,12 @@ function FormControl({ ...props }: React.ComponentProps<typeof Slot.Root>) {
 
 function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
   const { formDescriptionId } = useFormField()
+  const { setHasDescription } = React.useContext(FormItemContext)
+
+  React.useEffect(() => {
+    setHasDescription(true)
+    return () => setHasDescription(false)
+  }, [setHasDescription])
 
   return (
     <p

--- a/apps/v4/registry/new-york-v4/ui/form.tsx
+++ b/apps/v4/registry/new-york-v4/ui/form.tsx
@@ -53,7 +53,7 @@ const useFormField = () => {
     throw new Error("useFormField should be used within <FormField>")
   }
 
-  const { id, hasDescription } = itemContext
+  const { id, hasDescription, hasErrorMessage } = itemContext
 
   return {
     id,
@@ -62,6 +62,7 @@ const useFormField = () => {
     formDescriptionId: `${id}-form-item-description`,
     formMessageId: `${id}-form-item-message`,
     hasDescription,
+    hasErrorMessage,
     ...fieldState,
   }
 }
@@ -70,6 +71,8 @@ type FormItemContextValue = {
   id: string
   hasDescription: boolean
   setHasDescription: (value: boolean) => void
+  hasErrorMessage: boolean
+  setHasErrorMessage: (value: boolean) => void
 }
 
 const FormItemContext = React.createContext<FormItemContextValue>(
@@ -79,9 +82,18 @@ const FormItemContext = React.createContext<FormItemContextValue>(
 function FormItem({ className, ...props }: React.ComponentProps<"div">) {
   const id = React.useId()
   const [hasDescription, setHasDescription] = React.useState(false)
+  const [hasErrorMessage, setHasErrorMessage] = React.useState(false)
 
   return (
-    <FormItemContext.Provider value={{ id, hasDescription, setHasDescription }}>
+    <FormItemContext.Provider
+      value={{
+        id,
+        hasDescription,
+        setHasDescription,
+        hasErrorMessage,
+        setHasErrorMessage,
+      }}
+    >
       <div
         data-slot="form-item"
         className={cn("grid gap-2", className)}
@@ -115,11 +127,12 @@ function FormControl({ ...props }: React.ComponentProps<typeof Slot.Root>) {
     formDescriptionId,
     formMessageId,
     hasDescription,
+    hasErrorMessage,
   } = useFormField()
 
   const ariaDescribedBy = [
     hasDescription ? formDescriptionId : "",
-    error ? formMessageId : "",
+    hasErrorMessage ? formMessageId : "",
   ]
     .filter(Boolean)
     .join(" ")
@@ -156,7 +169,13 @@ function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
 
 function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
   const { error, formMessageId } = useFormField()
+  const { setHasErrorMessage } = React.useContext(FormItemContext)
   const body = error ? String(error?.message ?? "") : props.children
+
+  React.useLayoutEffect(() => {
+    setHasErrorMessage(Boolean(body))
+    return () => setHasErrorMessage(false)
+  }, [body, setHasErrorMessage])
 
   if (!body) {
     return null


### PR DESCRIPTION
## Summary

- Fixes accessibility bug where `FormControl` always set `aria-describedby` to `formDescriptionId` even when `<FormDescription />` was not rendered
- Adds `hasDescription` / `hasErrorMessage` state to `FormItem` context, set when description and error message mount
- Builds `aria-describedby` from visible description and error message ids only

Fixes #7171

## Test plan

- [x] Form field **without** `FormDescription`: input has no `aria-describedby` (or only message id after validation error)
- [x] Form field **with** `FormDescription`: input references description id
- [x] Form field with validation error: input references `formMessageId` when `error` is set
- [x] Form with both description and error: both ids appear in `aria-describedby`, space-separated

Verified manually on `http://localhost:4000/form-debug` (automated browser checks, May 25 2026).