### PR TITLE
docs: update outdated ReactDayPicker documentation URL

### DIFF
--- a/apps/v4/content/docs/components/base/calendar.mdx
+++ b/apps/v4/content/docs/components/base/calendar.mdx
@@ -4,7 +4,7 @@ description: A calendar component that allows users to select a date or a range 
 base: base
 component: true
 links:
-  doc: https://react-day-picker.js.org
+  doc: https://daypicker.dev/
 ---
 
 <ComponentPreview
@@ -78,11 +78,11 @@ return (
 )
 ```
 
-See the [React DayPicker](https://react-day-picker.js.org) documentation for more information.
+See the [React DayPicker](https://daypicker.dev/) documentation for more information.
 
 ## About
 
-The `Calendar` component is built on top of [React DayPicker](https://react-day-picker.js.org).
+The `Calendar` component is built on top of [React DayPicker](https://daypicker.dev/).
 
 ## Date Picker
 
@@ -260,7 +260,7 @@ import { arSA } from "react-day-picker/locale"
 
 ## API Reference
 
-See the [React DayPicker](https://react-day-picker.js.org) documentation for more information on the `Calendar` component.
+See the [React DayPicker](https://daypicker.dev/) documentation for more information on the `Calendar` component.
 
 ## Changelog
 

--- a/apps/v4/content/docs/components/base/date-picker.mdx
+++ b/apps/v4/content/docs/components/base/date-picker.mdx
@@ -56,7 +56,7 @@ export function DatePickerDemo() {
 }
 ```
 
-See the [React DayPicker](https://react-day-picker.js.org) documentation for more information.
+See the [React DayPicker](https://daypicker.dev/) documentation for more information.
 
 ## Composition
 

--- a/apps/v4/content/docs/components/radix/calendar.mdx
+++ b/apps/v4/content/docs/components/radix/calendar.mdx
@@ -4,7 +4,7 @@ description: A calendar component that allows users to select a date or a range 
 base: radix
 component: true
 links:
-  doc: https://react-day-picker.js.org
+  doc: https://daypicker.dev/
 ---
 
 <ComponentPreview
@@ -78,11 +78,11 @@ return (
 )
 ```
 
-See the [React DayPicker](https://react-day-picker.js.org) documentation for more information.
+See the [React DayPicker](https://daypicker.dev/) documentation for more information.
 
 ## About
 
-The `Calendar` component is built on top of [React DayPicker](https://react-day-picker.js.org).
+The `Calendar` component is built on top of [React DayPicker](https://daypicker.dev/).
 
 ## Date Picker
 
@@ -260,7 +260,7 @@ import { arSA } from "react-day-picker/locale"
 
 ## API Reference
 
-See the [React DayPicker](https://react-day-picker.js.org) documentation for more information on the `Calendar` component.
+See the [React DayPicker](https://daypicker.dev/) documentation for more information on the `Calendar` component.
 
 ## Changelog
 

--- a/apps/v4/content/docs/components/radix/date-picker.mdx
+++ b/apps/v4/content/docs/components/radix/date-picker.mdx
@@ -54,7 +54,7 @@ export function DatePickerDemo() {
 }
 ```
 
-See the [React DayPicker](https://react-day-picker.js.org) documentation for more information.
+See the [React DayPicker](https://daypicker.dev/) documentation for more information.
 
 ## Composition
 

--- a/apps/v4/registry/__index__.tsx
+++ b/apps/v4/registry/__index__.tsx
@@ -7170,7 +7170,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/base/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/base/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },
@@ -8503,7 +8503,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/radix/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/radix/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },
@@ -9836,7 +9836,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/radix/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/radix/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },
@@ -11169,7 +11169,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/radix/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/radix/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },
@@ -12502,7 +12502,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/radix/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/radix/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },
@@ -13835,7 +13835,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/radix/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/radix/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },
@@ -15168,7 +15168,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/radix/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/radix/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },
@@ -16501,7 +16501,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/radix/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/radix/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },
@@ -17834,7 +17834,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/radix/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/radix/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },
@@ -19166,7 +19166,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/base/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/base/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },
@@ -20498,7 +20498,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/base/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/base/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },
@@ -21830,7 +21830,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/base/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/base/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },
@@ -23162,7 +23162,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/base/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/base/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },
@@ -24494,7 +24494,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/base/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/base/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },
@@ -25826,7 +25826,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/base/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/base/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },
@@ -27158,7 +27158,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/base/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/base/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },

--- a/apps/v4/registry/bases/__index__.tsx
+++ b/apps/v4/registry/bases/__index__.tsx
@@ -226,7 +226,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/radix/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/radix/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },
@@ -3873,7 +3873,7 @@ export const Index: Record<string, Record<string, any>> = {
           docs: "https://ui.shadcn.com/docs/components/base/calendar",
           examples:
             "https://ui.shadcn.com/code/apps/v4/registry/bases/base/examples/calendar-example.tsx",
-          api: "https://react-day-picker.js.org",
+          api: "https://daypicker.dev/",
         },
       },
     },

--- a/apps/v4/registry/bases/base/ui/_registry.ts
+++ b/apps/v4/registry/bases/base/ui/_registry.ts
@@ -175,7 +175,7 @@ export const ui: Registry["items"] = [
         docs: "https://ui.shadcn.com/docs/components/base/calendar",
         examples:
           "https://ui.shadcn.com/code/apps/v4/registry/bases/base/examples/calendar-example.tsx",
-        api: "https://react-day-picker.js.org",
+        api: "https://daypicker.dev/",
       },
     },
   },

--- a/apps/v4/registry/bases/radix/ui/_registry.ts
+++ b/apps/v4/registry/bases/radix/ui/_registry.ts
@@ -176,7 +176,7 @@ export const ui: Registry["items"] = [
         docs: "https://ui.shadcn.com/docs/components/radix/calendar",
         examples:
           "https://ui.shadcn.com/code/apps/v4/registry/bases/radix/examples/calendar-example.tsx",
-        api: "https://react-day-picker.js.org",
+        api: "https://daypicker.dev/",
       },
     },
   },


### PR DESCRIPTION
Summary
Updated the documentation link for ReactDayPicker in the repository. The previous link pointed to an outdated domain/version.

🔄 Type of Change
[x] Bug fix (non-breaking change which fixes an issue with outdated documentation link)

[ ] New feature (non-breaking change which adds functionality)

[x] Documentation update (changes to documentation only)

🛠️ Changes Made
Located the outdated ReactDayPicker documentation link in the repository.

Removed the legacy domain structure.

Updated the reference to point directly to the live, updated ReactDayPicker documentation URL.

❓ Context & Motivation
While navigating through the docs, I noticed that clicking on the ReactDayPicker link led to an outdated version of the documentation due to an old domain format. Ensuring the documentation links are up-to-date prevents confusion for future developers and users trying to understand the integration.

Links
Old Link: [https://react-day-picker.js.org/]

New Link: [https://daypicker.dev/]

✅ Checklist
[x] My code follows the style guidelines of this project.

[x] I have performed a self-review of my own changes.

[x] The link has been verified and resolves correctly to the latest documentation.