### PR TITLE
fix(docs): disable ligatures in code blocks

### DIFF
--- a/apps/v4/app/globals.css
+++ b/apps/v4/app/globals.css
@@ -284,6 +284,14 @@
     }
   }
 
+  [data-rehype-pretty-code-figure] code,
+  [data-rehype-pretty-code-figure] code span {
+    font-variant-ligatures: none;
+    font-feature-settings:
+      "liga" 0,
+      "calt" 0;
+  }
+
   [data-rehype-pretty-code-title] {
     border-bottom: color-mix(in oklab, var(--border) 30%, transparent);
     border-bottom-width: 1px;


### PR DESCRIPTION
## Summary

Fixes a visual rendering issue in docs code blocks where JSX spread syntax like `{...controllerField}` could appear incorrectly in the browser.

The MDX source and copied code were already correct, so this updates the rendered docs code-block styles to disable font ligatures/contextual alternates for rehype-pretty-code blocks.

## Screenshots

Before:

<img width="886" height="709" alt="before" src="https://github.com/user-attachments/assets/f6bdb7cf-866b-47b7-adea-3fb955d61781" />

After:

[
<img width="823" height="727" alt="after" src="https://github.com/user-attachments/assets/2f466055-18ed-4157-bab8-78f5b5910a8c" />
](url)

## Testing

- Ran `pnpm --filter=v4 lint`
- Ran `pnpm --filter=v4 typecheck`
- Verified `/docs/forms/react-hook-form#using-usefieldarray` locally
- Confirmed `{...controllerField}` renders correctly in Chrome, Firefox, and Edge
- Confirmed other JSX spread syntax such as `{...field}` still renders correctly

Fixes #10796