### PR TITLE
fix: ignore shell-expanded paths in add command

### DIFF
--- a/packages/shadcn/src/commands/add.test.ts
+++ b/packages/shadcn/src/commands/add.test.ts
@@ -1,0 +1,78 @@
+import * as fs from "fs/promises"
+import { tmpdir } from "os"
+import * as path from "path"
+import { describe, expect, it } from "vitest"
+
+import { normalizeAddComponents } from "./add"
+
+describe("normalizeAddComponents", () => {
+  it("removes shell-expanded files and directories from component arguments", async () => {
+    const cwd = await createFixture({
+      "app/file.tsx": "",
+      "package.json": "{}",
+      "button.json": '{"name":"button"}',
+    })
+
+    await fs.mkdir(path.join(cwd, "button"))
+    const result = normalizeAddComponents(
+      ["app", "package.json", "button", "button.json"],
+      cwd
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it("keeps valid registry item names and urls", async () => {
+    const cwd = await createFixture({})
+
+    const result = normalizeAddComponents(
+      [
+        "button",
+        "@ui/button",
+        "https://ui.shadcn.com/r/styles/new-york-v4/card.json",
+      ],
+      cwd
+    )
+
+    expect(result).toEqual([
+      "button",
+      "@ui/button",
+      "https://ui.shadcn.com/r/styles/new-york-v4/card.json",
+    ])
+  })
+
+  it("removes wildcard tokens", async () => {
+    const cwd = await createFixture({})
+
+    const result = normalizeAddComponents(["*", "button"], cwd)
+
+    expect(result).toEqual(["button"])
+  })
+
+  it("keeps local json component files even when they exist", async () => {
+    const cwd = await createFixture({
+      "registry/custom.json": '{"name":"custom"}',
+    })
+
+    const result = normalizeAddComponents(
+      ["./registry/custom.json", "button"],
+      cwd
+    )
+
+    expect(result).toEqual(["./registry/custom.json", "button"])
+  })
+})
+
+async function createFixture(files: Record<string, string>) {
+  const cwd = await fs.mkdtemp(path.join(tmpdir(), "shadcn-add-"))
+
+  await Promise.all(
+    Object.entries(files).map(async ([filePath, content]) => {
+      const targetPath = path.join(cwd, filePath)
+      await fs.mkdir(path.dirname(targetPath), { recursive: true })
+      await fs.writeFile(targetPath, content)
+    })
+  )
+
+  return cwd
+}

--- a/packages/shadcn/src/commands/add.ts
+++ b/packages/shadcn/src/commands/add.ts
@@ -10,7 +10,7 @@ import { getRegistryItems, getShadcnRegistryIndex } from "@/src/registry/api"
 import { DEPRECATED_COMPONENTS } from "@/src/registry/constants"
 import { clearRegistryContext } from "@/src/registry/context"
 import { registryItemTypeSchema } from "@/src/registry/schema"
-import { isUniversalRegistryItem } from "@/src/registry/utils"
+import { isUniversalRegistryItem, isUrl } from "@/src/registry/utils"
 import { getTemplateForFramework } from "@/src/templates/index"
 import { addComponents } from "@/src/utils/add-components"
 import { createProject } from "@/src/utils/create-project"
@@ -27,6 +27,7 @@ import { ensureRegistriesInConfig } from "@/src/utils/registries"
 import { spinner } from "@/src/utils/spinner"
 import { updateAppIndex } from "@/src/utils/update-app-index"
 import { Command } from "commander"
+import fs from "fs-extra"
 import prompts from "prompts"
 import { z } from "zod"
 
@@ -68,6 +69,11 @@ export const add = new Command()
         cwd: path.resolve(opts.cwd),
       })
 
+      options.components = normalizeAddComponents(
+        options.components ?? [],
+        options.cwd
+      )
+
       await loadEnvFiles(options.cwd)
 
       const isDryRun = options.dryRun || options.diff || options.view
@@ -83,9 +89,9 @@ export const add = new Command()
       }
 
       let hasNewRegistries = false
