### PR TITLE
fix(message-scroller): register mount-time anchors so same-count swap…

### DIFF
--- a/packages/react/src/message-scroller/geometry.ts
+++ b/packages/react/src/message-scroller/geometry.ts
@@ -127,6 +127,10 @@ function getNewScrollAnchor(items: HTMLElement[], previousItemCount: number) {
   return null
 }
 
+function getScrollAnchors(items: HTMLElement[]) {
+  return items.filter((item) => item.dataset.scrollAnchor === "true")
+}
+
 function getUnanchoredScrollAnchor(
   items: HTMLElement[],
   handledAnchors: { has(element: HTMLElement): boolean }
@@ -381,6 +385,7 @@ export {
   getMessageScrollerScrollable,
   getMessageScrollerVisibilityState,
   getNewScrollAnchor,
+  getScrollAnchors,
   getTailSpacerHeight,
   getUnanchoredScrollAnchor,
   hasMultipleNewScrollAnchors,

--- a/packages/react/src/message-scroller/message-scroller.test.tsx
+++ b/packages/react/src/message-scroller/message-scroller.test.tsx
@@ -852,6 +852,42 @@ describe("MessageScroller", () => {
     expect(rendered.viewport().scrollTop).toBe(16)
   })
 
+  it("does not re-anchor to a mount-time anchor on a later same-count content swap", async () => {
+    // Regression test for #11128: anchors already on screen at mount were
+    // never registered as "handled", so a later same-count content swap
+    // (e.g. a transient "Typing…" row replaced by a reply row) treated
+    // every mount-time anchor as newly appeared and yanked the viewport
+    // back to the oldest one instead of leaving it resting at the end.
+    const rendered = await renderTestScroller({
+      autoScroll: true,
+      defaultScrollPosition: "end",
+      messages: [
+        { id: "seed-1", height: 80, scrollAnchor: true },
+        { id: "seed-2", height: 80 },
+        { id: "seed-3", height: 80, scrollAnchor: true },
+        { id: "typing", height: 40 },
+      ],
+    })
+
+    expect(rendered.viewport().scrollTop).toBe(180)
+
+    await rendered.rerender(
+      [
+        { id: "seed-1", height: 80, scrollAnchor: true },
+        { id: "seed-2", height: 80 },
+        { id: "seed-3", height: 80, scrollAnchor: true },
+        { id: "reply", height: 40 },
+      ],
+      { autoScroll: true }
+    )
+
+    expect(rendered.viewport().scrollTop).toBe(180)
+    expect(rendered.state()).toMatchObject({
+      start: true,
+      end: false,
+    })
+  })
+
   it("does not reconcile scroll position when only the parent re-renders", async () => {
     const rendered = await renderTestScrollerWithParent({
       messages: [

--- a/packages/react/src/message-scroller/use-message-scroller-controller.ts
+++ b/packages/react/src/message-scroller/use-message-scroller-controller.ts
@@ -11,6 +11,7 @@ import {
   getMessageScrollerScrollable,
   getMessageScrollerVisibilityState,
   getNewScrollAnchor,
+  getScrollAnchors,
   getUnanchoredScrollAnchor,
   hasMultipleNewScrollAnchors,
 } from "./geometry"
@@ -396,6 +397,16 @@ function useMessageScrollerController({
       }
 
       if (previousItemCount === 0) {
+        // Anchors already on screen at mount have been "seen" by the reader.
+        // Register them up front so a later same-count content swap (e.g. a
+        // transient row replaced in place) only ever treats anchors that
+        // appear *after* mount as new — not every anchor rendered on first
+        // paint. Otherwise getUnanchoredScrollAnchor() would find them all
+        // unhandled and re-anchor the viewport to the oldest one.
+        for (const anchor of getScrollAnchors(items)) {
+          handledScrollAnchorsRef.current.add(anchor)
+        }
+
         if (applyDefaultScrollPosition()) {
           return
         }


### PR DESCRIPTION
Fixes #11128

## Bug

Anchors present on screen at mount were never added to `handledScrollAnchorsRef`.
`applyDefaultScrollPosition()` scrolls to the configured position but doesn't
register the anchors that are already visible when it runs.

Later, if a content mutation leaves the item count unchanged (e.g. a
transient "Typing…" row replaced by a reply row in the same commit),
`reconcileScrollPosition()` falls into the `items.length === previousItemCount`
branch and calls `getUnanchoredScrollAnchor()`. Since none of the mount-time
anchors were ever registered as handled, this returns the *first* anchor
in document order the oldest one and the viewport jumps there instead
of staying where the reader was.

## Fix

In the `previousItemCount === 0` branch of `reconcileScrollPosition`, seed
`handledScrollAnchorsRef` with every anchor present at mount, before
`applyDefaultScrollPosition()` runs. This mirrors the `.add(anchor)` calls
the append and same count branches already do, so only anchors that appear
*after* mount are ever treated as new.

Added a `getScrollAnchors()` helper in `geometry.ts` to collect them.

## Testing

- Added a regression test reproducing the exact repro from #11128: a
  scroller mounted with `defaultScrollPosition="end"` and mixed anchor/
  non-anchor rows, followed by a same-count swap of a non-anchor row.
  Confirmed this test fails without the fix (`scrollTop` jumps to `0`)
  and passes with it (`scrollTop` stays at the end).
- `pnpm --filter @shadcn/react test` — 61/61 passing
- `pnpm --filter @shadcn/react typecheck` — clean
