### PR TITLE
fix: bump zod to ^3.25 for MCP SDK zod/v3 export compatibility

### DIFF
--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -112,8 +112,8 @@
     "ts-morph": "^26.0.0",
     "tsconfig-paths": "^4.2.0",
     "validate-npm-package-name": "^7.0.1",
-    "zod": "^3.24.1",
-    "zod-to-json-schema": "^3.24.6"
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@antfu/ni": "^25.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,11 +471,11 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       zod:
-        specifier: ^3.24.1
+        specifier: ^3.25.76
         version: 3.25.76
       zod-to-json-schema:
-        specifier: ^3.24.6
-        version: 3.24.6(zod@3.25.76)
+        specifier: ^3.25.2
+        version: 3.25.2(zod@3.25.76)
     devDependencies:
       '@antfu/ni':
         specifier: ^25.0.0
@@ -8423,15 +8423,10 @@ packages:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
 
-  zod-to-json-schema@3.24.6:
-    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
-      zod: ^3.24.1
-
-  zod-to-json-schema@3.25.1:
-    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
-    peerDependencies:
-      zod: ^3.25 || ^4
+      zod: ^3.25.28 || ^4
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -9746,7 +9741,7 @@ snapshots:
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
       zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - hono
       - supports-color
@@ -9769,7 +9764,7 @@ snapshots:
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
       zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -17167,11 +17162,7 @@ snapshots:
 
   yoctocolors@2.1.1: {}
 
-  zod-to-json-schema@3.24.6(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
-
-  zod-to-json-schema@3.25.1(zod@3.25.76):
+  zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 


### PR DESCRIPTION
## Fix: `pnpm dlx shadcn` fails with ERR_PACKAGE_PATH_NOT_EXPORTED

### Problem

Running `pnpm dlx shadcn@latest init` crashes with:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './v3' is not defined by "exports" in .../zod/package.json
imported from .../@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
```

### Root Cause

`@modelcontextprotocol/sdk@1.29.0` (a dependency of shadcn) unconditionally imports `zod/v3` in its `zod-compat.js`. The `./v3` subpath export was introduced in **zod 3.25**, but `packages/shadcn/package.json` declares `"zod": "^3.24.1"`, allowing pnpm to resolve `zod@3.24.1` which does not have this export.

The monorepo lockfile happens to resolve to `zod@3.25.76` so it works in development, but the published npm package's `^3.24.1` range causes `pnpm dlx` to pick `3.24.1` in a clean environment.

### Dependency chain

```
shadcn
├── zod: "^3.24.1" → resolves to 3.24.1 (missing ./v3 export)  ← this PR fixes
└── @modelcontextprotocol/sdk@1.29.0
    ├── zod: "^3.25 || ^4.0"
    └── zod-compat.js → import from 'zod/v3'  ← requires zod >= 3.25
```

### Fix

Bump the zod specifier from `^3.24.1` to `^3.25` so the minimum resolved version always includes the `zod/v3` subpath export that MCP SDK requires.
