### PR TITLE
fix(shadcn): handle Windows dotted ancestor alias paths

### DIFF
--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -145,7 +145,7 @@ async function resolveAliasPath(
     // to the directory root.
     if (
       !resolved.matchedAlias.includes("*") &&
-      /\/index\.[^/]+$/.test(resolved.path)
+      /(?:\/|\\)index\.[^/\\]+$/.test(resolved.path)
     ) {
       return path.dirname(resolved.path)
     }
@@ -153,8 +153,11 @@ async function resolveAliasPath(
     // Wildcard aliases with explicit extensions (e.g. `#components/*` →
     // `./src/components/*.tsx`) should strip the source extension so `ui`
     // resolves to `/src/components/ui` instead of `/src/components/ui.tsx`.
-    if (resolved.matchedAlias.includes("*") && /\.[^/]+$/.test(resolved.path)) {
-      return resolved.path.replace(/\.[^/]+$/, "")
+    if (
+      resolved.matchedAlias.includes("*") &&
+      /\.[^/\\]+$/.test(resolved.path)
+    ) {
+      return resolved.path.replace(/\.[^/\\]+$/, "")
     }
   }
 

--- a/packages/shadcn/test/utils/get-config.test.ts
+++ b/packages/shadcn/test/utils/get-config.test.ts
@@ -574,6 +574,36 @@ test("get workspace config resolves cross-package aliases without tsconfig paths
   })
 })
 
+test("get config resolves workspace aliases in dotted Windows ancestor paths", async () => {
+  if (process.platform !== "win32") {
+    return
+  }
+
+  const fixtureRoot = path.resolve(
+    __dirname,
+    "../fixtures/frameworks/vite-monorepo-imports"
+  )
+  const tempRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), "shadcn-workspace-config-dotted-")
+  )
+  const dottedRoot = path.resolve(tempRoot, "2.MY_APP", "1. MY_SHIFT")
+
+  try {
+    await fs.copy(fixtureRoot, dottedRoot)
+
+    const config = await getConfig(path.resolve(dottedRoot, "apps/web"))
+    if (!config) {
+      throw new Error("Failed to load dotted-path monorepo app config")
+    }
+
+    expect(config.resolvedPaths).toMatchObject({
+      ui: path.resolve(dottedRoot, "packages/ui/src/components"),
+    })
+  } finally {
+    await fs.remove(tempRoot)
+  }
+})
+
 test("get workspace config shows an actionable error when a workspace package is missing imports", async () => {
   const fixtureRoot = path.resolve(
     __dirname,


### PR DESCRIPTION
## Summary
- Make alias path resolution resilient to Windows dotted ancestor directories by updating `resolveAliasPath` to treat backslash path separators in `index` and extension stripping checks.
- Strip wildcard alias extensions using a Windows-safe regex.
- Add a focused regression test under `get-config` covering monorepo alias resolution in a dotted Windows-style directory name (`2.MY_APP/1. MY_SHIFT`).

## Validation
- Focused pass: `corepack pnpm exec vitest run test/utils/get-config.test.ts -t "get config resolves workspace aliases in dotted Windows ancestor paths"`
- Result: passed on this environment (1/1).
- Note: the full `test/utils/get-config.test.ts` suite has unrelated pre-existing failures in this branch unrelated to this patch.
