### PR TITLE
fix(create): left-panel selections flicker and do not stay selected

### DIFF
--- a/apps/v4/app/(app)/create/components/theme-picker.tsx
+++ b/apps/v4/app/(app)/create/components/theme-picker.tsx
@@ -38,11 +38,11 @@ export function ThemePicker({
     [params.theme]
   )
 
-  React.useEffect(() => {
-    if (!currentTheme && themes.length > 0) {
-      setParams({ theme: themes[0].name })
-    }
-  }, [currentTheme, themes, setParams])
+  // NOTE: The useEffect that called setParams({ theme: themes[0].name }) when
+  // currentTheme was undefined has been removed. Theme validation and fallback
+  // is already handled by normalizeDesignSystemParams in search-params.ts.
+  // The effect was causing a second racing setParams call after baseColor
+  // changes, which produced the flickering/selection-reset bug (#10910).
 
   return (
     <div className="group/picker relative">

--- a/apps/v4/app/(app)/create/lib/search-params.ts
+++ b/apps/v4/app/(app)/create/lib/search-params.ts
@@ -238,10 +238,14 @@ function resolvePresetParams(
 // Wraps nuqs useQueryStates with transparent preset encoding/decoding.
 // - Reads: if ?preset=CODE is in the URL, decodes it and returns individual values.
 // - Writes: when design system params are set, encodes them into a preset code.
+//
+// Default options use shallow: true so picker selections do not trigger a full
+// Next.js server navigation. This prevents the customizer panel from flickering
+// or resetting while the URL update propagates (#10910).
 export function useDesignSystemSearchParams(options: Options = {}) {
   const searchParams = useSearchParams()
   const [rawParams, rawSetParams] = useQueryStates(designSystemSearchParams, {
-    shallow: false,
+    shallow: true,
     history: "push",
     ...options,
   })


### PR DESCRIPTION
Fixes #10910

## Problem

On the `/create` page, selecting any option from the left-side configuration 
panel (Base Color, Theme, Style, Font, Radius, etc.) would flicker and not 
stay selected. The selection would briefly appear then reset, making the 
customizer unusable.

## Root Cause

Two compounding issues:

**1. Non-shallow routing on every selection**

`useDesignSystemSearchParams` defaulted to `shallow: false`, which triggered 
a full Next.js server navigation on every picker click. This caused the page 
to re-suspend mid-render, visually resetting the panel state while the URL 
update propagated.

**2. Racing `setParams` call in `ThemePicker`**

`ThemePicker` had a `useEffect` that fired `setParams({ theme: themes[0].name })` 
whenever `currentTheme` was undefined. After a `baseColor` change, there is a 
brief render window where `currentTheme` appears undefined — causing a second 
competing `setParams` call that raced against the first and produced the 
back-and-forth oscillation.

## Fix

**`search-params.ts`** — changed default to `shallow: true` in 
`useDesignSystemSearchParams`. This matches how `DesignSystemProvider` already 
calls it and prevents unnecessary server navigations on picker selections.

**`theme-picker.tsx`** — removed the redundant `useEffect`. Theme validation 
and fallback is already handled authoritatively by `normalizeDesignSystemParams` 
in `search-params.ts`, so the effect was never needed and only introduced a race condition.

## Testing

Tested on `http://localhost:4000/create?template=start` across all browsers:
- Base Color, Theme, Style, Font, Heading Font, Radius, Icon Library, Menu Color 
  all hold selection without flickering
- Changing Base Color correctly resets Theme to a valid value without oscillating
- Rapidly switching between options produces no flicker or state reset
- URL correctly updates to `?preset=CODE` format and selection persists on reload