### PR TITLE
docs: Prevent execution of getThemeScript on server-side

### DIFF
--- a/apps/v4/content/docs/dark-mode/tanstack-start.mdx
+++ b/apps/v4/content/docs/dark-mode/tanstack-start.mdx
@@ -27,6 +27,8 @@ type ThemeProviderState = {
 }
 
 function getThemeScript(storageKey: string, defaultTheme: Theme) {
+  if (typeof window === 'undefined') return
+
   const key = JSON.stringify(storageKey)
   const fallback = JSON.stringify(defaultTheme)
 


### PR DESCRIPTION
Add a check for the `window` object in the `getThemeScript` function. Without this check, the script attempts to access browser-specific APIs during server-side rendering, which can lead to hydration mismatches, as shown in the screenshot.


<img width="1913" height="861" alt="Capture d’écran du 2026-06-25 05-28-04" src="https://github.com/user-attachments/assets/b4ecaf72-c0b7-4afb-9bbf-22100d01b838" />
