### PR TITLE
fix(select): prevent dialog close on click outside select inside dialog (#10979)

### DIFF
--- a/apps/v4/registry/bases/radix/examples/select-example.tsx
+++ b/apps/v4/registry/bases/radix/examples/select-example.tsx
@@ -520,6 +520,8 @@ function SelectPlanItem({ plan }: { plan: (typeof plans)[number] }) {
 }
 
 function SelectInDialog() {
+  const [selectOpen, setSelectOpen] = React.useState(false)
+
   return (
     <Example title="In Dialog">
       <Dialog>
@@ -533,11 +535,23 @@ function SelectInDialog() {
               Use the select below to choose a fruit.
             </DialogDescription>
           </DialogHeader>
-          <Select>
+          <Select open={selectOpen} onOpenChange={setSelectOpen}>
             <SelectTrigger>
               <SelectValue placeholder="Select a fruit" />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent
+              onPointerDownOutside={(event) => {
+                const target = event.detail.originalEvent.target
+
+                if (
+                  target instanceof Element &&
+                  target.closest("[data-slot=dialog-content]")
+                ) {
+                  event.preventDefault()
+                  setSelectOpen(false)
+                }
+              }}
+            >
               <SelectGroup>
                 <SelectItem value="apple">Apple</SelectItem>
                 <SelectItem value="banana">Banana</SelectItem>

--- a/apps/v4/registry/bases/radix/examples/select-example.tsx
+++ b/apps/v4/registry/bases/radix/examples/select-example.tsx
@@ -520,8 +520,6 @@ function SelectPlanItem({ plan }: { plan: (typeof plans)[number] }) {
 }
 
 function SelectInDialog() {
-  const [selectOpen, setSelectOpen] = React.useState(false)
-
   return (
     <Example title="In Dialog">
       <Dialog>
@@ -535,23 +533,11 @@ function SelectInDialog() {
               Use the select below to choose a fruit.
             </DialogDescription>
           </DialogHeader>
-          <Select open={selectOpen} onOpenChange={setSelectOpen}>
+          <Select>
             <SelectTrigger>
               <SelectValue placeholder="Select a fruit" />
             </SelectTrigger>
-            <SelectContent
-              onPointerDownOutside={(event) => {
-                const target = event.detail.originalEvent.target
-
-                if (
-                  target instanceof Element &&
-                  target.closest("[data-slot=dialog-content]")
-                ) {
-                  event.preventDefault()
-                  setSelectOpen(false)
-                }
-              }}
-            >
+            <SelectContent>
               <SelectGroup>
                 <SelectItem value="apple">Apple</SelectItem>
                 <SelectItem value="banana">Banana</SelectItem>

--- a/apps/v4/registry/bases/radix/ui/dialog.tsx
+++ b/apps/v4/registry/bases/radix/ui/dialog.tsx
@@ -62,6 +62,21 @@ function DialogContent({
           className
         )}
         {...props}
+        onPointerDownOutside={(event) => {
+          const originalEvent = event.detail.originalEvent
+          const target = originalEvent.target as Element
+
+          if (
+            originalEvent.type === "pointerdown" &&
+            target.closest("[data-slot=dialog-content]")
+          ) {
+            event.preventDefault()
+          }
+
+          if (props.onPointerDownOutside) {
+            props.onPointerDownOutside(event)
+          }
+        }}
       >
         {children}
         {showCloseButton && (

--- a/apps/v4/registry/new-york-v4/ui/dialog.tsx
+++ b/apps/v4/registry/new-york-v4/ui/dialog.tsx
@@ -65,6 +65,21 @@ function DialogContent({
           className
         )}
         {...props}
+        onPointerDownOutside={(event) => {
+          const originalEvent = event.detail.originalEvent
+          const target = originalEvent.target as Element
+
+          if (
+            originalEvent.type === "pointerdown" &&
+            target.closest("[data-slot=dialog-content]")
+          ) {
+            event.preventDefault()
+          }
+
+          if (props.onPointerDownOutside) {
+            props.onPointerDownOutside(event)
+          }
+        }}
       >
         {children}
         {showCloseButton && (


### PR DESCRIPTION
Fixes #10979

When a Select component is placed inside a Dialog, clicking outside the Select dropdown but inside the DialogContent would incorrectly close the Dialog itself.

This PR addresses the issue by adding logic to `onPointerDownOutside` on `SelectContent` in the `SelectInDialog` example. It prevents the default behavior and only closes the Select dropdown if the click target is within the dialog content.