### PR TITLE
fix: fix(shadcn): missing `default` condition in `exports["./tailwind.css"]` breaks Turbopack

### DIFF
--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -57,7 +57,8 @@
       "default": "./dist/preset/index.js"
     },
     "./tailwind.css": {
-      "style": "./dist/tailwind.css"
+      "style": "./dist/tailwind.css",
+      "default": "./dist/tailwind.css"
     }
   },
   "bin": "./dist/index.js",


### PR DESCRIPTION
## Summary
# Agent Report

## Summary

Implemented and committed the fix.

What changed:
- Updated `packages/shadcn/package.json`
- Added a `"default"` condition for the `./tailwind.css` export:

```json
"./tailwind.css": {
  "style": "./dist/tailwind.css",
  "default": "./dist/tailwind.css"
}
```

Verification:
- Installed dependencies with `pnpm install --frozen-lockfile`
- Ran `pnpm --filter=shadcn build`
- Build completed successfully

Note:
- The container had Node `v18.20.4`, while `packages/shadcn` declares `node >=20.18.1`, so pnpm emitted an engine warning. The package build still completed successfully.

Commit:
- `62854c6ac fix(shadcn): add default export for tailwind css`

## Execution Stats

- Turns: 23
- Input tokens: 219141
- Output tokens: 1311
- Cache read tokens: 142592
- Cache write tokens: 0
- Tool calls: 22

## Tool Call Breakdown

- bash: 14
- edit: 1
- grep: 3
- read: 4

Closes #10931