### PR TITLE
fix(directory-list): wire mobile View button to registry homepage link

### DIFF
--- a/apps/v4/components/directory-list.tsx
+++ b/apps/v4/components/directory-list.tsx
@@ -258,8 +258,14 @@ function DirectoryListContent() {
                 <DirectoryAddButton registry={registry} />
               </ItemActions>
               <ItemFooter className="justify-start pl-16 sm:hidden">
-                <Button size="sm" variant="outline">
-                  View <IconArrowUpRight />
+                <Button size="sm" variant="outline" asChild>
+                  <a
+                    href={getHomepageUrl(registry.homepage)}
+                    target="_blank"
+                    rel="noopener noreferrer external"
+                  >
+                    View <IconArrowUpRight />
+                  </a>
                 </Button>
                 <DirectoryAddButton registry={registry} />
               </ItemFooter>


### PR DESCRIPTION
## What's changed
- The mobile "View" button in `apps/v4/components/directory-list.tsx` had no `href` — clicking it did nothing.
- Fixed by using `asChild` on the `Button` component and wrapping the content in an `<a>` tag pointing to `getHomepageUrl(registry.homepage)`, consistent with how the desktop title link works.

## Testing
Resize browser viewport below 640px on the `/directory` page — the "View" button now opens the registry homepage in a new tab.

Fixes #10899
