### PR TITLE
feat(registry): add @agentcn

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1526,5 +1526,12 @@
     "url": "https://kaui-shadcn-registry.vercel.app/r/{name}.json",
     "description": "Personal well crafted components for Shadcn ui",
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' fill='none'><rect width='32' height='32' rx='7' fill='#0a0a0a'/><path d='M9 7v18M9 16l14-8M9 16l14 8' stroke='#fff' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'/></svg>"
+  },
+  {
+    "name": "@agentcn",
+    "homepage": "https://agentcn.vercel.app",
+    "url": "https://agentcn.vercel.app/r/{name}.json",
+    "description": "Production-ready agents, made simple. Ready to use, customizable AI agent recipes. Built on Eve and Flue.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='var(--background)' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'><path d='M14 18a2 2 0 0 0-4 0m9-7-2.11-6.657a2 2 0 0 0-2.752-1.148l-1.276.61A2 2 0 0 1 12 4H8.5a2 2 0 0 0-1.925 1.456L5 11m-3 0h20'/><circle cx='17' cy='18' r='3'/><circle cx='7' cy='18' r='3'/><path d='M15.46 7.1 13.3 9.26m1.728-4.536-4.104 4.104' stroke-width='1.575'/></svg>"
   }
 ]


### PR DESCRIPTION
## Summary

Adds `@agentcn` to the community registry directory.

- **Registry URL**: `https://agentcn.vercel.app/r/{name}.json`
- **Homepage**: https://agentcn.vercel.app
- **Description**: Production-ready agents, made simple. Ready to use, customizable AI agent recipes. Built on Eve and Flue.

## Test plan

- [ ] `curl https://agentcn.vercel.app/r/registry.json` returns valid JSON
- [ ] `npx shadcn@latest add @agentcn/eve/weather` installs successfully