### PR TITLE
fix(sidebar): ignore extra modifier keys in keyboard shortcut handler

### DIFF
--- a/apps/v4/hooks/use-mobile.ts
+++ b/apps/v4/hooks/use-mobile.ts
@@ -4,12 +4,12 @@ export function useIsMobile(mobileBreakpoint = 768) {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`)
+    const mql = globalThis.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`)
     const onChange = () => {
-      setIsMobile(window.innerWidth < mobileBreakpoint)
+      setIsMobile(globalThis.innerWidth < mobileBreakpoint)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < mobileBreakpoint)
+    setIsMobile(globalThis.innerWidth < mobileBreakpoint)
     return () => mql.removeEventListener("change", onChange)
   }, [mobileBreakpoint])
 

--- a/apps/v4/registry/bases/base/hooks/use-mobile.ts
+++ b/apps/v4/registry/bases/base/hooks/use-mobile.ts
@@ -6,12 +6,12 @@ export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const mql = globalThis.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+      setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener("change", onChange)
   }, [])
 

--- a/apps/v4/registry/bases/base/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/base/ui/sidebar.tsx
@@ -98,7 +98,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/registry/bases/radix/hooks/use-mobile.ts
+++ b/apps/v4/registry/bases/radix/hooks/use-mobile.ts
@@ -6,12 +6,12 @@ export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const mql = globalThis.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+      setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener("change", onChange)
   }, [])
 

--- a/apps/v4/registry/bases/radix/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/radix/ui/sidebar.tsx
@@ -97,7 +97,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/registry/new-york-v4/hooks/use-mobile.ts
+++ b/apps/v4/registry/new-york-v4/hooks/use-mobile.ts
@@ -6,12 +6,12 @@ export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const mql = globalThis.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+      setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     }
     mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener("change", onChange)
   }, [])
 

--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -98,7 +98,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-luma/ui/sidebar.tsx
+++ b/apps/v4/styles/base-luma/ui/sidebar.tsx
@@ -98,7 +98,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-lyra/ui/sidebar.tsx
+++ b/apps/v4/styles/base-lyra/ui/sidebar.tsx
@@ -98,7 +98,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-maia/ui/sidebar.tsx
+++ b/apps/v4/styles/base-maia/ui/sidebar.tsx
@@ -98,7 +98,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-mira/ui/sidebar.tsx
+++ b/apps/v4/styles/base-mira/ui/sidebar.tsx
@@ -98,7 +98,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-nova/ui-rtl/sidebar.tsx
+++ b/apps/v4/styles/base-nova/ui-rtl/sidebar.tsx
@@ -98,7 +98,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-nova/ui/sidebar.tsx
+++ b/apps/v4/styles/base-nova/ui/sidebar.tsx
@@ -98,7 +98,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-rhea/ui/sidebar.tsx
+++ b/apps/v4/styles/base-rhea/ui/sidebar.tsx
@@ -98,7 +98,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-sera/ui/sidebar.tsx
+++ b/apps/v4/styles/base-sera/ui/sidebar.tsx
@@ -98,7 +98,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-vega/ui/sidebar.tsx
+++ b/apps/v4/styles/base-vega/ui/sidebar.tsx
@@ -98,7 +98,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-luma/ui/sidebar.tsx
+++ b/apps/v4/styles/radix-luma/ui/sidebar.tsx
@@ -97,7 +97,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-lyra/ui/sidebar.tsx
+++ b/apps/v4/styles/radix-lyra/ui/sidebar.tsx
@@ -97,7 +97,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-maia/ui/sidebar.tsx
+++ b/apps/v4/styles/radix-maia/ui/sidebar.tsx
@@ -97,7 +97,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-mira/ui/sidebar.tsx
+++ b/apps/v4/styles/radix-mira/ui/sidebar.tsx
@@ -97,7 +97,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-nova/ui-rtl/sidebar.tsx
+++ b/apps/v4/styles/radix-nova/ui-rtl/sidebar.tsx
@@ -97,7 +97,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-nova/ui/sidebar.tsx
+++ b/apps/v4/styles/radix-nova/ui/sidebar.tsx
@@ -97,7 +97,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-rhea/ui/sidebar.tsx
+++ b/apps/v4/styles/radix-rhea/ui/sidebar.tsx
@@ -97,7 +97,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-sera/ui/sidebar.tsx
+++ b/apps/v4/styles/radix-sera/ui/sidebar.tsx
@@ -97,7 +97,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-vega/ui/sidebar.tsx
+++ b/apps/v4/styles/radix-vega/ui/sidebar.tsx
@@ -97,7 +97,7 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()


### PR DESCRIPTION
## What

The `SidebarProvider` keyboard shortcut handler fires for any combination that includes `Cmd/Ctrl+B`, including `Cmd+Shift+B` (bookmark manager in Chrome) and `Cmd+Alt+B`. These combos call `event.preventDefault()`, swallowing the browser's default behavior.

Closes #11104

## Why

The check only tested `event.key === "b" && (event.metaKey || event.ctrlKey)` without requiring the absence of additional modifiers. The sidebar shortcut should only activate on plain `Cmd+B` / `Ctrl+B`.

## Fix

Added `!event.shiftKey && !event.altKey` to the condition in all 21 sidebar files (18 style variants + 3 registry templates):

```ts
if (
  event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
  (event.metaKey || event.ctrlKey) &&
  !event.shiftKey &&
  !event.altKey
) {
  event.preventDefault()
  toggleSidebar()
}
```

## Testing

- `Cmd+B` / `Ctrl+B` still toggles the sidebar
- `Cmd+Shift+B`, `Cmd+Alt+B`, `Ctrl+Shift+B` no longer prevent browser defaults