### PR TITLE
fix(shadcn): add missing data-selected selector for boolean attribute

### DIFF
--- a/packages/shadcn/src/tailwind.css
+++ b/packages/shadcn/src/tailwind.css
@@ -54,7 +54,8 @@
 }
 
 @custom-variant data-selected {
-  &:where([data-selected="true"]) {
+  &:where([data-selected="true"]),
+  &:where([data-selected]:not([data-selected="false"])) {
     @slot;
   }
 }


### PR DESCRIPTION
## Why

Fixes overwritten base-ui `data-selected` styles by adding(accidentally missed) selector to the `data-selected` custom variant.

## Context

https://github.com/shadcn-ui/ui/issues/11038