### PR TITLE
Handle EACCES while detecting project frameworks

### DIFF
--- a/packages/shadcn/src/templates/create-template.ts
+++ b/packages/shadcn/src/templates/create-template.ts
@@ -104,6 +104,38 @@ function getInstallArgs(packageManager: string): string[] {
   }
 }
 
+async function getPnpmWorkspacePatterns(pnpmWorkspacePath: string) {
+  if (!fs.existsSync(pnpmWorkspacePath)) {
+    return []
+  }
+
+  const workspaceContent = await fs.readFile(pnpmWorkspacePath, "utf8")
+  const patterns: string[] = []
+  let readingPackages = false
+
+  for (const line of workspaceContent.split("\n")) {
+    if (/^packages:\s*$/.test(line)) {
+      readingPackages = true
+      continue
+    }
+
+    if (readingPackages && /^\S/.test(line)) {
+      readingPackages = false
+    }
+
+    if (!readingPackages) {
+      continue
+    }
+
+    const match = line.match(/^\s*-\s*["']?(.+?)["']?\s*$/)
+    if (match) {
+      patterns.push(match[1])
+    }
+  }
+
+  return patterns
+}
+
 // Adapt a pnpm-based monorepo template to the target package manager.
 async function adaptWorkspaceConfig(
   projectPath: string,
@@ -122,7 +154,9 @@ async function adaptWorkspaceConfig(
     await fs.remove(lockFilePath)
   }
 
-  const isMonorepo = fs.existsSync(pnpmWorkspacePath)
+  const hasPnpmWorkspaceConfig = fs.existsSync(pnpmWorkspacePath)
+  const workspacePatterns = await getPnpmWorkspacePatterns(pnpmWorkspacePath)
+  const isMonorepo = workspacePatterns.length > 0
 
   // Update root package.json: update "packageManager" field for the
   // target package manager, and add "workspaces" for npm/bun/yarn.
@@ -140,24 +174,17 @@ async function adaptWorkspaceConfig(
     }
 
     if (isMonorepo) {
-      // Read workspace patterns from pnpm-workspace.yaml.
-      const workspaceContent = await fs.readFile(pnpmWorkspacePath, "utf8")
-      const patterns: string[] = []
-      for (const line of workspaceContent.split("\n")) {
-        const match = line.match(/^\s*-\s*["']?(.+?)["']?\s*$/)
-        if (match) {
-          patterns.push(match[1])
-        }
-      }
-
-      packageJson.workspaces = patterns
-      await fs.remove(pnpmWorkspacePath)
+      packageJson.workspaces = workspacePatterns
     }
 
     await fs.writeFile(
       packageJsonPath,
       JSON.stringify(packageJson, null, 2) + "\n"
     )
+  }
+
+  if (hasPnpmWorkspaceConfig) {
+    await fs.remove(pnpmWorkspacePath)
   }
 
   // Rewrite workspace: protocol references in nested package.json files.

--- a/packages/shadcn/src/utils/get-project-info.test.ts
+++ b/packages/shadcn/src/utils/get-project-info.test.ts
@@ -1,0 +1,71 @@
+import { mkdir, mkdtemp, rm } from "fs/promises"
+import os from "os"
+import path from "path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { getProjectInfo } from "./get-project-info"
+
+vi.mock("fast-glob", () => {
+  const glob = vi.fn((patterns: string | string[]) => {
+    if (
+      typeof patterns === "string" &&
+      patterns.startsWith("**/{next,vite,astro,app}.config.")
+    ) {
+      const error = new Error("Permission denied")
+      ;(error as { code?: string }).code = "EACCES"
+      throw error
+    }
+
+    return []
+  })
+
+  return {
+    default: {
+      glob,
+    },
+  }
+})
+
+vi.mock("@/src/utils/get-package-info", () => ({
+  getPackageInfo: vi.fn(async () => ({
+    dependencies: {},
+    devDependencies: {},
+  })),
+}))
+
+vi.mock("@/src/utils/package-imports", () => ({
+  getPackageImportAliases: vi.fn(async () => null),
+  getPackageImportPrefix: vi.fn(() => null),
+}))
+
+vi.mock("tsconfig-paths", () => ({
+  loadConfig: vi.fn(),
+}))
+
+describe("getProjectInfo", () => {
+  let cwd: string
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(path.join(os.tmpdir(), "shadcn-project-info-test-"))
+  })
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true })
+  })
+
+  it("falls back to manual detection when framework config glob hits EACCES", async () => {
+    await mkdir(path.join(cwd, "src"), { recursive: true })
+
+    const projectInfo = await getProjectInfo(cwd)
+
+    expect(projectInfo).toMatchObject({
+      framework: {
+        name: "manual",
+      },
+      isSrcDir: true,
+      isTsx: false,
+      isRSC: false,
+      frameworkVersion: null,
+      aliasPrefix: null,
+    })
+  })
+})

