### PR TITLE
chore(deps): replace fast-glob with tinyglobby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build
 .DS_Store
 .eslintcache
 *.pem
+mise.local.toml
 
 # debug
 npm-debug.log*

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -98,7 +98,6 @@
     "deepmerge": "^4.3.1",
     "diff": "^8.0.2",
     "execa": "^9.6.0",
-    "fast-glob": "^3.3.3",
     "fs-extra": "^11.3.1",
     "fuzzysort": "^3.1.0",
     "kleur": "^4.1.5",
@@ -110,6 +109,7 @@
     "recast": "^0.23.11",
     "stringify-object": "^5.0.0",
     "tailwind-merge": "^3.0.1",
+    "tinyglobby": "^0.2.17",
     "ts-morph": "^26.0.0",
     "tsconfig-paths": "^4.2.0",
     "undici": "^7.27.2",
@@ -123,10 +123,10 @@
     "@types/fs-extra": "^11.0.4",
     "@types/prompts": "^2.4.9",
     "@types/stringify-object": "^4.0.5",
+    "msw": "^2.10.4",
     "rimraf": "^6.0.1",
     "tsup": "^8.5.0",
     "type-fest": "^4.41.0",
-    "typescript": "^5.9.2",
-    "msw": "^2.10.4"
+    "typescript": "^5.9.2"
   }
 }

--- a/packages/shadcn/src/migrations/migrate-icons.ts
+++ b/packages/shadcn/src/migrations/migrate-icons.ts
@@ -10,7 +10,7 @@ import { LEGACY_ICON_LIBRARIES } from "@/src/utils/legacy-icon-libraries"
 import { logger } from "@/src/utils/logger"
 import { spinner } from "@/src/utils/spinner"
 import { updateDependencies } from "@/src/utils/updaters/update-dependencies"
-import fg from "fast-glob"
+import { glob } from "tinyglobby"
 import prompts from "prompts"
 import { Project, ScriptKind, SyntaxKind } from "ts-morph"
 import { z } from "zod"
