### PR TITLE
fix(slider): handle single numeric value/defaultValue, fall back to range

### DIFF
--- a/apps/v4/registry/bases/base/ui/slider.tsx
+++ b/apps/v4/registry/bases/base/ui/slider.tsx
@@ -12,9 +12,13 @@ function Slider({
 }: SliderPrimitive.Root.Props) {
   const _values = Array.isArray(value)
     ? value
-    : Array.isArray(defaultValue)
-      ? defaultValue
-      : [min, max]
+    : typeof value === "number"
+      ? [value]
+      : Array.isArray(defaultValue)
+        ? defaultValue
+        : typeof defaultValue === "number"
+          ? [defaultValue]
+          : [min, max]
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/registry/bases/radix/ui/slider.tsx
+++ b/apps/v4/registry/bases/radix/ui/slider.tsx
@@ -13,15 +13,13 @@ function Slider({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-  const _values = React.useMemo(
-    () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
-  )
+  const _values = React.useMemo(() => {
+    if (Array.isArray(value)) return value
+    if (typeof value === "number") return [value]
+    if (Array.isArray(defaultValue)) return defaultValue
+    if (typeof defaultValue === "number") return [defaultValue]
+    return [min, max]
+  }, [value, defaultValue, min, max])
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/registry/new-york-v4/ui/slider.tsx
+++ b/apps/v4/registry/new-york-v4/ui/slider.tsx
@@ -13,15 +13,13 @@ function Slider({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-  const _values = React.useMemo(
-    () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
-  )
+  const _values = React.useMemo(() => {
+    if (Array.isArray(value)) return value
+    if (typeof value === "number") return [value]
+    if (Array.isArray(defaultValue)) return defaultValue
+    if (typeof defaultValue === "number") return [defaultValue]
+    return [min, max]
+  }, [value, defaultValue, min, max])
 
   return (
     <SliderPrimitive.Root


### PR DESCRIPTION
Closes #10890.

The `<Slider />` component's `_values` derivation only recognised `Array.isArray(value)` / `Array.isArray(defaultValue)`, so a single number like `<Slider value={50} />` fell through to the `[min, max]` fallback and rendered a two-thumb range slider with thumbs at 0 and 100. The workaround of wrapping in `[field.value]` re-creates the array on every render — useMemo's dep array changes each call, the underlying primitive sees a new `value` reference, and its internal drag/transition state gets reset mid-interaction.

## Fix

Recognise `typeof value === "number"` (and the same for `defaultValue`) and wrap as `[value]` before falling back to `[min, max]` for the two-thumb default. The existing range-slider behaviour is preserved — only the single-number path is new.

```tsx
// Before
Array.isArray(value)
  ? value
  : Array.isArray(defaultValue)
    ? defaultValue
    : [min, max]

// After
if (Array.isArray(value)) return value
if (typeof value === "number") return [value]
if (Array.isArray(defaultValue)) return defaultValue
if (typeof defaultValue === "number") return [defaultValue]
return [min, max]
```

## Scope

Applied across every Slider variant in the registry (21 files) so the fix is consistent regardless of which style / base the user copies in:

- `apps/v4/registry/new-york-v4/ui/slider.tsx`
- `apps/v4/registry/bases/{base,radix}/ui/slider.tsx`
- 18 style variants under `apps/v4/styles/{base,radix}-{luma,lyra,maia,mira,nova,rhea,sera,vega}/ui/slider.tsx` (plus their `ui-rtl/` siblings)

Default behaviour for callers passing neither `value` nor `defaultValue` is **unchanged** — they still get a `[min, max]` range slider. The issue author proposed switching the default to a single thumb (`[max]`), but I left that out to avoid an API break; happy to add it as a follow-up if that's the preferred direction.