### PR TITLE
feat(cli): add --from-imports flag to shadcn add (#10069)

### DIFF
--- a/packages/shadcn/src/commands/add.ts
+++ b/packages/shadcn/src/commands/add.ts
@@ -18,8 +18,12 @@ import { dryRunComponents } from "@/src/utils/dry-run"
 import { formatDryRunResult } from "@/src/utils/dry-run-formatter"
 import { loadEnvFiles } from "@/src/utils/env-loader"
 import * as ERRORS from "@/src/utils/errors"
+import { scanImportsForComponents } from "@/src/utils/get-components-from-imports"
 import { createConfig, getConfig } from "@/src/utils/get-config"
-import { getProjectInfo } from "@/src/utils/get-project-info"
+import {
+  getProjectComponents,
+  getProjectInfo,
+} from "@/src/utils/get-project-info"
 import { handleError } from "@/src/utils/handle-error"
 import { highlighter } from "@/src/utils/highlighter"
 import { logger } from "@/src/utils/logger"
@@ -41,6 +45,7 @@ export const addOptionsSchema = z.object({
   dryRun: z.boolean(),
   diff: z.union([z.string(), z.literal(true)]).optional(),
   view: z.union([z.string(), z.literal(true)]).optional(),
+  fromImports: z.boolean(),
 })
 
 export const add = new Command()
@@ -60,6 +65,11 @@ export const add = new Command()
   .option("--dry-run", "preview changes without writing files.", false)
   .option("--diff [path]", "show diff for a file.")
   .option("--view [path]", "show file contents.")
+  .option(
+    "--from-imports",
+    "scan project files for component imports and add missing components.",
+    false
+  )
   .action(async (components, opts) => {
     try {
       const options = addOptionsSchema.parse({
@@ -80,6 +90,55 @@ export const add = new Command()
             cwd: options.cwd,
           },
         })
+      }
+
+      if (options.fromImports) {
+        if (options.components?.length || options.all) {
+          throw new Error(
+            "The --from-imports flag cannot be combined with component arguments or --all."
+          )
+        }
+
+        const aliasUi = initialConfig.aliases?.ui
+        if (!aliasUi) {
+          throw new Error(
+            `No shadcn/ui configuration found. Run ${highlighter.info("shadcn init")} to set up your project first.`
+          )
+        }
+
+        const found = await scanImportsForComponents(options.cwd, aliasUi)
+        if (found.length === 0) {
+          logger.log("No shadcn/ui component imports found in your project.")
+          return
+        }
+
+        const installed = await getProjectComponents(options.cwd)
+        const missing = found.filter((c) => !installed.includes(c))
+
+        if (missing.length === 0) {
+          logger.log("All imported shadcn/ui components are already installed.")
+          return
+        }
+
+        logger.log(
+          `${highlighter.info(String(missing.length))} missing shadcn/ui component(s) found: ${highlighter.info(missing.join(", "))}`
+        )
+
+        if (!options.yes) {
+          const { confirm } = await prompts({
+            type: "confirm",
+            name: "confirm",
+            message: `Install ${missing.length} component(s)?`,
+            initial: true,
+          })
+          if (!confirm) {
+            logger.break()
+            logger.log("Installation cancelled.")
+            return
+          }
+        }
+
+        options.components = missing
       }
 
       let hasNewRegistries = false

--- a/packages/shadcn/src/utils/get-components-from-imports.ts
+++ b/packages/shadcn/src/utils/get-components-from-imports.ts
@@ -1,0 +1,49 @@
+import path from "path"
+import fg from "fast-glob"
+import fs from "fs-extra"
+
+export async function scanImportsForComponents(
+  cwd: string,
+  aliasUi: string
+): Promise<string[]> {
+  const escapedAlias = aliasUi.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const importRegex = new RegExp(
+    `(?:from\\s+|import\\s*\\(\\s*)['"\`]${escapedAlias}/([\\w.-]+)['"\`]`,
+    "g"
+  )
+
+  const sourceFiles = await fg.glob("**/*.{ts,tsx,js,jsx}", {
+    cwd,
+    deep: 10,
+    ignore: [
+      "**/node_modules/**",
+      ".next/**",
+      "dist/**",
+      "build/**",
+      "**/__tests__/**",
+      "**/test/**",
+      "**/tests/**",
+      "**/*.test.*",
+      "**/*.spec.*",
+      "**/*.d.ts",
+    ],
+  })
+
+  const components = new Set<string>()
+
+  await Promise.all(
+    sourceFiles.map(async (filePath) => {
+      try {
+        const content = await fs.readFile(path.resolve(cwd, filePath), "utf8")
+        let match: RegExpExecArray | null
+        while ((match = importRegex.exec(content)) !== null) {
+          components.add(match[1])
+        }
+      } catch {
+        // Skip files that can't be read
+      }
+    })
+  )
+
+  return Array.from(components)
+}

--- a/packages/shadcn/test/utils/get-components-from-imports.test.ts
+++ b/packages/shadcn/test/utils/get-components-from-imports.test.ts
@@ -1,0 +1,392 @@
+import os from "os"
+import path from "path"
+import fs from "fs-extra"
+import { afterEach, describe, expect, test } from "vitest"
+
+import { scanImportsForComponents } from "../../src/utils/get-components-from-imports"
+
+const testDir = path.resolve(
+  __dirname,
+  "../fixtures/scan-imports-test"
+)
+
+async function writeSourceFile(relativePath: string, content: string) {
+  const fullPath = path.join(testDir, relativePath)
+  await fs.ensureDir(path.dirname(fullPath))
+  await fs.writeFile(fullPath, content)
+}
+
+describe("scanImportsForComponents", () => {
+  afterEach(async () => {
+    await fs.emptyDir(testDir)
+  })
+
+  test("finds default import", async () => {
+    await writeSourceFile(
+      "page.tsx",
+      `import { Button } from "@/components/ui/button"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual(["button"])
+  })
+
+  test("finds default export import", async () => {
+    await writeSourceFile(
+      "page.tsx",
+      `import Button from "@/components/ui/button"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual(["button"])
+  })
+
+  test("finds re-export", async () => {
+    await writeSourceFile(
+      "barrel.ts",
+      `export { Button } from "@/components/ui/button"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual(["button"])
+  })
+
+  test("finds dynamic import", async () => {
+    await writeSourceFile(
+      "lazy.tsx",
+      `const Button = await import("@/components/ui/button")\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual(["button"])
+  })
+
+  test("finds re-export with rename", async () => {
+    await writeSourceFile(
+      "barrel.ts",
+      `export { Button as MyButton } from "@/components/ui/button"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual(["button"])
+  })
+
+  test("deduplicates multiple occurrences", async () => {
+    await writeSourceFile(
+      "app.tsx",
+      [
+        `import { Button } from "@/components/ui/button"`,
+        `import { ButtonVariant } from "@/components/ui/button"`,
+      ].join("\n")
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual(["button"])
+  })
+
+  test("finds multiple distinct components in one file", async () => {
+    await writeSourceFile(
+      "app.tsx",
+      [
+        `import { Button } from "@/components/ui/button"`,
+        `import { Card } from "@/components/ui/card"`,
+      ].join("\n")
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result.sort()).toEqual(["button", "card"])
+  })
+
+  test("finds multiple components across multiple files", async () => {
+    await writeSourceFile(
+      "a.tsx",
+      `import { Button } from "@/components/ui/button"\n`
+    )
+    await writeSourceFile(
+      "b.tsx",
+      `import { Card } from "@/components/ui/card"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result.sort()).toEqual(["button", "card"])
+  })
+
+  test("handles custom alias prefix (package imports)", async () => {
+    await writeSourceFile(
+      "page.tsx",
+      `import { Dialog } from "#components/ui/dialog"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "#components/ui")
+
+    expect(result).toEqual(["dialog"])
+  })
+
+  test("handles custom alias prefix with @scope", async () => {
+    await writeSourceFile(
+      "page.tsx",
+      `import { Alert } from "@scope/ui/alert"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@scope/ui")
+
+    expect(result).toEqual(["alert"])
+  })
+
+  test("handles hyphenated component names", async () => {
+    await writeSourceFile(
+      "page.tsx",
+      `import { DataTable } from "@/components/ui/data-table"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual(["data-table"])
+  })
+
+  test("handles dotted component names", async () => {
+    await writeSourceFile(
+      "page.tsx",
+      `import { Icon } from "@/components/ui/icon.box"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual(["icon.box"])
+  })
+
+  test("returns empty array when no imports match the alias", async () => {
+    await writeSourceFile(
+      "page.tsx",
+      `import { useState } from "react"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual([])
+  })
+
+  test("returns empty array when no source files exist", async () => {
+    const result = await scanImportsForComponents(
+      path.resolve(__dirname, "../fixtures/scan-imports-empty"),
+    "@/components/ui"
+    )
+
+    expect(result).toEqual([])
+  })
+
+  test("ignores node_modules directory", async () => {
+    await writeSourceFile(
+      "node_modules/some-lib/index.ts",
+      `import { Button } from "@/components/ui/button"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual([])
+  })
+
+  test("ignores .next directory", async () => {
+    await writeSourceFile(
+      ".next/server/pages/page.tsx",
+      `import { Button } from "@/components/ui/button"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual([])
+  })
+
+  test("ignores dist directory", async () => {
+    await writeSourceFile(
+      "dist/output.js",
+      `import { Button } from "@/components/ui/button"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual([])
+  })
+
+  test("ignores build directory", async () => {
+    await writeSourceFile(
+      "build/bundle.js",
+      `import { Button } from "@/components/ui/button"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual([])
+  })
+
+  test("ignores test files", async () => {
+    await writeSourceFile(
+      "button.test.tsx",
+      `import { Button } from "@/components/ui/button"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual([])
+  })
+
+  test("ignores spec files", async () => {
+    await writeSourceFile(
+      "button.spec.ts",
+      `import { Button } from "@/components/ui/button"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual([])
+  })
+
+  test("ignores .d.ts declaration files", async () => {
+    await writeSourceFile(
+      "types.d.ts",
+      `import { Button } from "@/components/ui/button"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual([])
+  })
+
+  test("scans .js and .jsx files in addition to .ts and .tsx", async () => {
+    await writeSourceFile(
+      "legacy.js",
+      `import { Button } from "@/components/ui/button"\n`
+    )
+    await writeSourceFile(
+      "component.jsx",
+      `import { Card } from "@/components/ui/card"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result.sort()).toEqual(["button", "card"])
+  })
+
+  test("does not scan non-source file extensions", async () => {
+    await writeSourceFile(
+      "styles.css",
+      `import { Button } from "@/components/ui/button"\n`
+    )
+    await writeSourceFile(
+      "readme.md",
+      `import { Button } from "@/components/ui/button"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual([])
+  })
+
+  test("handles template literal imports", async () => {
+    await writeSourceFile(
+      "page.tsx",
+      "const name = 'button'; const mod = await import(`@/components/ui/button`)\n"
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual(["button"])
+  })
+
+  test("no false positive on similar but non-matching paths", async () => {
+    await writeSourceFile(
+      "page.tsx",
+      [
+        `import { Button } from "@/components/ui-button/button"`,
+        `import { helper } from "@/components/ui/helper"`,
+      ].join("\n")
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual(["helper"])
+  })
+
+  test("alias with trailing content does not match shorter alias", async () => {
+    await writeSourceFile(
+      "page.tsx",
+      [
+        `import { A } from "@org/shared/ui/button"`,
+        `import { B } from "@org/shared-ui/button"`,
+      ].join("\n")
+    )
+
+    const result = await scanImportsForComponents(testDir, "@org/shared/ui")
+
+    expect(result).toEqual(["button"])
+  })
+
+  test("handles deeply nested source files", async () => {
+    await writeSourceFile(
+      "src/features/dashboard/components/widget.tsx",
+      `import { Widget } from "@/components/ui/widget"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual(["widget"])
+  })
+
+  test("handles comments before import statement", async () => {
+    await writeSourceFile(
+      "page.tsx",
+      [
+        `// This is a comment`,
+        `import { Button } from "@/components/ui/button"`,
+      ].join("\n")
+    )
+
+    const result = await scanImportsForComponents(testDir, "@/components/ui")
+
+    expect(result).toEqual(["button"])
+  })
+})
+
+describe("scanImportsForComponents error handling", () => {
+  afterEach(async () => {
+    await fs.emptyDir(testDir)
+  })
+
+  test("handles non-existent directory", async () => {
+    const result = await scanImportsForComponents(
+      "/nonexistent/path",
+      "@/components/ui"
+    )
+    expect(result).toEqual([])
+  })
+
+  test("handles alias that doesn't match anything", async () => {
+    await writeSourceFile(
+      "page.tsx",
+      `import { Button } from "@/components/ui/button"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "#/ui")
+
+    expect(result).toEqual([])
+  })
+
+  test("alias with regex special characters is escaped", async () => {
+    await writeSourceFile(
+      "page.tsx",
+      `import { Button } from "$ui/button"\n`
+    )
+
+    const result = await scanImportsForComponents(testDir, "$ui")
+
+    expect(result).toEqual(["button"])
+  })
+})


### PR DESCRIPTION
## Description

Adds a `--from-imports` flag to `shadcn add` that scans project source files for shadcn/ui component imports and automatically installs any missing ones.

Closes #10069

## Usage

```bash
# Scan project, find missing components, prompt for confirmation
shadcn add --from-imports

# Skip confirmation
shadcn add --from-imports --yes

# Silent mode
shadcn add --from-imports -s
```

## How it works

1. Reads the UI alias from `components.json` (e.g. `@/components/ui`)
2. Globs `**/*.{ts,tsx,js,jsx}` (excluding `node_modules`, `.next`, `dist`, `build`, test files, `.d.ts`)
3. Regex-matches `from`, `export ... from`, and dynamic `import()` statements
4. Cross-references against `getProjectComponents()` to filter already-installed
5. Passes the missing list into the standard `addComponents` pipeline

## Design decisions

- Mutually exclusive with positional args and `--all` — prevents ambiguous behavior
- Requires existing `components.json` — if unconfigured, prompts user to run `shadcn init` first
- Supports any alias prefix (`@/`, `#`, `@scope/`, etc.)
- Works with dynamic imports and re-exports
- Uses `fast-glob` (already a dependency) for file discovery
- Reads files in parallel via `Promise.all`

## Testing

```
✓ test/utils/get-components-from-imports.test.ts (31 tests)

Test cases cover:
- Default import, named import, re-export, dynamic import
- Custom aliases (`#components/ui`, `@scope/ui`)
- Hyphenated and dotted component names
- `node_modules`, `.next`, `dist`, `build` exclusion
- `.d.ts`, `.test.*`, `.spec.*` exclusion
- Regex special character escaping in aliases
- Empty directories and non-existent paths
```

## Files changed

| File | Change |
|---|---|
| `src/utils/get-components-from-imports.ts` | **NEW** — scanner utility (49 lines) |
| `src/commands/add.ts` | +57/-1 — flag, Zod schema, integration |
| `test/utils/get-components-from-imports.test.ts` | **NEW** — 31 tests (392 lines) |

## Verification

- ✅ All 1524 existing tests pass (80 test files)
- ✅ `tsc --noEmit` clean
- ✅ `tsup` build (ESM + DTS) clean
- ✅ Prettier formatting clean