### PR TITLE
fix(examples): fix Enter key form submission in React Hook Form examples

### DIFF
--- a/apps/v4/registry/new-york-v4/examples/form-rhf-array.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-rhf-array.tsx
@@ -79,8 +79,8 @@ export default function FormRhfArray() {
         <CardTitle>Contact Emails</CardTitle>
         <CardDescription>Manage your contact email addresses.</CardDescription>
       </CardHeader>
-      <CardContent>
-        <form id="form-rhf-array" onSubmit={form.handleSubmit(onSubmit)}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <CardContent>
           <FieldSet className="gap-4">
             <FieldLegend variant="label">Email Addresses</FieldLegend>
             <FieldDescription>
@@ -143,18 +143,18 @@ export default function FormRhfArray() {
               <FieldError errors={[form.formState.errors.emails.root]} />
             )}
           </FieldSet>
-        </form>
-      </CardContent>
-      <CardFooter className="border-t">
-        <Field orientation="horizontal">
-          <Button type="button" variant="outline" onClick={() => form.reset()}>
-            Reset
-          </Button>
-          <Button type="submit" form="form-rhf-array">
-            Save
-          </Button>
-        </Field>
-      </CardFooter>
+        </CardContent>
+        <CardFooter className="border-t">
+          <Field orientation="horizontal">
+            <Button type="button" variant="outline" onClick={() => form.reset()}>
+              Reset
+            </Button>
+            <Button type="submit">
+              Save
+            </Button>
+          </Field>
+        </CardFooter>
+      </form>
     </Card>
   )
 }

--- a/apps/v4/registry/new-york-v4/examples/form-rhf-checkbox.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-rhf-checkbox.tsx
@@ -83,8 +83,8 @@ export default function FormRhfCheckbox() {
         <CardTitle>Notifications</CardTitle>
         <CardDescription>Manage your notification preferences.</CardDescription>
       </CardHeader>
-      <CardContent>
-        <form id="form-rhf-checkbox" onSubmit={form.handleSubmit(onSubmit)}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <CardContent>
           <FieldGroup>
             <Controller
               name="responses"
@@ -170,18 +170,18 @@ export default function FormRhfCheckbox() {
               )}
             />
           </FieldGroup>
-        </form>
-      </CardContent>
-      <CardFooter>
-        <Field orientation="horizontal">
-          <Button type="button" variant="outline" onClick={() => form.reset()}>
-            Reset
-          </Button>
-          <Button type="submit" form="form-rhf-checkbox">
-            Save
-          </Button>
-        </Field>
-      </CardFooter>
+        </CardContent>
+        <CardFooter>
+          <Field orientation="horizontal">
+            <Button type="button" variant="outline" onClick={() => form.reset()}>
+              Reset
+            </Button>
+            <Button type="submit">
+              Save
+            </Button>
+          </Field>
+        </CardFooter>
+      </form>
     </Card>
   )
 }

--- a/apps/v4/registry/new-york-v4/examples/form-rhf-complex.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-rhf-complex.tsx
@@ -122,8 +122,8 @@ export default function FormRhfComplex() {
           Choose your subscription plan and billing period.
         </CardDescription>
       </CardHeader>
-      <CardContent>
-        <form id="form-rhf-complex" onSubmit={form.handleSubmit(onSubmit)}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <CardContent>
           <FieldGroup>
             <Controller
               name="plan"
@@ -290,18 +290,18 @@ export default function FormRhfComplex() {
               )}
             />
           </FieldGroup>
-        </form>
-      </CardContent>
-      <CardFooter className="border-t">
-        <Field>
-          <Button type="submit" form="form-rhf-complex">
-            Save Preferences
-          </Button>
-          <Button type="button" variant="outline" onClick={() => form.reset()}>
-            Reset
-          </Button>
-        </Field>
-      </CardFooter>
+        </CardContent>
+        <CardFooter className="border-t">
+          <Field>
+            <Button type="submit">
+              Save Preferences
+            </Button>
+            <Button type="button" variant="outline" onClick={() => form.reset()}>
+              Reset
+            </Button>
+          </Field>
+        </CardFooter>
+      </form>
     </Card>
   )
 }

--- a/apps/v4/registry/new-york-v4/examples/form-rhf-demo.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-rhf-demo.tsx
@@ -75,8 +75,8 @@ export default function BugReportForm() {
           Help us improve by reporting bugs you encounter.
         </CardDescription>
       </CardHeader>
-      <CardContent>
-        <form id="form-rhf-demo" onSubmit={form.handleSubmit(onSubmit)}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <CardContent>
           <FieldGroup>
             <Controller
               name="title"
@@ -133,18 +133,18 @@ export default function BugReportForm() {
               )}
             />
           </FieldGroup>
