### PR TITLE
fix(v4): build @shadcn/react before registry build

### DIFF
--- a/apps/v4/package.json
+++ b/apps/v4/package.json
@@ -15,7 +15,7 @@
     "format:check": "prettier --check \"**/*.{ts,tsx,mdx}\" --cache",
     "icons:dev": "tsx --tsconfig ./tsconfig.scripts.json ./scripts/build-icons.ts --watch",
     "icons:build": "tsx --tsconfig ./tsconfig.scripts.json ./scripts/build-icons.ts",
-    "registry:build": "pnpm --filter=shadcn build && bun run ./scripts/build-registry.mts",
+    "registry:build": "pnpm --filter=@shadcn/react build && pnpm --filter=shadcn build && bun run ./scripts/build-registry.mts",
     "registry:capture": "tsx --tsconfig ./tsconfig.scripts.json ./scripts/capture-registry.mts",
     "explore:capture": "tsx --tsconfig ./tsconfig.scripts.json ./scripts/capture-explore.mts",
     "validate:registries": "tsx --tsconfig ./tsconfig.scripts.json ./scripts/validate-registries.mts",


### PR DESCRIPTION
Build @shadcn/react before the registry build so the v4 app's @shadcn/react/message-scroller import resolves in a fresh CI clone, fixing the dev-server compile failure that was timing out the test job across PRs.