### PR TITLE
fix(message-scroller): register mount-time anchors to prevent stale re-anchor (#11128)

### DIFF
--- a/.changeset/message-scroller-swap-anchor.md
+++ b/.changeset/message-scroller-swap-anchor.md
@@ -1,0 +1,5 @@
+---
+"@shadcn/react": patch
+---
+
+Fixed `MessageScroller` re-anchoring to a stale mount-time anchor on a same-count content swap. Mount-time anchors are now registered with the scroll-anchor handler, so a later swap (e.g. a transient "typing" row replaced by a streamed reply in one update) no longer yanks the viewport to the oldest message. Closes #11128.

--- a/packages/react/src/message-scroller/message-scroller.browser.test.tsx
+++ b/packages/react/src/message-scroller/message-scroller.browser.test.tsx
@@ -660,6 +660,49 @@ test("an anchored turn holds at the top when content below it collapses", async 
   expect(viewportOffsetOf("turn", getViewport())).toBeLessThanOrEqual(peek + 4)
 })
 
+test("does not re-anchor to an old mount anchor on a same-count content swap (#11128)", async () => {
+  // 20 seeds; every even-indexed row is a scroll anchor (the
+  // documented `scrollAnchor={message.role === "user"}` pattern).
+  const seeds = Array.from({ length: 20 }, (_, i) => ({
+    id: `m${i}`,
+    scrollAnchor: i % 2 === 0,
+  }))
+
+  await renderThread({
+    autoScroll: true,
+    defaultScrollPosition: "end",
+    items: seeds,
+  })
+
+  const viewport = getViewport()
+
+  // Opens pinned to the bottom.
+  expect(getDistanceToBottom(viewport)).toBeLessThanOrEqual(1)
+
+  // A same-count content swap: the trailing seed is replaced by a fresh
+  // non-anchor row (e.g. a streamed "reply" taking a "typing" row's
+  // place). Item count is unchanged, so the library takes its "item
+  // count unchanged" branch. Without seeding mount-time anchors,
+  // getUnanchoredScrollAnchor returns the oldest mount anchor (m0) and
+  // the viewport is yanked from the bottom up to the top.
+  flushSync(() => {
+    root!.render(
+      <Thread
+        autoScroll
+        defaultScrollPosition="end"
+        items={[
+          ...seeds.slice(0, 19),
+          { id: "reply", scrollAnchor: false },
+        ]}
+      />,
+    )
+  })
+  await settle()
+
+  // The viewport must stay pinned to the bottom, not jump up to m0.
+  expect(getDistanceToBottom(viewport)).toBeLessThanOrEqual(1)
+})
+
 test("auto-scroll and content updates survive a StrictMode remount", async () => {
   // StrictMode mounts, unmounts, then remounts on the same refs. The existing
   // StrictMode test covers the visibility frame; this one covers the rest of the

--- a/packages/react/src/message-scroller/use-message-scroller-controller.ts
+++ b/packages/react/src/message-scroller/use-message-scroller-controller.ts
@@ -369,6 +369,23 @@ function useMessageScrollerController({
 
     defaultScrollPositionAppliedRef.current = true
 
+    // Seed the handled-anchors set with every anchor already present in
+    // the DOM. The mount path (previousItemCount === 0) and any
+    // defaultScrollPosition change both reach here, but neither used to
+    // register mount-time anchors. Without this, a later same-count
+    // content swap (e.g. a transient row replaced by a real row in one
+    // update) treats those anchors as newly appeared and re-anchors the
+    // viewport to the oldest one — yanking the reader away from the
+    // row they were looking at. See #11128.
+    const seededContent = contentRef.current
+    if (seededContent) {
+      for (const el of getMessageScrollerItems(seededContent, spacerRef.current)) {
+        if (el.dataset.scrollAnchor === "true") {
+          handledScrollAnchorsRef.current.add(el)
+        }
+      }
+    }
+
     return true
   }, [defaultScrollPosition, scrollToElement, scrollToEnd, scrollToStart])
 


### PR DESCRIPTION
## Summary

Fixes MessageScroller jumping to an old message when a same-count content swap occurs, as reported in #11128.

When a transcript is mounted with defaultScrollPosition="end" and several rows marked scrollAnchor, the anchors present **at mount** are never added to the controller's handledScrollAnchorsRef bookkeeping. The previousItemCount === 0 mount path that honors defaultScrollPosition scrolls, but never registers those anchors.

Later, when a childList mutation leaves the item count unchanged (a transient row replaced by a real row in one update - e.g. a "Typing." indicator swapped for a streamed reply), handleContentChange's "item count unchanged" branch calls getUnanchoredScrollAnchor, which returns the **oldest** mount-time anchor (m0) and yanks the viewport from the bottom up to the top. The reader is pulled away from the row they were looking at.

## Fix

Seed handledScrollAnchorsRef with every anchor already present in the DOM inside pplyDefaultScrollPosition() (in packages/react/src/message-scroller/use-message-scroller-controller.ts), mirroring the handledScrollAnchorsRef.current.add(anchor) the append and same-count branches already do. Once the default scroll position is applied, mount-time anchors are treated as already handled, so a subsequent same-count swap leaves the reader exactly where they were.

This matches the fix direction suggested in #11128.

## Test

Adds a browser regression test in message-scroller.browser.test.tsx:
- Mounts 20 seeds where every even-indexed row is a scroll anchor (defaultScrollPosition="end").
- Performs a same-count content swap (the trailing seed replaced by a fresh non-anchor row).
- Asserts the viewport stays pinned to the bottom rather than jumping to m0.

The test fails without the fix (viewport yanked to the top, distanceToBottom approx 1400) and passes with it.

## Verification

- pnpm exec vitest run -c vitest.browser.config.ts src/message-scroller/ - 24 passing.
- pnpm --filter=@shadcn/react typecheck - clean.
- Changeset added (@shadcn/react patch).

Closes #11128.