### PR TITLE
feat(registry): add shadcn-ui-blocks

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1107,6 +1107,13 @@
     "logo": "<svg width='33' height='33' viewBox='0 0 33 33' fill='none' xmlns='http://www.w3.org/2000/svg'><rect x='0.5' y='0.5' width='32' height='32' rx='16' fill='var(--forgraound)'></rect><path d='M16.5993 7.50488V13.4044C16.5993 15.3441 15.0268 16.9166 13.0871 16.9166H7.35156' stroke='var(--background)' stroke-width='1.95122'></path><path d='M16.7562 26.3286L16.7562 20.4291C16.7562 18.4893 18.3286 16.9169 20.2684 16.9169L26.0039 16.9169' stroke='var(--background)' stroke-width='1.95122'></path><line x1='23.7326' y1='10.0919' x2='19.696' y2='14.081' stroke='var(--background)' stroke-width='1.95122'></line><line x1='13.7385' y1='20.0567' x2='9.70187' y2='24.0459' stroke='var(--background)' stroke-width='1.95122'></line><line x1='13.5426' y1='13.8681' x2='9.52961' y2='9.85513' stroke='var(--background)' stroke-width='1.95122'></line><line x1='23.689' y1='24.0419' x2='19.6761' y2='20.029' stroke='var(--background)' stroke-width='1.95122'></line></svg>"
   },
   {
+    "name": "@shadcn-ui-blocks",
+    "homepage": "https://www.shadcn-ui-blocks.com",
+    "url": "https://www.shadcn-ui-blocks.com/r/{name}.json",
+    "description": "Shadcn blocks across standard collections and handcrafted premium collections, plus a beautiful templates. Start free, then unlock more with Pro.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 24 24' fill='none' stroke='var(--foreground)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><rect width='24' height='24' fill='var(--background)' stroke='none'/><path d='m10 9-3 3 3 3'/><path d='m14 15 3-3-3-3'/><rect x='3' y='3' width='18' height='18' rx='2'/></svg>"
+  },
+  {
     "name": "@shadcnblocks",
     "homepage": "https://shadcnblocks.com",
     "url": "https://shadcnblocks.com/r/{name}.json",


### PR DESCRIPTION
Adds `@shadcn-ui-blocks` to the community registry directory
(`apps/v4/registry/directory.json`), following the registry index format at
https://ui.shadcn.com/docs/registry/registry-index.

### Entry

| Field | Value |
| --- | --- |
| name | `@shadcn-ui-blocks` |
| homepage | https://www.shadcn-ui-blocks.com |
| url | `https://www.shadcn-ui-blocks.com/r/{name}.json` |

A growing library of shadcn/ui blocks, component variants, and templates —
free to start, with a Pro tier.

### Notes

- Inserted in alphabetical order, between `@shadcn-studio` and `@shadcnblocks`.
- The `logo` uses `var(--foreground)` / `var(--background)` so it renders in both
  light and dark themes of the directory UI.
- `url` includes the required `{name}` placeholder; the endpoint serves a flat
  registry (`/r/{name}.json`) plus a public index at `/r/registry.json`.
- Verified the file is valid JSON and conforms to the directory schema in
  `apps/v4/scripts/validate-registries.mts`. No duplicate entry.
