### PR TITLE
fix(alert): improve destructive alert description WCAG AA contrast (#10431)

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/alert.tsx
+++ b/apps/v4/registry/new-york-v4/ui/alert.tsx
@@ -10,7 +10,7 @@ const alertVariants = cva(
       variant: {
         default: "bg-card text-card-foreground",
         destructive:
-          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current",
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive [&>svg]:text-current",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
Fixes #10431. Replace text-destructive/90 with text-destructive to meet 4.5:1 minimum contrast.