### PR TITLE
fix(shadcn): add missing default export condition for tailwind.css

### DIFF
--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -56,7 +56,10 @@
       "types": "./dist/preset/index.d.ts",
       "default": "./dist/preset/index.js"
     },
-    "./tailwind.css": "./dist/tailwind.css"
+    "./tailwind.css": {
+      "style": "./dist/tailwind.css",
+      "default": "./dist/tailwind.css"
+    }
   },
   "sideEffects": [
     "./dist/tailwind.css"


### PR DESCRIPTION
Closes #10931

Add a `default` condition alongside `style` in the exports map for `./tailwind.css`. Turbopack's resolver does not recognize the bare `style` condition without a `default` fallback, causing CssSyntaxError when importing `shadcn/tailwind.css`.

Other entries in the exports map already follow this pattern (both `types` and `default` conditions).