### PR TITLE
feat(registry): add @7ovr to registry directory

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1,5 +1,12 @@
 [
   {
+    "name": "@7ovr",
+    "homepage": "https://7ovr.com",
+    "url": "https://7ovr.com/r/{name}.json",
+    "description": "Free, production-ready UI blocks for marketing pages and application dashboards, built on Base UI and installable with the shadcn CLI.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='-1 -1 26 26' fill='var(--foreground)' width='24' height='24'><rect x='3' y='3' width='8' height='8' transform='rotate(-6 7 7)'/><rect x='3' y='13' width='8' height='8' transform='rotate(5 7 17)'/><rect x='13' y='13' width='8' height='8' transform='rotate(-4 17 17)'/><rect x='13' y='3' width='8' height='8' transform='rotate(15 17 7)'/></svg>"
+  },
+  {
     "name": "@8bitcn",
     "homepage": "https://www.8bitcn.com",
     "url": "https://www.8bitcn.com/r/{name}.json",


### PR DESCRIPTION
Adds `@7ovr` to the registry directory.

**7Ovr** is a free registry of production-ready UI blocks for marketing pages and application dashboards, built on Base UI and installable with the shadcn CLI.

- **Homepage:** https://7ovr.com
- **Registry index:** https://7ovr.com/r/registry.json
- **URL pattern:** `https://7ovr.com/r/{name}.json`
- **Example block:** https://7ovr.com/r/hero-1.json

**Install**

```bash
npx shadcn@latest add @7ovr/hero-1
```

**Checklist (per the directory guidelines)**

- [x] Publicly accessible (live at `https://7ovr.com/r/registry.json`); free block source is served in the registry JSON
- [x] Valid JSON conforming to the registry schema (includes `$schema`)
- [x] Flat registry (`/registry.json` and `/<name>.json` at the root)
- [x] `files` arrays contain no `content` property in the served index
- [x] Single entry added to `apps/v4/registry/directory.json` in alphabetical position
- [x] Verified `npx shadcn@latest add @7ovr/<block>` installs cleanly (resolves registry + npm dependencies, writes source files)