-        </form>
-      </CardContent>
-      <CardFooter>
-        <Field orientation="horizontal">
-          <Button type="button" variant="outline" onClick={() => form.reset()}>
-            Reset
-          </Button>
-          <Button type="submit" form="form-rhf-demo">
-            Submit
-          </Button>
-        </Field>
-      </CardFooter>
+        </CardContent>
+        <CardFooter>
+          <Field orientation="horizontal">
+            <Button type="button" variant="outline" onClick={() => form.reset()}>
+              Reset
+            </Button>
+            <Button type="submit">
+              Submit
+            </Button>
+          </Field>
+        </CardFooter>
+      </form>
     </Card>
   )
 }

--- a/apps/v4/registry/new-york-v4/examples/form-rhf-input.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-rhf-input.tsx
@@ -67,8 +67,8 @@ export default function FormRhfInput() {
           Update your profile information below.
         </CardDescription>
       </CardHeader>
-      <CardContent>
-        <form id="form-rhf-input" onSubmit={form.handleSubmit(onSubmit)}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <CardContent>
           <FieldGroup>
             <Controller
               name="username"
@@ -97,18 +97,18 @@ export default function FormRhfInput() {
               )}
             />
           </FieldGroup>
-        </form>
-      </CardContent>
-      <CardFooter>
-        <Field orientation="horizontal">
-          <Button type="button" variant="outline" onClick={() => form.reset()}>
-            Reset
-          </Button>
-          <Button type="submit" form="form-rhf-input">
-            Save
-          </Button>
-        </Field>
-      </CardFooter>
+        </CardContent>
+        <CardFooter>
+          <Field orientation="horizontal">
+            <Button type="button" variant="outline" onClick={() => form.reset()}>
+              Reset
+            </Button>
+            <Button type="submit">
+              Save
+            </Button>
+          </Field>
+        </CardFooter>
+      </form>
     </Card>
   )
 }

--- a/apps/v4/registry/new-york-v4/examples/form-rhf-password.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-rhf-password.tsx
@@ -131,8 +131,8 @@ export default function FormRhfPassword() {
           Choose a strong password to secure your account.
         </CardDescription>
       </CardHeader>
-      <CardContent>
-        <form id="form-rhf-password" onSubmit={form.handleSubmit(onSubmit)}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <CardContent>
           <FieldGroup>
             <Controller
               name="password"
@@ -207,18 +207,18 @@ export default function FormRhfPassword() {
               )}
             />
           </FieldGroup>
-        </form>
-      </CardContent>
-      <CardFooter className="border-t">
-        <Field>
-          <Button type="submit" form="form-rhf-password">
-            Create Password
-          </Button>
-          <Button type="button" variant="outline" onClick={() => form.reset()}>
-            Reset
-          </Button>
-        </Field>
-      </CardFooter>
+        </CardContent>
+        <CardFooter className="border-t">
+          <Field>
+            <Button type="submit">
+              Create Password
+            </Button>
+            <Button type="button" variant="outline" onClick={() => form.reset()}>
+              Reset
+            </Button>
+          </Field>
+        </CardFooter>
+      </form>
     </Card>
   )
 }

--- a/apps/v4/registry/new-york-v4/examples/form-rhf-radiogroup.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-rhf-radiogroup.tsx
@@ -86,8 +86,8 @@ export default function FormRhfRadioGroup() {
           See pricing and features for each plan.
         </CardDescription>
       </CardHeader>
-      <CardContent>
-        <form id="form-rhf-radiogroup" onSubmit={form.handleSubmit(onSubmit)}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <CardContent>
           <FieldGroup>
             <Controller
               name="plan"
@@ -135,18 +135,18 @@ export default function FormRhfRadioGroup() {
               )}
             />
           </FieldGroup>
-        </form>
-      </CardContent>
-      <CardFooter>
-        <Field orientation="horizontal">
-          <Button type="button" variant="outline" onClick={() => form.reset()}>
-            Reset
-          </Button>
-          <Button type="submit" form="form-rhf-radiogroup">
-            Save
-          </Button>
-        </Field>
-      </CardFooter>
+        </CardContent>
+        <CardFooter>
+          <Field orientation="horizontal">
+            <Button type="button" variant="outline" onClick={() => form.reset()}>
+              Reset
+            </Button>
+            <Button type="submit">
+              Save
+            </Button>
+          </Field>
+        </CardFooter>
+      </form>
     </Card>
   )
 }

