### PR TITLE
fix(shadcn): add default condition to tailwind.css export for Turbopack

### DIFF
--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -56,7 +56,9 @@
       "types": "./dist/preset/index.d.ts",
       "default": "./dist/preset/index.js"
     },
-    "./tailwind.css": "./dist/tailwind.css"
+    "./tailwind.css": {
+      "default": "./dist/tailwind.css"
+    }
   },
   "sideEffects": [
     "./dist/tailwind.css"


### PR DESCRIPTION
## Problem

The `./tailwind.css` entry in `packages/shadcn/package.json` exports is a plain string:

```json
"./tailwind.css": "./dist/tailwind.css"
```

Every other export entry uses an object with named conditions (`types`, `default`). Turbopack's resolver requires the `default` condition to be explicitly present in an object — it doesn't recognise the string shorthand — causing this error when importing `shadcn/tailwind.css`:

```
CssSyntaxError: Can't resolve 'shadcn/tailwind.css'
```

## Fix

Expand the string to the object form used by every other export entry:

```diff
-"./tailwind.css": "./dist/tailwind.css"
+"./tailwind.css": {
+  "default": "./dist/tailwind.css"
+}
```

No runtime behaviour change — this is purely a resolver compatibility fix for Turbopack.

Fixes #10931