### PR TITLE
fix(cli): keep nested at-rules scoped to their selector when merging CSS

### DIFF
--- a/packages/shadcn/src/utils/updaters/update-css.test.ts
+++ b/packages/shadcn/src/utils/updaters/update-css.test.ts
@@ -299,6 +299,38 @@ describe("transformCss", () => {
     `)
   })
 
+  it("should keep at-rules nested inside a selector scoped to that selector", async () => {
+    const input = `@tailwind base;
+@tailwind components;
+@tailwind utilities;`
+
+    const result = await transformCss(input, {
+      "@layer base": {
+        body: {
+          "--foo": "1rem",
+          "@media (width >= 40rem)": {
+            "--foo": "2rem",
+          },
+        },
+      },
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      "@tailwind base;
+      @tailwind components;
+      @tailwind utilities;
+
+      @layer base {
+        body {
+          --foo: 1rem;
+        @media (width >= 40rem) {
+          --foo: 2rem;
+          }
+        }
+      }"
+    `)
+  })
+
   it("should place keyframes under @theme inline directive", async () => {
     const input = `@import "tailwindcss";`
 

--- a/packages/shadcn/src/utils/updaters/update-css.ts
+++ b/packages/shadcn/src/utils/updaters/update-css.ts
@@ -522,7 +522,11 @@ function processAtRule(
   }
 }
 
-function processRule(parent: Root | AtRule, selector: string, properties: any) {
+function processRule(
+  parent: Root | AtRule | Rule,
+  selector: string,
+  properties: any
+) {
   let rule = parent.nodes?.find(
     (node): node is Rule => node.type === "rule" && node.selector === selector
   ) as Rule | undefined
@@ -594,6 +598,15 @@ function processRule(parent: Root | AtRule, selector: string, properties: any) {
         )
 
         existingDecl ? existingDecl.replaceWith(decl) : rule.append(decl)
+      } else if (
+        prop.startsWith("@") &&
+        typeof value === "object" &&
+        value !== null
+      ) {
+        // Nested at-rule with a body (e.g. @media, @supports, @container).
+        // Keep it scoped to the current rule instead of hoisting it up to the
+        // parent, so declarations stay inside the selector they belong to.
+        processRule(rule, prop, value)
       } else if (typeof value === "object") {
         // Nested selector (including & selectors).
         const nestedSelector = prop.startsWith("&")


### PR DESCRIPTION
When a registry item's css nests an at-rule such as @media inside a selector, the CLI placed it under the parent at-rule instead of the selector. This happened because processRule recursed with the parent container for nested objects, so the at-rule and its declarations were hoisted up one level and produced invalid css. The fix keeps nested at-rules scoped to the current rule so their declarations stay inside the correct selector. Includes a regression test.

Fixes #10375
