### PR TITLE
docs: update Embla Carousel documentation links

### DIFF
--- a/apps/v4/content/docs/components/base/carousel.mdx
+++ b/apps/v4/content/docs/components/base/carousel.mdx
@@ -4,8 +4,8 @@ description: A carousel with motion and swipe built using Embla.
 base: base
 component: true
 links:
-  doc: https://www.embla-carousel.com/get-started/react
-  api: https://www.embla-carousel.com/api
+  doc: https://www.embla-carousel.com/docs/get-started/react
+  api: https://www.embla-carousel.com/docs/api
 ---
 
 <ComponentPreview
@@ -176,7 +176,7 @@ Use the `orientation` prop to set the orientation of the carousel.
 
 ## Options
 
-You can pass options to the carousel using the `opts` prop. See the [Embla Carousel docs](https://www.embla-carousel.com/api/options/) for more information.
+You can pass options to the carousel using the `opts` prop. See the [Embla Carousel docs](https://www.embla-carousel.com/docs/api/options) for more information.
 
 ```tsx showLineNumbers {2-5}
 <Carousel
@@ -268,7 +268,7 @@ export function Example() {
 }
 ```
 
-See the [Embla Carousel docs](https://www.embla-carousel.com/api/events/) for more information on using events.
+See the [Embla Carousel docs](https://www.embla-carousel.com/docs/api/events) for more information on using events.
 
 ## Plugins
 
@@ -332,4 +332,4 @@ The `direction` option accepts `"ltr"` or `"rtl"` and should match the `dir` pro
 
 ## API Reference
 
-See the [Embla Carousel docs](https://www.embla-carousel.com/api/) for more information on props and plugins.
+See the [Embla Carousel docs](https://www.embla-carousel.com/docs/api) for more information on props and plugins.

--- a/apps/v4/content/docs/components/radix/carousel.mdx
+++ b/apps/v4/content/docs/components/radix/carousel.mdx
@@ -4,8 +4,8 @@ description: A carousel with motion and swipe built using Embla.
 base: radix
 component: true
 links:
-  doc: https://www.embla-carousel.com/get-started/react
-  api: https://www.embla-carousel.com/api
+  doc: https://www.embla-carousel.com/docs/get-started/react
+  api: https://www.embla-carousel.com/docs/api
 ---
 
 <ComponentPreview
@@ -176,7 +176,7 @@ Use the `orientation` prop to set the orientation of the carousel.
 
 ## Options
 
-You can pass options to the carousel using the `opts` prop. See the [Embla Carousel docs](https://www.embla-carousel.com/api/options/) for more information.
+You can pass options to the carousel using the `opts` prop. See the [Embla Carousel docs](https://www.embla-carousel.com/docs/api/options) for more information.
 
 ```tsx showLineNumbers {2-5}
 <Carousel
@@ -268,7 +268,7 @@ export function Example() {
 }
 ```
 
-See the [Embla Carousel docs](https://www.embla-carousel.com/api/events/) for more information on using events.
+See the [Embla Carousel docs](https://www.embla-carousel.com/docs/api/events) for more information on using events.
 
 ## Plugins
 
@@ -332,4 +332,4 @@ The `direction` option accepts `"ltr"` or `"rtl"` and should match the `dir` pro
 
 ## API Reference
 
-See the [Embla Carousel docs](https://www.embla-carousel.com/api/) for more information on props and plugins.
+See the [Embla Carousel docs](https://www.embla-carousel.com/docs/api) for more information on props and plugins.


### PR DESCRIPTION
Updated broken Embla Carousel documentation links in the Carousel component pages for both Radix and Base.