### PR TITLE
fix: exclude Shift and Alt from sidebar keyboard shortcut

### DIFF
--- a/apps/v4/styles/base-luma/ui/sidebar.tsx
+++ b/apps/v4/styles/base-luma/ui/sidebar.tsx
@@ -98,7 +98,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-lyra/ui/sidebar.tsx
+++ b/apps/v4/styles/base-lyra/ui/sidebar.tsx
@@ -98,7 +98,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-maia/ui/sidebar.tsx
+++ b/apps/v4/styles/base-maia/ui/sidebar.tsx
@@ -98,7 +98,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-mira/ui/sidebar.tsx
+++ b/apps/v4/styles/base-mira/ui/sidebar.tsx
@@ -98,7 +98,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-nova/ui-rtl/sidebar.tsx
+++ b/apps/v4/styles/base-nova/ui-rtl/sidebar.tsx
@@ -98,7 +98,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-nova/ui/sidebar.tsx
+++ b/apps/v4/styles/base-nova/ui/sidebar.tsx
@@ -98,7 +98,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-rhea/ui/sidebar.tsx
+++ b/apps/v4/styles/base-rhea/ui/sidebar.tsx
@@ -98,7 +98,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-sera/ui/sidebar.tsx
+++ b/apps/v4/styles/base-sera/ui/sidebar.tsx
@@ -98,7 +98,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/base-vega/ui/sidebar.tsx
+++ b/apps/v4/styles/base-vega/ui/sidebar.tsx
@@ -98,7 +98,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-luma/ui/sidebar.tsx
+++ b/apps/v4/styles/radix-luma/ui/sidebar.tsx
@@ -97,7 +97,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-lyra/ui/sidebar.tsx
+++ b/apps/v4/styles/radix-lyra/ui/sidebar.tsx
@@ -97,7 +97,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-maia/ui/sidebar.tsx
+++ b/apps/v4/styles/radix-maia/ui/sidebar.tsx
@@ -97,7 +97,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-mira/ui/sidebar.tsx
+++ b/apps/v4/styles/radix-mira/ui/sidebar.tsx
@@ -97,7 +97,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-nova/ui-rtl/sidebar.tsx
+++ b/apps/v4/styles/radix-nova/ui-rtl/sidebar.tsx
@@ -97,7 +97,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-nova/ui/sidebar.tsx
+++ b/apps/v4/styles/radix-nova/ui/sidebar.tsx
@@ -97,7 +97,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-rhea/ui/sidebar.tsx
+++ b/apps/v4/styles/radix-rhea/ui/sidebar.tsx
@@ -97,7 +97,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-sera/ui/sidebar.tsx
+++ b/apps/v4/styles/radix-sera/ui/sidebar.tsx
@@ -97,7 +97,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/styles/radix-vega/ui/sidebar.tsx
+++ b/apps/v4/styles/radix-vega/ui/sidebar.tsx
@@ -97,7 +97,8 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey && !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()


### PR DESCRIPTION
## Description

The `SidebarProvider` registers a global keyboard shortcut for toggling the sidebar with `Cmd+B` / `Ctrl+B`. The current matching logic only checks `event.key === 'b' && (event.metaKey || event.ctrlKey)`.

It does not exclude additional modifier keys like `Shift` or `Alt`. As a result, `Cmd+Shift+B` (a browser-level shortcut in many browsers) or `Cmd+Alt+B` also trigger the sidebar toggle, and `event.preventDefault()` blocks the browser's default behavior.

## Fix

Added `!event.shiftKey && !event.altKey` to the condition, so only the plain `Cmd+B` / `Ctrl+B` combination toggles the sidebar.

## Changes

Updated all 18 sidebar style variants across `apps/v4/styles/`:

```typescript
// Before
event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
  (event.metaKey || event.ctrlKey)

// After
event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
  (event.metaKey || event.ctrlKey) &&
  !event.shiftKey && !event.altKey
```

Fixes #11104