### PR TITLE
docs(calendar): document react-day-picker v10 Persian calendar migration

### DIFF
--- a/apps/v4/content/docs/components/base/calendar.mdx
+++ b/apps/v4/content/docs/components/base/calendar.mdx
@@ -90,11 +90,28 @@ You can use the `<Calendar>` component to build a date picker. See the [Date Pic
 
 ## Persian / Hijri / Jalali Calendar
 
-To use the Persian calendar, edit `components/ui/calendar.tsx` and replace `react-day-picker` with `react-day-picker/persian`.
+To use the Persian calendar, edit `components/ui/calendar.tsx` and replace the `DayPicker` import.
+
+**react-day-picker v9**
 
 ```diff
 - import { DayPicker } from "react-day-picker"
 + import { DayPicker } from "react-day-picker/persian"
+```
+
+**react-day-picker v10+**
+
+The Persian subpath was removed in v10 and moved to a separate package. Install it first:
+
+```bash
+npm install @daypicker/persian
+```
+
+Then update the import:
+
+```diff
+- import { DayPicker } from "react-day-picker"
++ import { DayPicker } from "@daypicker/persian"
 ```
 
 <ComponentPreview

--- a/apps/v4/content/docs/components/radix/calendar.mdx
+++ b/apps/v4/content/docs/components/radix/calendar.mdx
@@ -90,11 +90,28 @@ You can use the `<Calendar>` component to build a date picker. See the [Date Pic
 
 ## Persian / Hijri / Jalali Calendar
 
-To use the Persian calendar, edit `components/ui/calendar.tsx` and replace `react-day-picker` with `react-day-picker/persian`.
+To use the Persian calendar, edit `components/ui/calendar.tsx` and replace the `DayPicker` import.
+
+**react-day-picker v9**
 
 ```diff
 - import { DayPicker } from "react-day-picker"
 + import { DayPicker } from "react-day-picker/persian"
+```
+
+**react-day-picker v10+**
+
+The Persian subpath was removed in v10 and moved to a separate package. Install it first:
+
+```bash
+npm install @daypicker/persian
+```
+
+Then update the import:
+
+```diff
+- import { DayPicker } from "react-day-picker"
++ import { DayPicker } from "@daypicker/persian"
 ```
 
 <ComponentPreview


### PR DESCRIPTION
The `react-day-picker/persian` subpath was removed in v10 and moved to a separate `@daypicker/persian` package. Update the Persian/Hijri calendar section in both base and radix docs to show the correct import for both v9 and v10 users.

Fixes #11012