### PR TITLE
fix(cli): reject unsafe registry file paths

### DIFF
--- a/packages/shadcn/src/utils/add-components.test.ts
+++ b/packages/shadcn/src/utils/add-components.test.ts
@@ -202,4 +202,59 @@ describe("addComponents", () => {
       mockUpdateCss.mock.invocationCallOrder[0]
     )
   })
+
+  it("rejects unsafe registry file paths before writing files", async () => {
+    mockResolveRegistryTree.mockResolvedValue({
+      dependencies: [],
+      devDependencies: [],
+      files: [
+        {
+          path: "components/../../outside-project.tsx",
+          type: "registry:component",
+          content: "export function OutsideProject() {}",
+        },
+      ],
+    })
+
+    await addComponents(
+      ["unsafe"],
+      {
+        style: "base-nova",
+        rsc: true,
+        tsx: true,
+        tailwind: {
+          baseColor: "neutral",
+        },
+        aliases: {
+          components: "@/components",
+          utils: "@/lib/utils",
+          ui: "@/components/ui",
+          lib: "@/lib",
+          hooks: "@/hooks",
+        },
+        resolvedPaths: {
+          cwd: "/test/project",
+          tailwindCss: "/test/project/app/globals.css",
+          tailwindConfig: "/test/project/tailwind.config.js",
+          utils: "/test/project/lib/utils.ts",
+          components: "/test/project/components",
+          lib: "/test/project/lib",
+          hooks: "/test/project/hooks",
+          ui: "/test/project/components/ui",
+        },
+      } as any,
+      {
+        silent: true,
+      }
+    )
+
+    const { handleError } = await import("@/src/utils/handle-error")
+    const error = vi.mocked(handleError).mock.calls[0]?.[0]
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toContain("unsafe file path")
+    expect(mockUpdateDependencies).not.toHaveBeenCalled()
+    expect(mockUpdateFiles).not.toHaveBeenCalled()
+    expect(spinnerInstance.fail).toHaveBeenCalled()
+  })
 })

--- a/packages/shadcn/src/utils/add-components.ts
+++ b/packages/shadcn/src/utils/add-components.ts
@@ -449,13 +449,17 @@ function validateFilesTarget(
   cwd: string
 ) {
   for (const file of files) {
-    if (!file?.target) {
-      continue
-    }
+    const filePaths = [file?.path, file?.target].filter(
+      (filePath): filePath is string => Boolean(filePath)
+    )
 
-    if (!isSafeTarget(file.target, cwd)) {
+    for (const filePath of filePaths) {
+      if (isSafeTarget(filePath, cwd)) {
+        continue
+      }
+
       throw new Error(
-        `We found an unsafe file path "${file.target} in the registry item. Installation aborted.`
+        `We found an unsafe file path "${filePath}" in the registry item. Installation aborted.`
       )
     }
   }


### PR DESCRIPTION
This rejects unsafe registry file paths before the CLI writes component files into a project. Relative paths that stay under the intended target continue to work; absolute paths and parent-directory escapes are rejected.

Tested with:

`git diff --check`
`npx --yes esbuild@0.27.1 packages/shadcn/src/utils/add-components.ts packages/shadcn/src/utils/add-components.test.ts --bundle --platform=node --format=esm --packages=external --outdir=/tmp/shadcn-add-components-check`

The focused Vitest target could not be run in this checkout because pnpm/node_modules were unavailable.
