### PR TITLE
fix(registry): preserve auth headers across same-domain redirects

### DIFF
--- a/packages/shadcn/src/registry/proxy.test.ts
+++ b/packages/shadcn/src/registry/proxy.test.ts
@@ -1,0 +1,131 @@
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest"
+
+import { fetchWithProxy } from "./proxy"
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe("fetchWithProxy", () => {
+  it("keeps the Authorization header on a same-domain redirect (apex -> www)", async () => {
+    server.use(
+      http.get("https://example.com/r/component.json", () => {
+        return new HttpResponse(null, {
+          status: 308,
+          headers: { Location: "https://www.example.com/r/component.json" },
+        })
+      }),
+      http.get("https://www.example.com/r/component.json", ({ request }) => {
+        return HttpResponse.json({
+          authorization: request.headers.get("authorization"),
+        })
+      })
+    )
+
+    const response = await fetchWithProxy(
+      "https://example.com/r/component.json",
+      {
+        headers: new Headers({ Authorization: "Bearer secret-token" }),
+      }
+    )
+
+    await expect(response.json()).resolves.toEqual({
+      authorization: "Bearer secret-token",
+    })
+  })
+
+  it("keeps the Authorization header on a subdomain -> apex redirect", async () => {
+    server.use(
+      http.get("https://www.example.com/r/component.json", () => {
+        return new HttpResponse(null, {
+          status: 301,
+          headers: { Location: "https://example.com/r/component.json" },
+        })
+      }),
+      http.get("https://example.com/r/component.json", ({ request }) => {
+        return HttpResponse.json({
+          authorization: request.headers.get("authorization"),
+        })
+      })
+    )
+
+    const response = await fetchWithProxy(
+      "https://www.example.com/r/component.json",
+      {
+        headers: new Headers({ Authorization: "Bearer secret-token" }),
+      }
+    )
+
+    await expect(response.json()).resolves.toEqual({
+      authorization: "Bearer secret-token",
+    })
+  })
+
+  it("drops the Authorization header on a cross-domain redirect", async () => {
+    server.use(
+      http.get("https://example.com/r/component.json", () => {
+        return new HttpResponse(null, {
+          status: 308,
+          headers: { Location: "https://not-example.com/r/component.json" },
+        })
+      }),
+      http.get("https://not-example.com/r/component.json", ({ request }) => {
+        return HttpResponse.json({
+          authorization: request.headers.get("authorization"),
+          userAgent: request.headers.get("user-agent"),
+        })
+      })
+    )
+
+    const response = await fetchWithProxy(
+      "https://example.com/r/component.json",
+      {
+        headers: new Headers({
+          Authorization: "Bearer secret-token",
+          "User-Agent": "shadcn",
+        }),
+      }
+    )
+
+    // Sensitive headers are dropped across origins, but non-sensitive headers
+    // (like User-Agent) are preserved.
+    await expect(response.json()).resolves.toEqual({
+      authorization: null,
+      userAgent: "shadcn",
+    })
+  })
+
+  it("throws once the maximum number of redirects is exceeded", async () => {
+    server.use(
+      http.get("https://example.com/hop/:step", ({ params }) => {
+        const step = Number(params.step)
+        return new HttpResponse(null, {
+          status: 308,
+          headers: { Location: `https://example.com/hop/${step + 1}` },
+        })
+      })
+    )
+
+    await expect(fetchWithProxy("https://example.com/hop/0")).rejects.toThrow(
+      /maximum number of redirects/
+    )
+  })
+
+  it("returns the final response for a non-redirected request", async () => {
+    server.use(
+      http.get("https://example.com/r/component.json", () => {
+        return HttpResponse.json({ ok: true })
+      })
+    )
+
+    const response = await fetchWithProxy(
+      "https://example.com/r/component.json"
+    )
+
+    await expect(response.json()).resolves.toEqual({ ok: true })
+  })
+})

--- a/packages/shadcn/src/registry/proxy.ts
+++ b/packages/shadcn/src/registry/proxy.ts
@@ -11,14 +11,26 @@ const proxyDispatcher =
     ? new EnvHttpProxyAgent()
     : undefined
 
