### PR TITLE
fix(cli): resolve tanstack start tailwind v4 init bug

### DIFF
--- a/packages/shadcn/src/utils/get-project-info.ts
+++ b/packages/shadcn/src/utils/get-project-info.ts
@@ -272,8 +272,6 @@ export async function getTailwindCssFile(cwd: string, configCssFile?: string) {
     return null
   }
 
-  const needle =
-    tailwindVersion === "v4" ? `@import "tailwindcss"` : "@tailwind base"
   for (const file of files) {
     const contents = await fs.readFile(path.resolve(cwd, file), "utf8")
     if (
@@ -282,6 +280,23 @@ export async function getTailwindCssFile(cwd: string, configCssFile?: string) {
       contents.includes(`@tailwind base`)
     ) {
       return file
+    }
+
+    if (tailwindVersion === "v4" && contents.includes("@theme")) {
+      return file
+    }
+  }
+
+  // For Tailwind v4 with @tailwindcss/vite, the vite plugin handles injection
+  // so the CSS file may not contain any Tailwind directives.
+  if (tailwindVersion === "v4") {
+    const packageInfo = getPackageInfo(cwd, false)
+    const hasTailwindVitePlugin =
+      packageInfo?.dependencies?.["@tailwindcss/vite"] ||
+      packageInfo?.devDependencies?.["@tailwindcss/vite"]
+
+    if (hasTailwindVitePlugin && files.length > 0) {
+      return files[0]
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue where the CLI fails to initialize a project using TanStack Start + Tailwind CSS v4 + Presets.

### Description
In projects using Tailwind CSS v4 (especially via the `@tailwindcss/vite` plugin), the CLI wasn't able to automatically detect the main CSS file because it relied on finding legacy Tailwind directives (like `@tailwind base` or `@import "tailwindcss"`). This caused the CLI to improperly fall back to legacy defaults (like `app/globals.css` and the `New York` style prompt), leading to an `ENOENT` error.

This patch updates `getTailwindCssFile` to:
- Correctly check for the `@theme` directive used in v4.
- Gracefully handle cases where the `@tailwindcss/vite` plugin is used, bypassing the need for Tailwind CSS directives altogether.

Fixes #11015.