### PR TITLE
docs: polish component documentation

### DIFF
--- a/apps/v4/app/(app)/docs/changelog/page.tsx
+++ b/apps/v4/app/(app)/docs/changelog/page.tsx
@@ -93,7 +93,7 @@ export default function ChangelogPage() {
                       <Link
                         key={page.url}
                         href={page.url}
-                        className="flex w-full flex-col rounded-xl bg-surface px-4 py-3 text-surface-foreground transition-colors hover:bg-surface/80"
+                        className="flex w-full flex-col rounded-2xl bg-surface px-4 py-3 text-surface-foreground transition-colors hover:bg-surface/80"
                       >
                         <span className="text-xs text-muted-foreground">
                           {date}

--- a/apps/v4/app/globals.css
+++ b/apps/v4/app/globals.css
@@ -285,7 +285,7 @@
   [data-rehype-pretty-code-figure] {
     background-color: var(--color-code);
     color: var(--color-code-foreground);
-    border-radius: var(--radius-xl);
+    border-radius: var(--radius-2xl);
     border-width: 0px;
     border-color: var(--border);
     margin-top: calc(var(--spacing) * 6);

--- a/apps/v4/components/callout.tsx
+++ b/apps/v4/components/callout.tsx
@@ -20,7 +20,7 @@ export function Callout({
     <Alert
       data-variant={variant}
       className={cn(
-        "not-typeset mt-6 w-auto rounded-xl border-surface bg-surface text-surface-foreground md:-mx-1 **:[code]:border",
+        "not-typeset mt-6 w-auto rounded-2xl border-surface bg-surface text-surface-foreground md:-mx-1 **:[code]:border",
         className
       )}
       {...props}

--- a/apps/v4/components/component-preview-tabs.tsx
+++ b/apps/v4/components/component-preview-tabs.tsx
@@ -53,7 +53,7 @@ export function ComponentPreviewTabs({
       data-slot="component-preview"
       data-not-typeset
       className={cn(
-        "group relative mt-4 mb-12 flex flex-col overflow-hidden rounded-xl border",
+        "group relative mt-4 mb-12 flex flex-col overflow-hidden rounded-2xl border",
         className
       )}
       {...props}

--- a/apps/v4/components/component-preview.tsx
+++ b/apps/v4/components/component-preview.tsx
@@ -31,7 +31,7 @@ export function ComponentPreview({
 }) {
   if (type === "block") {
     const content = (
-      <div className="relative mt-6 aspect-[4/2.5] w-full overflow-hidden rounded-xl border md:-mx-1">
+      <div className="relative mt-6 aspect-[4/2.5] w-full overflow-hidden rounded-2xl border md:-mx-1">
         <Image
           src={`/r/styles/new-york-v4/${name}-light.png`}
           alt={name}

--- a/apps/v4/components/docs-sidebar.tsx
+++ b/apps/v4/components/docs-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import * as React from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 
@@ -56,12 +57,111 @@ const TOP_LEVEL_SECTIONS = [
 const EXCLUDED_SECTIONS = ["installation", "dark-mode", "changelog", "rtl"]
 const EXCLUDED_PAGES = ["/docs", "/docs/changelog", "/docs/rtl", "/docs/new"]
 
+const SCROLL_STORAGE_KEY = "docs-sidebar-scroll"
+
+// Runs before first paint on hard loads. A refresh restores the exact
+// position; arriving from another page brings the active item into view.
+const SCROLL_RESTORE_SCRIPT = `(function () {
+  try {
+    var container = document.currentScript.previousElementSibling
+    if (!container || !container.clientHeight) return
+    try {
+      var stored = JSON.parse(sessionStorage.getItem("${SCROLL_STORAGE_KEY}"))
+      if (stored && stored.pathname === location.pathname) {
+        container.scrollTop = stored.scrollTop
+        return
+      }
+    } catch (e) {}
+    var items = container.querySelectorAll('[data-active="true"]')
+    var active = items[items.length - 1]
+    if (!active) return
+    var containerRect = container.getBoundingClientRect()
+    var activeRect = active.getBoundingClientRect()
+    if (activeRect.top >= containerRect.top && activeRect.bottom <= containerRect.bottom) return
+    container.scrollTop += activeRect.top - containerRect.top - (container.clientHeight - activeRect.height) / 2
+  } catch (e) {}
+})()`
+
+function readScrollState() {
+  try {
+    return JSON.parse(sessionStorage.getItem(SCROLL_STORAGE_KEY) ?? "") as {
+      pathname: string
+      scrollTop: number
+    }
+  } catch {
+    return null
+  }
+}
+
+function saveScrollState(container: HTMLElement) {
+  try {
+    sessionStorage.setItem(
+      SCROLL_STORAGE_KEY,
+      JSON.stringify({
+        pathname: location.pathname,
+        scrollTop: container.scrollTop,
+      })
+    )
+  } catch {}
+}
+
 export function DocsSidebar({
   tree,
   ...props
 }: React.ComponentProps<typeof Sidebar> & { tree: typeof source.pageTree }) {
   const pathname = usePathname()
   const currentBase = getCurrentBase(pathname)
+  const contentRef = React.useRef<HTMLDivElement>(null)
+
+  React.useEffect(() => {
+    const container = contentRef.current
+
+    if (!container) {
+      return
+    }
+
+    // A refresh restores the exact position (the inline script already did).
+    // Only bring the active item into view when arriving from another page.
+    if (readScrollState()?.pathname !== pathname) {
+      // The last active item is the most specific one: section links also
+      // match by prefix, so a component page activates both.
+      const items = container.querySelectorAll<HTMLElement>(
+        '[data-active="true"]'
+      )
+      const active = items[items.length - 1]
+
+      if (active) {
+        const containerRect = container.getBoundingClientRect()
+        const activeRect = active.getBoundingClientRect()
+
+        if (
+          activeRect.top < containerRect.top ||
+          activeRect.bottom > containerRect.bottom
+        ) {
+          container.scrollTo({
+            top:
+              container.scrollTop +
+              (activeRect.top - containerRect.top) -
+              (container.clientHeight - activeRect.height) / 2,
+          })
+        }
+      }
+    }
+
+    saveScrollState(container)
+  }, [pathname])
+
+  React.useEffect(() => {
+    const container = contentRef.current
+
+    if (!container) {
+      return
+    }
+
+    const onScroll = () => saveScrollState(container)
+    container.addEventListener("scroll", onScroll, { passive: true })
+    return () => container.removeEventListener("scroll", onScroll)
+  }, [])
 
   return (
     <Sidebar
@@ -69,7 +169,11 @@ export function DocsSidebar({
       collapsible="none"
       {...props}
     >
-      <SidebarContent className="w-(--sidebar-menu-width) scroll-fade scrollbar-none overflow-x-hidden pl-2.5">
+      <div className="absolute top-12 right-2 bottom-0 hidden h-full w-px bg-[linear-gradient(to_bottom,transparent_0%,var(--border)_10%,var(--border)_90%,transparent_100%)] lg:flex" />
+      <SidebarContent
+        ref={contentRef}
+        className="w-(--sidebar-menu-width) scroll-fade scrollbar-none overflow-x-hidden pl-2.5"
+      >
         <SidebarGroup className="pt-12">
           <SidebarGroupLabel className="font-medium text-muted-foreground">
             Sections
@@ -158,6 +262,7 @@ export function DocsSidebar({
           )
         })}
       </SidebarContent>
+      <script dangerouslySetInnerHTML={{ __html: SCROLL_RESTORE_SCRIPT }} />
     </Sidebar>
   )
 }

--- a/apps/v4/components/open-in-v0-cta.tsx
+++ b/apps/v4/components/open-in-v0-cta.tsx
@@ -5,7 +5,7 @@ export function OpenInV0Cta({ className }: React.ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "group relative flex flex-col gap-2 rounded-lg bg-surface p-6 text-sm text-surface-foreground",
+        "group relative flex flex-col gap-2 rounded-2xl bg-surface p-6 text-sm text-surface-foreground",
         className
       )}
     >

--- a/apps/v4/components/theme-customizer.tsx
+++ b/apps/v4/components/theme-customizer.tsx
@@ -126,7 +126,7 @@ export function CopyCodeButton({
             Copy Code
           </Button>
         </DrawerTrigger>
-        <DrawerContent className="h-auto">
+        <DrawerContent className="h-auto rounded-t-2xl">
           <DrawerHeader>
             <DrawerTitle className="capitalize">{activeThemeName}</DrawerTitle>
             <DrawerDescription>
@@ -149,7 +149,7 @@ export function CopyCodeButton({
             </span>
           </Button>
         </DialogTrigger>
-        <DialogContent className="rounded-xl border-none bg-clip-padding shadow-2xl ring-4 ring-neutral-200/80 outline-none md:max-w-2xl dark:bg-neutral-800 dark:ring-neutral-900">
+        <DialogContent className="rounded-2xl border-none bg-clip-padding shadow-2xl ring-4 ring-neutral-200/80 outline-none md:max-w-2xl dark:bg-neutral-800 dark:ring-neutral-900">
           <DialogHeader>
             <DialogTitle className="capitalize">{activeThemeName}</DialogTitle>
             <DialogDescription>
@@ -198,7 +198,7 @@ function CustomizerCode({ themeName }: { themeName: string }) {
         <TabsContent value="v4-oklch">
           <figure
             data-rehype-pretty-code-figure
-            className="mx-0! mt-0 rounded-lg"
+            className="mx-0! mt-0 rounded-xl"
           >
             <figcaption
               className="flex items-center gap-2 text-code-foreground [&_svg]:size-4 [&_svg]:text-code-foreground [&_svg]:opacity-70"
@@ -278,7 +278,7 @@ function CustomizerCode({ themeName }: { themeName: string }) {
         <TabsContent value="v4-hsl">
           <figure
             data-rehype-pretty-code-figure
-            className="mx-0! mt-0 rounded-lg"
+            className="mx-0! mt-0 rounded-xl"
           >
             <figcaption
               className="flex items-center gap-2 text-code-foreground [&_svg]:size-4 [&_svg]:text-code-foreground [&_svg]:opacity-70"
@@ -362,7 +362,7 @@ function CustomizerCode({ themeName }: { themeName: string }) {
         <TabsContent value="v3">
           <figure
             data-rehype-pretty-code-figure
-            className="mx-0! mt-0 rounded-lg"
+            className="mx-0! mt-0 rounded-xl"
           >
             <figcaption
               className="flex items-center gap-2 text-code-foreground [&_svg]:size-4 [&_svg]:text-code-foreground [&_svg]:opacity-70"

--- a/apps/v4/content/docs/(root)/_blocks.mdx
+++ b/apps/v4/content/docs/(root)/_blocks.mdx
@@ -158,14 +158,14 @@ Once the build script is finished, you can view your block at `http://localhost:
   width="1432"
   height="960"
   alt="Block preview"
-  className="mt-6 w-full overflow-hidden rounded-lg border dark:hidden"
+  className="mt-6 w-full overflow-hidden rounded-2xl border dark:hidden"
 />
 <Image
   src="/images/block-preview-dark.png"
   width="1432"
   height="960"
   alt="Block preview"
-  className="mt-6 hidden w-full overflow-hidden rounded-lg border shadow-sm dark:block"
+  className="mt-6 hidden w-full overflow-hidden rounded-2xl border shadow-sm dark:block"
 />
 
 ### Build your block

--- a/apps/v4/content/docs/(root)/_v0.mdx
+++ b/apps/v4/content/docs/(root)/_v0.mdx
@@ -11,14 +11,14 @@ Every component on ui.shadcn.com is editable on [v0 by Vercel](https://v0.dev). 
     width="716"
     height="420"
     alt="Open in v0"
-    className="mt-6 w-full overflow-hidden rounded-lg border dark:hidden"
+    className="mt-6 w-full overflow-hidden rounded-2xl border dark:hidden"
   />
   <Image
     src="/images/open-in-v0-dark.png"
     width="716"
     height="420"
     alt="Open in v0"
-    className="mt-6 hidden w-full overflow-hidden rounded-lg border shadow-sm dark:block"
+    className="mt-6 hidden w-full overflow-hidden rounded-2xl border shadow-sm dark:block"
   />
   <span className="sr-only">Open in v0</span>
 </a>

--- a/apps/v4/content/docs/changelog/2023-06-new-cli.mdx
+++ b/apps/v4/content/docs/changelog/2023-06-new-cli.mdx
@@ -205,7 +205,7 @@ We are shipping two styles: `default` and `new-york` (with more coming soon).
   width="716"
   height="402"
   alt="Default vs New York style"
-  className="mt-6 overflow-hidden rounded-lg border"
+  className="mt-6 overflow-hidden rounded-2xl border"
 />
 
 The `default` style is the one you are used to. It's the one we've been using since the beginning of this project. It uses `lucide-react` for icons and `tailwindcss-animate` for animations.
@@ -229,7 +229,7 @@ Start with a style as the base then theme using CSS variables or Tailwind CSS ut
   width="716"
   height="402"
   alt="Style with theming"
-  className="mt-6 overflow-hidden rounded-lg border"
+  className="mt-6 overflow-hidden rounded-2xl border"
 />
 
 ---

--- a/apps/v4/content/docs/changelog/2024-03-blocks.mdx
+++ b/apps/v4/content/docs/changelog/2024-03-blocks.mdx
@@ -14,14 +14,14 @@ One of the most requested features since launch has been layouts: admin dashboar
     width="716"
     height="430"
     alt="Admin dashboard"
-    className="mt-6 w-full overflow-hidden rounded-lg border dark:hidden"
+    className="mt-6 w-full overflow-hidden rounded-2xl border dark:hidden"
   />
   <Image
     src="/images/dashboard-1-dark.jpg"
     width="716"
     height="430"
     alt="Admin dashboard"
-    className="mt-6 hidden w-full overflow-hidden rounded-lg border shadow-sm dark:block"
+    className="mt-6 hidden w-full overflow-hidden rounded-2xl border shadow-sm dark:block"
   />
   <span className="sr-only">View the blocks library</span>
 </a>
@@ -40,14 +40,14 @@ Blocks are open source. You can find the source on GitHub. Use them in your proj
     width="716"
     height="420"
     alt="AI Playground"
-    className="mt-6 w-full overflow-hidden rounded-lg border dark:hidden"
+    className="mt-6 w-full overflow-hidden rounded-2xl border dark:hidden"
   />
   <Image
     src="/images/dashboard-2-dark.jpg"
     width="716"
     height="420"
     alt="AI Playground"
-    className="mt-6 hidden w-full overflow-hidden rounded-lg border shadow-sm dark:block"
+    className="mt-6 hidden w-full overflow-hidden rounded-2xl border shadow-sm dark:block"
   />
   <span className="sr-only">View the blocks library</span>
 </a>
@@ -62,14 +62,14 @@ We're also introducing a "Request a Block" feature. If there's a specific block 
     width="716"
     height="420"
     alt="Settings Page"
-    className="mt-6 w-full overflow-hidden rounded-lg border dark:hidden"
+    className="mt-6 w-full overflow-hidden rounded-2xl border dark:hidden"
   />
   <Image
     src="/images/dashboard-3-dark.jpg"
     width="716"
     height="420"
     alt="Settings Page"
-    className="mt-6 hidden w-full overflow-hidden rounded-lg border shadow-sm dark:block"
+    className="mt-6 hidden w-full overflow-hidden rounded-2xl border shadow-sm dark:block"
   />
   <span className="sr-only">View the blocks library</span>
 </a>
@@ -78,7 +78,7 @@ We're also introducing a "Request a Block" feature. If there's a specific block 
 
 If you have a [v0](https://v0.dev) account, you can use the **Edit in v0** feature to open the code on v0 for prompting and further generation.
 
-<div className="mt-6 flex aspect-video w-full items-center justify-center overflow-hidden rounded-lg border bg-background shadow-sm">
+<div className="mt-6 flex aspect-video w-full items-center justify-center overflow-hidden rounded-2xl border bg-background shadow-sm">
   <svg
     viewBox="0 0 40 20"
     fill="none"

--- a/apps/v4/content/docs/changelog/2024-04-lift-mode.mdx
+++ b/apps/v4/content/docs/changelog/2024-04-lift-mode.mdx
@@ -14,14 +14,14 @@ Enable Lift Mode to automatically "lift" smaller components from a block templat
     width="1432"
     height="1050"
     alt="Lift Mode"
-    className="mt-6 w-full overflow-hidden rounded-lg border dark:hidden"
+    className="mt-6 w-full overflow-hidden rounded-2xl border dark:hidden"
   />
   <Image
     src="/images/lift-mode-dark.png"
     width="1432"
     height="1069"
     alt="Lift Mode"
-    className="mt-6 hidden w-full overflow-hidden rounded-lg border shadow-sm dark:block"
+    className="mt-6 hidden w-full overflow-hidden rounded-2xl border shadow-sm dark:block"
   />
   <span className="sr-only">View the blocks library</span>
 </a>

--- a/apps/v4/content/docs/changelog/2025-04-mcp.mdx
+++ b/apps/v4/content/docs/changelog/2025-04-mcp.mdx
@@ -11,7 +11,7 @@ We're working on zero-config MCP support for shadcn/ui registry. One command `np
   width="1432"
   height="1050"
   alt="MCP Server"
-  className="mt-6 w-full overflow-hidden rounded-lg border"
+  className="mt-6 w-full overflow-hidden rounded-2xl border"
 />
 
 Learn more in the [thread here](https://x.com/shadcn/status/1917597228513853603).

--- a/apps/v4/content/docs/changelog/2025-08-cli-3-mcp.mdx
+++ b/apps/v4/content/docs/changelog/2025-08-cli-3-mcp.mdx
@@ -126,7 +126,7 @@ Preview components before installing them. Search across multiple registries. Se
   width="1432"
   height="1050"
   alt="MCP Server"
-  className="mt-6 w-full overflow-hidden rounded-lg border"
+  className="mt-6 w-full overflow-hidden rounded-2xl border"
 />
 
 Back in April, we [introduced](https://x.com/shadcn/status/1917597228513853603) the first version of the MCP server. Since then, we've taken everything we learned and built a better MCP server.

--- a/apps/v4/content/docs/changelog/2026-03-luma.mdx
+++ b/apps/v4/content/docs/changelog/2026-03-luma.mdx
@@ -12,14 +12,14 @@ Introducing Luma, a new shadcn/ui style. Rounded geometry. Soft elevation. Breat
     width="2160"
     height="1832"
     alt="Luma style preview"
-    className="mt-6 w-full overflow-hidden rounded-lg border dark:hidden"
+    className="mt-6 w-full overflow-hidden rounded-2xl border dark:hidden"
   />
   <Image
     src="/images/luma-dark.png"
     width="2160"
     height="1832"
     alt="Luma style preview"
-    className="mt-6 hidden w-full overflow-hidden rounded-lg border shadow-sm dark:block"
+    className="mt-6 hidden w-full overflow-hidden rounded-2xl border shadow-sm dark:block"
   />
   <span className="sr-only">Try Luma in shadcn/create</span>
 </a>

--- a/apps/v4/content/docs/changelog/2026-04-sera.mdx
+++ b/apps/v4/content/docs/changelog/2026-04-sera.mdx
@@ -12,14 +12,14 @@ Introducing Sera, a new shadcn/ui style. Minimal. Editorial. Typographic. Underl
     width="2160"
     height="1832"
     alt="Sera style preview"
-    className="mt-6 w-full overflow-hidden rounded-lg border dark:hidden"
+    className="mt-6 w-full overflow-hidden rounded-2xl border dark:hidden"
   />
   <Image
     src="/images/sera-01-dark.png"
     width="2160"
     height="1832"
     alt="Sera style preview"
-    className="mt-6 hidden w-full overflow-hidden rounded-lg border shadow-sm dark:block"
+    className="mt-6 hidden w-full overflow-hidden rounded-2xl border shadow-sm dark:block"
   />
   <span className="sr-only">Try Sera in shadcn/create</span>
 </a>

--- a/apps/v4/content/docs/changelog/2026-05-rhea.mdx
+++ b/apps/v4/content/docs/changelog/2026-05-rhea.mdx
@@ -12,14 +12,14 @@ Introducing Rhea, a new shadcn/ui style. A more compact Luma. Smaller spacing. D
     width="3840"
     height="2160"
     alt="Rhea style preview"
-    className="mt-6 w-full overflow-hidden rounded-lg border dark:hidden"
+    className="mt-6 w-full overflow-hidden rounded-2xl border dark:hidden"
   />
   <Image
     src="/images/rhea-dark.png"
     width="3840"
     height="2160"
     alt="Rhea style preview"
-    className="mt-6 hidden w-full overflow-hidden rounded-lg border shadow-sm dark:block"
+    className="mt-6 hidden w-full overflow-hidden rounded-2xl border shadow-sm dark:block"
   />
   <span className="sr-only">Try Rhea in shadcn/create</span>
 </a>

--- a/apps/v4/content/docs/components/base/accordion.mdx
+++ b/apps/v4/content/docs/components/base/accordion.mdx
@@ -94,9 +94,7 @@ Accordion
     └── AccordionContent
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A basic accordion that shows one item at a time. The first item is open by default.
 
@@ -107,7 +105,7 @@ A basic accordion that shows one item at a time. The first item is open by defau
   previewClassName="*:data-[slot=accordion]:max-w-sm h-[300px]"
 />
 
-### Multiple
+## Multiple
 
 Use the `multiple` prop to allow multiple items to be open at the same time.
 
@@ -118,7 +116,7 @@ Use the `multiple` prop to allow multiple items to be open at the same time.
   previewClassName="*:data-[slot=accordion]:max-w-sm h-[450px]"
 />
 
-### Disabled
+## Disabled
 
 Use the `disabled` prop on `AccordionItem` to disable individual items.
 
@@ -129,7 +127,7 @@ Use the `disabled` prop on `AccordionItem` to disable individual items.
   previewClassName="*:data-[slot=accordion]:max-w-sm h-[300px]"
 />
 
-### Borders
+## Borders
 
 Add `border` to the `Accordion` and `border-b last:border-b-0` to the `AccordionItem` to add borders to the items.
 
@@ -140,7 +138,7 @@ Add `border` to the `Accordion` and `border-b last:border-b-0` to the `Accordion
   previewClassName="*:data-[slot=accordion]:max-w-sm h-[300px]"
 />
 
-### Card
+## Card
 
 Wrap the `Accordion` in a `Card` component.
 

--- a/apps/v4/content/docs/components/base/alert-dialog.mdx
+++ b/apps/v4/content/docs/components/base/alert-dialog.mdx
@@ -111,9 +111,7 @@ AlertDialog
         └── AlertDialogAction
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A basic alert dialog with a title, description, and cancel and continue buttons.
 
@@ -123,7 +121,7 @@ A basic alert dialog with a title, description, and cancel and continue buttons.
   previewClassName="h-56"
 />
 
-### Small
+## Small
 
 Use the `size="sm"` prop to make the alert dialog smaller.
 
@@ -133,7 +131,7 @@ Use the `size="sm"` prop to make the alert dialog smaller.
   previewClassName="h-56"
 />
 
-### Media
+## Media
 
 Use the `AlertDialogMedia` component to add a media element such as an icon or image to the alert dialog.
 
@@ -143,7 +141,7 @@ Use the `AlertDialogMedia` component to add a media element such as an icon or i
   previewClassName="h-56"
 />
 
-### Small with Media
+## Small with Media
 
 Use the `size="sm"` prop to make the alert dialog smaller and the `AlertDialogMedia` component to add a media element such as an icon or image to the alert dialog.
 
@@ -153,7 +151,7 @@ Use the `size="sm"` prop to make the alert dialog smaller and the `AlertDialogMe
   previewClassName="h-56"
 />
 
-### Destructive
+## Destructive
 
 Use the `AlertDialogAction` component to add a destructive action button to the alert dialog.
 

--- a/apps/v4/content/docs/components/base/alert.mdx
+++ b/apps/v4/content/docs/components/base/alert.mdx
@@ -83,9 +83,7 @@ Alert
 └── AlertAction
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A basic alert with an icon, title and description.
 
@@ -95,7 +93,7 @@ A basic alert with an icon, title and description.
   previewClassName="h-auto sm:h-72 p-6"
 />
 
-### Destructive
+## Destructive
 
 Use `variant="destructive"` to create a destructive alert.
 
@@ -105,7 +103,7 @@ Use `variant="destructive"` to create a destructive alert.
   previewClassName="h-auto sm:h-72 p-6"
 />
 
-### Action
+## Action
 
 Use `AlertAction` to add a button or other action element to the alert.
 
@@ -115,7 +113,7 @@ Use `AlertAction` to add a button or other action element to the alert.
   previewClassName="h-auto sm:h-72 p-6"
 />
 
-### Custom Colors
+## Custom Colors
 
 You can customize the alert colors by adding custom classes such as `bg-amber-50 dark:bg-amber-950` to the `Alert` component.
 

--- a/apps/v4/content/docs/components/base/aspect-ratio.mdx
+++ b/apps/v4/content/docs/components/base/aspect-ratio.mdx
@@ -61,15 +61,13 @@ import { AspectRatio } from "@/components/ui/aspect-ratio"
 </AspectRatio>
 ```
 
-## Examples
-
-### Square
+## Square
 
 A square aspect ratio component using the `ratio={1 / 1}` prop. This is useful for displaying images in a square format.
 
 <ComponentPreview name="aspect-ratio-square" styleName="base-nova" />
 
-### Portrait
+## Portrait
 
 A portrait aspect ratio component using the `ratio={9 / 16}` prop. This is useful for displaying images in a portrait format.
 

--- a/apps/v4/content/docs/components/base/attachment.mdx
+++ b/apps/v4/content/docs/components/base/attachment.mdx
@@ -118,9 +118,7 @@ AttachmentGroup
 - Scrollable, snapping `AttachmentGroup` with an edge fade
 - Customizable styling through the `className` prop on every part
 
-## Examples
-
-### Image
+## Image
 
 Set `variant="image"` on `AttachmentMedia` and render an `<img>` inside it. Use `orientation="vertical"` to stack the media above the content.
 
@@ -130,7 +128,7 @@ Set `variant="image"` on `AttachmentMedia` and render an `<img>` inside it. Use 
   previewClassName="h-auto theme-blue bg-surface dark:bg-background"
 />
 
-### States
+## States
 
 Set `state` to reflect the upload lifecycle. `uploading` and `processing` shimmer the title, and `error` switches to a destructive treatment.
 
@@ -140,7 +138,7 @@ Set `state` to reflect the upload lifecycle. `uploading` and `processing` shimme
   previewClassName="h-auto theme-blue bg-surface dark:bg-background"
 />
 
-### Sizes
+## Sizes
 
 Use `size` to switch between `default`, `sm`, and `xs`.
 
@@ -150,7 +148,7 @@ Use `size` to switch between `default`, `sm`, and `xs`.
   previewClassName="h-auto theme-blue bg-surface dark:bg-background"
 />
 
-### Group
+## Group
 
 Wrap attachments in `AttachmentGroup` to lay them out in a horizontally scrollable, snapping row with an edge fade.
 
@@ -160,7 +158,7 @@ Wrap attachments in `AttachmentGroup` to lay them out in a horizontally scrollab
   previewClassName="h-auto theme-blue bg-surface dark:bg-background"
 />
 
-### Trigger
+## Trigger
 
 Add an `AttachmentTrigger` to make the whole card open a link or dialog. It fills the card behind the actions, so the actions stay clickable.
 

--- a/apps/v4/content/docs/components/base/avatar.mdx
+++ b/apps/v4/content/docs/components/base/avatar.mdx
@@ -95,15 +95,13 @@ AvatarGroup
 └── AvatarGroupCount
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A basic avatar component with an image and a fallback.
 
 <ComponentPreview styleName="base-nova" name="avatar-basic" />
 
-### Badge
+## Badge
 
 Use the `AvatarBadge` component to add a badge to the avatar. The badge is positioned at the bottom right of the avatar.
 
@@ -119,37 +117,37 @@ Use the `className` prop to add custom styles to the badge such as custom colors
 </Avatar>
 ```
 
-### Badge with Icon
+## Badge with Icon
 
 You can also use an icon inside `<AvatarBadge>`.
 
 <ComponentPreview styleName="base-nova" name="avatar-badge-icon" />
 
-### Avatar Group
+## Avatar Group
 
 Use the `AvatarGroup` component to add a group of avatars.
 
 <ComponentPreview styleName="base-nova" name="avatar-group" />
 
-### Avatar Group Count
+## Avatar Group Count
 
 Use `<AvatarGroupCount>` to add a count to the group.
 
 <ComponentPreview styleName="base-nova" name="avatar-group-count" />
 
-### Avatar Group with Icon
+## Avatar Group with Icon
 
 You can also use an icon inside `<AvatarGroupCount>`.
 
 <ComponentPreview styleName="base-nova" name="avatar-group-count-icon" />
 
-### Sizes
+## Sizes
 
 Use the `size` prop to change the size of the avatar.
 
 <ComponentPreview styleName="base-nova" name="avatar-size" />
 
-### Dropdown
+## Dropdown
 
 You can use the `Avatar` component as a trigger for a dropdown menu.
 

--- a/apps/v4/content/docs/components/base/badge.mdx
+++ b/apps/v4/content/docs/components/base/badge.mdx
@@ -53,33 +53,31 @@ import { Badge } from "@/components/ui/badge"
 <Badge variant="default | outline | secondary | destructive">Badge</Badge>
 ```
 
-## Examples
-
-### Variants
+## Variants
 
 Use the `variant` prop to change the variant of the badge.
 
 <ComponentPreview styleName="base-nova" name="badge-variants" />
 
-### With Icon
+## With Icon
 
 You can render an icon inside the badge. Use `data-icon="inline-start"` to render the icon on the left and `data-icon="inline-end"` to render the icon on the right.
 
 <ComponentPreview styleName="base-nova" name="badge-icon" />
 
-### With Spinner
+## With Spinner
 
 You can render a spinner inside the badge. Remember to add the `data-icon="inline-start"` or `data-icon="inline-end"` prop to the spinner.
 
 <ComponentPreview styleName="base-nova" name="badge-spinner" />
 
-### Link
+## Link
 
 Use the `render` prop to render a link as a badge.
 
 <ComponentPreview styleName="base-nova" name="badge-link" />
 
-### Custom Colors
+## Custom Colors
 
 You can customize the colors of a badge by adding custom classes such as `bg-green-50 dark:bg-green-800` to the `Badge` component.
 

--- a/apps/v4/content/docs/components/base/breadcrumb.mdx
+++ b/apps/v4/content/docs/components/base/breadcrumb.mdx
@@ -97,27 +97,25 @@ Breadcrumb
         └── BreadcrumbPage
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A basic breadcrumb with a home link and a components link.
 
 <ComponentPreview styleName="base-nova" name="breadcrumb-basic" />
 
-### Custom separator
+## Custom separator
 
 Use a custom component as `children` for `<BreadcrumbSeparator />` to create a custom separator.
 
 <ComponentPreview styleName="base-nova" name="breadcrumb-separator" />
 
-### Dropdown
+## Dropdown
 
 You can compose `<BreadcrumbItem />` with a `<DropdownMenu />` to create a dropdown in the breadcrumb.
 
 <ComponentPreview styleName="base-nova" name="breadcrumb-dropdown" />
 
-### Collapsed
+## Collapsed
 
 We provide a `<BreadcrumbEllipsis />` component to show a collapsed state when the breadcrumb is too long.
 
@@ -127,7 +125,7 @@ We provide a `<BreadcrumbEllipsis />` component to show a collapsed state when t
   previewClassName="p-2"
 />
 
-### Link component
+## Link component
 
 To use a custom link component from your routing library, you can use the `render` prop on `<BreadcrumbLink />`.
 

--- a/apps/v4/content/docs/components/base/bubble.mdx
+++ b/apps/v4/content/docs/components/base/bubble.mdx
@@ -97,9 +97,7 @@ BubbleGroup
 - Polymorphic content via `render` for link and button bubbles
 - Customizable styling through the `className` prop on every part
 
-## Examples
-
-### Variants
+## Variants
 
 Use `variant` to change the visual treatment of the bubble.
 
@@ -121,7 +119,7 @@ Use `variant` to change the visual treatment of the bubble.
 
 A bubble sizes to its content, up to 80% of the container width. The `ghost` variant removes the max-width so assistant text and rich content can span the full row.
 
-### Alignment
+## Alignment
 
 Use `align` on `Bubble` to align the bubble to the start or end of the conversation.
 
@@ -138,7 +136,7 @@ Use `align` on `Bubble` to align the bubble to the start or end of the conversat
 
 **Note:** When building chat interfaces, you probably want to use alignment on the `Message` component itself, not the `Bubble` component. You can use the `role` prop on the `Message` component to automatically align the bubble to the start or end of the conversation.
 
-### Bubble Group
+## Bubble Group
 
 Use `BubbleGroup` to group consecutive bubbles from the same sender. Note the `align` prop should be set on the `Bubble` component itself, not the `BubbleGroup` component.
 
@@ -156,7 +154,7 @@ BubbleGroup
   previewClassName="h-auto theme-blue"
 />
 
-### Links and Buttons
+## Links and Buttons
 
 You can turn a bubble into a link or button by using the `render` prop on `BubbleContent`.
 
@@ -178,7 +176,7 @@ export function BubbleLinkDemo() {
 }
 ```
 
-### Reactions
+## Reactions
 
 Use `BubbleReactions` for bubble reactions. You can use it to display reactions or quick action buttons. Use `side` and `align` to position the row — `side="top"` anchors it to the upper edge. Reactions overlap the bubble edge, so leave vertical space between rows — the examples below use a larger `gap` for this reason.
 
@@ -188,7 +186,7 @@ Use `BubbleReactions` for bubble reactions. You can use it to display reactions 
   previewClassName="h-auto theme-blue"
 />
 
-### Show More / Collapsible
+## Show More / Collapsible
 
 Long bubble content can be composed with [`Collapsible`](/docs/components/collapsible) to allow for a show more or show less interaction. Use the `CollapsibleTrigger` component to trigger the collapsible content.
 
@@ -198,7 +196,7 @@ Long bubble content can be composed with [`Collapsible`](/docs/components/collap
   previewClassName="h-auto theme-blue"
 />
 
-### Tooltip
+## Tooltip
 
 Wrap a bubble in a [`Tooltip`](/docs/components/tooltip) to reveal metadata on hover, such as when a message was read.
 
@@ -208,7 +206,7 @@ Wrap a bubble in a [`Tooltip`](/docs/components/tooltip) to reveal metadata on h
   previewClassName="h-auto theme-blue"
 />
 
-### Popover
+## Popover
 
 Pair a bubble with a [`Popover`](/docs/components/popover) to surface more information on demand, such as the full error message for a failed action.
 

--- a/apps/v4/content/docs/components/base/button-group.mdx
+++ b/apps/v4/content/docs/components/base/button-group.mdx
@@ -95,27 +95,25 @@ ButtonGroup
 - Use the `ButtonGroup` component when you want to group buttons that perform an action.
 - Use the `ToggleGroup` component when you want to group buttons that toggle a state.
 
-## Examples
-
-### Orientation
+## Orientation
 
 Set the `orientation` prop to change the button group layout.
 
 <ComponentPreview styleName="base-nova" name="button-group-orientation" />
 
-### Size
+## Size
 
 Control the size of buttons using the `size` prop on individual buttons.
 
 <ComponentPreview styleName="base-nova" name="button-group-size" />
 
-### Nested
+## Nested
 
 Nest `<ButtonGroup>` components to create button groups with spacing.
 
 <ComponentPreview styleName="base-nova" name="button-group-nested" />
 
-### Separator
+## Separator
 
 The `ButtonGroupSeparator` component visually divides buttons within a group.
 
@@ -123,37 +121,37 @@ Buttons with variant `outline` do not need a separator since they have a border.
 
 <ComponentPreview styleName="base-nova" name="button-group-separator" />
 
-### Split
+## Split
 
 Create a split button group by adding two buttons separated by a `ButtonGroupSeparator`.
 
 <ComponentPreview styleName="base-nova" name="button-group-split" />
 
-### Input
+## Input
 
 Wrap an `Input` component with buttons.
 
 <ComponentPreview styleName="base-nova" name="button-group-input" />
 
-### Input Group
+## Input Group
 
 Wrap an `InputGroup` component to create complex input layouts.
 
 <ComponentPreview styleName="base-nova" name="button-group-input-group" />
 
-### Dropdown Menu
+## Dropdown Menu
 
 Create a split button group with a `DropdownMenu` component.
 
 <ComponentPreview styleName="base-nova" name="button-group-dropdown" />
 
-### Select
+## Select
 
 Pair with a `Select` component.
 
 <ComponentPreview styleName="base-nova" name="button-group-select" />
 
-### Popover
+## Popover
 
 Use with a `Popover` component.
 

--- a/apps/v4/content/docs/components/base/button.mdx
+++ b/apps/v4/content/docs/components/base/button.mdx
@@ -77,67 +77,65 @@ You can also enable this during project setup with `npx shadcn@latest init --poi
 }
 ```
 
-## Examples
-
-### Size
+## Size
 
 Use the `size` prop to change the size of the button.
 
 <ComponentPreview styleName="base-nova" name="button-size" />
 
-### Default
+## Default
 
 <ComponentPreview styleName="base-nova" name="button-default" />
 
-### Outline
+## Outline
 
 <ComponentPreview styleName="base-nova" name="button-outline" />
 
-### Secondary
+## Secondary
 
 <ComponentPreview styleName="base-nova" name="button-secondary" />
 
-### Ghost
+## Ghost
 
 <ComponentPreview styleName="base-nova" name="button-ghost" />
 
-### Destructive
+## Destructive
 
 <ComponentPreview styleName="base-nova" name="button-destructive" />
 
-### Link
+## Link
 
 <ComponentPreview styleName="base-nova" name="button-link" />
 
-### Icon
+## Icon
 
 <ComponentPreview styleName="base-nova" name="button-icon" />
 
-### With Icon
+## With Icon
 
 Remember to add the `data-icon="inline-start"` or `data-icon="inline-end"` attribute to the icon for the correct spacing.
 
 <ComponentPreview styleName="base-nova" name="button-with-icon" />
 
-### Rounded
+## Rounded
 
 Use the `rounded-full` class to make the button rounded.
 
 <ComponentPreview styleName="base-nova" name="button-rounded" />
 
-### Spinner
+## Spinner
 
 Render a `<Spinner />` component inside the button to show a loading state. Remember to add the `data-icon="inline-start"` or `data-icon="inline-end"` attribute to the spinner for the correct spacing.
 
 <ComponentPreview styleName="base-nova" name="button-spinner" />
 
-### Button Group
+## Button Group
 
 To create a button group, use the `ButtonGroup` component. See the [Button Group](/docs/components/base/button-group) documentation for more details.
 
 <ComponentPreview styleName="base-nova" name="button-group-demo" />
 
-### As Link
+## As Link
 
 You can use the `buttonVariants` helper to make a link look like a button.
 

--- a/apps/v4/content/docs/components/base/calendar.mdx
+++ b/apps/v4/content/docs/components/base/calendar.mdx
@@ -133,9 +133,7 @@ export function CalendarWithTimezone() {
 
 **Why client-side?** The timezone is detected using `Intl.DateTimeFormat().resolvedOptions().timeZone` inside a `useEffect` to ensure compatibility with server-side rendering. Detecting the timezone during render would cause hydration mismatches, as the server and client may be in different timezones.
 
-## Examples
-
-### Basic
+## Basic
 
 A basic calendar component. We used `className="rounded-lg border"` to style the calendar.
 
@@ -145,7 +143,7 @@ A basic calendar component. We used `className="rounded-lg border"` to style the
   previewClassName="h-96"
 />
 
-### Range Calendar
+## Range Calendar
 
 Use the `mode="range"` prop to enable range selection.
 
@@ -155,7 +153,7 @@ Use the `mode="range"` prop to enable range selection.
   previewClassName="h-[36rem] md:h-96"
 />
 
-### Month and Year Selector
+## Month and Year Selector
 
 Use `captionLayout="dropdown"` to show month and year dropdowns.
 
@@ -165,7 +163,7 @@ Use `captionLayout="dropdown"` to show month and year dropdowns.
   previewClassName="h-96"
 />
 
-### Presets
+## Presets
 
 <ComponentPreview
   styleName="base-nova"
@@ -173,7 +171,7 @@ Use `captionLayout="dropdown"` to show month and year dropdowns.
   previewClassName="h-[650px]"
 />
 
-### Date and Time Picker
+## Date and Time Picker
 
 <ComponentPreview
   styleName="base-nova"
@@ -181,7 +179,7 @@ Use `captionLayout="dropdown"` to show month and year dropdowns.
   previewClassName="h-[600px]"
 />
 
-### Booked dates
+## Booked dates
 
 <ComponentPreview
   styleName="base-nova"
@@ -189,7 +187,7 @@ Use `captionLayout="dropdown"` to show month and year dropdowns.
   previewClassName="h-96"
 />
 
-### Custom Cell Size
+## Custom Cell Size
 
 <ComponentPreview
   styleName="base-nova"
@@ -221,7 +219,7 @@ Or use fixed values:
 />
 ```
 
-### Week Numbers
+## Week Numbers
 
 Use `showWeekNumber` to show week numbers.
 

--- a/apps/v4/content/docs/components/base/card.mdx
+++ b/apps/v4/content/docs/components/base/card.mdx
@@ -91,9 +91,7 @@ Card
 └── CardFooter
 ```
 
-## Examples
-
-### Size
+## Size
 
 Use the `size="sm"` prop to set the size of the card to small. The small size variant uses smaller spacing.
 
@@ -103,7 +101,7 @@ Use the `size="sm"` prop to set the size of the card to small. The small size va
   previewClassName="h-96"
 />
 
-### Spacing
+## Spacing
 
 In addition to the `size` prop, you can use the `--card-spacing` CSS variable to control the spacing between sections and the inset of card parts.
 
@@ -121,7 +119,7 @@ Use negative margins with `-mx-(--card-spacing)` to make content go edge to edge
   previewClassName="h-[24rem]"
 />
 
-### Image
+## Image
 
 Add an image before the card header to create a card with an image.
 

--- a/apps/v4/content/docs/components/base/carousel.mdx
+++ b/apps/v4/content/docs/components/base/carousel.mdx
@@ -98,9 +98,7 @@ Carousel
 └── CarouselNext
 ```
 
-## Examples
-
-### Sizes
+## Sizes
 
 To set the size of the items, you can use the `basis` utility class on the `<CarouselItem />`.
 
@@ -128,7 +126,7 @@ To set the size of the items, you can use the `basis` utility class on the `<Car
 </Carousel>
 ```
 
-### Spacing
+## Spacing
 
 To set the spacing between the items, we use a `pl-[VALUE]` utility on the `<CarouselItem />` and a negative `-ml-[VALUE]` on the `<CarouselContent />`.
 
@@ -154,7 +152,7 @@ To set the spacing between the items, we use a `pl-[VALUE]` utility on the `<Car
 </Carousel>
 ```
 
-### Orientation
+## Orientation
 
 Use the `orientation` prop to set the orientation of the carousel.
 

--- a/apps/v4/content/docs/components/base/checkbox.mdx
+++ b/apps/v4/content/docs/components/base/checkbox.mdx
@@ -88,33 +88,31 @@ show the invalid styles.
 
 <ComponentPreview styleName="base-nova" name="checkbox-invalid" />
 
-## Examples
-
-### Basic
+## Basic
 
 Pair the checkbox with `Field` and `FieldLabel` for proper layout and labeling.
 
 <ComponentPreview styleName="base-nova" name="checkbox-basic" />
 
-### Description
+## Description
 
 Use `FieldContent` and `FieldDescription` for helper text.
 
 <ComponentPreview styleName="base-nova" name="checkbox-description" />
 
-### Disabled
+## Disabled
 
 Use the `disabled` prop to prevent interaction and add the `data-disabled` attribute to the `<Field>` component for disabled styles.
 
 <ComponentPreview styleName="base-nova" name="checkbox-disabled" />
 
-### Group
+## Group
 
 Use multiple fields to create a checkbox list.
 
 <ComponentPreview styleName="base-nova" name="checkbox-group" />
 
-### Table
+## Table
 
 <ComponentPreview
   styleName="base-nova"

--- a/apps/v4/content/docs/components/base/collapsible.mdx
+++ b/apps/v4/content/docs/components/base/collapsible.mdx
@@ -102,9 +102,7 @@ export function Example() {
 }
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 <ComponentPreview
   styleName="base-nova"
@@ -112,13 +110,13 @@ export function Example() {
   align="start"
 />
 
-### Settings Panel
+## Settings Panel
 
 Use a trigger button to reveal additional settings.
 
 <ComponentPreview styleName="base-nova" name="collapsible-settings" />
 
-### File Tree
+## File Tree
 
 Use nested collapsibles to build a file tree.
 

--- a/apps/v4/content/docs/components/base/combobox.mdx
+++ b/apps/v4/content/docs/components/base/combobox.mdx
@@ -250,63 +250,61 @@ export function ExampleComboboxMultiple() {
 }
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A simple combobox with a list of frameworks.
 
 <ComponentPreview styleName="base-nova" name="combobox-basic" />
 
-### Multiple
+## Multiple
 
 A combobox with multiple selection using `multiple` and `ComboboxChips`.
 
 <ComponentPreview styleName="base-nova" name="combobox-multiple" />
 
-### Clear Button
+## Clear Button
 
 Use the `showClear` prop to show a clear button.
 
 <ComponentPreview styleName="base-nova" name="combobox-clear" />
 
-### Groups
+## Groups
 
 Use `ComboboxGroup` and `ComboboxSeparator` to group items.
 
 <ComponentPreview styleName="base-nova" name="combobox-groups" />
 
-### Custom Items
+## Custom Items
 
 You can render a custom component inside `ComboboxItem`.
 
 <ComponentPreview styleName="base-nova" name="combobox-custom" />
 
-### Invalid
+## Invalid
 
 Use the `aria-invalid` prop to make the combobox invalid.
 
 <ComponentPreview styleName="base-nova" name="combobox-invalid" />
 
-### Disabled
+## Disabled
 
 Use the `disabled` prop to disable the combobox.
 
 <ComponentPreview styleName="base-nova" name="combobox-disabled" />
 
-### Auto Highlight
+## Auto Highlight
 
 Use the `autoHighlight` prop to automatically highlight the first item on filter.
 
 <ComponentPreview styleName="base-nova" name="combobox-auto-highlight" />
 
-### Popup
+## Popup
 
 You can trigger the combobox from a button or any other component by using the `render` prop. Move the `ComboboxInput` inside the `ComboboxContent`.
 
 <ComponentPreview styleName="base-nova" name="combobox-popup" />
 
-### Input Group
+## Input Group
 
 You can add an addon to the combobox by using the `InputGroupAddon` component inside the `ComboboxInput`.
 

--- a/apps/v4/content/docs/components/base/command.mdx
+++ b/apps/v4/content/docs/components/base/command.mdx
@@ -114,25 +114,23 @@ Command
         └── CommandItem
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A simple command menu in a dialog.
 
 <ComponentPreview styleName="base-nova" name="command-basic" />
 
-### Shortcuts
+## Shortcuts
 
 <ComponentPreview styleName="base-nova" name="command-shortcuts" />
 
-### Groups
+## Groups
 
 A command menu with groups, icons and separators.
 
 <ComponentPreview styleName="base-nova" name="command-groups" />
 
-### Scrollable
+## Scrollable
 
 Scrollable command menu with multiple items.
 

--- a/apps/v4/content/docs/components/base/context-menu.mdx
+++ b/apps/v4/content/docs/components/base/context-menu.mdx
@@ -110,57 +110,55 @@ ContextMenu
                 └── ContextMenuItem
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A simple context menu with a few actions.
 
 <ComponentPreview styleName="base-nova" name="context-menu-basic" />
 
-### Submenu
+## Submenu
 
 Use `ContextMenuSub` to nest secondary actions.
 
 <ComponentPreview styleName="base-nova" name="context-menu-submenu" />
 
-### Shortcuts
+## Shortcuts
 
 Add `ContextMenuShortcut` to show keyboard hints.
 
 <ComponentPreview styleName="base-nova" name="context-menu-shortcuts" />
 
-### Groups
+## Groups
 
 Group related actions and separate them with dividers.
 
 <ComponentPreview styleName="base-nova" name="context-menu-groups" />
 
-### Icons
+## Icons
 
 Combine icons with labels for quick scanning.
 
 <ComponentPreview styleName="base-nova" name="context-menu-icons" />
 
-### Checkboxes
+## Checkboxes
 
 Use `ContextMenuCheckboxItem` for toggles.
 
 <ComponentPreview styleName="base-nova" name="context-menu-checkboxes" />
 
-### Radio
+## Radio
 
 Use `ContextMenuRadioItem` for exclusive choices.
 
 <ComponentPreview styleName="base-nova" name="context-menu-radio" />
 
-### Destructive
+## Destructive
 
 Use `variant="destructive"` to style the menu item as destructive.
 
 <ComponentPreview styleName="base-nova" name="context-menu-destructive" />
 
-### Sides
+## Sides
 
 Control submenu placement with side and align props.
 

--- a/apps/v4/content/docs/components/base/date-picker.mdx
+++ b/apps/v4/content/docs/components/base/date-picker.mdx
@@ -69,39 +69,37 @@ Popover
     └── Calendar
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A basic date picker component.
 
 <ComponentPreview styleName="base-nova" name="date-picker-basic" />
 
-### Range Picker
+## Range Picker
 
 A date picker component for selecting a range of dates.
 
 <ComponentPreview styleName="base-nova" name="date-picker-range" />
 
-### Date of Birth
+## Date of Birth
 
 A date picker component for selecting a date of birth. This component includes a dropdown caption layout for date and month selection.
 
 <ComponentPreview styleName="base-nova" name="date-picker-dob" />
 
-### Input
+## Input
 
 A date picker component with an input field for selecting a date.
 
 <ComponentPreview styleName="base-nova" name="date-picker-input" />
 
-### Time Picker
+## Time Picker
 
 A date picker component with a time input field for selecting a time.
 
 <ComponentPreview styleName="base-nova" name="date-picker-time" />
 
-### Natural Language Picker
+## Natural Language Picker
 
 This component uses the `chrono-node` library to parse natural language dates.
 

--- a/apps/v4/content/docs/components/base/dialog.mdx
+++ b/apps/v4/content/docs/components/base/dialog.mdx
@@ -99,27 +99,25 @@ Dialog
     └── DialogFooter
 ```
 
-## Examples
-
-### Custom Close Button
+## Custom Close Button
 
 Replace the default close control with your own button.
 
 <ComponentPreview styleName="base-nova" name="dialog-close-button" />
 
-### No Close Button
+## No Close Button
 
 Use `showCloseButton={false}` to hide the close button.
 
 <ComponentPreview styleName="base-nova" name="dialog-no-close-button" />
 
-### Sticky Footer
+## Sticky Footer
 
 Keep actions visible while the content scrolls.
 
 <ComponentPreview styleName="base-nova" name="dialog-sticky-footer" />
 
-### Scrollable Content
+## Scrollable Content
 
 Long content can scroll while the header stays in view.
 

--- a/apps/v4/content/docs/components/base/drawer.mdx
+++ b/apps/v4/content/docs/components/base/drawer.mdx
@@ -168,9 +168,7 @@ The drawer also sets data attributes you can target with variants such as `data-
 | `data-swiping`            | Present                       | A swipe is in progress.               |
 | `data-nested-drawer-open` | Present                       | A nested drawer is open on top.       |
 
-## Examples
-
-### Position
+## Position
 
 Use the `swipeDirection` prop to set the side of the drawer.
 
@@ -178,25 +176,25 @@ Available options are `up`, `right`, `down`, and `left`.
 
 <ComponentPreview styleName="base-rhea" name="drawer-sides" />
 
-### Swipe Handle
+## Swipe Handle
 
 Use `showSwipeHandle` on `Drawer` to render a swipe handle.
 
 <ComponentPreview styleName="base-rhea" name="drawer-swipe-handle" />
 
-### Nested
+## Nested
 
 Open drawers from inside another drawer. Parent drawers stay mounted and stack behind the frontmost drawer.
 
 <ComponentPreview styleName="base-rhea" name="drawer-nested" />
 
-### Non Modal
+## Non Modal
 
 Set `modal={false}` to allow interaction with the rest of the page while the drawer is open. Combine with `disablePointerDismissal` to prevent the drawer from closing on outside presses. Use `modal="trap-focus"` to keep focus inside the drawer while leaving scroll and pointer interaction unrestricted.
 
 <ComponentPreview styleName="base-rhea" name="drawer-non-modal" />
 
-### Snap Points
+## Snap Points
 
 Use `snapPoints` to snap a drawer to preset heights. Numbers between `0` and `1` represent fractions of the viewport. Numbers greater than `1` are treated as pixel values. String values support `px` and `rem` units. Snap points apply to vertical drawers.
 
@@ -204,7 +202,7 @@ Track the active snap point with the controlled `snapPoint` and `onSnapPointChan
 
 <ComponentPreview styleName="base-rhea" name="drawer-snap-points" />
 
-### Responsive
+## Responsive
 
 You can combine the `Dialog` and `Drawer` components to create a responsive dialog. This renders a `Dialog` component on desktop and a `Drawer` on mobile.
 

--- a/apps/v4/content/docs/components/base/dropdown-menu.mdx
+++ b/apps/v4/content/docs/components/base/dropdown-menu.mdx
@@ -124,69 +124,67 @@ DropdownMenu
                 └── DropdownMenuItem
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A basic dropdown menu with labels and separators.
 
 <ComponentPreview styleName="base-nova" name="dropdown-menu-basic" />
 
-### Submenu
+## Submenu
 
 Use `DropdownMenuSub` to nest secondary actions.
 
 <ComponentPreview styleName="base-nova" name="dropdown-menu-submenu" />
 
-### Shortcuts
+## Shortcuts
 
 Add `DropdownMenuShortcut` to show keyboard hints.
 
 <ComponentPreview styleName="base-nova" name="dropdown-menu-shortcuts" />
 
-### Icons
+## Icons
 
 Combine icons with labels for quick scanning.
 
 <ComponentPreview styleName="base-nova" name="dropdown-menu-icons" />
 
-### Checkboxes
+## Checkboxes
 
 Use `DropdownMenuCheckboxItem` for toggles.
 
 <ComponentPreview styleName="base-nova" name="dropdown-menu-checkboxes" />
 
-### Checkboxes Icons
+## Checkboxes Icons
 
 Add icons to checkbox items.
 
 <ComponentPreview styleName="base-nova" name="dropdown-menu-checkboxes-icons" />
 
-### Radio Group
+## Radio Group
 
 Use `DropdownMenuRadioGroup` for exclusive choices.
 
 <ComponentPreview styleName="base-nova" name="dropdown-menu-radio-group" />
 
-### Radio Icons
+## Radio Icons
 
 Show radio options with icons.
 
 <ComponentPreview styleName="base-nova" name="dropdown-menu-radio-icons" />
 
-### Destructive
+## Destructive
 
 Use `variant="destructive"` for irreversible actions.
 
 <ComponentPreview styleName="base-nova" name="dropdown-menu-destructive" />
 
-### Avatar
+## Avatar
 
 An account switcher dropdown triggered by an avatar.
 
 <ComponentPreview styleName="base-nova" name="dropdown-menu-avatar" />
 
-### Complex
+## Complex
 
 A richer example combining groups, icons, and submenus.
 

--- a/apps/v4/content/docs/components/base/empty.mdx
+++ b/apps/v4/content/docs/components/base/empty.mdx
@@ -88,9 +88,7 @@ Empty
 └── EmptyContent
 ```
 
-## Examples
-
-### Outline
+## Outline
 
 Use the `border` utility class to create an outline empty state.
 
@@ -100,7 +98,7 @@ Use the `border` utility class to create an outline empty state.
   previewClassName="h-96 p-6 md:p-10"
 />
 
-### Background
+## Background
 
 Use the `bg-*` and `bg-gradient-*` utilities to add a background to the empty state.
 
@@ -110,7 +108,7 @@ Use the `bg-*` and `bg-gradient-*` utilities to add a background to the empty st
   previewClassName="h-96 p-0"
 />
 
-### Avatar
+## Avatar
 
 Use the `EmptyMedia` component to display an avatar in the empty state.
 
@@ -120,7 +118,7 @@ Use the `EmptyMedia` component to display an avatar in the empty state.
   previewClassName="h-96 p-0"
 />
 
-### Avatar Group
+## Avatar Group
 
 Use the `EmptyMedia` component to display an avatar group in the empty state.
 
@@ -130,7 +128,7 @@ Use the `EmptyMedia` component to display an avatar group in the empty state.
   previewClassName="h-96 p-0"
 />
 
-### InputGroup
+## InputGroup
 
 You can add an `InputGroup` component to the `EmptyContent` component.
 

--- a/apps/v4/content/docs/components/base/field.mdx
+++ b/apps/v4/content/docs/components/base/field.mdx
@@ -158,29 +158,27 @@ The `Field` family is designed for composing accessible forms. A typical field i
 
 See the [Form](/docs/forms) documentation for building forms with the `Field` component and [React Hook Form](/docs/forms/react-hook-form), [Tanstack Form](/docs/forms/tanstack-form), or [Formisch](/docs/forms/formisch).
 
-## Examples
-
-### Input
+## Input
 
 <ComponentPreview styleName="base-nova" name="field-input" />
 
-### Textarea
+## Textarea
 
 <ComponentPreview styleName="base-nova" name="field-textarea" />
 
-### Select
+## Select
 
 <ComponentPreview styleName="base-nova" name="field-select" />
 
-### Slider
+## Slider
 
 <ComponentPreview styleName="base-nova" name="field-slider" />
 
-### Fieldset
+## Fieldset
 
 <ComponentPreview styleName="base-nova" name="field-fieldset" />
 
-### Checkbox
+## Checkbox
 
 <ComponentPreview
   styleName="base-nova"
@@ -188,21 +186,21 @@ See the [Form](/docs/forms) documentation for building forms with the `Field` co
   previewClassName="h-[32rem]"
 />
 
-### Radio
+## Radio
 
 <ComponentPreview styleName="base-nova" name="field-radio" />
 
-### Switch
+## Switch
 
 <ComponentPreview styleName="base-nova" name="field-switch" />
 
-### Choice Card
+## Choice Card
 
 Wrap `Field` components inside `FieldLabel` to create selectable field groups. This works with `RadioItem`, `Checkbox` and `Switch` components.
 
 <ComponentPreview styleName="base-nova" name="field-choice-card" />
 
-### Field Group
+## Field Group
 
 Stack `Field` components with `FieldGroup`. Add `FieldSeparator` to divide them.
 

--- a/apps/v4/content/docs/components/base/hover-card.mdx
+++ b/apps/v4/content/docs/components/base/hover-card.mdx
@@ -112,9 +112,7 @@ Use the `side` and `align` props on `HoverCardContent` to control placement.
 </HoverCard>
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 <ComponentPreview
   styleName="base-nova"
@@ -122,7 +120,7 @@ Use the `side` and `align` props on `HoverCardContent` to control placement.
   previewClassName="h-80"
 />
 
-### Sides
+## Sides
 
 <ComponentPreview
   styleName="base-nova"

--- a/apps/v4/content/docs/components/base/input-group.mdx
+++ b/apps/v4/content/docs/components/base/input-group.mdx
@@ -133,9 +133,7 @@ Use `align="block-end"` to position the addon below the input.
   previewClassName="h-[26rem]"
 />
 
-## Examples
-
-### Icon
+## Icon
 
 <ComponentPreview
   styleName="base-nova"
@@ -143,7 +141,7 @@ Use `align="block-end"` to position the addon below the input.
   previewClassName="h-80"
 />
 
-### Text
+## Text
 
 <ComponentPreview
   styleName="base-nova"
@@ -151,7 +149,7 @@ Use `align="block-end"` to position the addon below the input.
   previewClassName="h-80"
 />
 
-### Button
+## Button
 
 <ComponentPreview
   styleName="base-nova"
@@ -159,7 +157,7 @@ Use `align="block-end"` to position the addon below the input.
   previewClassName="h-72"
 />
 
-### Kbd
+## Kbd
 
 <ComponentPreview
   styleName="base-nova"
@@ -167,7 +165,7 @@ Use `align="block-end"` to position the addon below the input.
   previewClassName="h-40"
 />
 
-### Dropdown
+## Dropdown
 
 <ComponentPreview
   styleName="base-nova"
@@ -175,7 +173,7 @@ Use `align="block-end"` to position the addon below the input.
   previewClassName="h-56"
 />
 
-### Spinner
+## Spinner
 
 <ComponentPreview
   styleName="base-nova"
@@ -183,7 +181,7 @@ Use `align="block-end"` to position the addon below the input.
   previewClassName="h-80"
 />
 
-### Textarea
+## Textarea
 
 <ComponentPreview
   styleName="base-nova"
@@ -191,7 +189,7 @@ Use `align="block-end"` to position the addon below the input.
   previewClassName="h-96"
 />
 
-### Custom Input
+## Custom Input
 
 Add the `data-slot="input-group-control"` attribute to your custom input for automatic focus state handling.
 

--- a/apps/v4/content/docs/components/base/input-otp.mdx
+++ b/apps/v4/content/docs/components/base/input-otp.mdx
@@ -117,45 +117,43 @@ import { REGEXP_ONLY_DIGITS_AND_CHARS } from "input-otp"
 
 <ComponentPreview styleName="base-nova" name="input-otp-pattern" />
 
-## Examples
-
-### Separator
+## Separator
 
 Use the `<InputOTPSeparator />` component to add a separator between input groups.
 
 <ComponentPreview styleName="base-nova" name="input-otp-separator" />
 
-### Disabled
+## Disabled
 
 Use the `disabled` prop to disable the input.
 
 <ComponentPreview styleName="base-nova" name="input-otp-disabled" />
 
-### Controlled
+## Controlled
 
 Use the `value` and `onChange` props to control the input value.
 
 <ComponentPreview styleName="base-nova" name="input-otp-controlled" />
 
-### Invalid
+## Invalid
 
 Use `aria-invalid` on the slots to show an error state.
 
 <ComponentPreview styleName="base-nova" name="input-otp-invalid" />
 
-### Four Digits
+## Four Digits
 
 A common pattern for PIN codes. This uses the `pattern={REGEXP_ONLY_DIGITS}` prop.
 
 <ComponentPreview styleName="base-nova" name="input-otp-four-digits" />
 
-### Alphanumeric
+## Alphanumeric
 
 Use `REGEXP_ONLY_DIGITS_AND_CHARS` to accept both letters and numbers.
 
 <ComponentPreview styleName="base-nova" name="input-otp-alphanumeric" />
 
-### Form
+## Form
 
 <ComponentPreview
   styleName="base-nova"

--- a/apps/v4/content/docs/components/base/input.mdx
+++ b/apps/v4/content/docs/components/base/input.mdx
@@ -57,9 +57,7 @@ import { Input } from "@/components/ui/input"
 <Input />
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 <ComponentPreview
   styleName="base-nova"
@@ -67,7 +65,7 @@ import { Input } from "@/components/ui/input"
   previewClassName="*:max-w-xs"
 />
 
-### Field
+## Field
 
 Use `Field`, `FieldLabel`, and `FieldDescription` to create an input with a
 label and description.
@@ -78,7 +76,7 @@ label and description.
   previewClassName="*:max-w-xs"
 />
 
-### Field Group
+## Field Group
 
 Use `FieldGroup` to show multiple `Field` blocks and to build forms.
 
@@ -88,7 +86,7 @@ Use `FieldGroup` to show multiple `Field` blocks and to build forms.
   previewClassName="*:max-w-xs"
 />
 
-### Disabled
+## Disabled
 
 Use the `disabled` prop to disable the input. To style the disabled state, add the `data-disabled` attribute to the `Field` component.
 
@@ -98,7 +96,7 @@ Use the `disabled` prop to disable the input. To style the disabled state, add t
   previewClassName="*:max-w-xs"
 />
 
-### Invalid
+## Invalid
 
 Use the `aria-invalid` prop to mark the input as invalid. To style the invalid state, add the `data-invalid` attribute to the `Field` component.
 
@@ -108,7 +106,7 @@ Use the `aria-invalid` prop to mark the input as invalid. To style the invalid s
   previewClassName="*:max-w-xs"
 />
 
-### File
+## File
 
 Use the `type="file"` prop to create a file input.
 
@@ -118,7 +116,7 @@ Use the `type="file"` prop to create a file input.
   previewClassName="*:max-w-xs"
 />
 
-### Inline
+## Inline
 
 Use `Field` with `orientation="horizontal"` to create an inline input.
 Pair with `Button` to create a search input with a button.
@@ -129,7 +127,7 @@ Pair with `Button` to create a search input with a button.
   previewClassName="*:max-w-xs"
 />
 
-### Grid
+## Grid
 
 Use a grid layout to place multiple inputs side by side.
 
@@ -139,7 +137,7 @@ Use a grid layout to place multiple inputs side by side.
   previewClassName="p-6"
 />
 
-### Required
+## Required
 
 Use the `required` attribute to indicate required inputs.
 
@@ -149,7 +147,7 @@ Use the `required` attribute to indicate required inputs.
   previewClassName="*:max-w-xs"
 />
 
-### Badge
+## Badge
 
 Use `Badge` in the label to highlight a recommended field.
 
@@ -159,7 +157,7 @@ Use `Badge` in the label to highlight a recommended field.
   previewClassName="*:max-w-xs"
 />
 
-### Input Group
+## Input Group
 
 To add icons, text, or buttons inside an input, use the `InputGroup` component. See the [Input Group](/docs/components/input-group) component for more examples.
 
@@ -169,7 +167,7 @@ To add icons, text, or buttons inside an input, use the `InputGroup` component. 
   previewClassName="*:max-w-xs"
 />
 
-### Button Group
+## Button Group
 
 To add buttons to an input, use the `ButtonGroup` component. See the [Button Group](/docs/components/button-group) component for more examples.
 
@@ -179,7 +177,7 @@ To add buttons to an input, use the `ButtonGroup` component. See the [Button Gro
   previewClassName="*:max-w-xs"
 />
 
-### Form
+## Form
 
 A full form example with multiple inputs, a select, and a button.
 

--- a/apps/v4/content/docs/components/base/item.mdx
+++ b/apps/v4/content/docs/components/base/item.mdx
@@ -115,27 +115,25 @@ Use the `size` prop to change the size of the item. Available sizes are `default
   previewClassName="h-96"
 />
 
-## Examples
-
-### Icon
+## Icon
 
 Use `ItemMedia` with `variant="icon"` to display an icon.
 
 <ComponentPreview styleName="base-nova" name="item-icon" />
 
-### Avatar
+## Avatar
 
 You can use `ItemMedia` with `variant="avatar"` to display an avatar.
 
 <ComponentPreview styleName="base-nova" name="item-avatar" />
 
-### Image
+## Image
 
 Use `ItemMedia` with `variant="image"` to display an image.
 
 <ComponentPreview styleName="base-nova" name="item-image" />
 
-### Group
+## Group
 
 Use `ItemGroup` to group related items together.
 
@@ -145,7 +143,7 @@ Use `ItemGroup` to group related items together.
   previewClassName="h-96"
 />
 
-### Header
+## Header
 
 Use `ItemHeader` to add a header above the item content.
 
@@ -155,7 +153,7 @@ Use `ItemHeader` to add a header above the item content.
   previewClassName="h-96"
 />
 
-### Link
+## Link
 
 Use the `render` prop to render the item as a link. The hover and focus states will be applied to the anchor element.
 
@@ -173,7 +171,7 @@ Use the `render` prop to render the item as a link. The hover and focus states w
 </Item>
 ```
 
-### Dropdown
+## Dropdown
 
 <ComponentPreview styleName="base-nova" name="item-dropdown" />
 

--- a/apps/v4/content/docs/components/base/kbd.mdx
+++ b/apps/v4/content/docs/components/base/kbd.mdx
@@ -64,27 +64,25 @@ KbdGroup
 └── Kbd
 ```
 
-## Examples
-
-### Group
+## Group
 
 Use the `KbdGroup` component to group keyboard keys together.
 
 <ComponentPreview styleName="base-nova" name="kbd-group" />
 
-### Button
+## Button
 
 Use the `Kbd` component inside a `Button` component to display a keyboard key inside a button.
 
 <ComponentPreview styleName="base-nova" name="kbd-button" />
 
-### Tooltip
+## Tooltip
 
 You can use the `Kbd` component inside a `Tooltip` component to display a tooltip with a keyboard key.
 
 <ComponentPreview styleName="base-nova" name="kbd-tooltip" />
 
-### Input Group
+## Input Group
 
 You can use the `Kbd` component inside a `InputGroupAddon` component to display a keyboard key inside an input group.
 

--- a/apps/v4/content/docs/components/base/marker.mdx
+++ b/apps/v4/content/docs/components/base/marker.mdx
@@ -82,9 +82,7 @@ Marker
 - Pairs with the [`shimmer`](/docs/utils/shimmer) utility for streaming status text
 - Customizable styling through the `className` prop on every part
 
-## Examples
-
-### Variants
+## Variants
 
 Use `variant` to switch between an inline marker, bordered row, and labeled separator.
 
@@ -100,7 +98,7 @@ Use `variant` to switch between an inline marker, bordered row, and labeled sepa
 | `border`    | A default marker with a bottom border under the row. |
 | `separator` | A centered label with divider lines on each side.    |
 
-### Status
+## Status
 
 Set `role="status"` and include a [`Spinner`](/docs/components/spinner) for streaming or in-progress markers so updates are announced.
 
@@ -110,7 +108,7 @@ Set `role="status"` and include a [`Spinner`](/docs/components/spinner) for stre
   previewClassName="h-auto theme-blue"
 />
 
-### Shimmer
+## Shimmer
 
 Add the [`shimmer`](/docs/utils/shimmer) utility class to `MarkerContent` for an animated streaming-text effect. The utility ships with the `shadcn` package — see the shimmer docs for installation.
 
@@ -120,7 +118,7 @@ Add the [`shimmer`](/docs/utils/shimmer) utility class to `MarkerContent` for an
   previewClassName="h-auto theme-blue"
 />
 
-### Separator
+## Separator
 
 Use the `separator` variant for labeled dividers, such as dates or section breaks, in a conversation.
 
@@ -130,7 +128,7 @@ Use the `separator` variant for labeled dividers, such as dates or section break
   previewClassName="h-auto theme-blue"
 />
 
-### Border
+## Border
 
 Use the `border` variant for status rows that should keep the default marker alignment while separating the next row.
 
@@ -140,7 +138,7 @@ Use the `border` variant for status rows that should keep the default marker ali
   previewClassName="h-auto theme-blue"
 />
 
-### With Icon
+## With Icon
 
 Use `MarkerIcon` to render an icon alongside the content. Use `flex-col` to stack the icon above the content.
 
@@ -150,7 +148,7 @@ Use `MarkerIcon` to render an icon alongside the content. Use `flex-col` to stac
   previewClassName="h-auto theme-blue"
 />
 
-### Links and Buttons
+## Links and Buttons
 
 Turn a marker into a link or button with the `render` prop on `Marker`.
 

--- a/apps/v4/content/docs/components/base/menubar.mdx
+++ b/apps/v4/content/docs/components/base/menubar.mdx
@@ -128,27 +128,25 @@ Menubar
             └── MenubarItem
 ```
 
-## Examples
-
-### Checkbox
+## Checkbox
 
 Use `MenubarCheckboxItem` for toggleable options.
 
 <ComponentPreview styleName="base-nova" name="menubar-checkbox" />
 
-### Radio
+## Radio
 
 Use `MenubarRadioGroup` and `MenubarRadioItem` for single-select options.
 
 <ComponentPreview styleName="base-nova" name="menubar-radio" />
 
-### Submenu
+## Submenu
 
 Use `MenubarSub`, `MenubarSubTrigger`, and `MenubarSubContent` for nested menus.
 
 <ComponentPreview styleName="base-nova" name="menubar-submenu" />
 
-### With Icons
+## With Icons
 
 <ComponentPreview styleName="base-nova" name="menubar-icons" />
 

--- a/apps/v4/content/docs/components/base/message.mdx
+++ b/apps/v4/content/docs/components/base/message.mdx
@@ -110,9 +110,7 @@ MessageGroup
 - Group wrapper for stacking consecutive messages from the same sender
 - Customizable styling through the `className` prop on every part
 
-## Examples
-
-### Avatar
+## Avatar
 
 Use `MessageAvatar` to render an avatar next to the message. Set `align="end"` on the message to align the avatar to the end of the message.
 
@@ -127,7 +125,7 @@ Use `MessageAvatar` to render an avatar next to the message. Set `align="end"` o
 | `start` | Align the message to the start of the conversation. |
 | `end`   | Align the message to the end of the conversation.   |
 
-### Group
+## Group
 
 Use `MessageGroup` to stack consecutive messages from the same sender. Render an empty `MessageAvatar` on the earlier messages to keep them aligned with the avatar on the last one.
 
@@ -137,7 +135,7 @@ Use `MessageGroup` to stack consecutive messages from the same sender. Render an
   previewClassName="h-auto theme-blue"
 />
 
-### Header and Footer
+## Header and Footer
 
 Use `MessageHeader` for a sender name and `MessageFooter` for metadata such as a delivery or read status.
 
@@ -147,7 +145,7 @@ Use `MessageHeader` for a sender name and `MessageFooter` for metadata such as a
   previewClassName="h-auto theme-blue"
 />
 
-### Actions
+## Actions
 
 Place message-level actions in `MessageFooter`, such as copy, retry, or feedback buttons.
 
@@ -157,7 +155,7 @@ Place message-level actions in `MessageFooter`, such as copy, retry, or feedback
   previewClassName="h-auto theme-blue"
 />
 
-### Attachment
+## Attachment
 
 <ComponentPreview
   styleName="base-rhea"

--- a/apps/v4/content/docs/components/base/native-select.mdx
+++ b/apps/v4/content/docs/components/base/native-select.mdx
@@ -98,21 +98,19 @@ NativeSelect
     └── NativeSelectOption
 ```
 
-## Examples
-
-### Groups
+## Groups
 
 Use `NativeSelectOptGroup` to organize options into categories.
 
 <ComponentPreview styleName="base-nova" name="native-select-groups" />
 
-### Disabled
+## Disabled
 
 Add the `disabled` prop to the `NativeSelect` component to disable the select.
 
 <ComponentPreview styleName="base-nova" name="native-select-disabled" />
 
-### Invalid
+## Invalid
 
 Use `aria-invalid` to show validation errors and the `data-invalid` attribute to the `Field` component for styling.
 

--- a/apps/v4/content/docs/components/base/pagination.mdx
+++ b/apps/v4/content/docs/components/base/pagination.mdx
@@ -101,15 +101,13 @@ Pagination
         └── PaginationNext
 ```
 
-## Examples
-
-### Simple
+## Simple
 
 A simple pagination with only page numbers.
 
 <ComponentPreview styleName="base-nova" name="pagination-simple" />
 
-### Icons Only
+## Icons Only
 
 Use just the previous and next buttons without page numbers. This is useful for data tables with a rows per page selector.
 

--- a/apps/v4/content/docs/components/base/popover.mdx
+++ b/apps/v4/content/docs/components/base/popover.mdx
@@ -89,21 +89,19 @@ Popover
 └── PopoverContent
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A simple popover with a header, title, and description.
 
 <ComponentPreview styleName="base-nova" name="popover-basic" />
 
-### Align
+## Align
 
 Use the `align` prop on `PopoverContent` to control the horizontal alignment.
 
 <ComponentPreview styleName="base-nova" name="popover-alignments" />
 
-### With Form
+## With Form
 
 A popover with form fields inside.
 

--- a/apps/v4/content/docs/components/base/progress.mdx
+++ b/apps/v4/content/docs/components/base/progress.mdx
@@ -89,15 +89,13 @@ Progress
     └── ProgressIndicator
 ```
 
-## Examples
-
-### Label
+## Label
 
 Use `ProgressLabel` and `ProgressValue` to add a label and value display.
 
 <ComponentPreview styleName="base-nova" name="progress-label" />
 
-### Controlled
+## Controlled
 
 A progress bar that can be controlled by a slider.
 

--- a/apps/v4/content/docs/components/base/radio-group.mdx
+++ b/apps/v4/content/docs/components/base/radio-group.mdx
@@ -82,33 +82,31 @@ RadioGroup
 └── RadioGroupItem
 ```
 
-## Examples
-
-### Description
+## Description
 
 Radio group items with a description using the `Field` component.
 
 <ComponentPreview styleName="base-nova" name="radio-group-description" />
 
-### Choice Card
+## Choice Card
 
 Use `FieldLabel` to wrap the entire `Field` for a clickable card-style selection.
 
 <ComponentPreview styleName="base-nova" name="radio-group-choice-card" />
 
-### Fieldset
+## Fieldset
 
 Use `FieldSet` and `FieldLegend` to group radio items with a label and description.
 
 <ComponentPreview styleName="base-nova" name="radio-group-fieldset" />
 
-### Disabled
+## Disabled
 
 Use the `disabled` prop on `RadioGroup` to disable all items.
 
 <ComponentPreview styleName="base-nova" name="radio-group-disabled" />
 
-### Invalid
+## Invalid
 
 Use `aria-invalid` on `RadioGroupItem` and `data-invalid` on `Field` to show validation errors.
 

--- a/apps/v4/content/docs/components/base/resizable.mdx
+++ b/apps/v4/content/docs/components/base/resizable.mdx
@@ -89,15 +89,13 @@ ResizablePanelGroup
 └── ResizablePanel
 ```
 
-## Examples
-
-### Vertical
+## Vertical
 
 Use `orientation="vertical"` for vertical resizing.
 
 <ComponentPreview styleName="base-nova" name="resizable-vertical" />
 
-### Handle
+## Handle
 
 Use the `withHandle` prop on `ResizableHandle` to show a visible handle.
 

--- a/apps/v4/content/docs/components/base/scroll-area.mdx
+++ b/apps/v4/content/docs/components/base/scroll-area.mdx
@@ -77,9 +77,7 @@ ScrollArea
 └── ScrollBar
 ```
 
-## Examples
-
-### Horizontal
+## Horizontal
 
 Use `ScrollBar` with `orientation="horizontal"` for horizontal scrolling.
 

--- a/apps/v4/content/docs/components/base/select.mdx
+++ b/apps/v4/content/docs/components/base/select.mdx
@@ -109,31 +109,29 @@ Select
         └── SelectItem
 ```
 
-## Examples
-
-### Align Item With Trigger
+## Align Item With Trigger
 
 Use `alignItemWithTrigger` on `SelectContent` to control whether the selected item aligns with the trigger. When `true` (default), the popup positions so the selected item appears over the trigger. When `false`, the popup aligns to the trigger edge.
 
 <ComponentPreview styleName="base-nova" name="select-align-item" />
 
-### Groups
+## Groups
 
 Use `SelectGroup`, `SelectLabel`, and `SelectSeparator` to organize items.
 
 <ComponentPreview styleName="base-nova" name="select-groups" />
 
-### Scrollable
+## Scrollable
 
 A select with many items that scrolls.
 
 <ComponentPreview styleName="base-nova" name="select-scrollable" />
 
-### Disabled
+## Disabled
 
 <ComponentPreview styleName="base-nova" name="select-disabled" />
 
-### Invalid
+## Invalid
 
 Add the `data-invalid` attribute to the `Field` component and the `aria-invalid` attribute to the `SelectTrigger` component to show an error state.
 

--- a/apps/v4/content/docs/components/base/separator.mdx
+++ b/apps/v4/content/docs/components/base/separator.mdx
@@ -62,21 +62,19 @@ import { Separator } from "@/components/ui/separator"
 <Separator />
 ```
 
-## Examples
-
-### Vertical
+## Vertical
 
 Use `orientation="vertical"` for a vertical separator.
 
 <ComponentPreview styleName="base-nova" name="separator-vertical" />
 
-### Menu
+## Menu
 
 Vertical separators between menu items with descriptions.
 
 <ComponentPreview styleName="base-nova" name="separator-menu" />
 
-### List
+## List
 
 Horizontal separators between list items.
 

--- a/apps/v4/content/docs/components/base/sheet.mdx
+++ b/apps/v4/content/docs/components/base/sheet.mdx
@@ -93,15 +93,13 @@ Sheet
     └── SheetFooter
 ```
 
-## Examples
-
-### Side
+## Side
 
 Use the `side` prop on `SheetContent` to set the edge of the screen where the sheet appears. Values are `top`, `right`, `bottom`, or `left`.
 
 <ComponentPreview styleName="base-nova" name="sheet-side" />
 
-### No Close Button
+## No Close Button
 
 Use `showCloseButton={false}` on `SheetContent` to hide the close button.
 

--- a/apps/v4/content/docs/components/base/sidebar.mdx
+++ b/apps/v4/content/docs/components/base/sidebar.mdx
@@ -148,14 +148,14 @@ SidebarProvider
   width="716"
   height="420"
   alt="Sidebar Structure"
-  className="mt-6 w-full overflow-hidden rounded-lg border dark:hidden"
+  className="mt-6 w-full overflow-hidden rounded-2xl border dark:hidden"
 />
 <Image
   src="/images/sidebar-structure-dark.png"
   width="716"
   height="420"
   alt="Sidebar Structure"
-  className="mt-6 hidden w-full overflow-hidden rounded-lg border dark:block"
+  className="mt-6 hidden w-full overflow-hidden rounded-2xl border dark:block"
 />
 
 ## SidebarProvider
@@ -366,14 +366,14 @@ The `SidebarMenu` component is used for building a menu within a `SidebarGroup`.
   width="716"
   height="420"
   alt="Sidebar Menu"
-  className="mt-6 w-full overflow-hidden rounded-lg border dark:hidden"
+  className="mt-6 w-full overflow-hidden rounded-2xl border dark:hidden"
 />
 <Image
   src="/images/sidebar-menu-dark.png"
   width="716"
   height="420"
   alt="Sidebar Menu"
-  className="mt-6 hidden w-full overflow-hidden rounded-lg border dark:block"
+  className="mt-6 hidden w-full overflow-hidden rounded-2xl border dark:block"
 />
 
 ```tsx showLineNumbers

--- a/apps/v4/content/docs/components/base/skeleton.mdx
+++ b/apps/v4/content/docs/components/base/skeleton.mdx
@@ -53,13 +53,11 @@ import { Skeleton } from "@/components/ui/skeleton"
 <Skeleton className="h-[20px] w-[100px] rounded-full" />
 ```
 
-## Examples
-
-### Avatar
+## Avatar
 
 <ComponentPreview styleName="base-nova" name="skeleton-avatar" />
 
-### Card
+## Card
 
 <ComponentPreview
   styleName="base-nova"
@@ -67,15 +65,15 @@ import { Skeleton } from "@/components/ui/skeleton"
   previewClassName="h-80"
 />
 
-### Text
+## Text
 
 <ComponentPreview styleName="base-nova" name="skeleton-text" />
 
-### Form
+## Form
 
 <ComponentPreview styleName="base-nova" name="skeleton-form" />
 
-### Table
+## Table
 
 <ComponentPreview styleName="base-nova" name="skeleton-table" />
 

--- a/apps/v4/content/docs/components/base/slider.mdx
+++ b/apps/v4/content/docs/components/base/slider.mdx
@@ -62,31 +62,29 @@ import { Slider } from "@/components/ui/slider"
 <Slider defaultValue={[33]} max={100} step={1} />
 ```
 
-## Examples
-
-### Range
+## Range
 
 Use an array with two values for a range slider.
 
 <ComponentPreview styleName="base-nova" name="slider-range" />
 
-### Multiple Thumbs
+## Multiple Thumbs
 
 Use an array with multiple values for multiple thumbs.
 
 <ComponentPreview styleName="base-nova" name="slider-multiple" />
 
-### Vertical
+## Vertical
 
 Use `orientation="vertical"` for a vertical slider.
 
 <ComponentPreview styleName="base-nova" name="slider-vertical" />
 
-### Controlled
+## Controlled
 
 <ComponentPreview styleName="base-nova" name="slider-controlled" />
 
-### Disabled
+## Disabled
 
 Use the `disabled` prop to disable the slider.
 

--- a/apps/v4/content/docs/components/base/sonner.mdx
+++ b/apps/v4/content/docs/components/base/sonner.mdx
@@ -105,17 +105,15 @@ import { toast } from "sonner"
 toast("Event has been created.")
 ```
 
-## Examples
-
-### Types
+## Types
 
 <ComponentPreview styleName="base-nova" name="sonner-types" />
 
-### Description
+## Description
 
 <ComponentPreview styleName="base-nova" name="sonner-description" />
 
-### Position
+## Position
 
 Use the `position` prop to change the position of the toast.
 

--- a/apps/v4/content/docs/components/base/spinner.mdx
+++ b/apps/v4/content/docs/components/base/spinner.mdx
@@ -78,31 +78,29 @@ function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
 export { Spinner }
 ```
 
-## Examples
-
-### Size
+## Size
 
 Use the `size-*` utility class to change the size of the spinner.
 
 <ComponentPreview styleName="base-nova" name="spinner-size" />
 
-### Button
+## Button
 
 Add a spinner to a button to indicate a loading state. Place the `<Spinner />` before the label with `data-icon="inline-start"` for a start position, or after the label with `data-icon="inline-end"` for an end position.
 
 <ComponentPreview styleName="base-nova" name="spinner-button" />
 
-### Badge
+## Badge
 
 Add a spinner to a badge to indicate a loading state. Place the `<Spinner />` before the label with `data-icon="inline-start"` for a start position, or after the label with `data-icon="inline-end"` for an end position.
 
 <ComponentPreview styleName="base-nova" name="spinner-badge" />
 
-### Input Group
+## Input Group
 
 <ComponentPreview styleName="base-nova" name="spinner-input-group" />
 
-### Empty
+## Empty
 
 <ComponentPreview styleName="base-nova" name="spinner-empty" />
 

--- a/apps/v4/content/docs/components/base/switch.mdx
+++ b/apps/v4/content/docs/components/base/switch.mdx
@@ -62,31 +62,29 @@ import { Switch } from "@/components/ui/switch"
 <Switch />
 ```
 
-## Examples
-
-### Description
+## Description
 
 <ComponentPreview styleName="base-nova" name="switch-description" />
 
-### Choice Card
+## Choice Card
 
 Card-style selection where `FieldLabel` wraps the entire `Field` for a clickable card pattern.
 
 <ComponentPreview styleName="base-nova" name="switch-choice-card" />
 
-### Disabled
+## Disabled
 
 Add the `disabled` prop to the `Switch` component to disable the switch. Add the `data-disabled` prop to the `Field` component for styling.
 
 <ComponentPreview styleName="base-nova" name="switch-disabled" />
 
-### Invalid
+## Invalid
 
 Add the `aria-invalid` prop to the `Switch` component to indicate an invalid state. Add the `data-invalid` prop to the `Field` component for styling.
 
 <ComponentPreview styleName="base-nova" name="switch-invalid" />
 
-### Size
+## Size
 
 Use the `size` prop to change the size of the switch.
 

--- a/apps/v4/content/docs/components/base/table.mdx
+++ b/apps/v4/content/docs/components/base/table.mdx
@@ -110,15 +110,13 @@ Table
 └── TableFooter
 ```
 
-## Examples
-
-### Footer
+## Footer
 
 Use the `<TableFooter />` component to add a footer to the table.
 
 <ComponentPreview styleName="base-nova" name="table-footer" />
 
-### Actions
+## Actions
 
 A table showing actions for each row using a `<DropdownMenu />` component.
 

--- a/apps/v4/content/docs/components/base/tabs.mdx
+++ b/apps/v4/content/docs/components/base/tabs.mdx
@@ -86,25 +86,23 @@ Tabs
 └── TabsContent
 ```
 
-## Examples
-
-### Line
+## Line
 
 Use the `variant="line"` prop on `TabsList` for a line style.
 
 <ComponentPreview styleName="base-nova" name="tabs-line" />
 
-### Vertical
+## Vertical
 
 Use `orientation="vertical"` for vertical tabs.
 
 <ComponentPreview styleName="base-nova" name="tabs-vertical" />
 
-### Disabled
+## Disabled
 
 <ComponentPreview styleName="base-nova" name="tabs-disabled" />
 
-### Icons
+## Icons
 
 <ComponentPreview styleName="base-nova" name="tabs-icons" />
 

--- a/apps/v4/content/docs/components/base/textarea.mdx
+++ b/apps/v4/content/docs/components/base/textarea.mdx
@@ -57,9 +57,7 @@ import { Textarea } from "@/components/ui/textarea"
 <Textarea />
 ```
 
-## Examples
-
-### Field
+## Field
 
 Use `Field`, `FieldLabel`, and `FieldDescription` to create a textarea with a label and description.
 
@@ -69,7 +67,7 @@ Use `Field`, `FieldLabel`, and `FieldDescription` to create a textarea with a la
   previewClassName="*:max-w-xs"
 />
 
-### Disabled
+## Disabled
 
 Use the `disabled` prop to disable the textarea. To style the disabled state, add the `data-disabled` attribute to the `Field` component.
 
@@ -79,7 +77,7 @@ Use the `disabled` prop to disable the textarea. To style the disabled state, ad
   previewClassName="*:max-w-xs"
 />
 
-### Invalid
+## Invalid
 
 Use the `aria-invalid` prop to mark the textarea as invalid. To style the invalid state, add the `data-invalid` attribute to the `Field` component.
 
@@ -89,7 +87,7 @@ Use the `aria-invalid` prop to mark the textarea as invalid. To style the invali
   previewClassName="*:max-w-xs"
 />
 
-### Button
+## Button
 
 Pair with `Button` to create a textarea with a submit button.
 

--- a/apps/v4/content/docs/components/base/toggle-group.mdx
+++ b/apps/v4/content/docs/components/base/toggle-group.mdx
@@ -76,37 +76,35 @@ ToggleGroup
 └── ToggleGroupItem
 ```
 
-## Examples
-
-### Outline
+## Outline
 
 Use `variant="outline"` for an outline style.
 
 <ComponentPreview styleName="base-nova" name="toggle-group-outline" />
 
-### Size
+## Size
 
 Use the `size` prop to change the size of the toggle group.
 
 <ComponentPreview styleName="base-nova" name="toggle-group-sizes" />
 
-### Spacing
+## Spacing
 
 Use `spacing` to add spacing between toggle group items.
 
 <ComponentPreview styleName="base-nova" name="toggle-group-spacing" />
 
-### Vertical
+## Vertical
 
 Use `orientation="vertical"` for vertical toggle groups.
 
 <ComponentPreview styleName="base-nova" name="toggle-group-vertical" />
 
-### Disabled
+## Disabled
 
 <ComponentPreview styleName="base-nova" name="toggle-group-disabled" />
 
-### Custom
+## Custom
 
 A custom toggle group example.
 

--- a/apps/v4/content/docs/components/base/toggle.mdx
+++ b/apps/v4/content/docs/components/base/toggle.mdx
@@ -62,25 +62,23 @@ import { Toggle } from "@/components/ui/toggle"
 <Toggle>Toggle</Toggle>
 ```
 
-## Examples
-
-### Outline
+## Outline
 
 Use `variant="outline"` for an outline style.
 
 <ComponentPreview styleName="base-nova" name="toggle-outline" />
 
-### With Text
+## With Text
 
 <ComponentPreview styleName="base-nova" name="toggle-text" />
 
-### Size
+## Size
 
 Use the `size` prop to change the size of the toggle.
 
 <ComponentPreview styleName="base-nova" name="toggle-sizes" />
 
-### Disabled
+## Disabled
 
 <ComponentPreview styleName="base-nova" name="toggle-disabled" />
 

--- a/apps/v4/content/docs/components/base/tooltip.mdx
+++ b/apps/v4/content/docs/components/base/tooltip.mdx
@@ -119,19 +119,17 @@ Tooltip
 └── TooltipContent
 ```
 
-## Examples
-
-### Side
+## Side
 
 Use the `side` prop to change the position of the tooltip.
 
 <ComponentPreview styleName="base-nova" name="tooltip-sides" />
 
-### With Keyboard Shortcut
+## With Keyboard Shortcut
 
 <ComponentPreview styleName="base-nova" name="tooltip-keyboard" />
 
-### Disabled Button
+## Disabled Button
 
 Show a tooltip on a disabled button by wrapping it with a span.
 

--- a/apps/v4/content/docs/components/radix/accordion.mdx
+++ b/apps/v4/content/docs/components/radix/accordion.mdx
@@ -94,9 +94,7 @@ Accordion
     └── AccordionContent
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A basic accordion that shows one item at a time. The first item is open by default.
 
@@ -107,7 +105,7 @@ A basic accordion that shows one item at a time. The first item is open by defau
   previewClassName="*:data-[slot=accordion]:max-w-sm h-[300px]"
 />
 
-### Multiple
+## Multiple
 
 Use `type="multiple"` to allow multiple items to be open at the same time.
 
@@ -118,7 +116,7 @@ Use `type="multiple"` to allow multiple items to be open at the same time.
   previewClassName="*:data-[slot=accordion]:max-w-sm h-[36rem] md:h-[30rem]"
 />
 
-### Disabled
+## Disabled
 
 Use the `disabled` prop on `AccordionItem` to disable individual items.
 
@@ -129,7 +127,7 @@ Use the `disabled` prop on `AccordionItem` to disable individual items.
   previewClassName="*:data-[slot=accordion]:max-w-sm h-[300px]"
 />
 
-### Borders
+## Borders
 
 Add `border` to the `Accordion` and `border-b last:border-b-0` to the `AccordionItem` to add borders to the items.
 
@@ -140,7 +138,7 @@ Add `border` to the `Accordion` and `border-b last:border-b-0` to the `Accordion
   previewClassName="*:data-[slot=accordion]:max-w-sm h-96 md:h-80"
 />
 
-### Card
+## Card
 
 Wrap the `Accordion` in a `Card` component.
 

--- a/apps/v4/content/docs/components/radix/alert-dialog.mdx
+++ b/apps/v4/content/docs/components/radix/alert-dialog.mdx
@@ -111,9 +111,7 @@ AlertDialog
         └── AlertDialogAction
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A basic alert dialog with a title, description, and cancel and continue buttons.
 
@@ -123,7 +121,7 @@ A basic alert dialog with a title, description, and cancel and continue buttons.
   previewClassName="h-56"
 />
 
-### Small
+## Small
 
 Use the `size="sm"` prop to make the alert dialog smaller.
 
@@ -133,7 +131,7 @@ Use the `size="sm"` prop to make the alert dialog smaller.
   previewClassName="h-56"
 />
 
-### Media
+## Media
 
 Use the `AlertDialogMedia` component to add a media element such as an icon or image to the alert dialog.
 
@@ -143,7 +141,7 @@ Use the `AlertDialogMedia` component to add a media element such as an icon or i
   previewClassName="h-56"
 />
 
-### Small with Media
+## Small with Media
 
 Use the `size="sm"` prop to make the alert dialog smaller and the `AlertDialogMedia` component to add a media element such as an icon or image to the alert dialog.
 
@@ -153,7 +151,7 @@ Use the `size="sm"` prop to make the alert dialog smaller and the `AlertDialogMe
   previewClassName="h-56"
 />
 
-### Destructive
+## Destructive
 
 Use the `AlertDialogAction` component to add a destructive action button to the alert dialog.
 

--- a/apps/v4/content/docs/components/radix/alert.mdx
+++ b/apps/v4/content/docs/components/radix/alert.mdx
@@ -83,9 +83,7 @@ Alert
 └── AlertAction
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A basic alert with an icon, title and description.
 
@@ -95,7 +93,7 @@ A basic alert with an icon, title and description.
   previewClassName="h-auto sm:h-72 p-6"
 />
 
-### Destructive
+## Destructive
 
 Use `variant="destructive"` to create a destructive alert.
 
@@ -105,7 +103,7 @@ Use `variant="destructive"` to create a destructive alert.
   previewClassName="h-auto sm:h-72 p-6"
 />
 
-### Action
+## Action
 
 Use `AlertAction` to add a button or other action element to the alert.
 
@@ -115,7 +113,7 @@ Use `AlertAction` to add a button or other action element to the alert.
   previewClassName="h-auto sm:h-72 p-6"
 />
 
-### Custom Colors
+## Custom Colors
 
 You can customize the alert colors by adding custom classes such as `bg-amber-50 dark:bg-amber-950` to the `Alert` component.
 

--- a/apps/v4/content/docs/components/radix/aspect-ratio.mdx
+++ b/apps/v4/content/docs/components/radix/aspect-ratio.mdx
@@ -64,15 +64,13 @@ import { AspectRatio } from "@/components/ui/aspect-ratio"
 </AspectRatio>
 ```
 
-## Examples
-
-### Square
+## Square
 
 A square aspect ratio component using the `ratio={1 / 1}` prop. This is useful for displaying images in a square format.
 
 <ComponentPreview name="aspect-ratio-square" styleName="radix-nova" />
 
-### Portrait
+## Portrait
 
 A portrait aspect ratio component using the `ratio={9 / 16}` prop. This is useful for displaying images in a portrait format.
 

--- a/apps/v4/content/docs/components/radix/attachment.mdx
+++ b/apps/v4/content/docs/components/radix/attachment.mdx
@@ -118,9 +118,7 @@ AttachmentGroup
 - Scrollable, snapping `AttachmentGroup` with an edge fade
 - Customizable styling through the `className` prop on every part
 
-## Examples
-
-### Image
+## Image
 
 Set `variant="image"` on `AttachmentMedia` and render an `<img>` inside it. Use `orientation="vertical"` to stack the media above the content.
 
@@ -130,7 +128,7 @@ Set `variant="image"` on `AttachmentMedia` and render an `<img>` inside it. Use 
   previewClassName="h-auto theme-blue bg-surface dark:bg-background"
 />
 
-### States
+## States
 
 Set `state` to reflect the upload lifecycle. `uploading` and `processing` shimmer the title, and `error` switches to a destructive treatment.
 
@@ -140,7 +138,7 @@ Set `state` to reflect the upload lifecycle. `uploading` and `processing` shimme
   previewClassName="h-auto theme-blue bg-surface dark:bg-background"
 />
 
-### Sizes
+## Sizes
 
 Use `size` to switch between `default`, `sm`, and `xs`.
 
@@ -150,7 +148,7 @@ Use `size` to switch between `default`, `sm`, and `xs`.
   previewClassName="h-auto theme-blue bg-surface dark:bg-background"
 />
 
-### Group
+## Group
 
 Wrap attachments in `AttachmentGroup` to lay them out in a horizontally scrollable, snapping row with an edge fade.
 
@@ -160,7 +158,7 @@ Wrap attachments in `AttachmentGroup` to lay them out in a horizontally scrollab
   previewClassName="h-auto theme-blue bg-surface dark:bg-background"
 />
 
-### Trigger
+## Trigger
 
 Add an `AttachmentTrigger` to make the whole card open a link or dialog. It fills the card behind the actions, so the actions stay clickable.
 

--- a/apps/v4/content/docs/components/radix/avatar.mdx
+++ b/apps/v4/content/docs/components/radix/avatar.mdx
@@ -91,15 +91,13 @@ AvatarGroup
 └── AvatarGroupCount
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A basic avatar component with an image and a fallback.
 
 <ComponentPreview styleName="radix-nova" name="avatar-basic" />
 
-### Badge
+## Badge
 
 Use the `AvatarBadge` component to add a badge to the avatar. The badge is positioned at the bottom right of the avatar.
 
@@ -115,7 +113,7 @@ Use the `className` prop to add custom styles to the badge such as custom colors
 </Avatar>
 ```
 
-### Badge with Icon
+## Badge with Icon
 
 You can also use an icon inside `<AvatarBadge>`.
 
@@ -125,7 +123,7 @@ You can also use an icon inside `<AvatarBadge>`.
 
 />
 
-### Avatar Group
+## Avatar Group
 
 Use the `AvatarGroup` component to add a group of avatars.
 
@@ -135,7 +133,7 @@ Use the `AvatarGroup` component to add a group of avatars.
 
 />
 
-### Avatar Group Count
+## Avatar Group Count
 
 Use `<AvatarGroupCount>` to add a count to the group.
 
@@ -145,7 +143,7 @@ Use `<AvatarGroupCount>` to add a count to the group.
 
 />
 
-### Avatar Group with Icon
+## Avatar Group with Icon
 
 You can also use an icon inside `<AvatarGroupCount>`.
 
@@ -155,7 +153,7 @@ You can also use an icon inside `<AvatarGroupCount>`.
 
 />
 
-### Sizes
+## Sizes
 
 Use the `size` prop to change the size of the avatar.
 
@@ -165,7 +163,7 @@ Use the `size` prop to change the size of the avatar.
 
 />
 
-### Dropdown
+## Dropdown
 
 You can use the `Avatar` component as a trigger for a dropdown menu.
 

--- a/apps/v4/content/docs/components/radix/badge.mdx
+++ b/apps/v4/content/docs/components/radix/badge.mdx
@@ -53,33 +53,31 @@ import { Badge } from "@/components/ui/badge"
 <Badge variant="default | outline | secondary | destructive">Badge</Badge>
 ```
 
-## Examples
-
-### Variants
+## Variants
 
 Use the `variant` prop to change the variant of the badge.
 
 <ComponentPreview styleName="radix-nova" name="badge-variants" />
 
-### With Icon
+## With Icon
 
 You can render an icon inside the badge. Use `data-icon="inline-start"` to render the icon on the left and `data-icon="inline-end"` to render the icon on the right.
 
 <ComponentPreview styleName="radix-nova" name="badge-icon" />
 
-### With Spinner
+## With Spinner
 
 You can render a spinner inside the badge. Remember to add the `data-icon="inline-start"` or `data-icon="inline-end"` prop to the spinner.
 
 <ComponentPreview styleName="radix-nova" name="badge-spinner" />
 
-### Link
+## Link
 
 Use the `asChild` prop to render a link as a badge.
 
 <ComponentPreview styleName="radix-nova" name="badge-link" />
 
-### Custom Colors
+## Custom Colors
 
 You can customize the colors of a badge by adding custom classes such as `bg-green-50 dark:bg-green-800` to the `Badge` component.
 

--- a/apps/v4/content/docs/components/radix/breadcrumb.mdx
+++ b/apps/v4/content/docs/components/radix/breadcrumb.mdx
@@ -95,27 +95,25 @@ Breadcrumb
         └── BreadcrumbPage
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A basic breadcrumb with a home link and a components link.
 
 <ComponentPreview styleName="radix-nova" name="breadcrumb-basic" />
 
-### Custom separator
+## Custom separator
 
 Use a custom component as `children` for `<BreadcrumbSeparator />` to create a custom separator.
 
 <ComponentPreview styleName="radix-nova" name="breadcrumb-separator" />
 
-### Dropdown
+## Dropdown
 
 You can compose `<BreadcrumbItem />` with a `<DropdownMenu />` to create a dropdown in the breadcrumb.
 
 <ComponentPreview styleName="radix-nova" name="breadcrumb-dropdown" />
 
-### Collapsed
+## Collapsed
 
 We provide a `<BreadcrumbEllipsis />` component to show a collapsed state when the breadcrumb is too long.
 
@@ -125,7 +123,7 @@ We provide a `<BreadcrumbEllipsis />` component to show a collapsed state when t
   previewClassName="p-2"
 />
 
-### Link component
+## Link component
 
 To use a custom link component from your routing library, you can use the `asChild` prop on `<BreadcrumbLink />`.
 

--- a/apps/v4/content/docs/components/radix/bubble.mdx
+++ b/apps/v4/content/docs/components/radix/bubble.mdx
@@ -97,9 +97,7 @@ BubbleGroup
 - Polymorphic content via `asChild` for link and button bubbles
 - Customizable styling through the `className` prop on every part
 
-## Examples
-
-### Variants
+## Variants
 
 Use `variant` to change the visual treatment of the bubble.
 
@@ -121,7 +119,7 @@ Use `variant` to change the visual treatment of the bubble.
 
 A bubble sizes to its content, up to 80% of the container width. The `ghost` variant removes the max-width so assistant text and rich content can span the full row.
 
-### Alignment
+## Alignment
 
 Use `align` on `Bubble` to align the bubble to the start or end of the conversation.
 
@@ -138,7 +136,7 @@ Use `align` on `Bubble` to align the bubble to the start or end of the conversat
 
 **Note:** When building chat interfaces, you probably want to use alignment on the `Message` component itself, not the `Bubble` component. You can use the `role` prop on the `Message` component to automatically align the bubble to the start or end of the conversation.
 
-### Bubble Group
+## Bubble Group
 
 Use `BubbleGroup` to group consecutive bubbles from the same sender. Note the `align` prop should be set on the `Bubble` component itself, not the `BubbleGroup` component.
 
@@ -156,7 +154,7 @@ BubbleGroup
   previewClassName="h-auto theme-blue"
 />
 
-### Links and Buttons
+## Links and Buttons
 
 You can turn a bubble into a link or button by using the `asChild` prop on `BubbleContent`.
 
@@ -180,7 +178,7 @@ export function BubbleLinkDemo() {
 }
 ```
 
-### Reactions
+## Reactions
 
 Use `BubbleReactions` for bubble reactions. You can use it to display reactions or quick action buttons. Use `side` and `align` to position the row — `side="top"` anchors it to the upper edge. Reactions overlap the bubble edge, so leave vertical space between rows — the examples below use a larger `gap` for this reason.
 
@@ -190,7 +188,7 @@ Use `BubbleReactions` for bubble reactions. You can use it to display reactions 
   previewClassName="h-auto theme-blue"
 />
 
-### Show More / Collapsible
+## Show More / Collapsible
 
 Long bubble content can be composed with [`Collapsible`](/docs/components/collapsible) to allow for a show more or show less interaction. Use the `CollapsibleTrigger` component to trigger the collapsible content.
 
@@ -200,7 +198,7 @@ Long bubble content can be composed with [`Collapsible`](/docs/components/collap
   previewClassName="h-auto theme-blue"
 />
 
-### Tooltip
+## Tooltip
 
 Wrap a bubble in a [`Tooltip`](/docs/components/tooltip) to reveal metadata on hover, such as when a message was read.
 
@@ -210,7 +208,7 @@ Wrap a bubble in a [`Tooltip`](/docs/components/tooltip) to reveal metadata on h
   previewClassName="h-auto theme-blue"
 />
 
-### Popover
+## Popover
 
 Pair a bubble with a [`Popover`](/docs/components/popover) to surface more information on demand, such as the full error message for a failed action.
 

--- a/apps/v4/content/docs/components/radix/button-group.mdx
+++ b/apps/v4/content/docs/components/radix/button-group.mdx
@@ -95,27 +95,25 @@ ButtonGroup
 - Use the `ButtonGroup` component when you want to group buttons that perform an action.
 - Use the `ToggleGroup` component when you want to group buttons that toggle a state.
 
-## Examples
-
-### Orientation
+## Orientation
 
 Set the `orientation` prop to change the button group layout.
 
 <ComponentPreview styleName="radix-nova" name="button-group-orientation" />
 
-### Size
+## Size
 
 Control the size of buttons using the `size` prop on individual buttons.
 
 <ComponentPreview styleName="radix-nova" name="button-group-size" />
 
-### Nested
+## Nested
 
 Nest `<ButtonGroup>` components to create button groups with spacing.
 
 <ComponentPreview styleName="radix-nova" name="button-group-nested" />
 
-### Separator
+## Separator
 
 The `ButtonGroupSeparator` component visually divides buttons within a group.
 
@@ -123,37 +121,37 @@ Buttons with variant `outline` do not need a separator since they have a border.
 
 <ComponentPreview styleName="radix-nova" name="button-group-separator" />
 
-### Split
+## Split
 
 Create a split button group by adding two buttons separated by a `ButtonGroupSeparator`.
 
 <ComponentPreview styleName="radix-nova" name="button-group-split" />
 
-### Input
+## Input
 
 Wrap an `Input` component with buttons.
 
 <ComponentPreview styleName="radix-nova" name="button-group-input" />
 
-### Input Group
+## Input Group
 
 Wrap an `InputGroup` component to create complex input layouts.
 
 <ComponentPreview styleName="radix-nova" name="button-group-input-group" />
 
-### Dropdown Menu
+## Dropdown Menu
 
 Create a split button group with a `DropdownMenu` component.
 
 <ComponentPreview styleName="radix-nova" name="button-group-dropdown" />
 
-### Select
+## Select
 
 Pair with a `Select` component.
 
 <ComponentPreview styleName="radix-nova" name="button-group-select" />
 
-### Popover
+## Popover
 
 Use with a `Popover` component.
 

--- a/apps/v4/content/docs/components/radix/button.mdx
+++ b/apps/v4/content/docs/components/radix/button.mdx
@@ -77,67 +77,65 @@ You can also enable this during project setup with `npx shadcn@latest init --poi
 }
 ```
 
-## Examples
-
-### Size
+## Size
 
 Use the `size` prop to change the size of the button.
 
 <ComponentPreview styleName="radix-nova" name="button-size" />
 
-### Default
+## Default
 
 <ComponentPreview styleName="radix-nova" name="button-default" />
 
-### Outline
+## Outline
 
 <ComponentPreview styleName="radix-nova" name="button-outline" />
 
-### Secondary
+## Secondary
 
 <ComponentPreview styleName="radix-nova" name="button-secondary" />
 
-### Ghost
+## Ghost
 
 <ComponentPreview styleName="radix-nova" name="button-ghost" />
 
-### Destructive
+## Destructive
 
 <ComponentPreview styleName="radix-nova" name="button-destructive" />
 
-### Link
+## Link
 
 <ComponentPreview styleName="radix-nova" name="button-link" />
 
-### Icon
+## Icon
 
 <ComponentPreview styleName="radix-nova" name="button-icon" />
 
-### With Icon
+## With Icon
 
 Remember to add the `data-icon="inline-start"` or `data-icon="inline-end"` attribute to the icon for the correct spacing.
 
 <ComponentPreview styleName="radix-nova" name="button-with-icon" />
 
-### Rounded
+## Rounded
 
 Use the `rounded-full` class to make the button rounded.
 
 <ComponentPreview styleName="radix-nova" name="button-rounded" />
 
-### Spinner
+## Spinner
 
 Render a `<Spinner />` component inside the button to show a loading state. Remember to add the `data-icon="inline-start"` or `data-icon="inline-end"` attribute to the spinner for the correct spacing.
 
 <ComponentPreview styleName="radix-nova" name="button-spinner" />
 
-### Button Group
+## Button Group
 
 To create a button group, use the `ButtonGroup` component. See the [Button Group](/docs/components/radix/button-group) documentation for more details.
 
 <ComponentPreview styleName="radix-nova" name="button-group-demo" />
 
-### As Child
+## As Child
 
 You can use the `asChild` prop on `<Button />` to make another component look like a button. Here's an example of a link that looks like a button.
 

--- a/apps/v4/content/docs/components/radix/calendar.mdx
+++ b/apps/v4/content/docs/components/radix/calendar.mdx
@@ -133,9 +133,7 @@ export function CalendarWithTimezone() {
 
 **Why client-side?** The timezone is detected using `Intl.DateTimeFormat().resolvedOptions().timeZone` inside a `useEffect` to ensure compatibility with server-side rendering. Detecting the timezone during render would cause hydration mismatches, as the server and client may be in different timezones.
 
-## Examples
-
-### Basic
+## Basic
 
 A basic calendar component. We used `className="rounded-lg border"` to style the calendar.
 
@@ -145,7 +143,7 @@ A basic calendar component. We used `className="rounded-lg border"` to style the
   previewClassName="h-96"
 />
 
-### Range Calendar
+## Range Calendar
 
 Use the `mode="range"` prop to enable range selection.
 
@@ -155,7 +153,7 @@ Use the `mode="range"` prop to enable range selection.
   previewClassName="h-[36rem] md:h-96"
 />
 
-### Month and Year Selector
+## Month and Year Selector
 
 Use `captionLayout="dropdown"` to show month and year dropdowns.
 
@@ -165,7 +163,7 @@ Use `captionLayout="dropdown"` to show month and year dropdowns.
   previewClassName="h-96"
 />
 
-### Presets
+## Presets
 
 <ComponentPreview
   styleName="radix-nova"
@@ -173,7 +171,7 @@ Use `captionLayout="dropdown"` to show month and year dropdowns.
   previewClassName="h-[650px]"
 />
 
-### Date and Time Picker
+## Date and Time Picker
 
 <ComponentPreview
   styleName="radix-nova"
@@ -181,7 +179,7 @@ Use `captionLayout="dropdown"` to show month and year dropdowns.
   previewClassName="h-[600px]"
 />
 
-### Booked dates
+## Booked dates
 
 <ComponentPreview
   styleName="radix-nova"
@@ -189,7 +187,7 @@ Use `captionLayout="dropdown"` to show month and year dropdowns.
   previewClassName="h-96"
 />
 
-### Custom Cell Size
+## Custom Cell Size
 
 <ComponentPreview
   styleName="radix-nova"
@@ -221,7 +219,7 @@ Or use fixed values:
 />
 ```
 
-### Week Numbers
+## Week Numbers
 
 Use `showWeekNumber` to show week numbers.
 

--- a/apps/v4/content/docs/components/radix/card.mdx
+++ b/apps/v4/content/docs/components/radix/card.mdx
@@ -91,9 +91,7 @@ Card
 └── CardFooter
 ```
 
-## Examples
-
-### Size
+## Size
 
 Use the `size="sm"` prop to set the size of the card to small. The small size variant uses smaller spacing.
 
@@ -103,7 +101,7 @@ Use the `size="sm"` prop to set the size of the card to small. The small size va
   previewClassName="h-96"
 />
 
-### Spacing
+## Spacing
 
 In addition to the `size` prop, you can use the `--card-spacing` CSS variable to control the spacing between sections and the inset of card parts.
 
@@ -121,7 +119,7 @@ Use negative margins with `-mx-(--card-spacing)` to make content go edge to edge
   previewClassName="h-[24rem]"
 />
 
-### Image
+## Image
 
 Add an image before the card header to create a card with an image.
 

--- a/apps/v4/content/docs/components/radix/carousel.mdx
+++ b/apps/v4/content/docs/components/radix/carousel.mdx
@@ -98,9 +98,7 @@ Carousel
 └── CarouselNext
 ```
 
-## Examples
-
-### Sizes
+## Sizes
 
 To set the size of the items, you can use the `basis` utility class on the `<CarouselItem />`.
 
@@ -128,7 +126,7 @@ To set the size of the items, you can use the `basis` utility class on the `<Car
 </Carousel>
 ```
 
-### Spacing
+## Spacing
 
 To set the spacing between the items, we use a `pl-[VALUE]` utility on the `<CarouselItem />` and a negative `-ml-[VALUE]` on the `<CarouselContent />`.
 
@@ -154,7 +152,7 @@ To set the spacing between the items, we use a `pl-[VALUE]` utility on the `<Car
 </Carousel>
 ```
 
-### Orientation
+## Orientation
 
 Use the `orientation` prop to set the orientation of the carousel.
 

--- a/apps/v4/content/docs/components/radix/checkbox.mdx
+++ b/apps/v4/content/docs/components/radix/checkbox.mdx
@@ -88,33 +88,31 @@ show the invalid styles.
 
 <ComponentPreview styleName="radix-nova" name="checkbox-invalid" />
 
-## Examples
-
-### Basic
+## Basic
 
 Pair the checkbox with `Field` and `FieldLabel` for proper layout and labeling.
 
 <ComponentPreview styleName="radix-nova" name="checkbox-basic" />
 
-### Description
+## Description
 
 Use `FieldContent` and `FieldDescription` for helper text.
 
 <ComponentPreview styleName="radix-nova" name="checkbox-description" />
 
-### Disabled
+## Disabled
 
 Use the `disabled` prop to prevent interaction and add the `data-disabled` attribute to the `<Field>` component for disabled styles.
 
 <ComponentPreview styleName="radix-nova" name="checkbox-disabled" />
 
-### Group
+## Group
 
 Use multiple fields to create a checkbox list.
 
 <ComponentPreview styleName="radix-nova" name="checkbox-group" />
 
-### Table
+## Table
 
 <ComponentPreview
   styleName="radix-nova"

--- a/apps/v4/content/docs/components/radix/collapsible.mdx
+++ b/apps/v4/content/docs/components/radix/collapsible.mdx
@@ -106,9 +106,7 @@ export function Example() {
 }
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 <ComponentPreview
   styleName="radix-nova"
@@ -116,13 +114,13 @@ export function Example() {
   align="start"
 />
 
-### Settings Panel
+## Settings Panel
 
 Use a trigger button to reveal additional settings.
 
 <ComponentPreview styleName="radix-nova" name="collapsible-settings" />
 
-### File Tree
+## File Tree
 
 Use nested collapsibles to build a file tree.
 

--- a/apps/v4/content/docs/components/radix/combobox.mdx
+++ b/apps/v4/content/docs/components/radix/combobox.mdx
@@ -250,63 +250,61 @@ export function ExampleComboboxMultiple() {
 }
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A simple combobox with a list of frameworks.
 
 <ComponentPreview styleName="base-nova" name="combobox-basic" />
 
-### Multiple
+## Multiple
 
 A combobox with multiple selection using `multiple` and `ComboboxChips`.
 
 <ComponentPreview styleName="base-nova" name="combobox-multiple" />
 
-### Clear Button
+## Clear Button
 
 Use the `showClear` prop to show a clear button.
 
 <ComponentPreview styleName="base-nova" name="combobox-clear" />
 
-### Groups
+## Groups
 
 Use `ComboboxGroup` and `ComboboxSeparator` to group items.
 
 <ComponentPreview styleName="base-nova" name="combobox-groups" />
 
-### Custom Items
+## Custom Items
 
 You can render a custom component inside `ComboboxItem`.
 
 <ComponentPreview styleName="base-nova" name="combobox-custom" />
 
-### Invalid
+## Invalid
 
 Use the `aria-invalid` prop to make the combobox invalid.
 
 <ComponentPreview styleName="base-nova" name="combobox-invalid" />
 
-### Disabled
+## Disabled
 
 Use the `disabled` prop to disable the combobox.
 
 <ComponentPreview styleName="base-nova" name="combobox-disabled" />
 
-### Auto Highlight
+## Auto Highlight
 
 Use the `autoHighlight` prop to automatically highlight the first item on filter.
 
 <ComponentPreview styleName="base-nova" name="combobox-auto-highlight" />
 
-### Popup
+## Popup
 
 You can trigger the combobox from a button or any other component by using the `render` prop. Move the `ComboboxInput` inside the `ComboboxContent`.
 
 <ComponentPreview styleName="base-nova" name="combobox-popup" />
 
-### Input Group
+## Input Group
 
 You can add an addon to the combobox by using the `InputGroupAddon` component inside the `ComboboxInput`.
 

--- a/apps/v4/content/docs/components/radix/command.mdx
+++ b/apps/v4/content/docs/components/radix/command.mdx
@@ -114,25 +114,23 @@ Command
         └── CommandItem
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A simple command menu in a dialog.
 
 <ComponentPreview styleName="radix-nova" name="command-basic" />
 
-### Shortcuts
+## Shortcuts
 
 <ComponentPreview styleName="radix-nova" name="command-shortcuts" />
 
-### Groups
+## Groups
 
 A command menu with groups, icons and separators.
 
 <ComponentPreview styleName="radix-nova" name="command-groups" />
 
-### Scrollable
+## Scrollable
 
 Scrollable command menu with multiple items.
 

--- a/apps/v4/content/docs/components/radix/context-menu.mdx
+++ b/apps/v4/content/docs/components/radix/context-menu.mdx
@@ -110,51 +110,49 @@ ContextMenu
                 └── ContextMenuItem
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A simple context menu with a few actions.
 
 <ComponentPreview styleName="radix-nova" name="context-menu-basic" />
 
-### Submenu
+## Submenu
 
 Use `ContextMenuSub` to nest secondary actions.
 
 <ComponentPreview styleName="radix-nova" name="context-menu-submenu" />
 
-### Shortcuts
+## Shortcuts
 
 Add `ContextMenuShortcut` to show keyboard hints.
 
 <ComponentPreview styleName="radix-nova" name="context-menu-shortcuts" />
 
-### Groups
+## Groups
 
 Group related actions and separate them with dividers.
 
 <ComponentPreview styleName="radix-nova" name="context-menu-groups" />
 
-### Icons
+## Icons
 
 Combine icons with labels for quick scanning.
 
 <ComponentPreview styleName="radix-nova" name="context-menu-icons" />
 
-### Checkboxes
+## Checkboxes
 
 Use `ContextMenuCheckboxItem` for toggles.
 
 <ComponentPreview styleName="radix-nova" name="context-menu-checkboxes" />
 
-### Radio
+## Radio
 
 Use `ContextMenuRadioItem` for exclusive choices.
 
 <ComponentPreview styleName="radix-nova" name="context-menu-radio" />
 
-### Destructive
+## Destructive
 
 Use `variant="destructive"` to style the menu item as destructive.
 

--- a/apps/v4/content/docs/components/radix/date-picker.mdx
+++ b/apps/v4/content/docs/components/radix/date-picker.mdx
@@ -67,39 +67,37 @@ Popover
     └── Calendar
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A basic date picker component.
 
 <ComponentPreview styleName="radix-nova" name="date-picker-basic" />
 
-### Range Picker
+## Range Picker
 
 A date picker component for selecting a range of dates.
 
 <ComponentPreview styleName="radix-nova" name="date-picker-range" />
 
-### Date of Birth
+## Date of Birth
 
 A date picker component for selecting a date of birth. This component includes a dropdown caption layout for date and month selection.
 
 <ComponentPreview styleName="radix-nova" name="date-picker-dob" />
 
-### Input
+## Input
 
 A date picker component with an input field for selecting a date.
 
 <ComponentPreview styleName="radix-nova" name="date-picker-input" />
 
-### Time Picker
+## Time Picker
 
 A date picker component with a time input field for selecting a time.
 
 <ComponentPreview styleName="radix-nova" name="date-picker-time" />
 
-### Natural Language Picker
+## Natural Language Picker
 
 This component uses the `chrono-node` library to parse natural language dates.
 

--- a/apps/v4/content/docs/components/radix/dialog.mdx
+++ b/apps/v4/content/docs/components/radix/dialog.mdx
@@ -99,27 +99,25 @@ Dialog
     └── DialogFooter
 ```
 
-## Examples
-
-### Custom Close Button
+## Custom Close Button
 
 Replace the default close control with your own button.
 
 <ComponentPreview styleName="radix-nova" name="dialog-close-button" />
 
-### No Close Button
+## No Close Button
 
 Use `showCloseButton={false}` to hide the close button.
 
 <ComponentPreview styleName="radix-nova" name="dialog-no-close-button" />
 
-### Sticky Footer
+## Sticky Footer
 
 Keep actions visible while the content scrolls.
 
 <ComponentPreview styleName="radix-nova" name="dialog-sticky-footer" />
 
-### Scrollable Content
+## Scrollable Content
 
 Long content can scroll while the header stays in view.
 

--- a/apps/v4/content/docs/components/radix/drawer.mdx
+++ b/apps/v4/content/docs/components/radix/drawer.mdx
@@ -102,21 +102,19 @@ Drawer
     └── DrawerFooter
 ```
 
-## Examples
-
-### Scrollable Content
+## Scrollable Content
 
 Keep actions visible while the content scrolls.
 
 <ComponentPreview styleName="radix-nova" name="drawer-scrollable-content" />
 
-### Sides
+## Sides
 
 Use the `direction` prop to set the side of the drawer. Available options are `top`, `right`, `bottom`, and `left`.
 
 <ComponentPreview styleName="radix-nova" name="drawer-sides" />
 
-### Responsive Dialog
+## Responsive Dialog
 
 You can combine the `Dialog` and `Drawer` components to create a responsive dialog. This renders a `Dialog` component on desktop and a `Drawer` on mobile.
 

--- a/apps/v4/content/docs/components/radix/dropdown-menu.mdx
+++ b/apps/v4/content/docs/components/radix/dropdown-menu.mdx
@@ -124,39 +124,37 @@ DropdownMenu
                 └── DropdownMenuItem
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A basic dropdown menu with labels and separators.
 
 <ComponentPreview styleName="radix-nova" name="dropdown-menu-basic" />
 
-### Submenu
+## Submenu
 
 Use `DropdownMenuSub` to nest secondary actions.
 
 <ComponentPreview styleName="radix-nova" name="dropdown-menu-submenu" />
 
-### Shortcuts
+## Shortcuts
 
 Add `DropdownMenuShortcut` to show keyboard hints.
 
 <ComponentPreview styleName="radix-nova" name="dropdown-menu-shortcuts" />
 
-### Icons
+## Icons
 
 Combine icons with labels for quick scanning.
 
 <ComponentPreview styleName="radix-nova" name="dropdown-menu-icons" />
 
-### Checkboxes
+## Checkboxes
 
 Use `DropdownMenuCheckboxItem` for toggles.
 
 <ComponentPreview styleName="radix-nova" name="dropdown-menu-checkboxes" />
 
-### Checkboxes Icons
+## Checkboxes Icons
 
 Add icons to checkbox items.
 
@@ -165,31 +163,31 @@ Add icons to checkbox items.
   name="dropdown-menu-checkboxes-icons"
 />
 
-### Radio Group
+## Radio Group
 
 Use `DropdownMenuRadioGroup` for exclusive choices.
 
 <ComponentPreview styleName="radix-nova" name="dropdown-menu-radio-group" />
 
-### Radio Icons
+## Radio Icons
 
 Show radio options with icons.
 
 <ComponentPreview styleName="radix-nova" name="dropdown-menu-radio-icons" />
 
-### Destructive
+## Destructive
 
 Use `variant="destructive"` for irreversible actions.
 
 <ComponentPreview styleName="radix-nova" name="dropdown-menu-destructive" />
 
-### Avatar
+## Avatar
 
 An account switcher dropdown triggered by an avatar.
 
 <ComponentPreview styleName="radix-nova" name="dropdown-menu-avatar" />
 
-### Complex
+## Complex
 
 A richer example combining groups, icons, and submenus.
 

--- a/apps/v4/content/docs/components/radix/empty.mdx
+++ b/apps/v4/content/docs/components/radix/empty.mdx
@@ -88,9 +88,7 @@ Empty
 └── EmptyContent
 ```
 
-## Examples
-
-### Outline
+## Outline
 
 Use the `border` utility class to create an outline empty state.
 
@@ -100,7 +98,7 @@ Use the `border` utility class to create an outline empty state.
   previewClassName="h-96 p-6 md:p-10"
 />
 
-### Background
+## Background
 
 Use the `bg-*` and `bg-gradient-*` utilities to add a background to the empty state.
 
@@ -110,7 +108,7 @@ Use the `bg-*` and `bg-gradient-*` utilities to add a background to the empty st
   previewClassName="h-96 p-0"
 />
 
-### Avatar
+## Avatar
 
 Use the `EmptyMedia` component to display an avatar in the empty state.
 
@@ -120,7 +118,7 @@ Use the `EmptyMedia` component to display an avatar in the empty state.
   previewClassName="h-96 p-0"
 />
 
-### Avatar Group
+## Avatar Group
 
 Use the `EmptyMedia` component to display an avatar group in the empty state.
 
@@ -130,7 +128,7 @@ Use the `EmptyMedia` component to display an avatar group in the empty state.
   previewClassName="h-96 p-0"
 />
 
-### InputGroup
+## InputGroup
 
 You can add an `InputGroup` component to the `EmptyContent` component.
 

--- a/apps/v4/content/docs/components/radix/field.mdx
+++ b/apps/v4/content/docs/components/radix/field.mdx
@@ -158,29 +158,27 @@ The `Field` family is designed for composing accessible forms. A typical field i
 
 See the [Form](/docs/forms) documentation for building forms with the `Field` component and [React Hook Form](/docs/forms/react-hook-form), [Tanstack Form](/docs/forms/tanstack-form), or [Formisch](/docs/forms/formisch).
 
-## Examples
-
-### Input
+## Input
 
 <ComponentPreview styleName="radix-nova" name="field-input" />
 
-### Textarea
+## Textarea
 
 <ComponentPreview styleName="radix-nova" name="field-textarea" />
 
-### Select
+## Select
 
 <ComponentPreview styleName="radix-nova" name="field-select" />
 
-### Slider
+## Slider
 
 <ComponentPreview styleName="radix-nova" name="field-slider" />
 
-### Fieldset
+## Fieldset
 
 <ComponentPreview styleName="radix-nova" name="field-fieldset" />
 
-### Checkbox
+## Checkbox
 
 <ComponentPreview
   styleName="radix-nova"
@@ -188,21 +186,21 @@ See the [Form](/docs/forms) documentation for building forms with the `Field` co
   previewClassName="h-[32rem]"
 />
 
-### Radio
+## Radio
 
 <ComponentPreview styleName="radix-nova" name="field-radio" />
 
-### Switch
+## Switch
 
 <ComponentPreview styleName="radix-nova" name="field-switch" />
 
-### Choice Card
+## Choice Card
 
 Wrap `Field` components inside `FieldLabel` to create selectable field groups. This works with `RadioItem`, `Checkbox` and `Switch` components.
 
 <ComponentPreview styleName="radix-nova" name="field-choice-card" />
 
-### Field Group
+## Field Group
 
 Stack `Field` components with `FieldGroup`. Add `FieldSeparator` to divide them.
 

--- a/apps/v4/content/docs/components/radix/hover-card.mdx
+++ b/apps/v4/content/docs/components/radix/hover-card.mdx
@@ -110,9 +110,7 @@ Use the `side` and `align` props on `HoverCardContent` to control placement.
 </HoverCard>
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 <ComponentPreview
   styleName="radix-nova"
@@ -120,7 +118,7 @@ Use the `side` and `align` props on `HoverCardContent` to control placement.
   previewClassName="h-80"
 />
 
-### Sides
+## Sides
 
 <ComponentPreview
   styleName="radix-nova"

--- a/apps/v4/content/docs/components/radix/input-group.mdx
+++ b/apps/v4/content/docs/components/radix/input-group.mdx
@@ -133,9 +133,7 @@ Use `align="block-end"` to position the addon below the input.
   previewClassName="h-[26rem]"
 />
 
-## Examples
-
-### Icon
+## Icon
 
 <ComponentPreview
   styleName="radix-nova"
@@ -143,7 +141,7 @@ Use `align="block-end"` to position the addon below the input.
   previewClassName="h-80"
 />
 
-### Text
+## Text
 
 <ComponentPreview
   styleName="radix-nova"
@@ -151,7 +149,7 @@ Use `align="block-end"` to position the addon below the input.
   previewClassName="h-80"
 />
 
-### Button
+## Button
 
 <ComponentPreview
   styleName="radix-nova"
@@ -159,7 +157,7 @@ Use `align="block-end"` to position the addon below the input.
   previewClassName="h-72"
 />
 
-### Kbd
+## Kbd
 
 <ComponentPreview
   styleName="radix-nova"
@@ -167,7 +165,7 @@ Use `align="block-end"` to position the addon below the input.
   previewClassName="h-40"
 />
 
-### Dropdown
+## Dropdown
 
 <ComponentPreview
   styleName="radix-nova"
@@ -175,7 +173,7 @@ Use `align="block-end"` to position the addon below the input.
   previewClassName="h-56"
 />
 
-### Spinner
+## Spinner
 
 <ComponentPreview
   styleName="radix-nova"
@@ -183,7 +181,7 @@ Use `align="block-end"` to position the addon below the input.
   previewClassName="h-80"
 />
 
-### Textarea
+## Textarea
 
 <ComponentPreview
   styleName="radix-nova"
@@ -191,7 +189,7 @@ Use `align="block-end"` to position the addon below the input.
   previewClassName="h-96"
 />
 
-### Custom Input
+## Custom Input
 
 Add the `data-slot="input-group-control"` attribute to your custom input for automatic focus state handling.
 

--- a/apps/v4/content/docs/components/radix/input-otp.mdx
+++ b/apps/v4/content/docs/components/radix/input-otp.mdx
@@ -117,45 +117,43 @@ import { REGEXP_ONLY_DIGITS_AND_CHARS } from "input-otp"
 
 <ComponentPreview styleName="radix-nova" name="input-otp-pattern" />
 
-## Examples
-
-### Separator
+## Separator
 
 Use the `<InputOTPSeparator />` component to add a separator between input groups.
 
 <ComponentPreview styleName="radix-nova" name="input-otp-separator" />
 
-### Disabled
+## Disabled
 
 Use the `disabled` prop to disable the input.
 
 <ComponentPreview styleName="radix-nova" name="input-otp-disabled" />
 
-### Controlled
+## Controlled
 
 Use the `value` and `onChange` props to control the input value.
 
 <ComponentPreview styleName="radix-nova" name="input-otp-controlled" />
 
-### Invalid
+## Invalid
 
 Use `aria-invalid` on the slots to show an error state.
 
 <ComponentPreview styleName="radix-nova" name="input-otp-invalid" />
 
-### Four Digits
+## Four Digits
 
 A common pattern for PIN codes. This uses the `pattern={REGEXP_ONLY_DIGITS}` prop.
 
 <ComponentPreview styleName="radix-nova" name="input-otp-four-digits" />
 
-### Alphanumeric
+## Alphanumeric
 
 Use `REGEXP_ONLY_DIGITS_AND_CHARS` to accept both letters and numbers.
 
 <ComponentPreview styleName="radix-nova" name="input-otp-alphanumeric" />
 
-### Form
+## Form
 
 <ComponentPreview
   styleName="radix-nova"

--- a/apps/v4/content/docs/components/radix/input.mdx
+++ b/apps/v4/content/docs/components/radix/input.mdx
@@ -57,9 +57,7 @@ import { Input } from "@/components/ui/input"
 <Input />
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 <ComponentPreview
   styleName="radix-nova"
@@ -67,7 +65,7 @@ import { Input } from "@/components/ui/input"
   previewClassName="*:max-w-xs"
 />
 
-### Field
+## Field
 
 Use `Field`, `FieldLabel`, and `FieldDescription` to create an input with a
 label and description.
@@ -78,7 +76,7 @@ label and description.
   previewClassName="*:max-w-xs"
 />
 
-### Field Group
+## Field Group
 
 Use `FieldGroup` to show multiple `Field` blocks and to build forms.
 
@@ -88,7 +86,7 @@ Use `FieldGroup` to show multiple `Field` blocks and to build forms.
   previewClassName="*:max-w-xs"
 />
 
-### Disabled
+## Disabled
 
 Use the `disabled` prop to disable the input. To style the disabled state, add the `data-disabled` attribute to the `Field` component.
 
@@ -98,7 +96,7 @@ Use the `disabled` prop to disable the input. To style the disabled state, add t
   previewClassName="*:max-w-xs"
 />
 
-### Invalid
+## Invalid
 
 Use the `aria-invalid` prop to mark the input as invalid. To style the invalid state, add the `data-invalid` attribute to the `Field` component.
 
@@ -108,7 +106,7 @@ Use the `aria-invalid` prop to mark the input as invalid. To style the invalid s
   previewClassName="*:max-w-xs"
 />
 
-### File
+## File
 
 Use the `type="file"` prop to create a file input.
 
@@ -118,7 +116,7 @@ Use the `type="file"` prop to create a file input.
   previewClassName="*:max-w-xs"
 />
 
-### Inline
+## Inline
 
 Use `Field` with `orientation="horizontal"` to create an inline input.
 Pair with `Button` to create a search input with a button.
@@ -129,7 +127,7 @@ Pair with `Button` to create a search input with a button.
   previewClassName="*:max-w-xs"
 />
 
-### Grid
+## Grid
 
 Use a grid layout to place multiple inputs side by side.
 
@@ -139,7 +137,7 @@ Use a grid layout to place multiple inputs side by side.
   previewClassName="p-6"
 />
 
-### Required
+## Required
 
 Use the `required` attribute to indicate required inputs.
 
@@ -149,7 +147,7 @@ Use the `required` attribute to indicate required inputs.
   previewClassName="*:max-w-xs"
 />
 
-### Badge
+## Badge
 
 Use `Badge` in the label to highlight a recommended field.
 
@@ -159,7 +157,7 @@ Use `Badge` in the label to highlight a recommended field.
   previewClassName="*:max-w-xs"
 />
 
-### Input Group
+## Input Group
 
 To add icons, text, or buttons inside an input, use the `InputGroup` component. See the [Input Group](/docs/components/input-group) component for more examples.
 
@@ -169,7 +167,7 @@ To add icons, text, or buttons inside an input, use the `InputGroup` component. 
   previewClassName="*:max-w-xs"
 />
 
-### Button Group
+## Button Group
 
 To add buttons to an input, use the `ButtonGroup` component. See the [Button Group](/docs/components/button-group) component for more examples.
 
@@ -179,7 +177,7 @@ To add buttons to an input, use the `ButtonGroup` component. See the [Button Gro
   previewClassName="*:max-w-xs"
 />
 
-### Form
+## Form
 
 A full form example with multiple inputs, a select, and a button.
 

--- a/apps/v4/content/docs/components/radix/item.mdx
+++ b/apps/v4/content/docs/components/radix/item.mdx
@@ -115,27 +115,25 @@ Use the `size` prop to change the size of the item. Available sizes are `default
   previewClassName="h-96"
 />
 
-## Examples
-
-### Icon
+## Icon
 
 Use `ItemMedia` with `variant="icon"` to display an icon.
 
 <ComponentPreview styleName="radix-nova" name="item-icon" />
 
-### Avatar
+## Avatar
 
 You can use `ItemMedia` with `variant="avatar"` to display an avatar.
 
 <ComponentPreview styleName="radix-nova" name="item-avatar" />
 
-### Image
+## Image
 
 Use `ItemMedia` with `variant="image"` to display an image.
 
 <ComponentPreview styleName="radix-nova" name="item-image" />
 
-### Group
+## Group
 
 Use `ItemGroup` to group related items together.
 
@@ -145,7 +143,7 @@ Use `ItemGroup` to group related items together.
   previewClassName="h-96"
 />
 
-### Header
+## Header
 
 Use `ItemHeader` to add a header above the item content.
 
@@ -155,7 +153,7 @@ Use `ItemHeader` to add a header above the item content.
   previewClassName="h-96"
 />
 
-### Link
+## Link
 
 Use the `asChild` prop to render the item as a link. The hover and focus states will be applied to the anchor element.
 
@@ -175,7 +173,7 @@ Use the `asChild` prop to render the item as a link. The hover and focus states 
 </Item>
 ```
 
-### Dropdown
+## Dropdown
 
 <ComponentPreview styleName="radix-nova" name="item-dropdown" />
 

--- a/apps/v4/content/docs/components/radix/kbd.mdx
+++ b/apps/v4/content/docs/components/radix/kbd.mdx
@@ -64,27 +64,25 @@ KbdGroup
 └── Kbd
 ```
 
-## Examples
-
-### Group
+## Group
 
 Use the `KbdGroup` component to group keyboard keys together.
 
 <ComponentPreview styleName="radix-nova" name="kbd-group" />
 
-### Button
+## Button
 
 Use the `Kbd` component inside a `Button` component to display a keyboard key inside a button.
 
 <ComponentPreview styleName="radix-nova" name="kbd-button" />
 
-### Tooltip
+## Tooltip
 
 You can use the `Kbd` component inside a `Tooltip` component to display a tooltip with a keyboard key.
 
 <ComponentPreview styleName="radix-nova" name="kbd-tooltip" />
 
-### Input Group
+## Input Group
 
 You can use the `Kbd` component inside a `InputGroupAddon` component to display a keyboard key inside an input group.
 

--- a/apps/v4/content/docs/components/radix/marker.mdx
+++ b/apps/v4/content/docs/components/radix/marker.mdx
@@ -82,9 +82,7 @@ Marker
 - Pairs with the [`shimmer`](/docs/utils/shimmer) utility for streaming status text
 - Customizable styling through the `className` prop on every part
 
-## Examples
-
-### Variants
+## Variants
 
 Use `variant` to switch between an inline marker, bordered row, and labeled separator.
 
@@ -100,7 +98,7 @@ Use `variant` to switch between an inline marker, bordered row, and labeled sepa
 | `border`    | A default marker with a bottom border under the row. |
 | `separator` | A centered label with divider lines on each side.    |
 
-### Status
+## Status
 
 Set `role="status"` and include a [`Spinner`](/docs/components/spinner) for streaming or in-progress markers so updates are announced.
 
@@ -110,7 +108,7 @@ Set `role="status"` and include a [`Spinner`](/docs/components/spinner) for stre
   previewClassName="h-auto theme-blue"
 />
 
-### Shimmer
+## Shimmer
 
 Add the [`shimmer`](/docs/utils/shimmer) utility class to `MarkerContent` for an animated streaming-text effect. The utility ships with the `shadcn` package — see the shimmer docs for installation.
 
@@ -120,7 +118,7 @@ Add the [`shimmer`](/docs/utils/shimmer) utility class to `MarkerContent` for an
   previewClassName="h-auto theme-blue"
 />
 
-### Separator
+## Separator
 
 Use the `separator` variant for labeled dividers, such as dates or section breaks, in a conversation.
 
@@ -130,7 +128,7 @@ Use the `separator` variant for labeled dividers, such as dates or section break
   previewClassName="h-auto theme-blue"
 />
 
-### Border
+## Border
 
 Use the `border` variant for status rows that should keep the default marker alignment while separating the next row.
 
@@ -140,7 +138,7 @@ Use the `border` variant for status rows that should keep the default marker ali
   previewClassName="h-auto theme-blue"
 />
 
-### With Icon
+## With Icon
 
 Use `MarkerIcon` to render an icon alongside the content. Use `flex-col` to stack the icon above the content.
 
@@ -150,7 +148,7 @@ Use `MarkerIcon` to render an icon alongside the content. Use `flex-col` to stac
   previewClassName="h-auto theme-blue"
 />
 
-### Links and Buttons
+## Links and Buttons
 
 Turn a marker into a link or button with the `asChild` prop on `Marker`.
 

--- a/apps/v4/content/docs/components/radix/menubar.mdx
+++ b/apps/v4/content/docs/components/radix/menubar.mdx
@@ -128,27 +128,25 @@ Menubar
             └── MenubarItem
 ```
 
-## Examples
-
-### Checkbox
+## Checkbox
 
 Use `MenubarCheckboxItem` for toggleable options.
 
 <ComponentPreview styleName="radix-nova" name="menubar-checkbox" />
 
-### Radio
+## Radio
 
 Use `MenubarRadioGroup` and `MenubarRadioItem` for single-select options.
 
 <ComponentPreview styleName="radix-nova" name="menubar-radio" />
 
-### Submenu
+## Submenu
 
 Use `MenubarSub`, `MenubarSubTrigger`, and `MenubarSubContent` for nested menus.
 
 <ComponentPreview styleName="radix-nova" name="menubar-submenu" />
 
-### With Icons
+## With Icons
 
 <ComponentPreview styleName="radix-nova" name="menubar-icons" />
 

--- a/apps/v4/content/docs/components/radix/message.mdx
+++ b/apps/v4/content/docs/components/radix/message.mdx
@@ -110,9 +110,7 @@ MessageGroup
 - Group wrapper for stacking consecutive messages from the same sender
 - Customizable styling through the `className` prop on every part
 
-## Examples
-
-### Avatar
+## Avatar
 
 Use `MessageAvatar` to render an avatar next to the message. Set `align="end"` on the message to align the avatar to the end of the message.
 
@@ -127,7 +125,7 @@ Use `MessageAvatar` to render an avatar next to the message. Set `align="end"` o
 | `start` | Align the message to the start of the conversation. |
 | `end`   | Align the message to the end of the conversation.   |
 
-### Group
+## Group
 
 Use `MessageGroup` to stack consecutive messages from the same sender. Render an empty `MessageAvatar` on the earlier messages to keep them aligned with the avatar on the last one.
 
@@ -137,7 +135,7 @@ Use `MessageGroup` to stack consecutive messages from the same sender. Render an
   previewClassName="h-auto theme-blue"
 />
 
-### Header and Footer
+## Header and Footer
 
 Use `MessageHeader` for a sender name and `MessageFooter` for metadata such as a delivery or read status.
 
@@ -147,7 +145,7 @@ Use `MessageHeader` for a sender name and `MessageFooter` for metadata such as a
   previewClassName="h-auto theme-blue"
 />
 
-### Actions
+## Actions
 
 Place message-level actions in `MessageFooter`, such as copy, retry, or feedback buttons.
 
@@ -157,7 +155,7 @@ Place message-level actions in `MessageFooter`, such as copy, retry, or feedback
   previewClassName="h-auto theme-blue"
 />
 
-### Attachment
+## Attachment
 
 <ComponentPreview
   styleName="radix-rhea"

--- a/apps/v4/content/docs/components/radix/native-select.mdx
+++ b/apps/v4/content/docs/components/radix/native-select.mdx
@@ -98,21 +98,19 @@ NativeSelect
     └── NativeSelectOption
 ```
 
-## Examples
-
-### Groups
+## Groups
 
 Use `NativeSelectOptGroup` to organize options into categories.
 
 <ComponentPreview styleName="radix-nova" name="native-select-groups" />
 
-### Disabled
+## Disabled
 
 Add the `disabled` prop to the `NativeSelect` component to disable the select.
 
 <ComponentPreview styleName="radix-nova" name="native-select-disabled" />
 
-### Invalid
+## Invalid
 
 Use `aria-invalid` to show validation errors and the `data-invalid` attribute to the `Field` component for styling.
 

--- a/apps/v4/content/docs/components/radix/pagination.mdx
+++ b/apps/v4/content/docs/components/radix/pagination.mdx
@@ -101,15 +101,13 @@ Pagination
         └── PaginationNext
 ```
 
-## Examples
-
-### Simple
+## Simple
 
 A simple pagination with only page numbers.
 
 <ComponentPreview styleName="radix-nova" name="pagination-simple" />
 
-### Icons Only
+## Icons Only
 
 Use just the previous and next buttons without page numbers. This is useful for data tables with a rows per page selector.
 

--- a/apps/v4/content/docs/components/radix/popover.mdx
+++ b/apps/v4/content/docs/components/radix/popover.mdx
@@ -89,21 +89,19 @@ Popover
 └── PopoverContent
 ```
 
-## Examples
-
-### Basic
+## Basic
 
 A simple popover with a header, title, and description.
 
 <ComponentPreview styleName="radix-nova" name="popover-basic" />
 
-### Align
+## Align
 
 Use the `align` prop on `PopoverContent` to control the horizontal alignment.
 
 <ComponentPreview styleName="radix-nova" name="popover-alignments" />
 
-### With Form
+## With Form
 
 A popover with form fields inside.
 

--- a/apps/v4/content/docs/components/radix/progress.mdx
+++ b/apps/v4/content/docs/components/radix/progress.mdx
@@ -62,15 +62,13 @@ import { Progress } from "@/components/ui/progress"
 <Progress value={33} />
 ```
 
-## Examples
-
-### Label
+## Label
 
 Use a `Field` component to add a label to the progress bar.
 
 <ComponentPreview styleName="radix-nova" name="progress-label" />
 
-### Controlled
+## Controlled
 
 A progress bar that can be controlled by a slider.
 

--- a/apps/v4/content/docs/components/radix/radio-group.mdx
+++ b/apps/v4/content/docs/components/radix/radio-group.mdx
@@ -82,33 +82,31 @@ RadioGroup
 └── RadioGroupItem
 ```
 
-## Examples
-
-### Description
+## Description
 
 Radio group items with a description using the `Field` component.
 
 <ComponentPreview styleName="radix-nova" name="radio-group-description" />
 
-### Choice Card
+## Choice Card
 
 Use `FieldLabel` to wrap the entire `Field` for a clickable card-style selection.
 
 <ComponentPreview styleName="radix-nova" name="radio-group-choice-card" />
 
-### Fieldset
+## Fieldset
 
 Use `FieldSet` and `FieldLegend` to group radio items with a label and description.
 
 <ComponentPreview styleName="radix-nova" name="radio-group-fieldset" />
 
-### Disabled
+## Disabled
 
 Use the `disabled` prop on `RadioGroupItem` to disable individual items.
 
 <ComponentPreview styleName="radix-nova" name="radio-group-disabled" />
 
-### Invalid
+## Invalid
 
 Use `aria-invalid` on `RadioGroupItem` and `data-invalid` on `Field` to show validation errors.
 

--- a/apps/v4/content/docs/components/radix/resizable.mdx
+++ b/apps/v4/content/docs/components/radix/resizable.mdx
@@ -89,15 +89,13 @@ ResizablePanelGroup
 └── ResizablePanel
 ```
 
-## Examples
-
-### Vertical
+## Vertical
 
 Use `orientation="vertical"` for vertical resizing.
 
 <ComponentPreview styleName="radix-nova" name="resizable-vertical" />
 
-### Handle
+## Handle
 
 Use the `withHandle` prop on `ResizableHandle` to show a visible handle.
 

--- a/apps/v4/content/docs/components/radix/scroll-area.mdx
+++ b/apps/v4/content/docs/components/radix/scroll-area.mdx
@@ -77,9 +77,7 @@ ScrollArea
 └── ScrollBar
 ```
 
-## Examples
-
-### Horizontal
+## Horizontal
 
 Use `ScrollBar` with `orientation="horizontal"` for horizontal scrolling.
 

--- a/apps/v4/content/docs/components/radix/select.mdx
+++ b/apps/v4/content/docs/components/radix/select.mdx
@@ -101,31 +101,29 @@ Select
         └── SelectItem
 ```
 
-## Examples
-
-### Align Item With Trigger
+## Align Item With Trigger
 
 Use the `position` prop on `SelectContent` to control alignment. When `position="item-aligned"` (default), the popup positions so the selected item appears over the trigger. When `position="popper"`, the popup aligns to the trigger edge.
 
 <ComponentPreview styleName="radix-nova" name="select-align-item" />
 
-### Groups
+## Groups
 
 Use `SelectGroup`, `SelectLabel`, and `SelectSeparator` to organize items.
 
 <ComponentPreview styleName="radix-nova" name="select-groups" />
 
-### Scrollable
+## Scrollable
 
 A select with many items that scrolls.
 
 <ComponentPreview styleName="radix-nova" name="select-scrollable" />
 
-### Disabled
+## Disabled
 
 <ComponentPreview styleName="radix-nova" name="select-disabled" />
 
-### Invalid
+## Invalid
 
 Add the `data-invalid` attribute to the `Field` component and the `aria-invalid` attribute to the `SelectTrigger` component to show an error state.
 

--- a/apps/v4/content/docs/components/radix/separator.mdx
+++ b/apps/v4/content/docs/components/radix/separator.mdx
@@ -62,21 +62,19 @@ import { Separator } from "@/components/ui/separator"
 <Separator />
 ```
 
-## Examples
-
-### Vertical
+## Vertical
 
 Use `orientation="vertical"` for a vertical separator.
 
 <ComponentPreview styleName="radix-nova" name="separator-vertical" />
 
-### Menu
+## Menu
 
 Vertical separators between menu items with descriptions.
 
 <ComponentPreview styleName="radix-nova" name="separator-menu" />
 
-### List
+## List
 
 Horizontal separators between list items.
 

--- a/apps/v4/content/docs/components/radix/sheet.mdx
+++ b/apps/v4/content/docs/components/radix/sheet.mdx
@@ -93,15 +93,13 @@ Sheet
     └── SheetFooter
 ```
 
-## Examples
-
-### Side
+## Side
 
 Use the `side` prop on `SheetContent` to set the edge of the screen where the sheet appears. Values are `top`, `right`, `bottom`, or `left`.
 
 <ComponentPreview styleName="radix-nova" name="sheet-side" />
 
-### No Close Button
+## No Close Button
 
 Use `showCloseButton={false}` on `SheetContent` to hide the close button.
 

--- a/apps/v4/content/docs/components/radix/sidebar.mdx
+++ b/apps/v4/content/docs/components/radix/sidebar.mdx
@@ -148,14 +148,14 @@ SidebarProvider
   width="716"
   height="420"
   alt="Sidebar Structure"
-  className="mt-6 w-full overflow-hidden rounded-lg border dark:hidden"
+  className="mt-6 w-full overflow-hidden rounded-2xl border dark:hidden"
 />
 <Image
   src="/images/sidebar-structure-dark.png"
   width="716"
   height="420"
   alt="Sidebar Structure"
-  className="mt-6 hidden w-full overflow-hidden rounded-lg border dark:block"
+  className="mt-6 hidden w-full overflow-hidden rounded-2xl border dark:block"
 />
 
 ## SidebarProvider
@@ -366,14 +366,14 @@ The `SidebarMenu` component is used for building a menu within a `SidebarGroup`.
   width="716"
   height="420"
   alt="Sidebar Menu"
-  className="mt-6 w-full overflow-hidden rounded-lg border dark:hidden"
+  className="mt-6 w-full overflow-hidden rounded-2xl border dark:hidden"
 />
 <Image
   src="/images/sidebar-menu-dark.png"
   width="716"
   height="420"
   alt="Sidebar Menu"
-  className="mt-6 hidden w-full overflow-hidden rounded-lg border dark:block"
+  className="mt-6 hidden w-full overflow-hidden rounded-2xl border dark:block"
 />
 
 ```tsx showLineNumbers

--- a/apps/v4/content/docs/components/radix/skeleton.mdx
+++ b/apps/v4/content/docs/components/radix/skeleton.mdx
@@ -53,13 +53,11 @@ import { Skeleton } from "@/components/ui/skeleton"
 <Skeleton className="h-[20px] w-[100px] rounded-full" />
 ```
 
-## Examples
-
-### Avatar
+## Avatar
 
 <ComponentPreview styleName="radix-nova" name="skeleton-avatar" />
 
-### Card
+## Card
 
 <ComponentPreview
   styleName="radix-nova"
@@ -67,15 +65,15 @@ import { Skeleton } from "@/components/ui/skeleton"
   previewClassName="h-80"
 />
 
-### Text
+## Text
 
 <ComponentPreview styleName="radix-nova" name="skeleton-text" />
 
-### Form
+## Form
 
 <ComponentPreview styleName="radix-nova" name="skeleton-form" />
 
-### Table
+## Table
 
 <ComponentPreview styleName="radix-nova" name="skeleton-table" />
 

--- a/apps/v4/content/docs/components/radix/slider.mdx
+++ b/apps/v4/content/docs/components/radix/slider.mdx
@@ -62,31 +62,29 @@ import { Slider } from "@/components/ui/slider"
 <Slider defaultValue={[33]} max={100} step={1} />
 ```
 
-## Examples
-
-### Range
+## Range
 
 Use an array with two values for a range slider.
 
 <ComponentPreview styleName="radix-nova" name="slider-range" />
 
-### Multiple Thumbs
+## Multiple Thumbs
 
 Use an array with multiple values for multiple thumbs.
 
 <ComponentPreview styleName="radix-nova" name="slider-multiple" />
 
-### Vertical
+## Vertical
 
 Use `orientation="vertical"` for a vertical slider.
 
 <ComponentPreview styleName="radix-nova" name="slider-vertical" />
 
-### Controlled
+## Controlled
 
 <ComponentPreview styleName="radix-nova" name="slider-controlled" />
 
-### Disabled
+## Disabled
 
 Use the `disabled` prop to disable the slider.
 

--- a/apps/v4/content/docs/components/radix/sonner.mdx
+++ b/apps/v4/content/docs/components/radix/sonner.mdx
@@ -105,17 +105,15 @@ import { toast } from "sonner"
 toast("Event has been created.")
 ```
 
-## Examples
-
-### Types
+## Types
 
 <ComponentPreview styleName="radix-nova" name="sonner-types" />
 
-### Description
+## Description
 
 <ComponentPreview styleName="radix-nova" name="sonner-description" />
 
-### Position
+## Position
 
 Use the `position` prop to change the position of the toast.
 

--- a/apps/v4/content/docs/components/radix/spinner.mdx
+++ b/apps/v4/content/docs/components/radix/spinner.mdx
@@ -78,31 +78,29 @@ function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
 export { Spinner }
 ```
 
-## Examples
-
-### Size
+## Size
 
 Use the `size-*` utility class to change the size of the spinner.
 
 <ComponentPreview styleName="radix-nova" name="spinner-size" />
 
-### Button
+## Button
 
 Add a spinner to a button to indicate a loading state. Place the `<Spinner />` before the label with `data-icon="inline-start"` for a start position, or after the label with `data-icon="inline-end"` for an end position.
 
 <ComponentPreview styleName="radix-nova" name="spinner-button" />
 
-### Badge
+## Badge
 
 Add a spinner to a badge to indicate a loading state. Place the `<Spinner />` before the label with `data-icon="inline-start"` for a start position, or after the label with `data-icon="inline-end"` for an end position.
 
 <ComponentPreview styleName="radix-nova" name="spinner-badge" />
 
-### Input Group
+## Input Group
 
 <ComponentPreview styleName="radix-nova" name="spinner-input-group" />
 
-### Empty
+## Empty
 
 <ComponentPreview styleName="radix-nova" name="spinner-empty" />
 

--- a/apps/v4/content/docs/components/radix/switch.mdx
+++ b/apps/v4/content/docs/components/radix/switch.mdx
@@ -62,31 +62,29 @@ import { Switch } from "@/components/ui/switch"
 <Switch />
 ```
 
-## Examples
-
-### Description
+## Description
 
 <ComponentPreview styleName="radix-nova" name="switch-description" />
 
-### Choice Card
+## Choice Card
 
 Card-style selection where `FieldLabel` wraps the entire `Field` for a clickable card pattern.
 
 <ComponentPreview styleName="radix-nova" name="switch-choice-card" />
 
-### Disabled
+## Disabled
 
 Add the `disabled` prop to the `Switch` component to disable the switch. Add the `data-disabled` prop to the `Field` component for styling.
 
 <ComponentPreview styleName="radix-nova" name="switch-disabled" />
 
-### Invalid
+## Invalid
 
 Add the `aria-invalid` prop to the `Switch` component to indicate an invalid state. Add the `data-invalid` prop to the `Field` component for styling.
 
 <ComponentPreview styleName="radix-nova" name="switch-invalid" />
 
-### Size
+## Size
 
 Use the `size` prop to change the size of the switch.
 

--- a/apps/v4/content/docs/components/radix/table.mdx
+++ b/apps/v4/content/docs/components/radix/table.mdx
@@ -110,15 +110,13 @@ Table
 └── TableFooter
 ```
 
-## Examples
-
-### Footer
+## Footer
 
 Use the `<TableFooter />` component to add a footer to the table.
 
 <ComponentPreview styleName="radix-nova" name="table-footer" />
 
-### Actions
+## Actions
 
 A table showing actions for each row using a `<DropdownMenu />` component.
 

--- a/apps/v4/content/docs/components/radix/tabs.mdx
+++ b/apps/v4/content/docs/components/radix/tabs.mdx
@@ -86,25 +86,23 @@ Tabs
 └── TabsContent
 ```
 
-## Examples
-
-### Line
+## Line
 
 Use the `variant="line"` prop on `TabsList` for a line style.
 
 <ComponentPreview styleName="radix-nova" name="tabs-line" />
 
-### Vertical
+## Vertical
 
 Use `orientation="vertical"` for vertical tabs.
 
 <ComponentPreview styleName="radix-nova" name="tabs-vertical" />
 
-### Disabled
+## Disabled
 
 <ComponentPreview styleName="radix-nova" name="tabs-disabled" />
 
-### Icons
+## Icons
 
 <ComponentPreview styleName="radix-nova" name="tabs-icons" />
 

--- a/apps/v4/content/docs/components/radix/textarea.mdx
+++ b/apps/v4/content/docs/components/radix/textarea.mdx
@@ -57,9 +57,7 @@ import { Textarea } from "@/components/ui/textarea"
 <Textarea />
 ```
 
-## Examples
-
-### Field
+## Field
 
 Use `Field`, `FieldLabel`, and `FieldDescription` to create a textarea with a label and description.
 
@@ -69,7 +67,7 @@ Use `Field`, `FieldLabel`, and `FieldDescription` to create a textarea with a la
   previewClassName="*:max-w-xs"
 />
 
-### Disabled
+## Disabled
 
 Use the `disabled` prop to disable the textarea. To style the disabled state, add the `data-disabled` attribute to the `Field` component.
 
@@ -79,7 +77,7 @@ Use the `disabled` prop to disable the textarea. To style the disabled state, ad
   previewClassName="*:max-w-xs"
 />
 
-### Invalid
+## Invalid
 
 Use the `aria-invalid` prop to mark the textarea as invalid. To style the invalid state, add the `data-invalid` attribute to the `Field` component.
 
@@ -89,7 +87,7 @@ Use the `aria-invalid` prop to mark the textarea as invalid. To style the invali
   previewClassName="*:max-w-xs"
 />
 
-### Button
+## Button
 
 Pair with `Button` to create a textarea with a submit button.
 

--- a/apps/v4/content/docs/components/radix/toggle-group.mdx
+++ b/apps/v4/content/docs/components/radix/toggle-group.mdx
@@ -76,37 +76,35 @@ ToggleGroup
 └── ToggleGroupItem
 ```
 
-## Examples
-
-### Outline
+## Outline
 
 Use `variant="outline"` for an outline style.
 
 <ComponentPreview styleName="radix-nova" name="toggle-group-outline" />
 
-### Size
+## Size
 
 Use the `size` prop to change the size of the toggle group.
 
 <ComponentPreview styleName="radix-nova" name="toggle-group-sizes" />
 
-### Spacing
+## Spacing
 
 Use `spacing` to add spacing between toggle group items.
 
 <ComponentPreview styleName="radix-nova" name="toggle-group-spacing" />
 
-### Vertical
+## Vertical
 
 Use `orientation="vertical"` for vertical toggle groups.
 
 <ComponentPreview styleName="radix-nova" name="toggle-group-vertical" />
 
-### Disabled
+## Disabled
 
 <ComponentPreview styleName="radix-nova" name="toggle-group-disabled" />
 
-### Custom
+## Custom
 
 A custom toggle group example.
 

--- a/apps/v4/content/docs/components/radix/toggle.mdx
+++ b/apps/v4/content/docs/components/radix/toggle.mdx
@@ -62,25 +62,23 @@ import { Toggle } from "@/components/ui/toggle"
 <Toggle>Toggle</Toggle>
 ```
 
-## Examples
-
-### Outline
+## Outline
 
 Use `variant="outline"` for an outline style.
 
 <ComponentPreview styleName="radix-nova" name="toggle-outline" />
 
-### With Text
+## With Text
 
 <ComponentPreview styleName="radix-nova" name="toggle-text" />
 
-### Size
+## Size
 
 Use the `size` prop to change the size of the toggle.
 
 <ComponentPreview styleName="radix-nova" name="toggle-sizes" />
 
-### Disabled
+## Disabled
 
 <ComponentPreview styleName="radix-nova" name="toggle-disabled" />
 

--- a/apps/v4/content/docs/components/radix/tooltip.mdx
+++ b/apps/v4/content/docs/components/radix/tooltip.mdx
@@ -119,19 +119,17 @@ Tooltip
 └── TooltipContent
 ```
 
-## Examples
-
-### Side
+## Side
 
 Use the `side` prop to change the position of the tooltip.
 
 <ComponentPreview styleName="radix-nova" name="tooltip-sides" />
 
-### With Keyboard Shortcut
+## With Keyboard Shortcut
 
 <ComponentPreview styleName="radix-nova" name="tooltip-keyboard" />
 
-### Disabled Button
+## Disabled Button
 
 Show a tooltip on a disabled button by wrapping it with a span.
 

--- a/apps/v4/content/docs/registry/index.mdx
+++ b/apps/v4/content/docs/registry/index.mdx
@@ -16,14 +16,14 @@ You can use the `shadcn` CLI to run your own code registry. Running your own reg
     width="1432"
     height="960"
     alt="Registry"
-    className="mt-6 w-full overflow-hidden rounded-lg border dark:hidden"
+    className="mt-6 w-full overflow-hidden rounded-2xl border dark:hidden"
   />
   <Image
     src="/images/registry-dark.png"
     width="1432"
     height="960"
     alt="Registry"
-    className="mt-6 hidden w-full overflow-hidden rounded-lg border shadow-sm dark:block"
+    className="mt-6 hidden w-full overflow-hidden rounded-2xl border shadow-sm dark:block"
   />
   <figcaption className="text-center text-sm text-gray-500">
     A distribution system for code

--- a/apps/v4/mdx-components.tsx
+++ b/apps/v4/mdx-components.tsx
@@ -278,7 +278,7 @@ export const mdxComponents = {
     ...props
   }: React.ComponentProps<"img">) => (
     <Image
-      className={cn("mt-6 rounded-md border", className)}
+      className={cn("mt-6 rounded-2xl border", className)}
       src={(src as string) || ""}
       width={Number(width)}
       height={Number(height)}
@@ -349,7 +349,7 @@ export const mdxComponents = {
     <Link
       data-not-typeset
       className={cn(
-        "flex w-full flex-col items-center rounded-xl bg-surface p-6 text-surface-foreground transition-colors hover:bg-surface/80 sm:p-10",
+        "flex w-full flex-col items-center rounded-2xl bg-surface p-6 text-surface-foreground transition-colors hover:bg-surface/80 sm:p-10",
         className
       )}
       {...props}

--- a/apps/v4/next.config.mjs
+++ b/apps/v4/next.config.mjs
@@ -59,6 +59,17 @@ const nextConfig = {
         destination: "/docs/forms",
         permanent: true,
       },
+      // Typography redirects to /docs/typeset.
+      {
+        source: "/docs/components/base/typography",
+        destination: "/docs/typeset",
+        permanent: true,
+      },
+      {
+        source: "/docs/components/radix/typography",
+        destination: "/docs/typeset",
+        permanent: true,
+      },
       // Component redirects (default to base).
       {
         source: "/docs/components/:name((?!radix|base|form)[^/]+)",


### PR DESCRIPTION
Polishes the docs with:

- persistent sidebar scroll position and a refined fading divider
- larger radii across code blocks, previews, media, and related surfaces
- first-class example sections across Base UI and Radix UI component docs
- redirects from the legacy typography pages to /docs/typeset

Note: the v4 typecheck currently reports an unrelated existing error in apps/v4/app/(app)/charts/[type]/page.tsx.