### PR TITLE
fix(shadcn): update zod version to resolve MCP SDK exports mismatch

### DIFF
--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -112,8 +112,8 @@
     "ts-morph": "^26.0.0",
     "tsconfig-paths": "^4.2.0",
     "validate-npm-package-name": "^7.0.1",
-    "zod": "^3.24.1",
-    "zod-to-json-schema": "^3.24.6"
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.25.1"
   },
   "devDependencies": {
     "@antfu/ni": "^25.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,11 +471,11 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       zod:
-        specifier: ^3.24.1
+        specifier: ^3.25.76
         version: 3.25.76
       zod-to-json-schema:
-        specifier: ^3.24.6
-        version: 3.24.6(zod@3.25.76)
+        specifier: ^3.25.1
+        version: 3.25.1(zod@3.25.76)
     devDependencies:
       '@antfu/ni':
         specifier: ^25.0.0
@@ -8420,11 +8420,6 @@ packages:
   yoctocolors@2.1.1:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
-
-  zod-to-json-schema@3.24.6:
-    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
-    peerDependencies:
-      zod: ^3.24.1
 
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
@@ -17162,10 +17157,6 @@ snapshots:
   yoctocolors-cjs@2.1.2: {}
 
   yoctocolors@2.1.1: {}
-
-  zod-to-json-schema@3.24.6(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
 
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
Fixes #10860

### Description
This PR resolves the runtime dependency conflict in the `shadcn` CLI package that caused:
`Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './v4' is not defined by "exports" in zod/package.json`

### Cause
- `@modelcontextprotocol/sdk` imports internally from `zod/v4` (a subpath introduced in Zod v3.25.0 to handle Zod v4 compatibility).
- `packages/shadcn` had its dependency set to `"zod": "^3.24.1"`.
- When running `pnpm dlx shadcn`, `pnpm` resolves the peer dependency of `@modelcontextprotocol/sdk` to `zod@3.24.x`. Because `3.24.x` does not have the `./v4` export defined in `package.json`, any invocation of `shadcn` crashed at runtime.

### Fix
- Updated `"zod"` in `packages/shadcn/package.json` to `"^3.25.76"`.
- Updated `"zod-to-json-schema"` to `"^3.25.1"` to align with the rest of the workspace and avoid dependency conflicts.
- Updated `pnpm-lock.yaml` accordingly.