--- a/apps/v4/registry/new-york-v4/examples/form-rhf-select.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-rhf-select.tsx
@@ -85,8 +85,8 @@ export default function FormRhfSelect() {
           Select your preferred spoken language.
         </CardDescription>
       </CardHeader>
-      <CardContent>
-        <form id="form-rhf-select" onSubmit={form.handleSubmit(onSubmit)}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <CardContent>
           <FieldGroup>
             <Controller
               name="language"
@@ -133,18 +133,18 @@ export default function FormRhfSelect() {
               )}
             />
           </FieldGroup>
-        </form>
-      </CardContent>
-      <CardFooter>
-        <Field orientation="horizontal">
-          <Button type="button" variant="outline" onClick={() => form.reset()}>
-            Reset
-          </Button>
-          <Button type="submit" form="form-rhf-select">
-            Save
-          </Button>
-        </Field>
-      </CardFooter>
+        </CardContent>
+        <CardFooter>
+          <Field orientation="horizontal">
+            <Button type="button" variant="outline" onClick={() => form.reset()}>
+              Reset
+            </Button>
+            <Button type="submit">
+              Save
+            </Button>
+          </Field>
+        </CardFooter>
+      </form>
     </Card>
   )
 }

--- a/apps/v4/registry/new-york-v4/examples/form-rhf-switch.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-rhf-switch.tsx
@@ -64,8 +64,8 @@ export default function FormRhfSwitch() {
           Manage your account security preferences.
         </CardDescription>
       </CardHeader>
-      <CardContent>
-        <form id="form-rhf-switch" onSubmit={form.handleSubmit(onSubmit)}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <CardContent>
           <FieldGroup>
             <Controller
               name="twoFactor"
@@ -97,18 +97,18 @@ export default function FormRhfSwitch() {
               )}
             />
           </FieldGroup>
-        </form>
-      </CardContent>
-      <CardFooter>
-        <Field orientation="horizontal">
-          <Button type="button" variant="outline" onClick={() => form.reset()}>
-            Reset
-          </Button>
-          <Button type="submit" form="form-rhf-switch">
-            Save
-          </Button>
-        </Field>
-      </CardFooter>
+        </CardContent>
+        <CardFooter>
+          <Field orientation="horizontal">
+            <Button type="button" variant="outline" onClick={() => form.reset()}>
+              Reset
+            </Button>
+            <Button type="submit">
+              Save
+            </Button>
+          </Field>
+        </CardFooter>
+      </form>
     </Card>
   )
 }

--- a/apps/v4/registry/new-york-v4/examples/form-rhf-textarea.tsx
+++ b/apps/v4/registry/new-york-v4/examples/form-rhf-textarea.tsx
@@ -64,8 +64,8 @@ export default function FormRhfTextarea() {
           Customize your experience by telling us more about yourself.
         </CardDescription>
       </CardHeader>
-      <CardContent>
-        <form id="form-rhf-textarea" onSubmit={form.handleSubmit(onSubmit)}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <CardContent>
           <FieldGroup>
             <Controller
               name="about"
@@ -93,18 +93,18 @@ export default function FormRhfTextarea() {
               )}
             />
           </FieldGroup>
-        </form>
-      </CardContent>
-      <CardFooter>
-        <Field orientation="horizontal">
-          <Button type="button" variant="outline" onClick={() => form.reset()}>
-            Reset
-          </Button>
-          <Button type="submit" form="form-rhf-textarea">
-            Save
-          </Button>
-        </Field>
-      </CardFooter>
+        </CardContent>
+        <CardFooter>
+          <Field orientation="horizontal">
+            <Button type="button" variant="outline" onClick={() => form.reset()}>
+              Reset
+            </Button>
+            <Button type="submit">
+              Save
+            </Button>
+          </Field>
+        </CardFooter>
+      </form>
     </Card>
   )
 }


### PR DESCRIPTION
## Summary

- Move the `<form>` element in all 10 `form-rhf-*.tsx` examples to wrap both `<CardContent>` and `<CardFooter>`, placing the submit button inside the form
- Remove the HTML `form="..."` attribute from submit buttons (no longer needed)
- This fixes unreliable Enter key (implicit) form submission caused by browser inconsistencies with the `form` attribute for default button resolution

Fixes #10994