### PR TITLE
fix(examples): wrap dropdown label in group in base message-scroller 'jumping to messages' example

### DIFF
--- a/apps/v4/examples/base/message-scroller-commands.tsx
+++ b/apps/v4/examples/base/message-scroller-commands.tsx
@@ -16,6 +16,7 @@ import {
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuTrigger,
@@ -137,22 +138,24 @@ function CommandMenu() {
         Jump to...
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" side="bottom" className="w-64">
-        <DropdownMenuLabel>Conversations</DropdownMenuLabel>
-        {userMessages.map((message) => (
-          <DropdownMenuItem
-            key={message.id}
-            onSelect={() =>
-              scrollToMessage(message.id, {
-                align: "start",
-                behavior: "smooth",
-              })
-            }
-          >
-            <span className="line-clamp-1 min-w-0">
-              {getTrimmedMessageText(message)}
-            </span>
-          </DropdownMenuItem>
-        ))}
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Conversations</DropdownMenuLabel>
+          {userMessages.map((message) => (
+            <DropdownMenuItem
+              key={message.id}
+              onSelect={() =>
+                scrollToMessage(message.id, {
+                  align: "start",
+                  behavior: "smooth",
+                })
+              }
+            >
+              <span className="line-clamp-1 min-w-0">
+                {getTrimmedMessageText(message)}
+              </span>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   )


### PR DESCRIPTION
The "Jump to..." menu in the Base UI MessageScroller "Jumping to messages"
example crashes on open with Base UI error https://base-ui.com/production-error?code=31

> Base UI: MenuGroupContext is missing. Menu group parts must be used
> within <Menu.Group> or <Menu.RadioGroup>.

`DropdownMenuLabel` renders Base UI's `Menu.GroupLabel`, which requires a
`Menu.Group` ancestor. The example rendered the label (and items) directly
inside `DropdownMenuContent` with no group, so opening the menu threw.

### Fix

Wrap the label and items in `DropdownMenuGroup` (Base UI `Menu.Group`) in
`apps/v4/examples/base/message-scroller-commands.tsx`.

### Affected

- Docs page: /docs/components/base/message-scroller#jumping-to-messages
- File: `apps/v4/examples/base/message-scroller-commands.tsx`

The Radix variant of this example does not use a group label, so no change
was needed there.

### Testing

- [x] Verified the menu opens without throwing in `pnpm --filter=v4 dev`
- [x] No registry index changes (content-only edit to an existing example;
      `__index__.tsx` / `__components__.tsx` reference the file by path)
      
Crash:

https://github.com/user-attachments/assets/485dc733-a8c2-4ec0-8779-ee1c6d113601

