### PR TITLE
fix(charts): round only top/right corners of bars instead of all four corners

### DIFF
--- a/apps/v4/registry/new-york-v4/charts/chart-bar-active.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-bar-active.tsx
@@ -84,7 +84,7 @@ export function ChartBarActive() {
             <Bar
               dataKey="visitors"
               strokeWidth={2}
-              radius={8}
+              radius={[8, 8, 0, 0]}
               shape={({ index, ...props }: BarShapeProps) =>
                 index === ACTIVE_INDEX ? (
                   <Rectangle

--- a/apps/v4/registry/new-york-v4/charts/chart-bar-default.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-bar-default.tsx
@@ -58,7 +58,7 @@ export function ChartBarDefault() {
               cursor={false}
               content={<ChartTooltipContent hideLabel />}
             />
-            <Bar dataKey="desktop" fill="var(--color-desktop)" radius={8} />
+            <Bar dataKey="desktop" fill="var(--color-desktop)" radius={[8, 8, 0, 0]} />
           </BarChart>
         </ChartContainer>
       </CardContent>

--- a/apps/v4/registry/new-york-v4/charts/chart-bar-horizontal.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-bar-horizontal.tsx
@@ -66,7 +66,7 @@ export function ChartBarHorizontal() {
               cursor={false}
               content={<ChartTooltipContent hideLabel />}
             />
-            <Bar dataKey="desktop" fill="var(--color-desktop)" radius={5} />
+            <Bar dataKey="desktop" fill="var(--color-desktop)" radius={[0, 5, 5, 0]} />
           </BarChart>
         </ChartContainer>
       </CardContent>

--- a/apps/v4/registry/new-york-v4/charts/chart-bar-label-custom.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-bar-label-custom.tsx
@@ -75,7 +75,7 @@ export function ChartBarLabelCustom() {
               cursor={false}
               content={<ChartTooltipContent indicator="line" />}
             />
-            <Bar dataKey="desktop" fill="var(--color-desktop)" radius={4}>
+            <Bar dataKey="desktop" fill="var(--color-desktop)" radius={[4, 4, 0, 0]}>
               <LabelList
                 dataKey="month"
                 position="insideLeft"

--- a/apps/v4/registry/new-york-v4/charts/chart-bar-label.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-bar-label.tsx
@@ -64,7 +64,7 @@ export function ChartBarLabel() {
               cursor={false}
               content={<ChartTooltipContent hideLabel />}
             />
-            <Bar dataKey="desktop" fill="var(--color-desktop)" radius={8}>
+            <Bar dataKey="desktop" fill="var(--color-desktop)" radius={[8, 8, 0, 0]}>
               <LabelList
                 position="top"
                 offset={12}

--- a/apps/v4/registry/new-york-v4/charts/chart-bar-mixed.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-bar-mixed.tsx
@@ -86,7 +86,7 @@ export function ChartBarMixed() {
               cursor={false}
               content={<ChartTooltipContent hideLabel />}
             />
-            <Bar dataKey="visitors" radius={5} />
+            <Bar dataKey="visitors" radius={[5, 5, 0, 0]} />
           </BarChart>
         </ChartContainer>
       </CardContent>

--- a/apps/v4/registry/new-york-v4/charts/chart-bar-multiple.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-bar-multiple.tsx
@@ -62,8 +62,8 @@ export function ChartBarMultiple() {
               cursor={false}
               content={<ChartTooltipContent indicator="dashed" />}
             />
-            <Bar dataKey="desktop" fill="var(--color-desktop)" radius={4} />
-            <Bar dataKey="mobile" fill="var(--color-mobile)" radius={4} />
+            <Bar dataKey="desktop" fill="var(--color-desktop)" radius={[4, 4, 0, 0]} />
+            <Bar dataKey="mobile" fill="var(--color-mobile)" radius={[4, 4, 0, 0]} />
           </BarChart>
         </ChartContainer>
       </CardContent>


### PR DESCRIPTION
## Summary

- Fixes #10741: Bar chart registry examples applied a uniform `radius={N}` which rounds **all four corners** including the bottom edge that sits on the axis baseline
- Rounded bottoms create a small visual gap between the bar and the baseline, making heights harder to compare accurately and undermining trust in the data

## Changes

All changes are in `apps/v4/registry/new-york-v4/charts/`:

| File | Before | After |
|------|--------|-------|
| `chart-bar-default.tsx` | `radius={8}` | `radius={[8, 8, 0, 0]}` |
| `chart-bar-active.tsx` | `radius={8}` | `radius={[8, 8, 0, 0]}` |
| `chart-bar-label.tsx` | `radius={8}` | `radius={[8, 8, 0, 0]}` |
| `chart-bar-multiple.tsx` (×2) | `radius={4}` | `radius={[4, 4, 0, 0]}` |
| `chart-bar-label-custom.tsx` | `radius={4}` | `radius={[4, 4, 0, 0]}` |
| `chart-bar-mixed.tsx` | `radius={5}` | `radius={[5, 5, 0, 0]}` |
| `chart-bar-horizontal.tsx` | `radius={5}` | `radius={[0, 5, 5, 0]}` |

In Recharts the array form is `[topLeft, topRight, bottomRight, bottomLeft]`:
- Vertical bars grow upward → round top corners only: `[N, N, 0, 0]`
- Horizontal bars grow rightward → round right corners only: `[0, N, N, 0]`

## Testing

Visual-only change. Default appearance is improved: bars now sit flush on the axis baseline. No logic or data changes.

Closes #10741

🤖 Generated with [Claude Code](https://claude.ai/code)