### PR TITLE
fix(button-group): show ButtonGroup in With Input Group example

### DIFF
--- a/apps/v4/registry/bases/base/examples/button-group-example.tsx
+++ b/apps/v4/registry/bases/base/examples/button-group-example.tsx
@@ -325,21 +325,32 @@ function ButtonGroupWithInputGroup() {
   return (
     <Example title="With Input Group">
       <div className="flex flex-col gap-4">
-        <InputGroup>
-          <InputGroupInput placeholder="Type to search..." />
-          <InputGroupAddon
-            align="inline-start"
-            className="text-muted-foreground"
-          >
+        <ButtonGroup>
+          <InputGroup>
+            <InputGroupInput placeholder="Type to search..." />
+            <InputGroupAddon
+              align="inline-start"
+              className="text-muted-foreground"
+            >
+              <IconPlaceholder
+                lucide="SearchIcon"
+                tabler="IconSearch"
+                hugeicons="Search01Icon"
+                phosphor="MagnifyingGlassIcon"
+                remixicon="RiSearchLine"
+              />
+            </InputGroupAddon>
+          </InputGroup>
+          <Button variant="outline">
             <IconPlaceholder
-              lucide="SearchIcon"
-              tabler="IconSearch"
-              hugeicons="Search01Icon"
-              phosphor="MagnifyingGlassIcon"
-              remixicon="RiSearchLine"
+              lucide="ArrowRightIcon"
+              tabler="IconArrowRight"
+              hugeicons="ArrowRight01Icon"
+              phosphor="ArrowRightIcon"
+              remixicon="RiArrowRightLine"
             />
-          </InputGroupAddon>
-        </InputGroup>
+          </Button>
+        </ButtonGroup>
       </div>
     </Example>
   )

--- a/apps/v4/registry/bases/radix/examples/button-group-example.tsx
+++ b/apps/v4/registry/bases/radix/examples/button-group-example.tsx
@@ -321,21 +321,32 @@ function ButtonGroupWithInputGroup() {
   return (
     <Example title="With Input Group">
       <div className="flex flex-col gap-4">
-        <InputGroup>
-          <InputGroupInput placeholder="Type to search..." />
-          <InputGroupAddon
-            align="inline-start"
-            className="text-muted-foreground"
-          >
+        <ButtonGroup>
+          <InputGroup>
+            <InputGroupInput placeholder="Type to search..." />
+            <InputGroupAddon
+              align="inline-start"
+              className="text-muted-foreground"
+            >
+              <IconPlaceholder
+                lucide="SearchIcon"
+                tabler="IconSearch"
+                hugeicons="Search01Icon"
+                phosphor="MagnifyingGlassIcon"
+                remixicon="RiSearchLine"
+              />
+            </InputGroupAddon>
+          </InputGroup>
+          <Button variant="outline">
             <IconPlaceholder
-              lucide="SearchIcon"
-              tabler="IconSearch"
-              hugeicons="Search01Icon"
-              phosphor="MagnifyingGlassIcon"
-              remixicon="RiSearchLine"
+              lucide="ArrowRightIcon"
+              tabler="IconArrowRight"
+              hugeicons="ArrowRight01Icon"
+              phosphor="ArrowRightIcon"
+              remixicon="RiArrowRightLine"
             />
-          </InputGroupAddon>
-        </InputGroup>
+          </Button>
+        </ButtonGroup>
       </div>
     </Example>
   )


### PR DESCRIPTION
#### summary

- Fixes the "With Input Group" example on the Button Group page. It previously showed only a search input; it now shows a ButtonGroup with the input group and an action button, consistent with the other examples.

Closes #10797

#### Test plan

- Open Button Group examples (create page or local preview)
- Confirm "With Input Group" shows a joined search field and button
- Confirm radix and base previews match