### PR TITLE
feat(registry): add @remotionui registry

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1940,5 +1940,12 @@
     "url": "https://knock.codes/r/react/{name}.json",
     "description": "Copy-paste, session-gated access blocks for React — PIN/Knock Code unlock screens, protected routes/layouts/modals, a headless useKnockCodes hook, and full-page templates.",
     "logo": "<svg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'><rect width='32' height='32' rx='7' fill='#0A0A0B'/><rect x='9' y='9' width='14' height='14' rx='3' fill='#F59E0B'/></svg>"
+  },
+  {
+    "name": "@remotionui",
+    "homepage": "https://remotionui.com",
+    "url": "https://remotionui.com/r/{name}.json",
+    "description": "Copy-paste motion components for Remotion video projects - 200 captions, charts, transitions, backgrounds, and full compositions.",
+    "logo": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"var(--foreground)\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 2L2 7l10 5 10-5-10-5z\"/><path d=\"M2 17l10 5 10-5\"/><path d=\"M2 12l10 5 10-5\"/></svg>"
   }
 ]


### PR DESCRIPTION
## What

Adds @remotionui to the shadcn registry directory.

## Why

RemotionUI provides 120+ production-ready motion components for Remotion video projects, including:
- Animation primitives (fade, slide, scale, blur, typewriter)
- Transitions (fade, slide, wipe, clock wipe, light leak, spatial push)
- Scenes (lower third, title card, feature list, stat card, quote card)
- Compositions (intro, showcase, hero loop, social clip, podcast clip)
- Utilities (timing, springs, layout, caption utils, audio viz utils)

## Registry Info

- **Name**: @remotionui
- **Homepage**: https://remotionui.com
- **URL Template**: https://remotionui.com/r/{name}.json
- **Description**: Production-ready motion components for Remotion video projects. 120+ copy-paste components for captions, charts, transitions, and compositions.

## Validation

- [x] Registry is open source (MIT license)
- [x] Registry is publicly accessible at remotionui.com
- [x] Registry conforms to the [registry schema specification](https://ui.shadcn.com/docs/registry/registry-json)
- [x] Files array does not include `content` property
- [x] Validated with `npx shadcn@latest build` - all 123 components built successfully