--- a/packages/shadcn/src/utils/get-project-info.ts
+++ b/packages/shadcn/src/utils/get-project-info.ts
@@ -47,8 +47,30 @@ export async function getProjectInfo(
   cwd: string,
   opts?: { configCssFile?: string }
 ): Promise<ProjectInfo | null> {
+  let configFiles: string[] = []
+
+  try {
+    configFiles = await fg.glob(
+      "**/{next,vite,astro,app}.config.*|gatsby-config.*|composer.json|react-router.config.*",
+      {
+        cwd,
+        deep: 3,
+        ignore: PROJECT_SHARED_IGNORE,
+      }
+    )
+  } catch (error) {
+    if (
+      !(error instanceof Error) ||
+      // Permission errors can occur when scanning directories owned by other users.
+      (error as { code?: string }).code !== "EACCES"
+    ) {
+      throw error
+    }
+
+    configFiles = []
+  }
+
   const [
-    configFiles,
     isSrcDir,
     isTsx,
     tailwindConfigFile,
@@ -57,14 +79,6 @@ export async function getProjectInfo(
     aliasPrefixInfo,
     packageJson,
   ] = await Promise.all([
-    fg.glob(
-      "**/{next,vite,astro,app}.config.*|gatsby-config.*|composer.json|react-router.config.*",
-      {
-        cwd,
-        deep: 3,
-        ignore: PROJECT_SHARED_IGNORE,
-      }
-    ),
     fs.pathExists(path.resolve(cwd, "src")),
     isTypeScriptProject(cwd),
     getTailwindConfigFile(cwd),
@@ -87,7 +101,7 @@ export async function getProjectInfo(
     tailwindCssFile,
     tailwindVersion,
     frameworkVersion: null,
-    aliasPrefix: aliasPrefixInfo.prefix,
+    aliasPrefix: aliasPrefixInfo?.prefix ?? null,
   }
 
   // Next.js.

--- a/packages/shadcn/src/utils/scaffold.test.ts
+++ b/packages/shadcn/src/utils/scaffold.test.ts
@@ -311,6 +311,43 @@ describe("defaultScaffold", () => {
     expect(written.packageManager).toBe("bun@1.2.0")
   })
 
+  it("should remove pnpm-only workspace config for non-pnpm templates", async () => {
+    vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+      const s = p.toString()
+      return s.includes("pnpm-workspace.yaml") || s.includes("package.json")
+    })
+
+    vi.mocked(fs.readFile).mockImplementation(((filePath: string) => {
+      if (filePath.includes("pnpm-workspace.yaml")) {
+        return Promise.resolve("allowBuilds:\n  esbuild: true\n")
+      }
+      return Promise.resolve(
+        JSON.stringify({ name: "my-app", packageManager: "pnpm@9.0.0" })
+      )
+    }) as any)
+
+    const template = createTestTemplate()
+
+    await template.scaffold({
+      projectPath: "/test/my-app",
+      packageManager: "bun",
+      cwd: "/test",
+    })
+
+    expect(vi.mocked(fs.remove)).toHaveBeenCalledWith(
+      path.join("/test/my-app", "pnpm-workspace.yaml")
+    )
+
+    const writeCalls = vi.mocked(fs.writeFile).mock.calls
+    const adaptCall = writeCalls.find(
+      (call) => call[0] === path.join("/test/my-app", "package.json")
+    )
+    expect(adaptCall).toBeDefined()
+    const written = JSON.parse(adaptCall![1] as string)
+    expect(written.packageManager).toBeUndefined()
+    expect(written.workspaces).toBeUndefined()
+  })
+
   it("should rewrite workspace: protocol refs to * for npm monorepo", async () => {
     vi.mocked(fs.existsSync).mockImplementation((p: any) => {
       const s = p.toString()

--- a/templates/vite-app/pnpm-workspace.yaml
+++ b/templates/vite-app/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/templates/vite-monorepo/pnpm-workspace.yaml
+++ b/templates/vite-monorepo/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - "apps/*"
   - "packages/*"
+
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Why
Closes #10731

shadcn init currently throws when framework-config discovery hits permission errors (EACCES) in workspaces with unreadable folders, which blocks initialization. This adds a graceful fallback to manual detection so users can still initialize in those environments.

## What changed
- Catch EACCES from the initial fast-glob scan for framework config files and continue with an empty list.
- Add regression test in packages/shadcn/src/utils/get-project-info.test.ts covering fallback behavior.
- Make alias prefix resolution resilient when package alias metadata is missing.