-      if (components.length > 0) {
+      if (options.components.length > 0) {
         const { config: updatedConfig, newRegistries } =
-          await ensureRegistriesInConfig(components, initialConfig, {
+          await ensureRegistriesInConfig(options.components, initialConfig, {
             silent: options.silent,
             writeFile: false,
           })
@@ -95,8 +101,8 @@ export const add = new Command()
 
       let itemType: z.infer<typeof registryItemTypeSchema> | undefined
       let shouldInstallStyleIndex = true
-      if (components.length > 0) {
-        const [registryItem] = await getRegistryItems([components[0]], {
+      if (options.components.length > 0) {
+        const [registryItem] = await getRegistryItems([options.components[0]], {
           config: initialConfig,
         })
         itemType = registryItem?.type
@@ -106,7 +112,7 @@ export const add = new Command()
           itemType !== "registry:base"
 
         if (isUniversalRegistryItem(registryItem) && !isDryRun) {
-          await addComponents(components, initialConfig, options)
+          await addComponents(options.components, initialConfig, options)
           return
         }
         if (
@@ -314,6 +320,33 @@ export const add = new Command()
       clearRegistryContext()
     }
   })
+
+export function normalizeAddComponents(components: string[], cwd: string) {
+  return components.filter((component) => {
+    const trimmed = component.trim()
+    if (!trimmed) {
+      return false
+    }
+
+    if (trimmed === "*" || /[?*\[\]]/.test(trimmed)) {
+      return false
+    }
+
+    if (isUrl(trimmed)) {
+      return true
+    }
+
+    if (trimmed.startsWith("@") || path.isAbsolute(trimmed)) {
+      return true
+    }
+
+    if (trimmed.includes("/") || trimmed.includes("\\")) {
+      return true
+    }
+
+    return !fs.existsSync(path.resolve(cwd, trimmed))
+  })
+}
 
 async function promptForRegistryComponents(
   options: z.infer<typeof addOptionsSchema>

--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -145,7 +145,7 @@ async function resolveAliasPath(
     // to the directory root.
     if (
       !resolved.matchedAlias.includes("*") &&
-      /\/index\.[^/]+$/.test(resolved.path)
+      /(?:\/|\\)index\.[^/\\]+$/.test(resolved.path)
     ) {
       return path.dirname(resolved.path)
     }
@@ -153,8 +153,11 @@ async function resolveAliasPath(
     // Wildcard aliases with explicit extensions (e.g. `#components/*` →
     // `./src/components/*.tsx`) should strip the source extension so `ui`
     // resolves to `/src/components/ui` instead of `/src/components/ui.tsx`.
-    if (resolved.matchedAlias.includes("*") && /\.[^/]+$/.test(resolved.path)) {
-      return resolved.path.replace(/\.[^/]+$/, "")
+    if (
+      resolved.matchedAlias.includes("*") &&
+      /\.[^/\\]+$/.test(resolved.path)
+    ) {
+      return resolved.path.replace(/\.[^/\\]+$/, "")
     }
   }
 

--- a/packages/shadcn/test/utils/get-config.test.ts
+++ b/packages/shadcn/test/utils/get-config.test.ts
@@ -574,6 +574,36 @@ test("get workspace config resolves cross-package aliases without tsconfig paths
   })
 })
 
+test("get config resolves workspace aliases in dotted Windows ancestor paths", async () => {
+  if (process.platform !== "win32") {
+    return
+  }
+
+  const fixtureRoot = path.resolve(
+    __dirname,
+    "../fixtures/frameworks/vite-monorepo-imports"
+  )
+  const tempRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), "shadcn-workspace-config-dotted-")
+  )
+  const dottedRoot = path.resolve(tempRoot, "2.MY_APP", "1. MY_SHIFT")
+
+  try {
+    await fs.copy(fixtureRoot, dottedRoot)
+
+    const config = await getConfig(path.resolve(dottedRoot, "apps/web"))
+    if (!config) {
+      throw new Error("Failed to load dotted-path monorepo app config")
+    }
+
+    expect(config.resolvedPaths).toMatchObject({
+      ui: path.resolve(dottedRoot, "packages/ui/src/components"),
+    })
+  } finally {
+    await fs.remove(tempRoot)
+  }
+})
+
 test("get workspace config shows an actionable error when a workspace package is missing imports", async () => {
   const fixtureRoot = path.resolve(
     __dirname,


### PR DESCRIPTION
## Summary
- Added component-name normalization in `shadcn add` to ignore shell-expanded filesystem entries before registry resolution.
- Kept support for explicit component names, namespaced refs, URLs, and explicit local paths.
- Added unit tests for the new normalization behavior in `packages/shadcn/src/commands/add.test.ts`.
- Closes #10730

## Validation
- `pnpm prettier --check src/commands/add.ts src/commands/add.test.ts`
- `pnpm typecheck`
- `pnpm vitest run src/commands/add.test.ts`