### PR TITLE
fix(registry): add missing base-ui dependency and fallback rewrites for legacy styles

### DIFF
--- a/apps/v4/next.config.mjs
+++ b/apps/v4/next.config.mjs
@@ -150,16 +150,29 @@ const nextConfig = {
     ]
   },
   rewrites() {
-    return [
-      {
-        source: "/docs/:path*.md",
-        destination: "/llm/:path*",
-      },
-      {
-        source: "/init.md",
-        destination: "/init/md",
-      },
-    ]
+    return {
+      beforeFiles: [],
+      afterFiles: [
+        {
+          source: "/docs/:path*.md",
+          destination: "/llm/:path*",
+        },
+        {
+          source: "/init.md",
+          destination: "/init/md",
+        },
+      ],
+      fallback: [
+        {
+          source: "/r/styles/new-york/:path*",
+          destination: "/r/styles/new-york-v4/:path*",
+        },
+        {
+          source: "/r/styles/default/:path*",
+          destination: "/r/styles/new-york-v4/:path*",
+        },
+      ],
+    }
   },
 }
 

--- a/apps/v4/public/r/index.json
+++ b/apps/v4/public/r/index.json
@@ -96,6 +96,7 @@
   {
     "name": "attachment",
     "type": "registry:ui",
+    "dependencies": ["@base-ui/react"],
     "registryDependencies": ["button"],
     "files": [
       {

--- a/apps/v4/public/r/styles/base-luma/attachment.json
+++ b/apps/v4/public/r/styles/base-luma/attachment.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "attachment",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-luma/registry.json
+++ b/apps/v4/public/r/styles/base-luma/registry.json
@@ -1006,6 +1006,7 @@
     },
     {
       "name": "attachment",
+      "dependencies": ["@base-ui/react"],
       "registryDependencies": ["button"],
       "files": [
         {

--- a/apps/v4/public/r/styles/base-lyra/attachment.json
+++ b/apps/v4/public/r/styles/base-lyra/attachment.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "attachment",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-lyra/registry.json
+++ b/apps/v4/public/r/styles/base-lyra/registry.json
@@ -1006,6 +1006,7 @@
     },
     {
       "name": "attachment",
+      "dependencies": ["@base-ui/react"],
       "registryDependencies": ["button"],
       "files": [
         {

--- a/apps/v4/public/r/styles/base-maia/attachment.json
+++ b/apps/v4/public/r/styles/base-maia/attachment.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "attachment",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-maia/registry.json
+++ b/apps/v4/public/r/styles/base-maia/registry.json
@@ -1006,6 +1006,7 @@
     },
     {
       "name": "attachment",
+      "dependencies": ["@base-ui/react"],
       "registryDependencies": ["button"],
       "files": [
         {

--- a/apps/v4/public/r/styles/base-mira/attachment.json
+++ b/apps/v4/public/r/styles/base-mira/attachment.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "attachment",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-mira/registry.json
+++ b/apps/v4/public/r/styles/base-mira/registry.json
@@ -1006,6 +1006,7 @@
     },
     {
       "name": "attachment",
+      "dependencies": ["@base-ui/react"],
       "registryDependencies": ["button"],
       "files": [
         {

--- a/apps/v4/public/r/styles/base-nova/attachment.json
+++ b/apps/v4/public/r/styles/base-nova/attachment.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "attachment",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-nova/registry.json
+++ b/apps/v4/public/r/styles/base-nova/registry.json
@@ -1006,6 +1006,7 @@
     },
     {
       "name": "attachment",
+      "dependencies": ["@base-ui/react"],
       "registryDependencies": ["button"],
       "files": [
         {

--- a/apps/v4/public/r/styles/base-rhea/attachment.json
+++ b/apps/v4/public/r/styles/base-rhea/attachment.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "attachment",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-rhea/registry.json
+++ b/apps/v4/public/r/styles/base-rhea/registry.json
@@ -1006,6 +1006,7 @@
     },
     {
       "name": "attachment",
+      "dependencies": ["@base-ui/react"],
       "registryDependencies": ["button"],
       "files": [
         {

--- a/apps/v4/public/r/styles/base-sera/attachment.json
+++ b/apps/v4/public/r/styles/base-sera/attachment.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "attachment",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-sera/registry.json
+++ b/apps/v4/public/r/styles/base-sera/registry.json
@@ -1006,6 +1006,7 @@
     },
     {
       "name": "attachment",
+      "dependencies": ["@base-ui/react"],
       "registryDependencies": ["button"],
       "files": [
         {

--- a/apps/v4/public/r/styles/base-vega/attachment.json
+++ b/apps/v4/public/r/styles/base-vega/attachment.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry-item.json",
   "name": "attachment",
+  "dependencies": [
+    "@base-ui/react"
+  ],
   "registryDependencies": [
     "button"
   ],

--- a/apps/v4/public/r/styles/base-vega/registry.json
+++ b/apps/v4/public/r/styles/base-vega/registry.json
@@ -1006,6 +1006,7 @@
     },
     {
       "name": "attachment",
+      "dependencies": ["@base-ui/react"],
       "registryDependencies": ["button"],
       "files": [
         {

--- a/apps/v4/registry/bases/base/ui/_registry.ts
+++ b/apps/v4/registry/bases/base/ui/_registry.ts
@@ -1025,6 +1025,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   {
     name: "attachment",
     type: "registry:ui",
+    dependencies: ["@base-ui/react"],
     registryDependencies: ["button"],
     files: [
       {


### PR DESCRIPTION
## Description

This PR fixes two separate issues reported with the `attachment` component when using the Shadcn CLI:

1. **Missing Dependency in Base Registry:** The `attachment` component in the `base` style imports `@base-ui/react`, but it was missing from the `dependencies` array in the component registry (`bases/base/ui/_registry.ts`). This required users to manually install `@base-ui/react` to avoid compilation errors. The dependency has now been properly declared.
2. **404 Errors & CLI Crash for Legacy Styles:** For users who haven't updated their `components.json` to the newer styles (and still use `new-york` or `default`), running `npx shadcn@latest add attachment` attempts to fetch `new-york/attachment.json` which does not exist since v4. This 404 response subsequently triggered an unhandled socket closure on Windows resulting in the `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)` CLI crash. 
To ensure seamless backward compatibility, graceful fallback rewrites were added to `next.config.mjs`, which route requests for missing `new-york` and `default` components directly to `new-york-v4` (falling back only after checking existing static files).

## Verification
- Built the registry (`pnpm registry:build`) and verified that `base-nova/attachment.json` correctly outputs `@base-ui/react`.
- Next.js rewrite fallback verified for `new-york` compatibility.

Closes #11107