+// Headers that must not leak to a different origin across a redirect. Native
+// fetch/undici strips these on every cross-origin hop, which breaks
+// authenticated registries that redirect between the apex and `www` host. We
+// follow redirects manually so we can re-attach them when the redirect stays on
+// the same registrable domain, matching the previous node-fetch behavior.
+const SENSITIVE_HEADERS = [
+  "authorization",
+  "cookie",
+  "cookie2",
+  "www-authenticate",
+]
+
+// Matches the redirect cap used by browsers and undici.
+const MAX_REDIRECTS = 20
+
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308])
+
 export async function fetchWithProxy(url: string | URL, init?: RequestInit) {
   try {
-    // The `dispatcher` option is supported by Node's fetch at runtime but
-    // missing from the ambient RequestInit type, hence the cast.
-    return await fetch(url, {
-      ...init,
-      dispatcher: proxyDispatcher,
-    } as RequestInit)
+    return await fetchFollowingRedirects(url, init)
   } catch (error) {
     // Native fetch reports network failures as a generic "fetch failed"
     // TypeError with the actual reason buried in `cause`. The casts are
@@ -38,6 +50,80 @@ export async function fetchWithProxy(url: string | URL, init?: RequestInit) {
 
     throw error
   }
+}
+
+// Follows redirects manually (with `redirect: "manual"`) so that per-registry
+// headers such as Authorization survive redirects that only change the host to
+// a same-domain target (e.g. apex -> www). Native fetch would silently drop
+// them on any cross-origin hop.
+async function fetchFollowingRedirects(url: string | URL, init?: RequestInit) {
+  let currentUrl = new URL(typeof url === "string" ? url : url.toString())
+  let method = (init?.method ?? "GET").toUpperCase()
+  let body = init?.body
+  const headers = new Headers(init?.headers)
+
+  for (let redirectCount = 0; ; redirectCount++) {
+    // The `dispatcher` option is supported by Node's fetch at runtime but
+    // missing from the ambient RequestInit type, hence the cast.
+    const response = await fetch(currentUrl, {
+      ...init,
+      method,
+      body,
+      headers,
+      redirect: "manual",
+      dispatcher: proxyDispatcher,
+    } as RequestInit)
+
+    const location = response.headers.get("location")
+    if (!REDIRECT_STATUS_CODES.has(response.status) || !location) {
+      return response
+    }
+
+    if (redirectCount >= MAX_REDIRECTS) {
+      throw new TypeError(
+        `Reached the maximum number of redirects (${MAX_REDIRECTS}) while requesting ${currentUrl.href}`
+      )
+    }
+
+    const nextUrl = new URL(location, currentUrl)
+
+    // Drop sensitive headers when the redirect leaves the original registrable
+    // domain (or downgrades the protocol), but keep them for same-site hops.
+    if (!isSameSite(currentUrl, nextUrl)) {
+      for (const name of SENSITIVE_HEADERS) {
+        headers.delete(name)
+      }
+    }
+
+    // Per the fetch redirect semantics, 303 (and 301/302 on POST) become a
+    // bodyless GET.
+    if (
+      response.status === 303 ||
+      ((response.status === 301 || response.status === 302) &&
+        method === "POST")
+    ) {
+      method = "GET"
+      body = undefined
+      headers.delete("content-length")
+      headers.delete("content-type")
+    }
+
+    currentUrl = nextUrl
+  }
+}
+
+// A redirect is "same-site" when it keeps the same protocol and the target host
+// is the same domain or a sub/parent-domain of the original (e.g. apex <-> www).
+// This mirrors node-fetch's rule for preserving sensitive headers.
+function isSameSite(original: URL, destination: URL): boolean {
+  if (original.protocol !== destination.protocol) {
+    return false
+  }
+
+  const orig = original.hostname
+  const dest = destination.hostname
+
+  return orig === dest || orig.endsWith(`.${dest}`) || dest.endsWith(`.${orig}`)
 }
 
 function getFailureReason(cause: unknown): string {


### PR DESCRIPTION
## Summary

Closes #11071

Restores authentication for registries whose URL redirects across hosts (e.g. apex → `www`). Since CLI 4.11.1 replaced `node-fetch` with native `fetch`/`undici`, the `Authorization` header was stripped on every cross-origin redirect, so `shadcn add` returned `401 Unauthorized` for these registries even with a valid API key.

## Problem

`4.11.1` (commit `9197676`) swapped `node-fetch` for native `fetch` + `undici`.

- `node-fetch` kept `Authorization` when the redirect target was the **same domain or a subdomain** (so apex ↔ `www` preserved the header).
- Native `fetch`/`undici` strips `Authorization` on **any cross-origin redirect**, including apex ↔ `www`.

Registries that rely on a host-level redirect (apex → `www` is extremely common on Vercel/Netlify/Cloudflare) broke for authenticated installs after a routine, unpinned `npx shadcn@latest` upgrade — with no change on the user's side.

## Fix

`fetchWithProxy` now follows redirects manually (`redirect: "manual"`) instead of delegating to native follow:

- Re-attach per-registry headers when the redirect stays on the **same registrable domain and protocol** (apex ↔ `www`, sub/parent domains), matching the previous `node-fetch` behavior.
- Still drop sensitive headers (`authorization`, `cookie`, `cookie2`, `www-authenticate`) on genuine cross-origin hops (different registrable domain or protocol downgrade).
- Preserve non-sensitive headers (`User-Agent`, `Accept-Encoding`) on every hop, so GitHub raw → CDN redirects keep working.
- Normalize method/body per the fetch spec (303, and 301/302 on POST, become a bodyless GET) and cap redirects at 20 to guard against loops.

## Tests

Added `packages/shadcn/src/registry/proxy.test.ts` covering:

- keeps `Authorization` on a same-domain redirect (apex → `www`).
- keeps `Authorization` on a subdomain → apex redirect.
- drops `Authorization` on a cross-domain redirect, while preserving `User-Agent`.
- throws once the maximum number of redirects is exceeded.
- returns the final response for a non-redirected request.

## Verification

- `npx tsc --noEmit` (typecheck) ✅
- `npx prettier --check` on changed files ✅
- `npx vitest run` — full `shadcn` package suite green: **1528 passed (80 files)**, including `github.test.ts` and `fetcher.test.ts` ✅

## Scope

- 2 files changed:
  - `packages/shadcn/src/registry/proxy.ts`
  - `packages/shadcn/src/registry/proxy.test.ts`
- No generated registry files or docs changed.