### PR TITLE
fix(ci): prefix MCP dependencies for Deno

### DIFF
--- a/.changeset/fuzzy-ducks-jump.md
+++ b/.changeset/fuzzy-ducks-jump.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+prefix MCP dependencies with `npm:` when installing with Deno.

--- a/packages/shadcn/src/commands/mcp.test.ts
+++ b/packages/shadcn/src/commands/mcp.test.ts
@@ -1,0 +1,89 @@
+import { getConfig } from "@/src/utils/get-config"
+import { getPackageManager } from "@/src/utils/get-package-manager"
+import { handleError } from "@/src/utils/handle-error"
+import { execa } from "execa"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { mcp } from "./mcp"
+
+vi.mock("fs", () => ({
+  promises: {
+    readFile: vi.fn().mockRejectedValue(new Error("not found")),
+    writeFile: vi.fn(),
+  },
+}))
+
+vi.mock("execa", () => ({
+  execa: vi.fn(),
+}))
+
+vi.mock("fs-extra", () => ({
+  default: {
+    ensureDir: vi.fn(),
+  },
+}))
+
+vi.mock("@/src/mcp", () => ({
+  server: {
+    connect: vi.fn(),
+  },
+}))
+
+vi.mock("@/src/utils/get-config", () => ({
+  getConfig: vi.fn(),
+}))
+
+vi.mock("@/src/utils/get-package-manager", () => ({
+  getPackageManager: vi.fn(),
+}))
+
+vi.mock("@/src/utils/handle-error", () => ({
+  handleError: vi.fn(),
+}))
+
+vi.mock("@/src/utils/logger", () => ({
+  logger: {
+    break: vi.fn(),
+    info: vi.fn(),
+    log: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+vi.mock("@/src/utils/spinner", () => ({
+  spinner: vi.fn(() => {
+    const instance = {
+      start: vi.fn(),
+      succeed: vi.fn(),
+    }
+    instance.start.mockReturnValue(instance)
+    return instance
+  }),
+}))
+
+vi.mock("@/src/utils/updaters/update-dependencies", () => ({
+  updateDependencies: vi.fn(),
+}))
+
+describe("mcp init", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getConfig).mockResolvedValue(null)
+    vi.mocked(getPackageManager).mockResolvedValue("deno")
+    vi.mocked(execa).mockResolvedValue({} as never)
+  })
+
+  it("prefixes npm dependencies when installing with deno", async () => {
+    await mcp.parseAsync(
+      ["--cwd", "/test/project", "init", "--client", "vscode"],
+      { from: "user" }
+    )
+
+    expect(handleError).not.toHaveBeenCalled()
+    expect(execa).toHaveBeenCalledWith(
+      "deno",
+      ["add", "-D", "npm:shadcn@latest"],
+      { cwd: "/test/project" }
+    )
+  })
+})

--- a/packages/shadcn/src/commands/mcp.ts
+++ b/packages/shadcn/src/commands/mcp.ts
@@ -158,18 +158,8 @@ mcp
             silent: false,
           })
         } else {
-          const packageManager = await getPackageManager(options.cwd)
-          const installCommand = packageManager === "npm" ? "install" : "add"
-          const devFlag = packageManager === "npm" ? "--save-dev" : "-D"
-
           const installSpinner = spinner("Installing dependencies...").start()
-          await execa(
-            packageManager,
-            [installCommand, devFlag, ...DEPENDENCIES],
-            {
-              cwd: options.cwd,
-            }
-          )
+          await installMcpDependencies(options.cwd)
           installSpinner.succeed("Installing dependencies.")
         }
 
@@ -201,18 +191,8 @@ args = ["shadcn@${SHADCN_MCP_VERSION}", "mcp"]`)
           silent: false,
         })
       } else {
-        const packageManager = await getPackageManager(options.cwd)
-        const installCommand = packageManager === "npm" ? "install" : "add"
-        const devFlag = packageManager === "npm" ? "--save-dev" : "-D"
-
         const installSpinner = spinner("Installing dependencies...").start()
-        await execa(
-          packageManager,
-          [installCommand, devFlag, ...DEPENDENCIES],
-          {
-            cwd: options.cwd,
-          }
-        )
+        await installMcpDependencies(options.cwd)
         installSpinner.succeed("Installing dependencies.")
       }
 
@@ -262,4 +242,18 @@ async function runMcpInit(options: z.infer<typeof mcpInitOptionsSchema>) {
   )
 
   return clientInfo.configPath
+}
+
+async function installMcpDependencies(cwd: string) {
+  const packageManager = await getPackageManager(cwd)
+  const installCommand = packageManager === "npm" ? "install" : "add"
+  const devFlag = packageManager === "npm" ? "--save-dev" : "-D"
+  const dependencies =
+    packageManager === "deno"
+      ? DEPENDENCIES.map((dependency) => `npm:${dependency}`)
+      : DEPENDENCIES
+
+  await execa(packageManager, [installCommand, devFlag, ...dependencies], {
+    cwd,
+  })
 }


### PR DESCRIPTION
## Summary

- prefix the shadcn MCP dependency with `npm:` when installing with Deno
- share the no-config MCP dependency installer across Codex and other clients
- add a command-level regression test and a patch changeset

## Root cause

When `mcp init` could not resolve a shadcn project configuration, it bypassed
`updateDependencies` and passed the bare `shadcn@latest` specifier directly to
Deno. Unlike the other supported package managers, Deno requires npm packages
to use the `npm:` specifier.

## Validation

- `pnpm --filter shadcn exec vitest run src/commands/mcp.test.ts`
- `pnpm --filter shadcn typecheck`
- `pnpm --filter shadcn build`
- `pnpm exec prettier --check packages/shadcn/src/commands/mcp.ts packages/shadcn/src/commands/mcp.test.ts .changeset/fuzzy-ducks-jump.md`

The complete shadcn test suite was also run on Windows. The new MCP test passes;
the suite reports 1425 passing tests and 101 unrelated failures concentrated in
existing POSIX path expectations, snapshots, and Windows fixture handling.
