### PR TITLE
fix(dialog): prevent closing when interacting with portal content (#10469)

### DIFF
--- a/apps/v4/registry/bases/radix/ui/combobox.tsx
+++ b/apps/v4/registry/bases/radix/ui/combobox.tsx
@@ -121,7 +121,7 @@ function ComboboxContent({
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
-        className="isolate z-50"
+        className="isolate z-50 pointer-events-auto"
       >
         <ComboboxPrimitive.Popup
           data-slot="combobox-content"

--- a/apps/v4/registry/bases/radix/ui/dialog.tsx
+++ b/apps/v4/registry/bases/radix/ui/dialog.tsx
@@ -48,6 +48,7 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  onInteractOutside,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
@@ -61,6 +62,17 @@ function DialogContent({
           "cn-dialog-content fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
           className
         )}
+        onInteractOutside={(e) => {
+          const target = e.detail.originalEvent.target as Element
+          if (
+            target?.closest("[data-radix-popper-content-wrapper]") ||
+            target?.closest("[data-base-ui-portal]")
+          ) {
+            e.preventDefault()
+            return
+          }
+          onInteractOutside?.(e)
+        }}
         {...props}
       >
         {children}

--- a/apps/v4/registry/new-york-v4/ui/combobox.tsx
+++ b/apps/v4/registry/new-york-v4/ui/combobox.tsx
@@ -110,7 +110,7 @@ function ComboboxContent({
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
-        className="isolate z-50"
+        className="isolate z-50 pointer-events-auto"
       >
         <ComboboxPrimitive.Popup
           data-slot="combobox-content"

--- a/apps/v4/registry/new-york-v4/ui/dialog.tsx
+++ b/apps/v4/registry/new-york-v4/ui/dialog.tsx
@@ -51,6 +51,7 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  onInteractOutside,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
@@ -64,6 +65,17 @@ function DialogContent({
           "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
           className
         )}
+        onInteractOutside={(e) => {
+          const target = e.detail.originalEvent.target as Element
+          if (
+            target?.closest("[data-radix-popper-content-wrapper]") ||
+            target?.closest("[data-base-ui-portal]")
+          ) {
+            e.preventDefault()
+            return
+          }
+          onInteractOutside?.(e)
+        }}
         {...props}
       >
         {children}


### PR DESCRIPTION
Fixes #10469. When Combobox/Popover is inside a Dialog, clicking items via mouse closes the Dialog due to Radix portal interaction. Added onInteractOutside portal guard + pointer-events-auto.