### PR TITLE
fix(react): don't re-anchor historical turns on same-count content changes

### DIFF
--- a/.changeset/gentle-anchors-stay-put.md
+++ b/.changeset/gentle-anchors-stay-put.md
@@ -1,0 +1,5 @@
+---
+"@shadcn/react": patch
+---
+
+fix message scroller re-anchoring a historical turn on same-count content changes

--- a/packages/react/src/message-scroller/geometry.ts
+++ b/packages/react/src/message-scroller/geometry.ts
@@ -140,6 +140,17 @@ function getUnanchoredScrollAnchor(
   return null
 }
 
+function markScrollAnchorsHandled(
+  items: HTMLElement[],
+  handledAnchors: { add(element: HTMLElement): unknown }
+) {
+  for (const item of items) {
+    if (item.dataset.scrollAnchor === "true") {
+      handledAnchors.add(item)
+    }
+  }
+}
+
 function hasMultipleNewScrollAnchors(
   items: HTMLElement[],
   previousItemCount: number
@@ -384,4 +395,5 @@ export {
   getTailSpacerHeight,
   getUnanchoredScrollAnchor,
   hasMultipleNewScrollAnchors,
+  markScrollAnchorsHandled,
 }

--- a/packages/react/src/message-scroller/message-scroller.browser.test.tsx
+++ b/packages/react/src/message-scroller/message-scroller.browser.test.tsx
@@ -311,6 +311,100 @@ test("keeps the end pinned when bulk appending anchored turns with autoScroll", 
   expect(getDistanceToBottom(viewport)).toBeLessThanOrEqual(1)
 })
 
+test("does not re-anchor a historical turn when an item is swapped at the same count", async () => {
+  // A loaded chat: anchored user turns that mounted with the initial content.
+  const history = [
+    { id: "user-1", scrollAnchor: true },
+    { id: "assistant-1", height: 160 },
+    { id: "user-2", scrollAnchor: true },
+    { id: "assistant-2", height: 160 },
+  ]
+
+  await renderThread({
+    autoScroll: true,
+    items: history,
+    scrollPreviousItemPeek: 0,
+  })
+
+  const viewport = getViewport()
+
+  // A send appends the user turn plus a pending loader.
+  const sent = [
+    ...history,
+    { id: "user-3", scrollAnchor: true },
+    { id: "loader" },
+  ]
+  flushSync(() => {
+    root!.render(<Thread autoScroll items={sent} scrollPreviousItemPeek={0} />)
+  })
+  await settle()
+
+  expect(viewportOffsetOf("user-3", viewport)).toBeLessThanOrEqual(1)
+  const anchoredScrollTop = getScrollTop(viewport)
+
+  // First streamed chunk: the loader swaps for the assistant item in one
+  // commit, so the item count is unchanged. The scroller used to scan for any
+  // never-handled anchor, find user-1 (initial-content anchors were never
+  // marked handled), and yank the viewport to the top.
+  flushSync(() => {
+    root!.render(
+      <Thread
+        autoScroll
+        items={[
+          ...history,
+          { id: "user-3", scrollAnchor: true },
+          { id: "assistant-3" },
+        ]}
+        scrollPreviousItemPeek={0}
+      />
+    )
+  })
+  await settle()
+
+  expect(getScrollTop(viewport)).toBe(anchoredScrollTop)
+})
+
+test("still anchors a new turn swapped in at the same count", async () => {
+  const history = [
+    { id: "user-1", scrollAnchor: true },
+    { id: "assistant-1", height: 160 },
+  ]
+
+  await renderThread({
+    autoScroll: true,
+    items: history,
+    scrollPreviousItemPeek: 0,
+  })
+
+  const viewport = getViewport()
+
+  // An optimistic user message replaced by its confirmed id (same count, new
+  // anchor element) should still be anchored to the reading line.
+  flushSync(() => {
+    root!.render(
+      <Thread
+        autoScroll
+        items={[...history, { id: "optimistic", scrollAnchor: true }]}
+        scrollPreviousItemPeek={0}
+      />
+    )
+  })
+  await settle()
+
+  flushSync(() => {
+    root!.render(
+      <Thread
+        autoScroll
+        items={[...history, { id: "confirmed", scrollAnchor: true }]}
+        scrollPreviousItemPeek={0}
+      />
+    )
+  })
+  await settle()
+
+  expect(viewportOffsetOf("confirmed", viewport)).toBeLessThanOrEqual(1)
+})
+
 test("does not keep the end pinned when appending after the default bottom open", async () => {
   const initial = createItems(6)
 

--- a/packages/react/src/message-scroller/use-message-scroller-controller.ts
+++ b/packages/react/src/message-scroller/use-message-scroller-controller.ts
@@ -13,6 +13,7 @@ import {
   getNewScrollAnchor,
   getUnanchoredScrollAnchor,
   hasMultipleNewScrollAnchors,
+  markScrollAnchorsHandled,
 } from "./geometry"
 import {
   DEFAULT_SCROLL_EDGE_THRESHOLD,
@@ -448,7 +449,6 @@ function useMessageScrollerController({
             { align: "start" },
             { keepPreviousPeek: true }
           )
-          handledScrollAnchorsRef.current.add(anchor)
           return
         }
       }
@@ -465,7 +465,6 @@ function useMessageScrollerController({
             { align: "start" },
             { keepPreviousPeek: true }
           )
-          handledScrollAnchorsRef.current.add(anchor)
           return
         }
       }
@@ -481,6 +480,9 @@ function useMessageScrollerController({
     }
 
     reconcileScrollPosition()
+    // An anchor only gets the reconcile pass that introduced it; afterwards it
+    // is handled, so a later same-count change can never re-anchor an old turn.
+    markScrollAnchorsHandled(items, handledScrollAnchorsRef.current)
     capturePrependAnchor()
   }, [
     applyDefaultScrollPosition,


### PR DESCRIPTION
Fixes #11181

### The bug

`MessageScroller` scrolls a historical anchor to the reading line (usually the very top of the thread) whenever a content mutation replaces one child with another at the same item count. The canonical trigger is the standard chat pattern: send appends the user turn + a pending loader, then the first streamed chunk swaps the loader for the assistant item in one commit. Every turn, the viewport jumps to the oldest unhandled user message.

Cause: the first-content branch of `handleContentChange` never adds initially mounted anchors to `handledScrollAnchorsRef`, and the same-count branch scans the whole list for any never-handled anchor — so it matches anchors that mounted with the initial content instead of only just-swapped-in ones.

### The fix

Mark every current anchor as handled at the end of each `handleContentChange` pass (new `markScrollAnchorsHandled` helper in `geometry.ts`). An anchor still gets exactly the reconcile pass that introduced it:

- appended anchors are still scrolled to the reading line (existing behavior, existing tests),
- an anchor swapped in at the same count (optimistic → confirmed user message) is still anchored, because marking runs after the branch logic within the same pass — covered by the new `still anchors a new turn swapped in at the same count` test,
- but a later mutation can never re-anchor an older turn — covered by the new `does not re-anchor a historical turn when an item is swapped at the same count` test, which fails on `main` and passes with this change.

The two inline `handledScrollAnchorsRef.current.add(anchor)` calls became redundant and were removed.

### Tests

- `pnpm --filter @shadcn/react test` — 60 passed
- `pnpm --filter @shadcn/react test:browser` — 25 passed (both new regression tests fail without the source change)
- `pnpm --filter @shadcn/react typecheck` — clean
