### PR TITLE
fix: add `default` export condition for `shadcn/tailwind.css`

### DIFF
--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -57,7 +57,8 @@
       "default": "./dist/preset/index.js"
     },
     "./tailwind.css": {
-      "style": "./dist/tailwind.css"
+      "style": "./dist/tailwind.css",
+      "default": "./dist/tailwind.css"
     }
   },
   "bin": "./dist/index.js",


### PR DESCRIPTION
Fixes #10931

The `./tailwind.css` entry in `packages/shadcn/package.json` exports only has a `"style"` condition but no `"default"` fallback. Turbopack's resolver doesn't recognize the bare `"style"` condition, so importing `shadcn/tailwind.css` fails with a `CssSyntaxError`.

Every other entry in the exports map already has `"default"` alongside `"types"`, so this just fills in the missing fallback.
