### PR TITLE
Add @vllnt-ui to registry directory

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1638,5 +1638,12 @@
     "url": "https://threecn.dev/r/{name}.json",
     "description": "3D scenes for shadcn/ui. Theme-aware React Three Fiber components, one command away.",
     "logo": "<svg viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M12 2.5 21 7v10l-9 4.5L3 17V7l9-4.5Z' stroke='var(--foreground)' stroke-width='1.5' stroke-linejoin='round'/><path d='M3 7l9 4.5L21 7M12 11.5V21.5' stroke='var(--foreground)' stroke-width='1.5' stroke-linejoin='round' opacity='.6'/><path d='M12 11.5 21 7v5l-9 4.5-9-4.5V7l9 4.5Z' fill='var(--foreground)' fill-opacity='.15'/></svg>"
+  },
+  {
+    "name": "@vllnt-ui",
+    "homepage": "https://ui.vllnt.com",
+    "url": "https://ui.vllnt.com/r/{name}.json",
+    "description": "VLLNT UI — agent-first React components for AI-native products, from UI primitives to finance and ops domains. Accessible, Radix + Tailwind, you own the code.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'><rect width='128' height='128' rx='28' fill='var(--foreground)'/><text x='64' y='64' text-anchor='middle' dominant-baseline='central' font-family='ui-sans-serif, system-ui, sans-serif' font-size='26' font-weight='700' letter-spacing='-1' fill='var(--background)'>VLLNT</text></svg>"
   }
 ]


### PR DESCRIPTION
Adds the **VLLNT UI** registry to the directory so users can install components via the shadcn namespace.

- **name:** `@vllnt-ui`
- **homepage:** https://ui.vllnt.com
- **url:** `https://ui.vllnt.com/r/{name}.json`

### Usage

```bash
npx shadcn@latest add @vllnt-ui/button
```

The registry is live and already serves standard shadcn registry-item JSON (e.g. https://ui.vllnt.com/r/button.json returns a valid `registry:component` item). Logo is a theme-aware inline SVG using `var(--foreground)` / `var(--background)`.

Validated against `apps/v4/scripts/validate-registries.mts` schema: `name` matches `^@[a-zA-Z0-9][a-zA-Z0-9-_]*$`, `homepage` is a valid URL, `url` contains `{name}`, `description` and `logo` are present.
