### PR TITLE
feat(registry): add @knock-codes to registry directory

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1638,5 +1638,12 @@
     "url": "https://threecn.dev/r/{name}.json",
     "description": "3D scenes for shadcn/ui. Theme-aware React Three Fiber components, one command away.",
     "logo": "<svg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M12 2.5 21 7v10l-9 4.5L3 17V7l9-4.5Z' stroke='var(--foreground)' stroke-width='1.5' stroke-linejoin='round'/><path d='M3 7l9 4.5L21 7M12 11.5V21.5' stroke='var(--foreground)' stroke-width='1.5' stroke-linejoin='round' opacity='.6'/><path d='M12 11.5 21 7v5l-9 4.5-9-4.5V7l9 4.5Z' fill='var(--foreground)' fill-opacity='.15'/></svg>"
+  },
+  {
+    "name": "@knock-codes",
+    "homepage": "https://knock.codes",
+    "url": "https://knock.codes/r/react/{name}.json",
+    "description": "Copy-paste, session-gated access blocks for React — PIN/Knock Code unlock screens, protected routes/layouts/modals, a headless useKnockCodes hook, and full-page templates.",
+    "logo": "<svg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'><rect width='32' height='32' rx='7' fill='#0A0A0B'/><rect x='9' y='9' width='14' height='14' rx='3' fill='#F59E0B'/></svg>"
   }
 ]


### PR DESCRIPTION
## Add @knock-codes to the registry directory

[knock.codes](https://knock.codes) is an open source registry of copy-paste, session-gated access blocks for React — Knock Code / PIN unlock screens, protected route/layout/modal/card components, a headless `useKnockCodes` hook, and full-page templates. Framework-agnostic core (hash/session/storage/verify) with no runtime dependencies shipped to consumers.

- **Homepage**: https://knock.codes
- **Registry**: https://knock.codes/r/react/registry.json (flat, no `content` in `files`)
- **Source**: https://github.com/trivedi-vatsal/knock-codes (open source, MIT)

### Checklist

- [x] Added entry to `apps/v4/registry/directory.json`
- [x] `pnpm validate:registries` passes
- [x] Registry is publicly accessible and conforms to the registry schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)