### PR TITLE
docs(message-scroller): clarify MessageAnimated is a demo wrapper

### DIFF
--- a/apps/v4/content/docs/components/base/message-scroller.mdx
+++ b/apps/v4/content/docs/components/base/message-scroller.mdx
@@ -365,6 +365,15 @@ const MotionMessageScrollerItem = motion.create(MessageScrollerItem)
   previewClassName="h-auto theme-blue bg-surface dark:bg-background p-4 min-[480px]:p-8 min-[560px]:p-10 sm:px-10 sm:py-16"
 />
 
+<Callout>
+  The `MessageAnimated` import in the example above is a demo wrapper used to
+  keep this documentation focused. It is not a published component, so it is not
+  available through the CLI or as a separate page—it only bundles the
+  `motion.create(MessageScrollerItem)` pattern shown above with the message
+  rendering. Build your own animated row from that pattern instead of importing
+  it.
+</Callout>
+
 Avoid animating height, margin, or padding for row entrances; those changes can
 fight the scroller's positioning work. If the reader prefers reduced motion,
 skip the entrance animation and keep the scroll behavior the same.

--- a/apps/v4/content/docs/components/radix/message-scroller.mdx
+++ b/apps/v4/content/docs/components/radix/message-scroller.mdx
@@ -365,6 +365,15 @@ const MotionMessageScrollerItem = motion.create(MessageScrollerItem)
   previewClassName="h-auto theme-blue bg-surface dark:bg-background p-4 min-[480px]:p-8 min-[560px]:p-10 sm:px-10 sm:py-16"
 />
 
+<Callout>
+  The `MessageAnimated` import in the example above is a demo wrapper used to
+  keep this documentation focused. It is not a published component, so it is not
+  available through the CLI or as a separate page—it only bundles the
+  `motion.create(MessageScrollerItem)` pattern shown above with the message
+  rendering. Build your own animated row from that pattern instead of importing
+  it.
+</Callout>
+
 Avoid animating height, margin, or padding for row entrances; those changes can
 fight the scroller's positioning work. If the reader prefers reduced motion,
 skip the entrance animation and keep the scroll behavior the same.


### PR DESCRIPTION
## Summary
- The "Animating New Messages" preview on the Message Scroller docs exposes source that imports `MessageAnimated` from `@/components/message-animated`, an internal demo helper that is not published to the registry — it cannot be installed via the CLI and has no docs page, so it read as a missing/broken component
- Add a `Callout` to the radix and base Message Scroller pages clarifying that `MessageAnimated` is a demo wrapper, pointing readers to the documented `motion.create(MessageScrollerItem)` pattern to build their own animated row
Fixes #11077

## Test plan
- [ ] `pnpm --filter=v4 dev`
- [ ] Open `/docs/components/radix/message-scroller` → "Animating New Messages" — the new Callout renders below the preview
- [ ] Open `/docs/components/base/message-scroller` → "Animating New Messages" — same Callout renders
- [ ] `pnpm exec prettier --check "apps/v4/content/docs/components/**/message-scroller.mdx"`