### PR TITLE
fix(v4): use border-based separator rendering

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/separator.tsx
+++ b/apps/v4/registry/new-york-v4/ui/separator.tsx
@@ -17,7 +17,7 @@ function Separator({
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        "shrink-0 border-none border-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=horizontal]:border-b data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px data-[orientation=vertical]:border-l",
         className
       )}
       {...props}

--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -145,7 +145,7 @@ async function resolveAliasPath(
     // to the directory root.
     if (
       !resolved.matchedAlias.includes("*") &&
-      /\/index\.[^/]+$/.test(resolved.path)
+      /(?:\/|\\)index\.[^/\\]+$/.test(resolved.path)
     ) {
       return path.dirname(resolved.path)
     }
@@ -153,8 +153,11 @@ async function resolveAliasPath(
     // Wildcard aliases with explicit extensions (e.g. `#components/*` →
     // `./src/components/*.tsx`) should strip the source extension so `ui`
     // resolves to `/src/components/ui` instead of `/src/components/ui.tsx`.
-    if (resolved.matchedAlias.includes("*") && /\.[^/]+$/.test(resolved.path)) {
-      return resolved.path.replace(/\.[^/]+$/, "")
+    if (
+      resolved.matchedAlias.includes("*") &&
+      /\.[^/\\]+$/.test(resolved.path)
+    ) {
+      return resolved.path.replace(/\.[^/\\]+$/, "")
     }
   }
 

--- a/packages/shadcn/test/utils/get-config.test.ts
+++ b/packages/shadcn/test/utils/get-config.test.ts
@@ -574,6 +574,36 @@ test("get workspace config resolves cross-package aliases without tsconfig paths
   })
 })
 
+test("get config resolves workspace aliases in dotted Windows ancestor paths", async () => {
+  if (process.platform !== "win32") {
+    return
+  }
+
+  const fixtureRoot = path.resolve(
+    __dirname,
+    "../fixtures/frameworks/vite-monorepo-imports"
+  )
+  const tempRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), "shadcn-workspace-config-dotted-")
+  )
+  const dottedRoot = path.resolve(tempRoot, "2.MY_APP", "1. MY_SHIFT")
+
+  try {
+    await fs.copy(fixtureRoot, dottedRoot)
+
+    const config = await getConfig(path.resolve(dottedRoot, "apps/web"))
+    if (!config) {
+      throw new Error("Failed to load dotted-path monorepo app config")
+    }
+
+    expect(config.resolvedPaths).toMatchObject({
+      ui: path.resolve(dottedRoot, "packages/ui/src/components"),
+    })
+  } finally {
+    await fs.remove(tempRoot)
+  }
+})
+
 test("get workspace config shows an actionable error when a workspace package is missing imports", async () => {
   const fixtureRoot = path.resolve(
     __dirname,


### PR DESCRIPTION
## What Changed
- Updated the new-york v4 Separator to render with border styles (order-b/order-l) instead of background color in horizontal and vertical orientations.
- This preserves full width/height while avoiding line thickness inconsistencies in constrained flex containers.

Closes #10760

### Validation
- pnpm --filter=v4 typecheck (blocked by unrelated pre-existing type issues in local workspace)