### PR TITLE
fix: handle single numeric value prop in Slider component (#10890)

### DIFF
--- a/apps/v4/registry/bases/base/ui/slider.tsx
+++ b/apps/v4/registry/bases/base/ui/slider.tsx
@@ -10,11 +10,12 @@ function Slider({
   max = 100,
   ...props
 }: SliderPrimitive.Root.Props) {
-  const _values = Array.isArray(value)
-    ? value
-    : Array.isArray(defaultValue)
-      ? defaultValue
-      : [min, max]
+  const _values = (
+    Array.isArray(value) ? value :
+    typeof value === "number" ? [value] :
+    Array.isArray(defaultValue) ? defaultValue :
+    [min, max]
+  )
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/registry/bases/radix/ui/slider.tsx
+++ b/apps/v4/registry/bases/radix/ui/slider.tsx
@@ -15,11 +15,10 @@ function Slider({
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
   const _values = React.useMemo(
     () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
+      Array.isArray(value) ? value :
+      typeof value === "number" ? [value] :
+      Array.isArray(defaultValue) ? defaultValue :
+      [min, max],
     [value, defaultValue, min, max]
   )
 

--- a/apps/v4/registry/new-york-v4/ui/slider.tsx
+++ b/apps/v4/registry/new-york-v4/ui/slider.tsx
@@ -15,11 +15,10 @@ function Slider({
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
   const _values = React.useMemo(
     () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
+      Array.isArray(value) ? value :
+      typeof value === "number" ? [value] :
+      Array.isArray(defaultValue) ? defaultValue :
+      [min, max],
     [value, defaultValue, min, max]
   )
 


### PR DESCRIPTION
## Fixes shadcn-ui/ui#10890

**Bug:** Slider component breaks when given a single numeric `value` prop (e.g. `value={50}`). It falls back to `[min, max]` = `[0, 100]` and renders two thumbs instead of one.

**Root Cause:** The `_values` logic only checked `Array.isArray(value)`, which returns `false` for a plain number. Non-array values fell through to the `[min, max]` default.

**Fix:** Added `typeof value === "number"` check before the array checks. If `value` is a number, wrap it in `[value]`.

```javascript
// Before (broken for single numbers)
const _values = Array.isArray(value) ? value :
                Array.isArray(defaultValue) ? defaultValue :
                [min, max];

// After (handles all cases)
const _values = Array.isArray(value) ? value :
                typeof value === "number" ? [value] :
                Array.isArray(defaultValue) ? defaultValue :
                [min, max];
```

**Files changed:** 3 sliders all had the same issue:
- `apps/v4/registry/bases/base/ui/slider.tsx`
- `apps/v4/registry/bases/radix/ui/slider.tsx`
- `apps/v4/registry/new-york-v4/ui/slider.tsx`

**Test:** `value={50}` now correctly renders a single-thumb slider at position 50.