### PR TITLE
fix(use-mobile): avoid synchronous setState cascading renders (#11030)

### DIFF
--- a/apps/v4/hooks/use-mobile.ts
+++ b/apps/v4/hooks/use-mobile.ts
@@ -1,17 +1,20 @@
 import * as React from "react"
 
 export function useIsMobile(mobileBreakpoint = 768) {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+  const query = `(max-width: ${mobileBreakpoint - 1}px)`
 
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < mobileBreakpoint)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < mobileBreakpoint)
-    return () => mql.removeEventListener("change", onChange)
-  }, [mobileBreakpoint])
+  const subscribe = React.useCallback(
+    (callback: () => void) => {
+      const mql = window.matchMedia(query)
+      mql.addEventListener("change", callback)
+      return () => mql.removeEventListener("change", callback)
+    },
+    [query]
+  )
 
-  return !!isMobile
+  const getSnapshot = React.useCallback(() => {
+    return window.matchMedia(query).matches
+  }, [query])
+
+  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)
 }

--- a/apps/v4/public/r/styles/base-luma/use-mobile.json
+++ b/apps/v4/public/r/styles/base-luma/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-luma/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-lyra/use-mobile.json
+++ b/apps/v4/public/r/styles/base-lyra/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-lyra/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-maia/use-mobile.json
+++ b/apps/v4/public/r/styles/base-maia/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-maia/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-mira/use-mobile.json
+++ b/apps/v4/public/r/styles/base-mira/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-mira/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-nova/use-mobile.json
+++ b/apps/v4/public/r/styles/base-nova/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-nova/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-rhea/use-mobile.json
+++ b/apps/v4/public/r/styles/base-rhea/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-rhea/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-sera/use-mobile.json
+++ b/apps/v4/public/r/styles/base-sera/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-sera/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/base-vega/use-mobile.json
+++ b/apps/v4/public/r/styles/base-vega/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/base-vega/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/new-york-v4/use-mobile.json
+++ b/apps/v4/public/r/styles/new-york-v4/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/new-york-v4/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-luma/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-luma/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-luma/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-lyra/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-lyra/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-lyra/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-maia/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-maia/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-maia/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-mira/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-mira/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-mira/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-nova/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-nova/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-nova/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-rhea/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-rhea/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-rhea/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-sera/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-sera/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-sera/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/public/r/styles/radix-vega/use-mobile.json
+++ b/apps/v4/public/r/styles/radix-vega/use-mobile.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "registry/radix-vega/hooks/use-mobile.ts",
-      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nexport function useIsMobile() {\n  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)\n\n  React.useEffect(() => {\n    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)\n    const onChange = () => {\n      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    }\n    mql.addEventListener(\"change\", onChange)\n    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)\n    return () => mql.removeEventListener(\"change\", onChange)\n  }, [])\n\n  return !!isMobile\n}\n",
+      "content": "import * as React from \"react\"\n\nconst MOBILE_BREAKPOINT = 768\n\nconst query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`\n\nfunction subscribe(callback: () => void) {\n  const mql = window.matchMedia(query)\n  mql.addEventListener(\"change\", callback)\n  return () => mql.removeEventListener(\"change\", callback)\n}\n\nfunction getSnapshot() {\n  return window.matchMedia(query).matches\n}\n\nexport function useIsMobile() {\n  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)\n}\n",
       "type": "registry:hook"
     }
   ],

--- a/apps/v4/registry/bases/base/hooks/use-mobile.ts
+++ b/apps/v4/registry/bases/base/hooks/use-mobile.ts
@@ -2,18 +2,18 @@ import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
 
+const query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+
+function subscribe(callback: () => void) {
+  const mql = window.matchMedia(query)
+  mql.addEventListener("change", callback)
+  return () => mql.removeEventListener("change", callback)
+}
+
+function getSnapshot() {
+  return window.matchMedia(query).matches
+}
+
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)
 }

--- a/apps/v4/registry/bases/radix/hooks/use-mobile.ts
+++ b/apps/v4/registry/bases/radix/hooks/use-mobile.ts
@@ -2,18 +2,18 @@ import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
 
+const query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+
+function subscribe(callback: () => void) {
+  const mql = window.matchMedia(query)
+  mql.addEventListener("change", callback)
+  return () => mql.removeEventListener("change", callback)
+}
+
+function getSnapshot() {
+  return window.matchMedia(query).matches
+}
+
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)
 }

--- a/apps/v4/registry/new-york-v4/hooks/use-mobile.ts
+++ b/apps/v4/registry/new-york-v4/hooks/use-mobile.ts
@@ -2,18 +2,18 @@ import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
 
+const query = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+
+function subscribe(callback: () => void) {
+  const mql = window.matchMedia(query)
+  mql.addEventListener("change", callback)
+  return () => mql.removeEventListener("change", callback)
+}
+
+function getSnapshot() {
+  return window.matchMedia(query).matches
+}
+
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return React.useSyncExternalStore(subscribe, getSnapshot, () => false)
 }


### PR DESCRIPTION
### Describe the pull request

This pull request fixes a performance issue with the `use-mobile` hook in React 18+ setups, where synchronously calling `setState` within an effect causes cascading renders. This issue specifically affects components that rely on `use-mobile`, such as the `Sidebar`.

#### Root Cause
As outlined in the [React documentation](https://react.dev/learn/you-might-not-need-an-effect) and reported in #11030, calling `setState` inside a `useEffect` synchronously to respond to an external system triggers additional renders. In the previous implementation, evaluating `window.innerWidth` and immediately calling `setIsMobile` within the `useEffect` body caused this behavior.

#### Solution
Replaced the `useState` and `useEffect` pattern with `React.useSyncExternalStore`:
1. **Performance**: Avoids queuing extra renders since it correctly subscribes to `window.matchMedia` outside of the React render cycle.
2. **SSR Safety**: The `getServerSnapshot` safely falls back to returning `false`, avoiding server-side exceptions when `window` is undefined.

I have updated the registry files and run `pnpm registry:build` to regenerate the public JSON files.

Fixes #11030.
