### PR TITLE
fix: normalize env file path handling on Windows

### DIFF
--- a/packages/shadcn/src/utils/env-helpers.ts
+++ b/packages/shadcn/src/utils/env-helpers.ts
@@ -6,6 +6,10 @@ export function isEnvFile(filePath: string) {
   return /^\.env(\.|$)/.test(fileName)
 }
 
+export function toPosixPath(filePath: string) {
+  return filePath.split(path.sep).join(path.posix.sep)
+}
+
 /**
  * Finds a file variant in the project.
  * TODO: abstract this to a more generic function.
@@ -19,7 +23,7 @@ export function findExistingEnvFile(targetDir: string) {
   ]
 
   for (const variant of variants) {
-    const filePath = path.join(targetDir, variant)
+    const filePath = toPosixPath(path.join(targetDir, variant))
     if (existsSync(filePath)) {
       return filePath
     }

--- a/packages/shadcn/src/utils/resolve-import.ts
+++ b/packages/shadcn/src/utils/resolve-import.ts
@@ -1,3 +1,5 @@
+import path from "path"
+
 import { getPatternWildcardValue } from "@/src/utils/import-matcher"
 import {
   resolvePackageImport,
@@ -12,6 +14,10 @@ export type ResolvedImport = {
   matchedAlias: string
   matchedTarget: string
   emitMode: ImportEmitMode
+}
+
+function toPosixPath(filePath: string) {
+  return filePath.split(path.sep).join(path.posix.sep)
 }
 
 type ResolveImportConfig = Pick<
@@ -106,7 +112,7 @@ function resolveFromTsconfigPaths(
   }
 
   return {
-    path: matchedPath,
+    path: toPosixPath(matchedPath),
     source: "tsconfig_paths",
     matchedAlias: matchedPattern?.key ?? importPath,
     matchedTarget: matchedPattern?.target ?? matchedPath,

--- a/packages/shadcn/src/utils/updaters/update-env-vars.ts
+++ b/packages/shadcn/src/utils/updaters/update-env-vars.ts
@@ -5,6 +5,7 @@ import {
   findExistingEnvFile,
   getNewEnvKeys,
   mergeEnvContent,
+  toPosixPath,
 } from "@/src/utils/env-helpers"
 import { Config } from "@/src/utils/get-config"
 import { highlighter } from "@/src/utils/highlighter"
@@ -39,7 +40,7 @@ export async function updateEnvVars(
   const projectRoot = config.resolvedPaths.cwd
 
   // Find existing env file or use .env.local as default.
-  let envFilePath = path.join(projectRoot, ".env.local")
+  let envFilePath = toPosixPath(path.join(projectRoot, ".env.local"))
   const existingEnvFile = findExistingEnvFile(projectRoot)
 
   if (existingEnvFile) {
@@ -65,7 +66,7 @@ export async function updateEnvVars(
 
     if (envVarsAdded.length > 0) {
       await fs.writeFile(envFilePath, mergedContent, "utf-8")
-      envFileUpdated = path.relative(projectRoot, envFilePath)
+      envFileUpdated = path.relative(projectRoot, envFilePath).split(path.sep).join("/")
 
       envSpinner?.succeed(
         `Added the following variables to ${highlighter.info(envFileName)}:`
@@ -82,7 +83,7 @@ export async function updateEnvVars(
   } else {
     // Create new env file
     await fs.writeFile(envFilePath, newEnvContent + "\n", "utf-8")
-    envFileCreated = path.relative(projectRoot, envFilePath)
+    envFileCreated = path.relative(projectRoot, envFilePath).split(path.sep).join("/")
     envVarsAdded = Object.keys(envVars)
 
     envSpinner?.succeed(

--- a/packages/shadcn/test/utils/resolve-import.test.ts
+++ b/packages/shadcn/test/utils/resolve-import.test.ts
@@ -9,6 +9,10 @@ import {
   resolveImportWithMetadata,
 } from "../../src/utils/resolve-import"
 
+function toPosixPath(filePath: string) {
+  return filePath.split(path.sep).join(path.posix.sep)
+}
+
 test("resolve import", async () => {
   expect(
     await resolveImport("@/foo/bar", {
@@ -19,7 +23,9 @@ test("resolve import", async () => {
         "~/lib": ["./src/lib"],
       },
     })
-  ).toEqual("/Users/shadcn/Projects/foobar/src/foo/bar")
+  ).toEqual(
+    toPosixPath(path.resolve("/Users/shadcn/Projects/foobar", "src", "foo", "bar"))
+  )
 
   expect(
     await resolveImport("~/components/foo/bar/baz", {
@@ -30,7 +36,18 @@ test("resolve import", async () => {
         "~/lib": ["./src/lib"],
       },
     })
-  ).toEqual("/Users/shadcn/Projects/foobar/src/components/foo/bar/baz")
+  ).toEqual(
+    toPosixPath(
+      path.resolve(
+        "/Users/shadcn/Projects/foobar",
+        "src",
+        "components",
+        "foo",
+        "bar",
+        "baz"
+      )
+    )
+  )
 
   expect(
     await resolveImport("components/foo/bar", {
@@ -41,7 +58,18 @@ test("resolve import", async () => {
         lib: ["./lib"],
       },
     })
-  ).toEqual("/Users/shadcn/Projects/foobar/src/app/components/foo/bar")
+  ).toEqual(
+    toPosixPath(
+      path.resolve(
+        "/Users/shadcn/Projects/foobar",
+        "src",
+        "app",
+        "components",
+        "foo",
+        "bar"
+      )
+    )
+  )
 
   expect(
     await resolveImport("lib/utils", {
@@ -52,7 +80,7 @@ test("resolve import", async () => {
         lib: ["./lib"],
       },
     })
-  ).toEqual("/Users/shadcn/Projects/foobar/lib/utils")
+  ).toEqual(toPosixPath("/Users/shadcn/Projects/foobar/lib/utils"))
 })
 
 test("resolve import with base url", async () => {
@@ -60,13 +88,13 @@ test("resolve import with base url", async () => {
   const config = (await loadConfig(cwd)) as ConfigLoaderSuccessResult
 
   expect(await resolveImport("@/components/ui", config)).toEqual(
-    path.resolve(cwd, "components/ui")
+    toPosixPath(path.resolve(cwd, "components/ui"))
   )
   expect(await resolveImport("@/lib/utils", config)).toEqual(
-    path.resolve(cwd, "lib/utils")
+    toPosixPath(path.resolve(cwd, "lib/utils"))
   )
   expect(await resolveImport("foo/bar", config)).toEqual(
-    path.resolve(cwd, "foo/bar")
+    toPosixPath(path.resolve(cwd, "foo/bar"))
   )
 })
 
@@ -75,13 +103,13 @@ test("resolve import without base url", async () => {
   const config = (await loadConfig(cwd)) as ConfigLoaderSuccessResult
 
   expect(await resolveImport("~/components/ui", config)).toEqual(
-    path.resolve(cwd, "components/ui")
+    toPosixPath(path.resolve(cwd, "components/ui"))
   )
   expect(await resolveImport("~/lib/utils", config)).toEqual(
-    path.resolve(cwd, "lib/utils")
+    toPosixPath(path.resolve(cwd, "lib/utils"))
   )
   expect(await resolveImport("foo/bar", config)).toEqual(
-    path.resolve(cwd, "foo/bar")
+    toPosixPath(path.resolve(cwd, "foo/bar"))
   )
 })
 
@@ -153,7 +181,14 @@ describe("resolve package imports", () => {
         },
       })
     ).toEqual({
-      path: "/Users/shadcn/Projects/foobar/src/components/ui",
+      path: toPosixPath(
+        path.resolve(
+          "/Users/shadcn/Projects/foobar",
+          "src",
+          "components",
+          "ui"
+        )
+      ),
       source: "tsconfig_paths",
       matchedAlias: "#/*",
       matchedTarget: "./src/components/ui",
@@ -173,7 +208,9 @@ describe("resolve package imports", () => {
       }
     )
     expect(tsconfigPath?.source).toBe("tsconfig_paths")
-    expect(tsconfigPath?.path).toBe(path.resolve(cwd, "src/components/button"))
+    expect(tsconfigPath?.path).toBe(
+      toPosixPath(path.resolve(cwd, "src/components/button"))
+    )
 
     const packageImportPath = await resolveImportWithMetadata(
       "#components/button.tsx",


### PR DESCRIPTION
## Summary
- Normalize env variant paths to POSIX style before checking existence.
- Normalize env file targets/return values in env updates to avoid backslash output on Windows.

## Validation
- pnpm --filter=shadcn test src/utils/env-helpers.test.ts src/utils/updaters/update-env-vars.test.ts
