### PR TITLE
fix(use-mobile): prefer globalThis over window (#10999)

### DIFF
--- a/apps/v4/hooks/use-mobile.ts
+++ b/apps/v4/hooks/use-mobile.ts
@@ -4,12 +4,12 @@ export function useIsMobile(mobileBreakpoint = 768) {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`)
+    const mql = globalThis.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`)
     const onChange = () => {
-      setIsMobile(window.innerWidth < mobileBreakpoint)
+      setIsMobile(globalThis.innerWidth < mobileBreakpoint)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < mobileBreakpoint)
+    setIsMobile(globalThis.innerWidth < mobileBreakpoint)
     return () => mql.removeEventListener("change", onChange)
   }, [mobileBreakpoint])
 

--- a/apps/v4/registry/bases/base/hooks/use-mobile.ts
+++ b/apps/v4/registry/bases/base/hooks/use-mobile.ts
@@ -6,12 +6,12 @@ export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const mql = globalThis.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+      setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener("change", onChange)
   }, [])
 

--- a/apps/v4/registry/bases/radix/hooks/use-mobile.ts
+++ b/apps/v4/registry/bases/radix/hooks/use-mobile.ts
@@ -6,12 +6,12 @@ export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const mql = globalThis.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+      setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener("change", onChange)
   }, [])
 

--- a/apps/v4/registry/new-york-v4/hooks/use-mobile.ts
+++ b/apps/v4/registry/new-york-v4/hooks/use-mobile.ts
@@ -6,12 +6,12 @@ export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const mql = globalThis.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+      setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener("change", onChange)
   }, [])
 


### PR DESCRIPTION
Fixes #10999

## Summary
Replaces bare `window` references in `use-mobile.ts` (and the three matching registry templates under `apps/v4/registry/.../hooks/use-mobile.ts`) with `globalThis`. This matches the pattern already used elsewhere in the codebase (e.g. `use-media-query`, `use-locale-storage`) and resolves the SonarQube violation reported in the issue. `globalThis` resolves to the same `window` object in browsers but works in environments where `window` is not defined, mirroring how the codebase already tolerates SSR/Node environments.

## Test plan
- `pnpm test --filter @workspace/v4 -- use-mobile` (uses `globalThis` and `window` interchangeably — behavior is identical)
- Manual: load the sidebar in a browser; resize window; confirm `isMobile` toggles on/off at the breakpoint.
- Diff is byte-for-byte equivalent except for the keyword on the binding surface.

## AI assistance
Generated-by: Dodothereal with Anthropic's Claude.

Reviewed and edited by hand.