@@ -24,7 +24,7 @@ export async function migrateIcons(config: Config) {
 
   const uiPath = config.resolvedPaths.ui
   const [files, registryIcons] = await Promise.all([
-    fg("**/*.{js,ts,jsx,tsx}", {
+    glob("**/*.{js,ts,jsx,tsx}", {
       cwd: uiPath,
     }),
     getRegistryIcons(),

--- a/packages/shadcn/src/migrations/migrate-radix.test.ts
+++ b/packages/shadcn/src/migrations/migrate-radix.test.ts
@@ -12,8 +12,9 @@ vi.mock("fs", () => ({
   },
 }))
 
-vi.mock("fast-glob", () => ({
-  default: vi.fn(),
+vi.mock("tinyglobby", () => ({
+  glob: vi.fn(),
+  globSync: vi.fn(),
 }))
 
 vi.mock("prompts", () => ({
@@ -910,9 +911,9 @@ describe("migrateRadix - package.json updates", () => {
     // Mock file system
     mockFs.writeFile.mockResolvedValue(undefined)
 
-    // Mock fast-glob to return files with Radix imports
-    const fg = await import("fast-glob")
-    vi.mocked(fg.default).mockResolvedValue(["dialog.tsx", "select.tsx"])
+    // Mock tinyglobby to return files with Radix imports
+    const { glob } = await import("tinyglobby")
+    vi.mocked(glob).mockResolvedValue(["dialog.tsx", "select.tsx"])
 
     // Mock file reads to return content with Radix imports
     mockFs.readFile
@@ -957,8 +958,8 @@ describe("migrateRadix - package.json updates", () => {
       "@/src/utils/updaters/update-dependencies"
     )
 
-    const fg = await import("fast-glob")
-    vi.mocked(fg.default).mockResolvedValue(["component.tsx"])
+    const { glob } = await import("tinyglobby")
+    vi.mocked(glob).mockResolvedValue(["component.tsx"])
 
     // Mock file read to return content with no Radix imports
     mockFs.readFile.mockResolvedValue('import React from "react"')
@@ -982,8 +983,8 @@ describe("migrateRadix - package.json updates", () => {
     const { getPackageInfo } = await import("@/src/utils/get-package-info")
     vi.mocked(getPackageInfo).mockReturnValue(null)
 
-    const fg = await import("fast-glob")
-    vi.mocked(fg.default).mockResolvedValue(["component.tsx"])
+    const { glob } = await import("tinyglobby")
+    vi.mocked(glob).mockResolvedValue(["component.tsx"])
 
     // Mock file read
     mockFs.readFile.mockResolvedValue('import React from "react"')
@@ -1012,8 +1013,8 @@ describe("migrateRadix - package.json updates", () => {
 
     mockFs.writeFile.mockResolvedValue(undefined)
 
-    const fg = await import("fast-glob")
-    vi.mocked(fg.default).mockResolvedValue(["dialog.tsx"])
+    const { glob } = await import("tinyglobby")
+    vi.mocked(glob).mockResolvedValue(["dialog.tsx"])
 
     // Mock file read to return content with Radix imports
     mockFs.readFile.mockResolvedValue(
@@ -1068,9 +1069,9 @@ describe("migrateRadix - package.json updates", () => {
 
     mockFs.writeFile.mockResolvedValue(undefined)
 
-    // Mock fast-glob to return files with only dialog and select imports
-    const fg = await import("fast-glob")
-    vi.mocked(fg.default).mockResolvedValue(["dialog.tsx"])
+    // Mock tinyglobby to return files with only dialog and select imports
+    const { glob } = await import("tinyglobby")
+    vi.mocked(glob).mockResolvedValue(["dialog.tsx"])
 
     // Mock file read to return content with only dialog and select
     mockFs.readFile.mockResolvedValue(`
@@ -1123,8 +1124,8 @@ describe("migrateRadix - package.json updates", () => {
 
     mockFs.writeFile.mockResolvedValue(undefined)
 
-    const fg = await import("fast-glob")
-    vi.mocked(fg.default).mockResolvedValue(["dialog.tsx"])
+    const { glob } = await import("tinyglobby")
+    vi.mocked(glob).mockResolvedValue(["dialog.tsx"])
 
     // Mock file read to return content with dialog imports but NOT icons
     mockFs.readFile.mockResolvedValue(

--- a/packages/shadcn/src/migrations/migrate-radix.ts
+++ b/packages/shadcn/src/migrations/migrate-radix.ts
@@ -6,7 +6,7 @@ import { highlighter } from "@/src/utils/highlighter"
 import { logger } from "@/src/utils/logger"
 import { spinner } from "@/src/utils/spinner"
 import { updateDependencies } from "@/src/utils/updaters/update-dependencies"
-import fg from "fast-glob"
+import { glob } from "tinyglobby"
 import prompts from "prompts"
 
 function toPascalCase(str: string): string {
@@ -112,7 +112,7 @@ export async function migrateRadix(
     const isGlob = options.path.includes("*")
 
     if (isGlob) {
-      files = await fg(options.path, {
+      files = await glob(options.path, {
         cwd: basePath,
         onlyFiles: true,
         ignore: ["**/node_modules/**"],
@@ -127,7 +127,7 @@ export async function migrateRadix(
 
       if (stat.isDirectory()) {
         basePath = fullPath
-        files = await fg("**/*.{js,ts,jsx,tsx}", {
+        files = await glob("**/*.{js,ts,jsx,tsx}", {
           cwd: basePath,
           onlyFiles: true,
           ignore: ["**/node_modules/**"],
@@ -151,7 +151,7 @@ export async function migrateRadix(
     }
 
     basePath = config.resolvedPaths.ui
-    files = await fg("**/*.{js,ts,jsx,tsx}", {
+    files = await glob("**/*.{js,ts,jsx,tsx}", {
       cwd: basePath,
       onlyFiles: true,
     })

--- a/packages/shadcn/src/migrations/migrate-rtl.ts
+++ b/packages/shadcn/src/migrations/migrate-rtl.ts
@@ -6,7 +6,7 @@ import { highlighter } from "@/src/utils/highlighter"
 import { logger } from "@/src/utils/logger"
 import { spinner } from "@/src/utils/spinner"
 import { transformDirection } from "@/src/utils/transformers/transform-rtl"
-import fg from "fast-glob"
+import { glob } from "tinyglobby"
 import prompts from "prompts"
 
 // Files that may need manual RTL adjustments.
@@ -32,7 +32,7 @@ export async function migrateRtl(
     const isGlob = options.path.includes("*")
 
     if (isGlob) {
-      files = await fg(options.path, {
+      files = await glob(options.path, {
         cwd: basePath,
         onlyFiles: true,
         ignore: ["**/node_modules/**"],
@@ -47,7 +47,7 @@ export async function migrateRtl(
 
       if (stat.isDirectory()) {
         basePath = fullPath
-        files = await fg("**/*.{js,ts,jsx,tsx}", {
+        files = await glob("**/*.{js,ts,jsx,tsx}", {
           cwd: basePath,
           onlyFiles: true,
           ignore: ["**/node_modules/**"],
@@ -71,7 +71,7 @@ export async function migrateRtl(
     }
 
     basePath = config.resolvedPaths.ui
-    files = await fg("**/*.{js,ts,jsx,tsx}", {
+    files = await glob("**/*.{js,ts,jsx,tsx}", {
       cwd: basePath,
       onlyFiles: true,
     })

--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -9,7 +9,7 @@ import { getProjectInfo } from "@/src/utils/get-project-info"
 import { highlighter } from "@/src/utils/highlighter"
 import { resolveImportWithMetadata } from "@/src/utils/resolve-import"
 import { cosmiconfig } from "cosmiconfig"
-import fg from "fast-glob"
+import { glob } from "tinyglobby"
 import { loadConfig, type ConfigLoaderSuccessResult } from "tsconfig-paths"
 import { z } from "zod"
 
@@ -275,7 +275,7 @@ export async function findPackageRoot(cwd: string, resolvedPath: string) {
   const commonRoot = findCommonRoot(cwd, resolvedPath)
   const relativePath = path.relative(commonRoot, resolvedPath)
 
-  const packageRoots = await fg.glob("**/package.json", {
+  const packageRoots = await glob("**/package.json", {
     cwd: commonRoot,
     deep: 3,
     ignore: ["**/node_modules/**", "**/dist/**", "**/build/**", "**/public/**"],

--- a/packages/shadcn/src/utils/get-monorepo-info.ts
+++ b/packages/shadcn/src/utils/get-monorepo-info.ts
@@ -1,7 +1,7 @@
 import path from "path"
 import { highlighter } from "@/src/utils/highlighter"
 import { logger } from "@/src/utils/logger"
-import fg from "fast-glob"
+import { glob, globSync } from "tinyglobby"
 import fs from "fs-extra"
 
 const FRAMEWORK_CONFIG_FILES = [
@@ -57,7 +57,7 @@ export async function getMonorepoTargets(cwd: string) {
   }
 
   // Resolve patterns to directories.
-  const dirs = await fg(patterns, {
+  const dirs = await glob(patterns, {
     cwd,
     onlyDirectories: true,
     ignore: ["**/node_modules/**"],
@@ -65,7 +65,10 @@ export async function getMonorepoTargets(cwd: string) {
 
   const targets: { name: string; hasConfig: boolean }[] = []
 
-  for (const dir of dirs) {
+  for (let dir of dirs) {
+    // Strip trailing slash added by tinyglobby (unlike fast-glob) for consistent directory names
+    dir = dir.replace(/\/$/, "")
+
     const fullPath = path.resolve(cwd, dir)
 
     // Check if it has a package.json (it's an actual workspace).
@@ -79,7 +82,7 @@ export async function getMonorepoTargets(cwd: string) {
 
     // Check for framework config files.
     const hasFrameworkConfig = FRAMEWORK_CONFIG_FILES.some((pattern) => {
-      const matches = fg.sync(pattern, {
+      const matches = globSync(pattern, {
         cwd: fullPath,
         dot: true,
       })

--- a/packages/shadcn/src/utils/get-project-info.ts
+++ b/packages/shadcn/src/utils/get-project-info.ts
@@ -10,8 +10,8 @@ import {
   getPackageImportAliases,
   getPackageImportPrefix,
 } from "@/src/utils/package-imports"
-import fg from "fast-glob"
 import fs from "fs-extra"
+import { glob } from "tinyglobby"
 import { loadConfig } from "tsconfig-paths"
 import { z } from "zod"
 
@@ -57,7 +57,7 @@ export async function getProjectInfo(
     aliasPrefixInfo,
     packageJson,
   ] = await Promise.all([
-    fg.glob(
+    glob(
       "**/{next,vite,astro,app}.config.*|gatsby-config.*|composer.json|react-router.config.*",
       {
         cwd,
@@ -260,7 +260,7 @@ export async function getTailwindCssFile(cwd: string, configCssFile?: string) {
   }
 
   const [files, tailwindVersion] = await Promise.all([
-    fg.glob(["**/*.css", "**/*.scss"], {
+    glob(["**/*.css", "**/*.scss"], {
       cwd,
       deep: 5,
       ignore: PROJECT_SHARED_IGNORE,
@@ -289,7 +289,7 @@ export async function getTailwindCssFile(cwd: string, configCssFile?: string) {
 }
 
 export async function getTailwindConfigFile(cwd: string) {
-  const files = await fg.glob("tailwind.config.*", {
+  const files = await glob("tailwind.config.*", {
     cwd,
     deep: 3,
     ignore: PROJECT_SHARED_IGNORE,
@@ -363,7 +363,7 @@ export async function getProjectAliasInfo(cwd: string) {
 }
 
 export async function isTypeScriptProject(cwd: string) {
-  const files = await fg.glob("tsconfig.*", {
+  const files = await glob("tsconfig.*", {
     cwd,
     deep: 1,
     ignore: PROJECT_SHARED_IGNORE,

--- a/packages/shadcn/src/utils/workspace.ts
+++ b/packages/shadcn/src/utils/workspace.ts
@@ -9,7 +9,7 @@ import {
   type ImportResolutionEntry,
   type ImportResolutionMatch,
 } from "@/src/utils/import-matcher"
-import fg from "fast-glob"
+import { glob } from "tinyglobby"
 import fs from "fs-extra"
 
 type WorkspacePackageInfo = {
@@ -133,7 +133,7 @@ async function loadWorkspacePackages(root: string) {
     return packageMap
   }
 
-  const packageJsonPaths = await fg(
+  const packageJsonPaths = await glob(
     patterns.map((pattern) =>
       path.posix.join(pattern.split(path.sep).join("/"), "package.json")
     ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,9 +419,6 @@ importers:
       execa:
         specifier: ^9.6.0
         version: 9.6.0
-      fast-glob:
-        specifier: ^3.3.3
-        version: 3.3.3
       fs-extra:
         specifier: ^11.3.1
         version: 11.3.1
@@ -455,6 +452,9 @@ importers:
       tailwind-merge:
         specifier: ^3.0.1
         version: 3.3.1
+      tinyglobby:
+        specifier: ^0.2.17
+        version: 0.2.17
       ts-morph:
         specifier: ^26.0.0
         version: 26.0.0
@@ -7804,14 +7804,6 @@ packages:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.14:
-    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
-    engines: {node: '>=12.0.0'}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -13474,7 +13466,7 @@ snapshots:
       picomatch: 4.0.3
       remark-mdx: 3.1.1
       tinyexec: 1.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.0.0
@@ -16496,16 +16488,6 @@ snapshots:
 
   tinyexec@1.0.2: {}
 
-  tinyglobby@0.2.14:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -16599,7 +16581,7 @@ snapshots:
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.6
@@ -16992,7 +16974,7 @@ snapshots:
       picomatch: 4.0.4
       postcss: 8.5.8
       rollup: 4.60.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 20.19.10
       fsevents: 2.3.3


### PR DESCRIPTION
Replace `fast-glob` with `tinyglobby` - it has 15 fewer dependencies, is [faster](https://e18e.dev/blog/tinyglobby-migration.html#performance), and is used in many large projects, such as Vite, Nuxt, and others. Unnecessary dependencies will only be removed if you update `@ts-morph` to at least v28.x - in that version, `fast-glob` was also replaced with `tinyglobby`.