### PR TITLE
fix(shadcn): overwrite existing destination directory on init --template

### DIFF
--- a/packages/shadcn/src/templates/create-template.ts
+++ b/packages/shadcn/src/templates/create-template.ts
@@ -265,7 +265,7 @@ function defaultScaffold({
           "templates",
           templateDir
         )
-        await fs.move(extractedPath, projectPath)
+        await fs.move(extractedPath, projectPath, { overwrite: true })
         await fs.remove(templatePath)
       }
 

--- a/packages/shadcn/src/utils/scaffold.test.ts
+++ b/packages/shadcn/src/utils/scaffold.test.ts
@@ -109,7 +109,8 @@ describe("defaultScaffold", () => {
 
     expect(vi.mocked(fs.move)).toHaveBeenCalledWith(
       expect.stringContaining(path.join("templates", "next-app")),
-      "/test/my-app"
+      "/test/my-app",
+      { overwrite: true }
     )
   })
 


### PR DESCRIPTION
Resolves https://github.com/shadcn-ui/ui/issues/10885

### Description
When running `shadcn init --template` and the target project directory already exists on disk (e.g., from a previous failed attempt), it throws the error `dest already exists`.

### Cause
In `create-template.ts`, `fs.move()` is called without `{ overwrite: true }`. In `fs-extra` v11+, `move()` defaults to `overwrite: false`.

### Solution
Added `{ overwrite: true }` to the `fs.move()` call, and updated the corresponding test in `scaffold.test.ts`.