### PR TITLE
fix(docs): restore sidebar scroll before hydration

### DIFF
--- a/apps/v4/app/layout.tsx
+++ b/apps/v4/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next"
 import { NuqsAdapter } from "nuqs/adapters/next/app"
 
 import { META_THEME_COLORS, siteConfig } from "@/lib/config"
+import { DOCS_SIDEBAR_SCROLL_RESTORE_SCRIPT } from "@/lib/docs-sidebar-scroll"
 import { fontVariables } from "@/lib/fonts"
 import { cn } from "@/lib/utils"
 import { ActiveThemeProvider } from "@/components/active-theme"
@@ -81,6 +82,11 @@ export default function RootLayout({
       )}
     >
       <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: DOCS_SIDEBAR_SCROLL_RESTORE_SCRIPT,
+          }}
+        />
         <script
           dangerouslySetInnerHTML={{
             __html: `

--- a/apps/v4/components/docs-sidebar.tsx
+++ b/apps/v4/components/docs-sidebar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 
 import { PAGES_NEW } from "@/lib/docs"
+import { DOCS_SIDEBAR_SCROLL_STORAGE_KEY } from "@/lib/docs-sidebar-scroll"
 import { showMcpDocs } from "@/lib/flags"
 import { getCurrentBase, getPagesFromFolder } from "@/lib/page-tree"
 import type { source } from "@/lib/source"
@@ -57,49 +58,11 @@ const TOP_LEVEL_SECTIONS = [
 const EXCLUDED_SECTIONS = ["installation", "dark-mode", "changelog", "rtl"]
 const EXCLUDED_PAGES = ["/docs", "/docs/changelog", "/docs/rtl", "/docs/new"]
 
-const SCROLL_STORAGE_KEY = "docs-sidebar-scroll"
-
-// Runs before first paint on hard loads. A refresh restores the exact
-// position; arriving from another page brings the active item into view.
-const SCROLL_RESTORE_SCRIPT = `(function () {
-  try {
-    var container = document.currentScript.previousElementSibling
-    if (!container || !container.clientHeight) return
-    try {
-      var stored = JSON.parse(sessionStorage.getItem("${SCROLL_STORAGE_KEY}"))
-      if (stored && stored.pathname === location.pathname) {
-        container.scrollTop = stored.scrollTop
-        return
-      }
-    } catch (e) {}
-    var items = container.querySelectorAll('[data-active="true"]')
-    var active = null
-    var activePathLength = -1
-    var activeDistance = Infinity
-    var containerCenter = container.getBoundingClientRect().top + container.clientHeight / 2
-    for (var i = 0; i < items.length; i++) {
-      var link = items[i].querySelector('a[href]')
-      var href = items[i].getAttribute('href') || (link && link.getAttribute('href'))
-      var pathLength = href ? href.length : 0
-      var itemRect = items[i].getBoundingClientRect()
-      var distance = Math.abs(itemRect.top + itemRect.height / 2 - containerCenter)
-      if (pathLength > activePathLength || (pathLength === activePathLength && distance < activeDistance)) {
-        active = items[i]
-        activePathLength = pathLength
-        activeDistance = distance
-      }
-    }
-    if (!active) return
-    var containerRect = container.getBoundingClientRect()
-    var activeRect = active.getBoundingClientRect()
-    if (activeRect.top >= containerRect.top && activeRect.bottom <= containerRect.bottom) return
-    container.scrollTop += activeRect.top - containerRect.top - (container.clientHeight - activeRect.height) / 2
-  } catch (e) {}
-})()`
-
 function readScrollState() {
   try {
-    return JSON.parse(sessionStorage.getItem(SCROLL_STORAGE_KEY) ?? "") as {
+    return JSON.parse(
+      sessionStorage.getItem(DOCS_SIDEBAR_SCROLL_STORAGE_KEY) ?? ""
+    ) as {
       pathname: string
       scrollTop: number
     }
@@ -111,7 +74,7 @@ function readScrollState() {
 function saveScrollState(container: HTMLElement) {
   try {
     sessionStorage.setItem(
-      SCROLL_STORAGE_KEY,
+      DOCS_SIDEBAR_SCROLL_STORAGE_KEY,
       JSON.stringify({
         pathname: location.pathname,
         scrollTop: container.scrollTop,
@@ -158,16 +121,18 @@ export function DocsSidebar({
   const currentBase = getCurrentBase(pathname)
   const contentRef = React.useRef<HTMLDivElement>(null)
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     const container = contentRef.current
 
     if (!container) {
       return
     }
 
-    // A refresh restores the exact position (the inline script already did).
-    // Only bring the active item into view when arriving from another page.
-    if (readScrollState()?.pathname !== pathname) {
+    const scrollState = readScrollState()
+
+    if (scrollState?.pathname === pathname) {
+      container.scrollTop = scrollState.scrollTop
+    } else {
       // Prefer the longest route because section links also match by prefix.
       // Equal routes keep the item closest to the current viewport.
       const active = getActiveItem(container)
@@ -180,12 +145,10 @@ export function DocsSidebar({
           activeRect.top < containerRect.top ||
           activeRect.bottom > containerRect.bottom
         ) {
-          container.scrollTo({
-            top:
-              container.scrollTop +
-              (activeRect.top - containerRect.top) -
-              (container.clientHeight - activeRect.height) / 2,
-          })
+          container.scrollTop +=
+            activeRect.top -
+            containerRect.top -
+            (container.clientHeight - activeRect.height) / 2
         }
       }
     }
@@ -214,6 +177,7 @@ export function DocsSidebar({
       <div className="absolute top-12 right-2 bottom-0 hidden h-full w-px bg-[linear-gradient(to_bottom,transparent_0%,var(--border)_10%,var(--border)_90%,transparent_100%)] lg:flex" />
       <SidebarContent
         ref={contentRef}
+        data-docs-sidebar-content=""
         className="w-(--sidebar-menu-width) scroll-fade scrollbar-none overflow-x-hidden pl-2.5"
       >
         <SidebarGroup className="pt-12">
@@ -304,7 +268,6 @@ export function DocsSidebar({
           )
         })}
       </SidebarContent>
-      <script dangerouslySetInnerHTML={{ __html: SCROLL_RESTORE_SCRIPT }} />
     </Sidebar>
   )
 }

--- a/apps/v4/lib/docs-sidebar-scroll.ts
+++ b/apps/v4/lib/docs-sidebar-scroll.ts
@@ -1,0 +1,66 @@
+export const DOCS_SIDEBAR_SCROLL_STORAGE_KEY = "docs-sidebar-scroll"
+
+export const DOCS_SIDEBAR_SCROLL_RESTORE_SCRIPT = `(function () {
+  if (location.pathname !== "/docs" && !location.pathname.startsWith("/docs/")) return
+
+  var stored = null
+  try {
+    stored = JSON.parse(sessionStorage.getItem("${DOCS_SIDEBAR_SCROLL_STORAGE_KEY}"))
+  } catch (e) {}
+
+  function getActiveItem(container) {
+    var items = container.querySelectorAll('[data-active="true"]')
+    var active = null
+    var activePathLength = -1
+    var activeDistance = Infinity
+    var containerCenter = container.getBoundingClientRect().top + container.clientHeight / 2
+
+    for (var i = 0; i < items.length; i++) {
+      var link = items[i].querySelector('a[href]')
+      var href = items[i].getAttribute('href') || (link && link.getAttribute('href'))
+      var pathLength = href ? href.length : 0
+      var itemRect = items[i].getBoundingClientRect()
+      var distance = Math.abs(itemRect.top + itemRect.height / 2 - containerCenter)
+
+      if (pathLength > activePathLength || (pathLength === activePathLength && distance < activeDistance)) {
+        active = items[i]
+        activePathLength = pathLength
+        activeDistance = distance
+      }
+    }
+
+    return active
+  }
+
+  function restoreScroll() {
+    var container = document.querySelector('[data-docs-sidebar-content]')
+    if (!container || !container.clientHeight) return
+
+    if (stored && stored.pathname === location.pathname) {
+      container.scrollTop = stored.scrollTop
+      return
+    }
+
+    var active = getActiveItem(container)
+    if (!active) return
+
+    var containerRect = container.getBoundingClientRect()
+    var activeRect = active.getBoundingClientRect()
+    if (activeRect.top >= containerRect.top && activeRect.bottom <= containerRect.bottom) return
+
+    container.scrollTop += activeRect.top - containerRect.top - (container.clientHeight - activeRect.height) / 2
+  }
+
+  var observer = new MutationObserver(restoreScroll)
+  observer.observe(document.documentElement, { childList: true, subtree: true })
+  restoreScroll()
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", function () {
+      restoreScroll()
+      observer.disconnect()
+    }, { once: true })
+  } else {
+    observer.disconnect()
+  }
+})()`


### PR DESCRIPTION
Move the initial docs sidebar restoration into the root pre-hydration bootstrap so hard refreshes restore before paint without rendering a script inside the client component. Keep the layout effect for subsequent client navigations.