### PR TITLE
fix(hooks): use globalThis instead of window in use-mobile for SSR safety

### DIFF
--- a/apps/v4/hooks/use-mobile.ts
+++ b/apps/v4/hooks/use-mobile.ts
@@ -4,12 +4,12 @@ export function useIsMobile(mobileBreakpoint = 768) {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`)
+    const mql = globalThis.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`)
     const onChange = () => {
-      setIsMobile(window.innerWidth < mobileBreakpoint)
+      setIsMobile(globalThis.innerWidth < mobileBreakpoint)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < mobileBreakpoint)
+    setIsMobile(globalThis.innerWidth < mobileBreakpoint)
     return () => mql.removeEventListener("change", onChange)
   }, [mobileBreakpoint])
 

--- a/apps/v4/registry/bases/base/hooks/use-mobile.ts
+++ b/apps/v4/registry/bases/base/hooks/use-mobile.ts
@@ -6,12 +6,12 @@ export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const mql = globalThis.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+      setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener("change", onChange)
   }, [])
 

--- a/apps/v4/registry/bases/radix/hooks/use-mobile.ts
+++ b/apps/v4/registry/bases/radix/hooks/use-mobile.ts
@@ -6,12 +6,12 @@ export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const mql = globalThis.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+      setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener("change", onChange)
   }, [])
 

--- a/apps/v4/registry/new-york-v4/hooks/use-mobile.ts
+++ b/apps/v4/registry/new-york-v4/hooks/use-mobile.ts
@@ -6,12 +6,12 @@ export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const mql = globalThis.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+      setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener("change", onChange)
   }, [])
 


### PR DESCRIPTION
## What

Replaces direct `window` references in `use-mobile.ts` with `globalThis` across all registry variants.

## Why

`window` is not defined in SSR environments (Next.js App Router server components, Node.js). Accessing it throws `ReferenceError: window is not defined`. `globalThis` is the universal global object that resolves correctly in both browser and server contexts.

## Changes

Replaced `window.matchMedia(...)` and `window.innerWidth` with `globalThis.matchMedia(...)` and `globalThis.innerWidth` in:

- `apps/v4/hooks/use-mobile.ts`
- `apps/v4/registry/bases/base/hooks/use-mobile.ts`
- `apps/v4/registry/bases/radix/hooks/use-mobile.ts`
- `apps/v4/registry/new-york-v4/hooks/use-mobile.ts`

Closes #10999