### PR TITLE
Fix Windows path detection for registry local JSON inputs

### DIFF
--- a/packages/shadcn/src/registry/utils.test.ts
+++ b/packages/shadcn/src/registry/utils.test.ts
@@ -101,6 +101,8 @@ describe("isUrl", () => {
     expect(isUrl("../relative/path.json")).toBe(false)
     expect(isUrl("/absolute/path.json")).toBe(false)
     expect(isUrl("component-name")).toBe(false)
+    expect(isUrl("C:\\Users\\user\\component.json")).toBe(false)
+    expect(isUrl("C:/Users/user/component.json")).toBe(false)
     expect(isUrl("")).toBe(false)
     expect(isUrl("just-text")).toBe(false)
   })
@@ -115,6 +117,8 @@ describe("isLocalFile", () => {
     expect(isLocalFile("nested/directory/dialog.json")).toBe(true)
     expect(isLocalFile("~/Desktop/component.json")).toBe(true)
     expect(isLocalFile("~/Documents/shared/button.json")).toBe(true)
+    expect(isLocalFile("C:\\Users\\user\\component.json")).toBe(true)
+    expect(isLocalFile("C:/Users/user/component.json")).toBe(true)
   })
 
   it("should return false for URLs ending with .json", () => {

--- a/packages/shadcn/src/registry/utils.ts
+++ b/packages/shadcn/src/registry/utils.ts
@@ -262,6 +262,11 @@ function determineFileType(
 
 // Additional utility functions for local file support
 export function isUrl(path: string) {
+  // On Windows, absolute local paths like C:\... are not URLs.
+  if (/^[a-zA-Z]:[\\/]/.test(path)) {
+    return false
+  }
+
   try {
     new URL(path)
     return true


### PR DESCRIPTION
Summary: - Guard isUrl against Windows drive-letter paths before URL parsing in src/registry/utils.ts so local files like C:\\Users\\user\\component.json are treated as local. - Add regression tests in src/registry/utils.test.ts for both isUrl false and isLocalFile true on Windows absolute .json paths. Validation: - pnpm --filter=shadcn test src/registry/utils.test.ts