### PR TITLE
fix: update zod version to fix pnpm init error

### DIFF
--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -113,8 +113,8 @@
     "ts-morph": "^26.0.0",
     "tsconfig-paths": "^4.2.0",
     "validate-npm-package-name": "^7.0.1",
-    "zod": "^3.24.1",
-    "zod-to-json-schema": "^3.24.6"
+    "zod": "^3.25.0",
+    "zod-to-json-schema": "^3.25.1"
   },
   "devDependencies": {
     "@antfu/ni": "^25.0.0",


### PR DESCRIPTION
fixes #10860

  ## Problem

  Running `pnpm dlx shadcn@latest init` fails with `ERR_PACKAGE_PATH_NOT_EXPORTED` error because
  `@modelcontextprotocol/sdk` tries to import `zod/v4` which is not available in `zod@3.24.x`.

  ## Root Cause

  `@modelcontextprotocol/sdk@1.29.0` requires `zod: ^3.25 || ^4.0`, but shadcn has `zod: ^3.24.1` in its dependencies.

  ## Fix

  Updated `zod` from `^3.24.1` to `^3.25.0` and `zod-to-json-schema` from `^3.24.6` to `^3.25.1` to be compatible with
  the SDK's requirements.