### PR TITLE
  feat(registry): add @contentbit to the registry index

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -245,6 +245,13 @@
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='120 120 272 272' fill='currentColor'><path d='M120 160Q120 120 160 120H260Q300 120 300 160V220H352Q392 220 392 260V352Q392 392 352 392H260Q220 392 220 352V292H160Q120 292 120 252Z'/></svg>"
   },
   {
+    "name": "@contentbit",
+    "homepage": "https://contentbit.dev",
+    "url": "https://contentbit.dev/r/{name}.json",
+    "description": "React components that render Content Blocks: plain Markdown with schema-validated directive blocks. Built for content written by humans, CMSes, and LLMs.",
+    "logo": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"400\" height=\"400\" viewBox=\"0 0 512 512\"><rect width=\"512\" height=\"512\" fill=\"var(--foreground)\"/><g fill=\"var(--background)\"><rect x=\"128\" y=\"160\" width=\"64\" height=\"64\"/><rect x=\"128\" y=\"288\" width=\"64\" height=\"64\"/><rect x=\"224\" y=\"160\" width=\"64\" height=\"64\"/><rect x=\"224\" y=\"288\" width=\"64\" height=\"64\"/><rect x=\"320\" y=\"160\" width=\"64\" height=\"64\"/><rect x=\"320\" y=\"288\" width=\"64\" height=\"64\"/></g></svg>"
+  },
+  {
     "name": "@corr",
     "homepage": "https://ui.corr.sh",
     "url": "https://ui.corr.sh/r/{name}.json",


### PR DESCRIPTION
 Adds [@contentbit](https://github.com/agonist/contentbit) to the open source registry index.

  Homepage: https://contentbit.dev
  Registry URL: https://contentbit.dev/r/{name}.json

  contentbit: React components that render Content Blocks, plain Markdown with
  schema-validated directive blocks. Built for content written by humans, CMSes,
  and LLMs.
  
  The registry ships the styled pack for the generic blocks (callout, steps,
  key-metrics, quick-ref, comparison, pros-cons, tabs, faq) plus a renderer
  component, 10 items total. Items install as editable source; the underlying
  @contentbit packages are MIT-licensed and published on npm.

  Note: validated with pnpm validate:registries. The install flow is also
  exercised end to end by our CLI (npx contentbit@latest init), which configures
  the namespace and runs shadcn add against this registry.