### PR TITLE
fix(v4): resolve hydration flash in search registry using Suspense

### DIFF
--- a/apps/v4/components/directory-list.tsx
+++ b/apps/v4/components/directory-list.tsx
@@ -174,7 +174,6 @@ export function DirectoryList() {
 function DirectoryListContent() {
   const pathname = usePathname()
   const {
-    isLoading,
     paginatedRegistries,
     page,
     query,
@@ -215,10 +214,6 @@ function DirectoryListContent() {
     },
     [page, setPage]
   )
-
-  if (isLoading) {
-    return <DirectoryListSkeleton />
-  }
 
   return (
     <>

--- a/apps/v4/hooks/use-search-registry.ts
+++ b/apps/v4/hooks/use-search-registry.ts
@@ -1,6 +1,5 @@
 import { debounce, parseAsInteger, useQueryState } from "nuqs"
 
-import { useMounted } from "@/hooks/use-mounted"
 import globalRegistries from "@/registry/directory.json"
 
 const PAGE_SIZE = 10
@@ -29,7 +28,6 @@ const searchDirectory = (query: string | null) => {
 }
 
 export function useSearchRegistry() {
-  const mounted = useMounted()
   const [query, setQuery] = useQueryState("q", {
     defaultValue: "",
     limitUrlUpdates: debounce(250),
@@ -41,14 +39,11 @@ export function useSearchRegistry() {
     history: "push",
   })
 
-  const currentQuery = mounted ? query : ""
-  const currentPageValue = mounted ? page : 1
-
-  const registries = searchDirectory(currentQuery)
+  const registries = searchDirectory(query)
   const totalPages = Math.ceil(registries.length / PAGE_SIZE)
 
   // Clamp page to valid range.
-  const currentPage = Math.max(1, Math.min(currentPageValue, totalPages))
+  const currentPage = Math.max(1, Math.min(page, totalPages))
 
   const paginatedRegistries = registries.slice(
     (currentPage - 1) * PAGE_SIZE,
@@ -56,8 +51,7 @@ export function useSearchRegistry() {
   )
 
   return {
-    isLoading: !mounted,
-    query: currentQuery,
+    query,
     setQuery: (value: string | null) => {
       setQuery(value)
       setPage(null)


### PR DESCRIPTION
### Description
Fixes a visual glitch where the directory search registry list would flash the skeleton loader on every client-side mount / hydration, even when the server-rendered HTML was fully available.

Fixes #10787

### Rationale
- Removed the manual `useMounted` check inside `useSearchRegistry` which acted as a hydration mismatch escape hatch but forced a client-only render layout initially.
- Delegated state management loading to `<React.Suspense>` surrounding `<DirectoryListContent />` in the parent `DirectoryList`.
- Since `nuqs` natively supports Suspense, this solves hydration mismatches cleanly, aligns the page with modern React best practices, and improves initial FCP/SEO indexability.

### Checklist
- [x] Verified code compiles clean (`tsc --noEmit`)
- [x] Verified ESLint passes clean
- [x] Verified Prettier formatting passes clean