### PR TITLE
fix: rename 'table' to 'month_grid' in Calendar component styles

### DIFF
--- a/apps/v4/registry/bases/base/ui/calendar.tsx
+++ b/apps/v4/registry/bases/base/ui/calendar.tsx
@@ -87,7 +87,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/registry/bases/radix/ui/calendar.tsx
+++ b/apps/v4/registry/bases/radix/ui/calendar.tsx
@@ -87,7 +87,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/registry/new-york-v4/ui/calendar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/calendar.tsx
@@ -88,7 +88,7 @@ function Calendar({
             : "flex h-8 items-center gap-1 rounded-md pr-1 pl-2 text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-md text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/base-luma/ui/calendar.tsx
+++ b/apps/v4/styles/base-luma/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/base-lyra/ui/calendar.tsx
+++ b/apps/v4/styles/base-lyra/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/base-maia/ui/calendar.tsx
+++ b/apps/v4/styles/base-maia/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/base-mira/ui/calendar.tsx
+++ b/apps/v4/styles/base-mira/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/base-nova/ui-rtl/calendar.tsx
+++ b/apps/v4/styles/base-nova/ui-rtl/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/base-nova/ui/calendar.tsx
+++ b/apps/v4/styles/base-nova/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/base-rhea/ui/calendar.tsx
+++ b/apps/v4/styles/base-rhea/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/base-sera/ui/calendar.tsx
+++ b/apps/v4/styles/base-sera/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/base-vega/ui/calendar.tsx
+++ b/apps/v4/styles/base-vega/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/radix-luma/ui/calendar.tsx
+++ b/apps/v4/styles/radix-luma/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/radix-lyra/ui/calendar.tsx
+++ b/apps/v4/styles/radix-lyra/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/radix-maia/ui/calendar.tsx
+++ b/apps/v4/styles/radix-maia/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/radix-mira/ui/calendar.tsx
+++ b/apps/v4/styles/radix-mira/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/radix-nova/ui-rtl/calendar.tsx
+++ b/apps/v4/styles/radix-nova/ui-rtl/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/radix-nova/ui/calendar.tsx
+++ b/apps/v4/styles/radix-nova/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/radix-rhea/ui/calendar.tsx
+++ b/apps/v4/styles/radix-rhea/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/radix-sera/ui/calendar.tsx
+++ b/apps/v4/styles/radix-sera/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",

--- a/apps/v4/styles/radix-vega/ui/calendar.tsx
+++ b/apps/v4/styles/radix-vega/ui/calendar.tsx
@@ -91,7 +91,7 @@ function Calendar({
             : "cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",


### PR DESCRIPTION
This pull request updates the `Calendar` component across multiple themes and style variants to rename the `table` class key to `month_grid` for consistency and clarity. This change ensures that the styling and class naming are uniform throughout all calendar implementations in the codebase.

**Class name standardization:**

* Renamed the `table` class key to `month_grid` in the `Calendar` component for all theme and style files, including base, radix, and new-york variants [[1]](diffhunk://#diff-eb5d9ffdfaf3897e814a8e3f37e574e384623f777855b05e4f3d4355177c6768L90-R90) [[2]](diffhunk://#diff-9c9e9235476c8393f5da12637e1f458ff97810a3295e054dc93b62198d60c443L90-R90) [[3]](diffhunk://#diff-3a41fb77174f5ff5da3b87479b54de7cac687823221446c2cce21aa65f38fdcaL91-R91) [[4]](diffhunk://#diff-f8b133e520a41ce12996bd674ae8f4fd470379ae9ff2c1f3c644f177be72b442L94-R94) [[5]](diffhunk://#diff-80cd82c680211e66ffcfe2a4bf33d2747d747d0ff609f79afa2c69e1f83943d9L94-R94) [[6]](diffhunk://#diff-035e13975f0836c73ea3072758e90c3a9bb8e20b7db79d63f0d774dc89b7072eL94-R94) [[7]](diffhunk://#diff-9725abf5b0e7750faebbb18b244dde1310eb424446065a252e5a6a7d228e4234L94-R94) [[8]](diffhunk://#diff-c428b6015ffcb47dcb1075ad6983ceb9ce510d6e7cbc8d5a40f45c543dbddf81L94-R94) [[9]](diffhunk://#diff-c297cf2c179f1dcf35d7073dc67f438782762e0baf896966b2ba62e3c390f95dL94-R94) [[10]](diffhunk://#diff-7098675b1e8174b523852de7d148cbe21fbf4f58d36181830172665860fb209fL94-R94) [[11]](diffhunk://#diff-e41d65cf0ac6b2b6676a07038233a85435aa3e576963e550244800f634f49ac9L94-R94) [[12]](diffhunk://#diff-090b6fa0547d89bb935a28d3ff02cb6cf84450190f01e5a5d561feadee334546L94-R94) [[13]](diffhunk://#diff-6172f0b767f8fc34563e098eeafd615819087781741f2bd8f46e36d462c8e892L94-R94) [[14]](diffhunk://#diff-c307a91f16d93648ca11ccfaff38614f2e82129c98b103b762b708662999f4e5L94-R94) [[15]](diffhunk://#diff-e122e3f7a11ed6072e168a15126cc3fe2a2aad4634ee3a30c1d5c86f0af9acb6L94-R94) [[16]](diffhunk://#diff-1440dd64f7808e6fa0361f69e29d73bfcbfefb9d654ca345f84471b8f21de8ffL94-R94) [[17]](diffhunk://#diff-e09d740af0164a74a6e1211689a98fdc7304072c875d74d0ed0693f1cd9b14baL94-R94) [[18]](diffhunk://#diff-ab953adefb8aa7776f935a47288d6242a7fd084e349283c3d0789d1296752ef9L94-R94) [[19]](diffhunk://#diff-eaf621cdb1d48fbc1ef87589dfc409b3cded60478772f6c52c9728c06890c23bL94-R94) [[20]](diffhunk://#diff-3e3a402d78131e12d7bbaf77f2f42456d580b09b848efa608a6a2f7ade74ddbfL94-R94).


close: #10914