### PR TITLE
fix(components): remove reInit event listener on carousel cleanup

### DIFF
--- a/apps/v4/registry/bases/base/ui/carousel.tsx
+++ b/apps/v4/registry/bases/base/ui/carousel.tsx
@@ -100,6 +100,7 @@ function Carousel({
     api.on("select", onSelect)
 
     return () => {
+      api?.off("reInit", onSelect)
       api?.off("select", onSelect)
     }
   }, [api, onSelect])

--- a/apps/v4/registry/bases/radix/ui/carousel.tsx
+++ b/apps/v4/registry/bases/radix/ui/carousel.tsx
@@ -100,6 +100,7 @@ function Carousel({
     api.on("select", onSelect)
 
     return () => {
+      api?.off("reInit", onSelect)
       api?.off("select", onSelect)
     }
   }, [api, onSelect])

--- a/apps/v4/registry/new-york-v4/ui/carousel.tsx
+++ b/apps/v4/registry/new-york-v4/ui/carousel.tsx
@@ -100,6 +100,7 @@ function Carousel({
     api.on("select", onSelect)
 
     return () => {
+      api?.off("reInit", onSelect)
       api?.off("select", onSelect)
     }
   }, [api, onSelect])


### PR DESCRIPTION
api.on("reInit", onSelect): was registered in the useEffect but the cleanup only called api.off("select", onSelect), leaving the reInit listener attached when the api changes or component unmounts. Fixed across all three carousel implementations (new-york-v4, bases/base, bases/radix).