### PR TITLE
fix(form): omit aria-describedby when no FormDescription is rendered

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/form.tsx
+++ b/apps/v4/registry/new-york-v4/ui/form.tsx
@@ -53,10 +53,12 @@ const useFormField = () => {
     throw new Error("useFormField should be used within <FormField>")
   }
 
-  const { id } = itemContext
+  const { id, hasDescription, setHasDescription } = itemContext
 
   return {
     id,
+    hasDescription,
+    setHasDescription,
     name: fieldContext.name,
     formItemId: `${id}-form-item`,
     formDescriptionId: `${id}-form-item-description`,
@@ -67,6 +69,8 @@ const useFormField = () => {
 
 type FormItemContextValue = {
   id: string
+  hasDescription: boolean
+  setHasDescription: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 const FormItemContext = React.createContext<FormItemContextValue>(
@@ -75,9 +79,10 @@ const FormItemContext = React.createContext<FormItemContextValue>(
 
 function FormItem({ className, ...props }: React.ComponentProps<"div">) {
   const id = React.useId()
+  const [hasDescription, setHasDescription] = React.useState(false)
 
   return (
-    <FormItemContext.Provider value={{ id }}>
+    <FormItemContext.Provider value={{ id, hasDescription, setHasDescription }}>
       <div
         data-slot="form-item"
         className={cn("grid gap-2", className)}
@@ -105,16 +110,22 @@ function FormLabel({
 }
 
 function FormControl({ ...props }: React.ComponentProps<typeof Slot.Root>) {
-  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+  const {
+    error,
+    formItemId,
+    formDescriptionId,
+    formMessageId,
+    hasDescription,
+  } = useFormField()
 
   return (
     <Slot.Root
       data-slot="form-control"
       id={formItemId}
       aria-describedby={
-        !error
-          ? `${formDescriptionId}`
-          : `${formDescriptionId} ${formMessageId}`
+        [error ? formMessageId : null, hasDescription ? formDescriptionId : null]
+          .filter(Boolean)
+          .join(" ") || undefined
       }
       aria-invalid={!!error}
       {...props}
@@ -123,7 +134,12 @@ function FormControl({ ...props }: React.ComponentProps<typeof Slot.Root>) {
 }
 
 function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
-  const { formDescriptionId } = useFormField()
+  const { formDescriptionId, setHasDescription } = useFormField()
+
+  React.useEffect(() => {
+    setHasDescription(true)
+    return () => setHasDescription(false)
+  }, [setHasDescription])
 
   return (
     <p


### PR DESCRIPTION
Closes #7171

## Summary

`FormControl` always set `aria-describedby` referencing `formDescriptionId`, even when no `FormDescription` element was rendered. This created a dangling ARIA reference (pointing to a non-existent element), causing accessibility tools (WAVE Evaluation Tool, screen readers) to report errors.

## Changes

- Added `hasDescription` state to `FormItemContextValue` to track whether a `FormDescription` is mounted
- `FormDescription` registers itself via `useEffect` on mount and unregisters on unmount
- `FormControl` now conditionally includes `formDescriptionId` in `aria-describedby` only when a `FormDescription` is present
- When neither error message nor description exists, `aria-describedby` is set to `undefined` (React drops the attribute)

## Test Plan

1. Create a form field with `FormLabel` + `FormControl` but WITHOUT `FormDescription`
2. Inspect the DOM — `aria-describedby` should NOT be present on the form control
3. Add a `FormDescription` — `aria-describedby` should now reference it
4. Trigger a validation error — `aria-describedby` should reference both description and error message
5. Remove the `FormDescription` while error is active — only the error message ID should remain