### PR TITLE
fix(select): change default position to popper for overflow compatibility (#9589)

### DIFF
--- a/apps/v4/registry/bases/radix/ui/select.tsx
+++ b/apps/v4/registry/bases/radix/ui/select.tsx
@@ -67,7 +67,8 @@ function SelectTrigger({
 function SelectContent({
   className,
   children,
-  position = "item-aligned",
+  position = "popper",
+  sideOffset = 4,
   align = "center",
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {

--- a/apps/v4/registry/new-york-v4/ui/select.tsx
+++ b/apps/v4/registry/new-york-v4/ui/select.tsx
@@ -53,7 +53,8 @@ function SelectTrigger({
 function SelectContent({
   className,
   children,
-  position = "item-aligned",
+  position = "popper",
+  sideOffset = 4,
   align = "center",
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {


### PR DESCRIPTION
Fixes #9589. position=item-aligned breaks in overflow containers. Changed to position=popper with sideOffset=4.