### PR TITLE
fix(tailwind): support boolean data-selected attribute from Base UI

### DIFF
--- a/packages/shadcn/src/tailwind.css
+++ b/packages/shadcn/src/tailwind.css
@@ -54,7 +54,8 @@
 }
 
 @custom-variant data-selected {
-  &:where([data-selected="true"]) {
+  &:where([data-selected="true"]),
+  &:where([data-selected]:not([data-selected="false"])) {
     @slot;
   }
 }


### PR DESCRIPTION
## Problem

`@custom-variant data-selected` in `packages/shadcn/src/tailwind.css` only matched `[data-selected="true"]`, but Base UI sets `data-selected` as a **boolean attribute** (bare presence, no value) — not as `="true"`.

This means `data-selected:font-medium` and similar utilities had no effect on Base UI's Combobox, Select, and other components that use the attribute selector.

All other `@custom-variant` definitions in this file already handle both forms:

| Variant | Boolean form |
|---|---|
| `data-checked` | ✅ `[data-checked]:not([data-checked="false"])` |
| `data-disabled` | ✅ `[data-disabled]:not([data-disabled="false"])` |
| `data-active` | ✅ `[data-active]:not([data-active="false"])` |
| `data-selected` | ❌ only `[data-selected="true"]` ← **this PR** |

## Fix

```diff
 @custom-variant data-selected {
-  &:where([data-selected="true"]) {
+  &:where([data-selected="true"]),
+  &:where([data-selected]:not([data-selected="false"])) {
     @slot;
   }
 }
```

This matches the exact same pattern used by `data-checked`, `data-disabled`, and `data-active`.

Fixes #11038