### PR TITLE
fix(hooks): align useIsMobile with the react-hooks/set-state-in-effect

### DIFF
--- a/apps/v4/hooks/use-mobile.ts
+++ b/apps/v4/hooks/use-mobile.ts
@@ -1,17 +1,26 @@
 import * as React from "react"
 
-export function useIsMobile(mobileBreakpoint = 768) {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+const MOBILE_BREAKPOINT = 768
+const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
 
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < mobileBreakpoint)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < mobileBreakpoint)
-    return () => mql.removeEventListener("change", onChange)
-  }, [mobileBreakpoint])
+function subscribe(callback: () => void) {
+  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)
 
-  return !!isMobile
+  mql.addEventListener("change", callback)
+
+  return () => {
+    mql.removeEventListener("change", callback)
+  }
+}
+
+function getSnapshot() {
+  return window.matchMedia(MOBILE_MEDIA_QUERY).matches
+}
+
+function getServerSnapshot() {
+  return false
+}
+
+export function useIsMobile() {
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }

--- a/apps/v4/public/r/styles/base-luma/use-mobile.json
+++ b/apps/v4/public/r/styles/base-luma/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-luma/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-lyra/use-mobile.json
+++ b/apps/v4/public/r/styles/base-lyra/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-lyra/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-maia/use-mobile.json
+++ b/apps/v4/public/r/styles/base-maia/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-maia/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-mira/use-mobile.json
+++ b/apps/v4/public/r/styles/base-mira/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-mira/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-nova/use-mobile.json
+++ b/apps/v4/public/r/styles/base-nova/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-nova/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-rhea/use-mobile.json
+++ b/apps/v4/public/r/styles/base-rhea/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-rhea/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-sera/use-mobile.json
+++ b/apps/v4/public/r/styles/base-sera/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-sera/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-vega/use-mobile.json
+++ b/apps/v4/public/r/styles/base-vega/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-vega/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/new-york-v4/use-mobile.json
+++ b/apps/v4/public/r/styles/new-york-v4/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/new-york-v4/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-luma/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-luma/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-luma/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-lyra/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-lyra/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-lyra/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-maia/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-maia/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-maia/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-mira/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-mira/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-mira/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-nova/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-nova/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-nova/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-rhea/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-rhea/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-rhea/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-sera/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-sera/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-sera/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-vega/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-vega/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-vega/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\nconst MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)\n\n  mql.addEventListener(\"change\", callback)\n\n  return () => {\n    mql.removeEventListener(\"change\", callback)\n  }\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(MOBILE_MEDIA_QUERY).matches\n}\n\nfunction getServerSnapshot() {\n  return false\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/registry/bases/base/hooks/use-mobile.ts
+++ b/apps/v4/registry/bases/base/hooks/use-mobile.ts
@@ -1,19 +1,26 @@
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
+const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+
+function subscribe(callback: () => void) {
+  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)
+
+  mql.addEventListener("change", callback)
+
+  return () => {
+    mql.removeEventListener("change", callback)
+  }
+}
+
+function getSnapshot() {
+  return window.matchMedia(MOBILE_MEDIA_QUERY).matches
+}
+
+function getServerSnapshot() {
+  return false
+}
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }

--- a/apps/v4/registry/bases/radix/hooks/use-mobile.ts
+++ b/apps/v4/registry/bases/radix/hooks/use-mobile.ts
@@ -1,19 +1,26 @@
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
+const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+
+function subscribe(callback: () => void) {
+  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)
+
+  mql.addEventListener("change", callback)
+
+  return () => {
+    mql.removeEventListener("change", callback)
+  }
+}
+
+function getSnapshot() {
+  return window.matchMedia(MOBILE_MEDIA_QUERY).matches
+}
+
+function getServerSnapshot() {
+  return false
+}
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }

--- a/apps/v4/registry/new-york-v4/hooks/use-mobile.ts
+++ b/apps/v4/registry/new-york-v4/hooks/use-mobile.ts
@@ -1,19 +1,26 @@
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
+const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+
+function subscribe(callback: () => void) {
+  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)
+
+  mql.addEventListener("change", callback)
+
+  return () => {
+    mql.removeEventListener("change", callback)
+  }
+}
+
+function getSnapshot() {
+  return window.matchMedia(MOBILE_MEDIA_QUERY).matches
+}
+
+function getServerSnapshot() {
+  return false
+}
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }


### PR DESCRIPTION
Replaces the `setState` in `useEffect` pattern with `useSyncExternalStore`, React 19's prescribed API for mirroring browser/external state into React. This resolves the hard lint error introduced by the `react-hooks/set-state-in-effect` rule in `eslint-config-next` `16.2.5`+ and makes the hook compile cleanly under the React 19 Compiler.

ℹ️ No public interface changes. No extra logic added. Drop-in replacement for all callers.

- Eliminates `boolean | undefined` flicker - `getSnapshot` returns a real boolean on the first client render, no undefined intermediate state
- SSR-safe via `getServerSnapshot` returning `false`
- Tear-free under concurrent rendering (`useSyncExternalStore` guarantee)
- Applied to all four hook copies: `apps/v4/hooks` and the three registry bases (base, radix, new-york-v4); registry JSON rebuilt accordingly

Fixes: #8739 