### PR TITLE
fix: upgrade zod to fix ERR_PACKAGE_PATH_NOT_EXPORTED error

### DIFF
--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -86,7 +86,7 @@
     "@babel/plugin-transform-typescript": "^7.28.0",
     "@babel/preset-typescript": "^7.27.1",
     "@dotenvx/dotenvx": "^1.48.4",
-    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@modelcontextprotocol/sdk": "~1.28.0",
     "@types/validate-npm-package-name": "^4.0.2",
     "browserslist": "^4.26.2",
     "commander": "^14.0.0",


### PR DESCRIPTION
fixes #10860

## Problem
Running `pnpm dlx shadcn@latest init` fails with `ERR_PACKAGE_PATH_NOT_EXPORTED` error because `@modelcontextprotocol/sdk` auto-upgrades to v1.29.0+, which tries to import `zod/v4` - a subpath not available in `zod@3.24.x`.

## Root Cause
- `@modelcontextprotocol/sdk` v1.29.0+ requires zod v4 features
- Previous dependency used caret range: `"@modelcontextprotocol/sdk": "^1.26.0"`
- Caret (^) allows minor version updates (1.26.x → 1.29.x), causing automatic breaking upgrades

## Fix
Changed `@modelcontextprotocol/sdk` from `^1.26.0` to `~1.28.0` to prevent auto-upgrade to `v1.29.0+` while still allowing patch updates (1.28.x).