### PR TITLE
feat(registry): add @mozaika to the registry directory

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -820,6 +820,13 @@
     "logo": "<svg role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 70 70' aria-label='MP Logo' width='70' height='70' fill='none'><path stroke='currentColor' stroke-linecap='round' stroke-width='3' d='M51.883 26.495c-7.277-4.124-18.08-7.004-26.519-7.425-2.357-.118-4.407-.244-6.364 1.06M59.642 51c-10.47-7.25-26.594-13.426-39.514-15.664-3.61-.625-6.744-1.202-9.991.263'/></svg>"
   },
   {
+    "name": "@mozaika",
+    "homepage": "https://mozaika.design",
+    "url": "https://mozaika.design/r/{name}.json",
+    "description": "Design systems measured from real product UIs — color roles, typography and spacing as themes installable with the shadcn CLI. Free open shelf; companion MCP server for AI coding agents.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='var(--foreground)' width='24' height='24'><rect x='3' y='3' width='8' height='8'/><rect x='13' y='3' width='8' height='8' opacity='.4'/><rect x='3' y='13' width='8' height='8' opacity='.4'/><rect x='13' y='13' width='8' height='8'/></svg>"
+  },
+  {
     "name": "@mui-treasury",
     "homepage": "https://www.mui-treasury.com",
     "url": "https://mui-treasury.com/r/{name}.json",


### PR DESCRIPTION
Adds **@mozaika** to `apps/v4/registry/directory.json` — single-file, 7-line diff, inserted alphabetically between `@motion-primitives` and `@mui-treasury`.

## What the registry is

Design systems **measured from real product UIs** (colors by role, typography, spacing, radii — probed from the live DOM, not eyeballed), served as `registry:theme` items installable with the shadcn CLI. The measured action color maps to `primary` + `ring`; fonts ship as Google Fonts `@import` with free fallback stacks.

- Registry index: https://mozaika.design/r/registry.json (351 items, public, flat root, `{name}` placeholder preserved)
- Example items (public): https://mozaika.design/r/linear.json · https://mozaika.design/r/mercury.json · https://mozaika.design/r/vercel.json

## Free/paid split — stated upfront

A rotating **open shelf** (30 items/month, always including a flagship core set) returns `200` for everyone. Off-shelf items return `402` with a structured payload unless the request carries an entitled key (`?token=`). The index itself is fully public and marks free items. This follows the existing freemium precedent in the directory (e.g. shadcn-ui-blocks). If the directory policy requires all items open, happy to adjust before merge.

## Checks

- JSON validated; entry mirrors the documented format (name/homepage/url/description/logo)
- Logo is inline SVG using `var(--foreground)` — renders in light and dark
- No other files touched

Note: the commit is not GPG-signed (CLI push) — glad to re-submit signed if required.