### PR TITLE
Fix Nova primary button hover state

### DIFF
--- a/apps/v4/styles/base-nova/ui-rtl/button.tsx
+++ b/apps/v4/styles/base-nova/ui-rtl/button.tsx
@@ -8,7 +8,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        default: "bg-primary text-primary-foreground hover:bg-primary/80",
         outline:
           "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:

--- a/apps/v4/styles/base-nova/ui/button.tsx
+++ b/apps/v4/styles/base-nova/ui/button.tsx
@@ -8,7 +8,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        default: "bg-primary text-primary-foreground hover:bg-primary/80",
         outline:
           "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:

--- a/apps/v4/styles/radix-nova/ui-rtl/button.tsx
+++ b/apps/v4/styles/radix-nova/ui-rtl/button.tsx
@@ -9,7 +9,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        default: "bg-primary text-primary-foreground hover:bg-primary/80",
         outline:
           "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:

--- a/apps/v4/styles/radix-nova/ui/button.tsx
+++ b/apps/v4/styles/radix-nova/ui/button.tsx
@@ -9,7 +9,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        default: "bg-primary text-primary-foreground hover:bg-primary/80",
         outline:
           "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:


### PR DESCRIPTION
## Problem
Nova primary buttons do not visually respond on hover, while other styles such as Vega do.

## Root cause
The Nova button variant used `[a]:hover:bg-primary/80`, which targets an `a` descendant instead of applying the hover state to the button itself.

## Fix
Replace the descendant selector with `hover:bg-primary/80` for both Base Nova and Radix Nova button implementations, including their RTL variants.

## Testing
- Ran `git diff --check` successfully.
- Attempted `pnpm exec prettier --check` on the changed files
Fixes #10798