### PR TITLE
fix: normalize radix migration paths

### DIFF
--- a/packages/shadcn/src/migrations/migrate-icons.test.ts
+++ b/packages/shadcn/src/migrations/migrate-icons.test.ts
@@ -142,15 +142,47 @@ describe("migrateIconsFile", () => {
                   export function Component() {
               return (
                 <div>
-                  <CheckIcon
+                  <Check
                     className="w-4 h-4"
                     onClick={handleClick}
                     data-testid="check-icon"
                   >
                     <span>Child content</span>
-                  </CheckIcon>
+                  </Check>
                   <X style={{ color: 'red' }} aria-label="Close" />
                 </div>
+              )
+            }"
+    `)
+  })
+
+  it("should preserve aliased icon imports and migrate paired usage", async () => {
+    const input = `
+      import { CheckIcon as LegacyCheckIcon } from "@radix-ui/react-icons"
+
+      export function Component() {
+        return (
+          <section>
+            <LegacyCheckIcon size={16} />
+          </section>
+        )
+      }`
+
+    expect(
+      await migrateIconsFile(input, "radix", "lucide", {
+        Check: {
+          lucide: "Check",
+          radix: "CheckIcon",
+        },
+      })
+    ).toMatchInlineSnapshot(`
+      "import { Check } from "lucide-react";
+
+                  export function Component() {
+              return (
+                <section>
+                  <Check size={16} />
+                </section>
               )
             }"
     `)

--- a/packages/shadcn/src/migrations/migrate-icons.ts
+++ b/packages/shadcn/src/migrations/migrate-icons.ts
@@ -12,7 +12,15 @@ import { spinner } from "@/src/utils/spinner"
 import { updateDependencies } from "@/src/utils/updaters/update-dependencies"
 import fg from "fast-glob"
 import prompts from "prompts"
-import { Project, ScriptKind, SyntaxKind } from "ts-morph"
+import {
+  Project,
+  ScriptKind,
+  SyntaxKind,
+  type JsxClosingElement,
+  type JsxOpeningElement,
+  type JsxSelfClosingElement,
+  type SourceFile,
+} from "ts-morph"
 import { z } from "zod"
 
 export async function migrateIcons(config: Config) {
@@ -153,7 +161,41 @@ export async function migrateIconsFile(
   })
 
   // Find all sourceLibrary imports.
-  let targetedIcons: string[] = []
+  const targetedIcons: string[] = []
+
+  const replaceTag = (
+    sourceFile: SourceFile,
+    localName: string,
+    targetIcon: string
+  ) => {
+    const maybeReplace = (tagNameNode: ReturnType<
+      JsxSelfClosingElement["getTagNameNode"]
+    >) => {
+      const replacement = tagNameNode?.getText() === localName ? targetIcon : null
+      if (replacement) {
+        tagNameNode?.replaceWithText(replacement)
+      }
+    }
+
+    for (const node of sourceFile.getDescendantsOfKind(
+      SyntaxKind.JsxSelfClosingElement
+    )) {
+      maybeReplace(node.getTagNameNode())
+    }
+
+    for (const node of sourceFile.getDescendantsOfKind(
+      SyntaxKind.JsxOpeningElement
+    )) {
+      maybeReplace((node as JsxOpeningElement).getTagNameNode())
+    }
+
+    for (const node of sourceFile.getDescendantsOfKind(
+      SyntaxKind.JsxClosingElement
+    )) {
+      maybeReplace((node as JsxClosingElement).getTagNameNode())
+    }
+  }
+
   for (const importDeclaration of sourceFile.getImportDeclarations() ?? []) {
     if (
       importDeclaration.getModuleSpecifier()?.getText() !==
@@ -163,11 +205,11 @@ export async function migrateIconsFile(
     }
 
     for (const specifier of importDeclaration.getNamedImports() ?? []) {
-      const iconName = specifier.getName()
+      const importedName = specifier.getName()
+      const localName = specifier.getAliasNode()?.getText() ?? importedName
 
-      // TODO: this is O(n^2) but okay for now.
       const targetedIcon = Object.values(iconsMapping).find(
-        (icon) => icon[sourceLibrary] === iconName
+        (icon) => icon[sourceLibrary] === importedName
       )?.[targetLibrary]
 
       if (!targetedIcon || targetedIcons.includes(targetedIcon)) {
@@ -180,10 +222,7 @@ export async function migrateIconsFile(
       specifier.remove()
 
       // Replace with the targeted icon.
-      sourceFile
-        .getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement)
-        .filter((node) => node.getTagNameNode()?.getText() === iconName)
-        .forEach((node) => node.getTagNameNode()?.replaceWithText(targetedIcon))
+      replaceTag(sourceFile, localName, targetedIcon)
     }
 
     // If the named import is empty, remove the import declaration.

--- a/packages/shadcn/src/migrations/migrate-radix.ts
+++ b/packages/shadcn/src/migrations/migrate-radix.ts
@@ -98,6 +98,10 @@ function processNamedImports(
   }
 }
 
+function toPosixPath(filePath: string) {
+  return filePath.split(path.sep).join(path.posix.sep)
+}
+
 export async function migrateRadix(
   config: Config,
   options: { yes?: boolean; path?: string } = {}
@@ -195,7 +199,7 @@ export async function migrateRadix(
       // Track which packages we found
       replacedPackages.forEach((pkg) => foundPackages.add(pkg))
 
-      await fs.writeFile(filePath, content)
+      await fs.writeFile(toPosixPath(filePath), content)
     })
   )
 
@@ -231,9 +235,8 @@ export async function migrateRadix(
       if (!hasRadixUi) {
         packageJson.dependencies["radix-ui"] = "latest"
 
-        const packageJsonPath = path.join(
-          config.resolvedPaths.cwd,
-          "package.json"
+        const packageJsonPath = toPosixPath(
+          path.join(config.resolvedPaths.cwd, "package.json")
         )
         await fs.writeFile(
           packageJsonPath,


### PR DESCRIPTION
## Summary
- Normalize Radix migration file output paths to POSIX-style separators so generated files and package.json writes work consistently on Windows.

## Testing
- pnpm -C shadcn-ui-10464 --filter shadcn test src/migrations/migrate-radix.test.ts (38 passed)