### PR TITLE
fix(mcp): await async npxShadcn call in formatSearchResultsWithPagination

### DIFF
--- a/packages/shadcn/src/mcp/index.ts
+++ b/packages/shadcn/src/mcp/index.ts
@@ -291,10 +291,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: "text",
               text:
-                formatSearchResultsWithPagination(results, {
+                (await formatSearchResultsWithPagination(results, {
                   query: args.query,
                   registries,
-                }) + skippedNote,
+                })) + skippedNote,
             },
           ],
         }
@@ -367,9 +367,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: "text",
               text:
-                formatSearchResultsWithPagination(results, {
+                (await formatSearchResultsWithPagination(results, {
                   registries,
-                }) + skippedNote,
+                })) + skippedNote,
             },
           ],
         }

--- a/packages/shadcn/src/mcp/utils.ts
+++ b/packages/shadcn/src/mcp/utils.ts
@@ -21,7 +21,7 @@ export async function getMcpConfig(cwd = process.cwd()) {
   }
 }
 
-export function formatSearchResultsWithPagination(
+export async function formatSearchResultsWithPagination(
   results: z.infer<typeof searchResultsSchema>,
   options?: {
     query?: string
@@ -29,6 +29,7 @@ export function formatSearchResultsWithPagination(
   }
 ) {
   const { query, registries } = options || {}
+  const packageRunner = await getPackageRunner(process.cwd())
 
   const formattedItems = results.items.map((item) => {
     const parts: string[] = [`- ${item.name}`]
@@ -46,7 +47,7 @@ export function formatSearchResultsWithPagination(
     }
 
     parts.push(
-      `\n  Add command: \`${npxShadcn(`add ${item.addCommandArgument}`)}\``
+      `\n  Add command: \`${packageRunner} ${SHADCN_CLI_COMMAND} add ${item.addCommandArgument}\``
     )
 
     return parts.join(" ")


### PR DESCRIPTION
## Description

Fix a bug in `formatSearchResultsWithPagination` where the async `npxShadcn()` function was called without `await`, producing `[object Promise]` in the output text instead of the actual CLI command string. This affected MCP search results and registry item listings shown to users.

## Changes

- **Make `formatSearchResultsWithPagination` async** — The function now properly awaits the package runner resolution
- **Optimize `getPackageRunner` call** — Instead of calling `npxShadcn()` for each search result item (which reads `package.json` every time), resolve the package runner once at the function start and reuse it
- **Update call sites** — Add `await` at the two call locations in `mcp/index.ts`

## Verification

- ✅ `pnpm --filter=shadcn typecheck` passes
- ✅ `pnpm --filter=shadcn build` succeeds  
- ✅ All related tests pass