### PR TITLE
docs(base/data-table): replace asChild with render prop in DropdownMenuTrigger

### DIFF
--- a/apps/v4/content/docs/components/base/data-table.mdx
+++ b/apps/v4/content/docs/components/base/data-table.mdx
@@ -349,11 +349,9 @@ export const columns: ColumnDef<Payment>[] = [
 
       return (
         <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" className="h-8 w-8 p-0">
-              <span className="sr-only">Open menu</span>
-              <MoreHorizontal className="h-4 w-4" />
-            </Button>
+          <DropdownMenuTrigger render={<Button variant="ghost" className="h-8 w-8 p-0" />}>
+            <span className="sr-only">Open menu</span>
+            <MoreHorizontal className="h-4 w-4" />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuLabel>Actions</DropdownMenuLabel>
@@ -694,10 +692,8 @@ export function DataTable<TData, TValue>({
           className="max-w-sm"
         />
         <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" className="ml-auto">
-              Columns
-            </Button>
+          <DropdownMenuTrigger render={<Button variant="outline" className="ml-auto" />}>
+            Columns
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             {table


### PR DESCRIPTION
## Summary

- Fixes #10934: Base data table docs used Radix-style `asChild` prop on `DropdownMenuTrigger`, inconsistent with Base UI's `render` prop API
- Updated both the row-actions column and column-visibility examples to use `render={<Button ... />}` pattern, matching the Base Dropdown Menu docs

## Changes

- `apps/v4/content/docs/components/base/data-table.mdx`: replaced `<DropdownMenuTrigger asChild><Button .../></DropdownMenuTrigger>` with `<DropdownMenuTrigger render={<Button ... />}>` in two places (row actions and column visibility snippets)

## Testing

Docs-only change — no runtime behavior modified. Verified the updated snippets match the pattern used in `apps/v4/content/docs/components/base/dropdown-menu.mdx`.

Closes #10934

🤖 Generated with [Claude Code](https://claude.ai/code)