### PR TITLE
fix: [bug]: Slider Component Fails to Handle Single Numeric value Props and Breaks Controlled State

### DIFF
--- a/apps/v4/registry/bases/base/ui/slider.tsx
+++ b/apps/v4/registry/bases/base/ui/slider.tsx
@@ -12,9 +12,13 @@ function Slider({
 }: SliderPrimitive.Root.Props) {
   const _values = Array.isArray(value)
     ? value
-    : Array.isArray(defaultValue)
-      ? defaultValue
-      : [min, max]
+    : value !== undefined
+      ? [value]
+      : Array.isArray(defaultValue)
+        ? defaultValue
+        : defaultValue !== undefined
+          ? [defaultValue]
+          : [max]
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/registry/bases/radix/ui/slider.tsx
+++ b/apps/v4/registry/bases/radix/ui/slider.tsx
@@ -13,15 +13,13 @@ function Slider({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-  const _values = React.useMemo(
-    () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
-  )
+  const _values = React.useMemo(() => {
+    if (Array.isArray(value)) return value
+    if (value !== undefined) return [value]
+    if (Array.isArray(defaultValue)) return defaultValue
+    if (defaultValue !== undefined) return [defaultValue]
+    return [max]
+  }, [value, defaultValue, max])
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/registry/new-york-v4/ui/slider.tsx
+++ b/apps/v4/registry/new-york-v4/ui/slider.tsx
@@ -13,15 +13,13 @@ function Slider({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-  const _values = React.useMemo(
-    () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
-  )
+  const _values = React.useMemo(() => {
+    if (Array.isArray(value)) return value
+    if (value !== undefined) return [value]
+    if (Array.isArray(defaultValue)) return defaultValue
+    if (defaultValue !== undefined) return [defaultValue]
+    return [max]
+  }, [value, defaultValue, max])
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/base-luma/ui/slider.tsx
+++ b/apps/v4/styles/base-luma/ui/slider.tsx
@@ -12,9 +12,13 @@ function Slider({
 }: SliderPrimitive.Root.Props) {
   const _values = Array.isArray(value)
     ? value
-    : Array.isArray(defaultValue)
-      ? defaultValue
-      : [min, max]
+    : value !== undefined
+      ? [value]
+      : Array.isArray(defaultValue)
+        ? defaultValue
+        : defaultValue !== undefined
+          ? [defaultValue]
+          : [max]
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/base-lyra/ui/slider.tsx
+++ b/apps/v4/styles/base-lyra/ui/slider.tsx
@@ -12,9 +12,13 @@ function Slider({
 }: SliderPrimitive.Root.Props) {
   const _values = Array.isArray(value)
     ? value
-    : Array.isArray(defaultValue)
-      ? defaultValue
-      : [min, max]
+    : value !== undefined
+      ? [value]
+      : Array.isArray(defaultValue)
+        ? defaultValue
+        : defaultValue !== undefined
+          ? [defaultValue]
+          : [max]
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/base-maia/ui/slider.tsx
+++ b/apps/v4/styles/base-maia/ui/slider.tsx
@@ -12,9 +12,13 @@ function Slider({
 }: SliderPrimitive.Root.Props) {
   const _values = Array.isArray(value)
     ? value
-    : Array.isArray(defaultValue)
-      ? defaultValue
-      : [min, max]
+    : value !== undefined
+      ? [value]
+      : Array.isArray(defaultValue)
+        ? defaultValue
+        : defaultValue !== undefined
+          ? [defaultValue]
+          : [max]
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/base-mira/ui/slider.tsx
+++ b/apps/v4/styles/base-mira/ui/slider.tsx
@@ -12,9 +12,13 @@ function Slider({
 }: SliderPrimitive.Root.Props) {
   const _values = Array.isArray(value)
     ? value
-    : Array.isArray(defaultValue)
-      ? defaultValue
-      : [min, max]
+    : value !== undefined
+      ? [value]
+      : Array.isArray(defaultValue)
+        ? defaultValue
+        : defaultValue !== undefined
+          ? [defaultValue]
+          : [max]
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/base-nova/ui-rtl/slider.tsx
+++ b/apps/v4/styles/base-nova/ui-rtl/slider.tsx
@@ -12,9 +12,13 @@ function Slider({
 }: SliderPrimitive.Root.Props) {
   const _values = Array.isArray(value)
     ? value
-    : Array.isArray(defaultValue)
-      ? defaultValue
-      : [min, max]
+    : value !== undefined
+      ? [value]
+      : Array.isArray(defaultValue)
+        ? defaultValue
+        : defaultValue !== undefined
+          ? [defaultValue]
+          : [max]
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/base-nova/ui/slider.tsx
+++ b/apps/v4/styles/base-nova/ui/slider.tsx
@@ -12,9 +12,13 @@ function Slider({
 }: SliderPrimitive.Root.Props) {
   const _values = Array.isArray(value)
     ? value
-    : Array.isArray(defaultValue)
-      ? defaultValue
-      : [min, max]
+    : value !== undefined
+      ? [value]
+      : Array.isArray(defaultValue)
+        ? defaultValue
+        : defaultValue !== undefined
+          ? [defaultValue]
+          : [max]
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/base-rhea/ui/slider.tsx
+++ b/apps/v4/styles/base-rhea/ui/slider.tsx
@@ -12,9 +12,13 @@ function Slider({
 }: SliderPrimitive.Root.Props) {
   const _values = Array.isArray(value)
     ? value
-    : Array.isArray(defaultValue)
-      ? defaultValue
-      : [min, max]
+    : value !== undefined
+      ? [value]
+      : Array.isArray(defaultValue)
+        ? defaultValue
+        : defaultValue !== undefined
+          ? [defaultValue]
+          : [max]
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/base-sera/ui/slider.tsx
+++ b/apps/v4/styles/base-sera/ui/slider.tsx
@@ -12,9 +12,13 @@ function Slider({
 }: SliderPrimitive.Root.Props) {
   const _values = Array.isArray(value)
     ? value
-    : Array.isArray(defaultValue)
-      ? defaultValue
-      : [min, max]
+    : value !== undefined
+      ? [value]
+      : Array.isArray(defaultValue)
+        ? defaultValue
+        : defaultValue !== undefined
+          ? [defaultValue]
+          : [max]
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/base-vega/ui/slider.tsx
+++ b/apps/v4/styles/base-vega/ui/slider.tsx
@@ -12,9 +12,13 @@ function Slider({
 }: SliderPrimitive.Root.Props) {
   const _values = Array.isArray(value)
     ? value
-    : Array.isArray(defaultValue)
-      ? defaultValue
-      : [min, max]
+    : value !== undefined
+      ? [value]
+      : Array.isArray(defaultValue)
+        ? defaultValue
+        : defaultValue !== undefined
+          ? [defaultValue]
+          : [max]
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/radix-luma/ui/slider.tsx
+++ b/apps/v4/styles/radix-luma/ui/slider.tsx
@@ -13,15 +13,13 @@ function Slider({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-  const _values = React.useMemo(
-    () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
-  )
+  const _values = React.useMemo(() => {
+    if (Array.isArray(value)) return value
+    if (value !== undefined) return [value]
+    if (Array.isArray(defaultValue)) return defaultValue
+    if (defaultValue !== undefined) return [defaultValue]
+    return [max]
+  }, [value, defaultValue, max])
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/radix-lyra/ui/slider.tsx
+++ b/apps/v4/styles/radix-lyra/ui/slider.tsx
@@ -13,15 +13,13 @@ function Slider({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-  const _values = React.useMemo(
-    () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
-  )
+  const _values = React.useMemo(() => {
+    if (Array.isArray(value)) return value
+    if (value !== undefined) return [value]
+    if (Array.isArray(defaultValue)) return defaultValue
+    if (defaultValue !== undefined) return [defaultValue]
+    return [max]
+  }, [value, defaultValue, max])
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/radix-maia/ui/slider.tsx
+++ b/apps/v4/styles/radix-maia/ui/slider.tsx
@@ -13,15 +13,13 @@ function Slider({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-  const _values = React.useMemo(
-    () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
-  )
+  const _values = React.useMemo(() => {
+    if (Array.isArray(value)) return value
+    if (value !== undefined) return [value]
+    if (Array.isArray(defaultValue)) return defaultValue
+    if (defaultValue !== undefined) return [defaultValue]
+    return [max]
+  }, [value, defaultValue, max])
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/radix-mira/ui/slider.tsx
+++ b/apps/v4/styles/radix-mira/ui/slider.tsx
@@ -13,15 +13,13 @@ function Slider({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-  const _values = React.useMemo(
-    () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
-  )
+  const _values = React.useMemo(() => {
+    if (Array.isArray(value)) return value
+    if (value !== undefined) return [value]
+    if (Array.isArray(defaultValue)) return defaultValue
+    if (defaultValue !== undefined) return [defaultValue]
+    return [max]
+  }, [value, defaultValue, max])
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/radix-nova/ui-rtl/slider.tsx
+++ b/apps/v4/styles/radix-nova/ui-rtl/slider.tsx
@@ -13,15 +13,13 @@ function Slider({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-  const _values = React.useMemo(
-    () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
-  )
+  const _values = React.useMemo(() => {
+    if (Array.isArray(value)) return value
+    if (value !== undefined) return [value]
+    if (Array.isArray(defaultValue)) return defaultValue
+    if (defaultValue !== undefined) return [defaultValue]
+    return [max]
+  }, [value, defaultValue, max])
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/radix-nova/ui/slider.tsx
+++ b/apps/v4/styles/radix-nova/ui/slider.tsx
@@ -13,15 +13,13 @@ function Slider({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-  const _values = React.useMemo(
-    () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
-  )
+  const _values = React.useMemo(() => {
+    if (Array.isArray(value)) return value
+    if (value !== undefined) return [value]
+    if (Array.isArray(defaultValue)) return defaultValue
+    if (defaultValue !== undefined) return [defaultValue]
+    return [max]
+  }, [value, defaultValue, max])
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/radix-rhea/ui/slider.tsx
+++ b/apps/v4/styles/radix-rhea/ui/slider.tsx
@@ -13,15 +13,13 @@ function Slider({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-  const _values = React.useMemo(
-    () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
-  )
+  const _values = React.useMemo(() => {
+    if (Array.isArray(value)) return value
+    if (value !== undefined) return [value]
+    if (Array.isArray(defaultValue)) return defaultValue
+    if (defaultValue !== undefined) return [defaultValue]
+    return [max]
+  }, [value, defaultValue, max])
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/radix-sera/ui/slider.tsx
+++ b/apps/v4/styles/radix-sera/ui/slider.tsx
@@ -13,15 +13,13 @@ function Slider({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-  const _values = React.useMemo(
-    () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
-  )
+  const _values = React.useMemo(() => {
+    if (Array.isArray(value)) return value
+    if (value !== undefined) return [value]
+    if (Array.isArray(defaultValue)) return defaultValue
+    if (defaultValue !== undefined) return [defaultValue]
+    return [max]
+  }, [value, defaultValue, max])
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/styles/radix-vega/ui/slider.tsx
+++ b/apps/v4/styles/radix-vega/ui/slider.tsx
@@ -13,15 +13,13 @@ function Slider({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-  const _values = React.useMemo(
-    () =>
-      Array.isArray(value)
-        ? value
-        : Array.isArray(defaultValue)
-          ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
-  )
+  const _values = React.useMemo(() => {
+    if (Array.isArray(value)) return value
+    if (value !== undefined) return [value]
+    if (Array.isArray(defaultValue)) return defaultValue
+    if (defaultValue !== undefined) return [defaultValue]
+    return [max]
+  }, [value, defaultValue, max])
 
   return (
     <SliderPrimitive.Root


### PR DESCRIPTION
## Summary
# Agent Report

## Summary

Implemented and committed the Slider fix.

What changed:
- Updated Slider thumb-count value resolution across the v4 registry and generated style variants.
- Numeric `value` and `defaultValue` props are now wrapped as single-value arrays.
- Missing values now default to a single thumb at `[max]` instead of dual thumbs `[min, max]`.
- Radix Slider variants keep the updated `React.useMemo` dependency list as `[value, defaultValue, max]`.

Verified:
- Installed project dependencies with `pnpm install --frozen-lockfile`.
- Built the `shadcn` package with `pnpm --filter=shadcn build`.
- Ran `pnpm --filter=v4 typecheck` successfully.

Commit:
- `65f64b492 fix(registry): handle single slider values`

Note:
- The environment uses Node `18.20.4`, while `packages/shadcn` warns it expects Node `>=20.18.1`; despite the warning, the build and v4 typecheck completed successfully.

## Execution Stats

- Turns: 40
- Input tokens: 907646
- Output tokens: 4688
- Cache read tokens: 641792
- Cache write tokens: 0
- Tool calls: 39

## Tool Call Breakdown

- bash: 24
- grep: 6
- read: 9

Closes #10890