### PR TITLE
fix(registry): add beUI logo

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -172,7 +172,7 @@
     "homepage": "https://beui.saura3h.xyz",
     "url": "https://beui.saura3h.xyz/r/{name}.json",
     "description": "Bespoke motion components for React. Copy-paste components with shadcn-compatible installs, Tailwind CSS v4, and Motion.",
-    "logo": ""
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512' fill='none' viewBox='0 0 512 512'><rect width='512' height='512' fill='var(--foreground)' rx='128'/><rect x='86' y='86' width='340' height='340' fill='var(--background)' rx='122'/><rect x='171' y='171' width='170' height='170' fill='var(--foreground)' rx='46'/></svg>"
   },
   {
     "name": "@billingsdk",


### PR DESCRIPTION
Follow-up to #10887, which added the beUI registry with an empty logo field, so no logo renders on the directory page.

This fills it with an inline SVG following the existing convention: a 512x512 rounded tile using var(--foreground) with the mark in var(--background), so it adapts to both themes like the other entries.

No other fields changed.