### PR TITLE
fix(empty): correct EmptyDescription prop type from ComponentProps<"p"> to ComponentProps<"div">

### DIFF
--- a/apps/v4/registry/bases/base/ui/empty.tsx
+++ b/apps/v4/registry/bases/base/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/registry/bases/radix/ui/empty.tsx
+++ b/apps/v4/registry/bases/radix/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/registry/new-york-v4/ui/empty.tsx
+++ b/apps/v4/registry/new-york-v4/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/base-luma/ui/empty.tsx
+++ b/apps/v4/styles/base-luma/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/base-lyra/ui/empty.tsx
+++ b/apps/v4/styles/base-lyra/ui/empty.tsx
@@ -65,7 +65,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/base-maia/ui/empty.tsx
+++ b/apps/v4/styles/base-maia/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/base-mira/ui/empty.tsx
+++ b/apps/v4/styles/base-mira/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/base-nova/ui-rtl/empty.tsx
+++ b/apps/v4/styles/base-nova/ui-rtl/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/base-nova/ui/empty.tsx
+++ b/apps/v4/styles/base-nova/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/base-rhea/ui/empty.tsx
+++ b/apps/v4/styles/base-rhea/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/base-sera/ui/empty.tsx
+++ b/apps/v4/styles/base-sera/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/base-vega/ui/empty.tsx
+++ b/apps/v4/styles/base-vega/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/radix-luma/ui/empty.tsx
+++ b/apps/v4/styles/radix-luma/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/radix-lyra/ui/empty.tsx
+++ b/apps/v4/styles/radix-lyra/ui/empty.tsx
@@ -65,7 +65,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/radix-maia/ui/empty.tsx
+++ b/apps/v4/styles/radix-maia/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/radix-mira/ui/empty.tsx
+++ b/apps/v4/styles/radix-mira/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/radix-nova/ui-rtl/empty.tsx
+++ b/apps/v4/styles/radix-nova/ui-rtl/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/radix-nova/ui/empty.tsx
+++ b/apps/v4/styles/radix-nova/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/radix-rhea/ui/empty.tsx
+++ b/apps/v4/styles/radix-rhea/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/radix-sera/ui/empty.tsx
+++ b/apps/v4/styles/radix-sera/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/styles/radix-vega/ui/empty.tsx
+++ b/apps/v4/styles/radix-vega/ui/empty.tsx
@@ -68,7 +68,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"


### PR DESCRIPTION
EmptyDescription renders a <div> element but its function signature types props as React.ComponentProps<"p">. Every other sub-component in the Empty family correctly matches its type annotation to its rendered element EmptyTitle, EmptyContent, EmptyHeader, etc. all use ComponentProps<"div">).

This inconsistency means the type annotation misrepresents what the component actually renders. The fix is to align the type with the rendered element across all 21 theme variants (new-york-v4, base, radix, and all style variants).

No behavior change — purely a type correction.