### PR TITLE
fix(separator): improve horizontal separator rendering consistency

### DIFF
--- a/apps/v4/styles/base-luma/ui/separator.tsx
+++ b/apps/v4/styles/base-luma/ui/separator.tsx
@@ -14,7 +14,7 @@ function Separator({
       data-slot="separator"
       orientation={orientation}
       className={cn(
-        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        "shrink-0 box-border data-horizontal:w-full data-horizontal:border-t data-horizontal:border-border data-vertical:h-full data-vertical:w-px data-vertical:bg-border",
         className
       )}
       {...props}


### PR DESCRIPTION
Replaced background-based horizontal separator rendering:

data-horizontal:h-px data-horizontal:w-full bg-border

with border-based rendering:

data-horizontal:w-full data-horizontal:border-t data-horizontal:border-border

to improve visual consistency and reduce uneven separator appearance in narrow flex-column layouts and zoomed rendering.