### PR TITLE
fix: handle empty CSS file in addCustomVariant during init (fixes #10856)

### DIFF
--- a/packages/shadcn/src/utils/updaters/update-css-vars.ts
+++ b/packages/shadcn/src/utils/updaters/update-css-vars.ts
@@ -542,9 +542,12 @@ function addCustomVariant({ params }: { params: string }) {
           // Insert after the last import
           const lastImport = importNodes[importNodes.length - 1]
           root.insertAfter(lastImport, variantNode)
-        } else {
+        } else if (root.nodes.length > 0) {
           // If no imports, insert after the first node
           root.insertAfter(root.nodes[0], variantNode)
+        } else {
+          // If the file is empty, just append the variant
+          root.append(variantNode)
         }
 
         root.insertBefore(variantNode, postcss.comment({ text: "---break---" }))


### PR DESCRIPTION
## Description

Fixes #10856

When  is completely empty,  crashes with .

## Root Cause

In , when the CSS file is empty,  is . Calling  causes PostCSS to crash.

## Fix

Added a check for  before calling . When the file is empty, the variant node is appended directly to the root.

## Changes

- :
  - Added  guard before 
  - Added  branch that appends the variant when the file is empty

## Verification

The fix handles three cases:
1. CSS file with imports - inserts after last import (unchanged)
2. CSS file with other content but no imports - inserts after first node (unchanged)
3. **Empty CSS file - appends variant directly (new)**