### PR TITLE
fix(avatar): remove overflow-hidden to prevent badge clipping (#9678)

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/avatar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/avatar.tsx
@@ -17,7 +17,7 @@ function Avatar({
       data-slot="avatar"
       data-size={size}
       className={cn(
-        "group/avatar relative flex size-8 shrink-0 overflow-hidden rounded-full select-none data-[size=lg]:size-10 data-[size=sm]:size-6",
+        "group/avatar relative flex size-8 shrink-0 rounded-full select-none data-[size=lg]:size-10 data-[size=sm]:size-6",
         className
       )}
       {...props}


### PR DESCRIPTION
Fixes #9678. overflow-hidden on Avatar root clipped the positioned badge.