### PR TITLE
fix(react): message-scroller - prevent scroll clamp jitter while an anchored turn streams

### DIFF
--- a/packages/react/src/message-scroller/message-scroller.test.tsx
+++ b/packages/react/src/message-scroller/message-scroller.test.tsx
@@ -555,6 +555,99 @@ describe("MessageScroller", () => {
     expect(rendered.state().end).toBe(false)
   })
 
+  it("pads and holds the anchored tail spacer so a transient dip cannot clamp the pinned turn", async () => {
+    const rendered = await renderTestScroller({
+      defaultScrollPosition: "end",
+      messages: [
+        { id: "message-1", height: 80 },
+        { id: "message-2", height: 80 },
+        { id: "message-3", height: 80 },
+      ],
+    })
+
+    await rendered.rerender([
+      { id: "message-1", height: 80 },
+      { id: "message-2", height: 80 },
+      { id: "message-3", height: 80 },
+      { id: "message-4", height: 20, scrollAnchor: true },
+    ])
+
+    expect(rendered.viewport().scrollTop).toBe(176)
+    expect(rendered.message("message-4").getBoundingClientRect().top).toBe(64)
+
+    // The exact fit (16) is padded with slack so the pinned position does not
+    // sit at the very bottom of the scroll range.
+    const spacer = rendered
+      .content()
+      .querySelector<HTMLElement>("[data-message-scroller-spacer]")
+
+    expect(spacer?.style.height).toBe("144px")
+
+    // The reply streams in below the anchor. The spacer holds instead of
+    // shrinking to the smaller exact fit, keeping scrollHeight monotonic.
+    await rendered.rerender([
+      { id: "message-1", height: 80 },
+      { id: "message-2", height: 80 },
+      { id: "message-3", height: 80 },
+      { id: "message-4", height: 20, scrollAnchor: true },
+      { id: "message-5", height: 8 },
+    ])
+    await triggerResize(rendered.content())
+
+    expect(spacer?.style.height).toBe("144px")
+    expect(rendered.viewport().scrollTop).toBe(176)
+    expect(rendered.message("message-4").getBoundingClientRect().top).toBe(64)
+
+    // A transient dip (streamed markdown reflowing, a pending marker
+    // collapsing) shrinks the reply. scrollHeight stays above the pinned
+    // scrollTop, so the browser has nothing to clamp.
+    rendered.message("message-5").dataset.testHeight = "2"
+    await triggerResize(rendered.content())
+
+    expect(spacer?.style.height).toBe("144px")
+    expect(rendered.viewport().scrollTop).toBe(176)
+    expect(rendered.message("message-4").getBoundingClientRect().top).toBe(64)
+  })
+
+  it("trims the held spacer slack on user scroll intent", async () => {
+    const rendered = await renderTestScroller({
+      defaultScrollPosition: "end",
+      messages: [
+        { id: "message-1", height: 80 },
+        { id: "message-2", height: 80 },
+        { id: "message-3", height: 80 },
+      ],
+    })
+
+    await rendered.rerender([
+      { id: "message-1", height: 80 },
+      { id: "message-2", height: 80 },
+      { id: "message-3", height: 80 },
+      { id: "message-4", height: 20, scrollAnchor: true },
+      { id: "message-5", height: 8 },
+    ])
+    await triggerResize(rendered.content())
+
+    const spacer = rendered
+      .content()
+      .querySelector<HTMLElement>("[data-message-scroller-spacer]")
+
+    expect(spacer?.style.height).toBe("136px")
+
+    // A deliberate gesture releases the anchor hold and gives back the slack:
+    // the spacer shrinks to the exact fit for the current scroll position, so
+    // the reader cannot scroll into blank space the stream no longer needs.
+    await act(async () => {
+      rendered
+        .viewport()
+        .dispatchEvent(new WheelEvent("wheel", { bubbles: true }))
+      await flushAnimationFrames()
+    })
+
+    expect(spacer?.style.height).toBe("8px")
+    expect(rendered.viewport().scrollTop).toBe(176)
+  })
+
   it("applies the default end target after async messages mount", async () => {
     const rendered = await renderTestScroller({
       messages: [],

--- a/packages/react/src/message-scroller/types.ts
+++ b/packages/react/src/message-scroller/types.ts
@@ -21,6 +21,11 @@ const SCROLL_POSITION_EPSILON = 0.5
 // before clearing.
 const AUTOSCROLLING_CLEAR_DELAY = 180
 
+// Extra tail-spacer height beyond the exact anchored fit, so the pinned
+// position never sits at the very bottom of the scroll range where a transient
+// content dip would clamp scrollTop.
+const ANCHORED_TAIL_SLACK = 128
+
 // Viewport keys that count as deliberate scroll intent and release follow-bottom.
 const USER_SCROLL_KEYS = new Set([
   "ArrowDown",
@@ -206,6 +211,7 @@ const EMPTY_MESSAGE_SCROLLER_VISIBILITY_STATE: MessageScrollerVisibilityState =
   }
 
 export {
+  ANCHORED_TAIL_SLACK,
   AUTOSCROLLING_CLEAR_DELAY,
   DEFAULT_SCROLL_EDGE_THRESHOLD,
   DEFAULT_SCROLL_MARGIN,

--- a/packages/react/src/message-scroller/use-message-scroller-commands.ts
+++ b/packages/react/src/message-scroller/use-message-scroller-commands.ts
@@ -6,7 +6,11 @@ import {
   getMaxScrollTop,
   getTailSpacerHeight,
 } from "./geometry"
-import { AUTOSCROLLING_CLEAR_DELAY, SCROLL_POSITION_EPSILON } from "./types"
+import {
+  ANCHORED_TAIL_SLACK,
+  AUTOSCROLLING_CLEAR_DELAY,
+  SCROLL_POSITION_EPSILON,
+} from "./types"
 import type { MessageScrollerScrollOptions } from "./types"
 import type { MessageScrollerRefs } from "./use-message-scroller-refs"
 
@@ -176,8 +180,10 @@ function useMessageScrollerCommands({
         scrollMargin = scrollMarginRef.current,
       }: MessageScrollerScrollOptions = {},
       {
+        holdTailSpacer = false,
         keepPreviousPeek = false,
       }: {
+        holdTailSpacer?: boolean
         keepPreviousPeek?: boolean
       } = {}
     ) => {
@@ -205,7 +211,28 @@ function useMessageScrollerCommands({
         viewport,
       })
 
-      setTailSpacerHeight(nextSpacerHeight)
+      // An anchored placement must never sit at the exact bottom of the scroll
+      // range: a transient content dip (streamed markdown reflowing, a pending
+      // marker collapsing) would shrink scrollHeight below the pinned
+      // scrollTop, and the browser clamps the scroll and paints a one-frame
+      // jump before the coalesced resize handler corrects it. Padding the
+      // spacer with slack keeps the pinned position clear of the clamp from
+      // the first frame, and holding the maximum while the turn streams keeps
+      // scrollHeight monotonic after that. The slack is blank space below the
+      // fold; leaving the anchor hold trims it (see relaxTailSpacer). A turn
+      // placed with no spacer (it already fills the viewport) stays unpadded:
+      // it has natural slack below the fold, and a padded spacer would read as
+      // "placed with spacer room" to the autoScroll handoff.
+      const paddedSpacerHeight =
+        keepPreviousPeek && nextSpacerHeight > 0
+          ? nextSpacerHeight + ANCHORED_TAIL_SLACK
+          : nextSpacerHeight
+
+      setTailSpacerHeight(
+        holdTailSpacer
+          ? Math.max(paddedSpacerHeight, spacerHeightRef.current)
+          : paddedSpacerHeight
+      )
       // Seed the prepend anchor with the jump target so a prepend that lands
       // before this scroll settles still preserves the jumped-to row; once it
       // settles, syncAfterScroll's capturePrependAnchor re-captures it from the
@@ -244,9 +271,30 @@ function useMessageScrollerCommands({
     return scrollToElement(
       element,
       { align: "start" },
-      { keepPreviousPeek: true }
+      { holdTailSpacer: true, keepPreviousPeek: true }
     )
   }, [scrollToElement])
+
+  // A held tail spacer outlives its stream as reachable blank space below the
+  // last turn. Shrink it back to the exact height for the current scroll
+  // position; the held height is always >= the exact one, so this never clamps.
+  const relaxTailSpacer = React.useCallback(() => {
+    const content = contentRef.current
+    const viewport = viewportRef.current
+
+    if (!content || !viewport) {
+      return
+    }
+
+    setTailSpacerHeight(
+      getTailSpacerHeight({
+        content,
+        scrollTop: viewport.scrollTop,
+        spacer: spacerRef.current,
+        viewport,
+      })
+    )
+  }, [setTailSpacerHeight])
 
   // The target row may not be mounted yet (e.g. an async-loaded transcript).
   // When it is missing the request is queued in pendingScrollToMessageRef and
@@ -316,6 +364,7 @@ function useMessageScrollerCommands({
   return {
     flushPendingScrollToMessage,
     reanchorToAnchoredMessage,
+    relaxTailSpacer,
     scrollToElement,
     scrollToEnd,
     scrollToMessage,

--- a/packages/react/src/message-scroller/use-message-scroller-controller.ts
+++ b/packages/react/src/message-scroller/use-message-scroller-controller.ts
@@ -11,6 +11,7 @@ import {
   getMessageScrollerScrollable,
   getMessageScrollerVisibilityState,
   getNewScrollAnchor,
+  getTailSpacerHeight,
   getUnanchoredScrollAnchor,
   hasMultipleNewScrollAnchors,
 } from "./geometry"
@@ -238,6 +239,7 @@ function useMessageScrollerController({
   const {
     flushPendingScrollToMessage,
     reanchorToAnchoredMessage,
+    relaxTailSpacer,
     scrollToElement,
     scrollToEnd,
     scrollToMessage,
@@ -508,15 +510,26 @@ function useMessageScrollerController({
       // The reply streaming below the anchor consumes the tail spacer as it
       // grows. Once the last of it is gone the reply has filled the viewport
       // and the reader is genuinely at the live edge, so autoScroll hands off
-      // from the anchor hold to following the bottom. Requiring the >0 → 0
-      // transition keeps a turn taller than the viewport (placed with no
-      // spacer) held instead of yanked to the end.
-      if (
-        autoScrollRef.current &&
-        previousSpacerHeight > 0 &&
-        spacerHeightRef.current === 0
-      ) {
-        scrollToEnd({ behavior: "auto" })
+      // from the anchor hold to following the bottom. Requiring a >0 spacer
+      // keeps a turn taller than the viewport (placed with no spacer) held
+      // instead of yanked to the end. The held spacer never shrinks itself, so
+      // the handoff keys off the exact height the reply has left to consume.
+      if (autoScrollRef.current && previousSpacerHeight > 0) {
+        const content = contentRef.current
+        const viewport = viewportRef.current
+        const remaining =
+          content && viewport
+            ? getTailSpacerHeight({
+                content,
+                scrollTop: viewport.scrollTop,
+                spacer: spacerRef.current,
+                viewport,
+              })
+            : spacerHeightRef.current
+
+        if (remaining <= 0) {
+          scrollToEnd({ behavior: "auto" })
+        }
       }
 
       return
@@ -629,10 +642,18 @@ function useMessageScrollerController({
     ) {
       // A deliberate gesture releases auto-follow, turn-anchoring, and an in-flight
       // programmatic jump so re-pinning (and re-arming) never fights the reader.
+      const wasAnchored = modeRef.current === "anchored-to-message"
+
       streamingTurnRef.current = null
       modeRef.current = "free-scrolling"
+
+      // Leaving the anchor hold also gives back the held spacer slack, so the
+      // reader cannot scroll into blank space the stream no longer needs.
+      if (wasAnchored) {
+        relaxTailSpacer()
+      }
     }
-  }, [])
+  }, [relaxTailSpacer])
 
   const mirrorStateAttributes = React.useCallback(
     () => writeStateAttributes(stateStore.getSnapshot()),


### PR DESCRIPTION
## The problem

While a reply streams below an anchored turn (`defaultScrollPosition="last-anchor"` / a newly appended `scrollAnchor` item), the pinned turn visibly jitters: it shifts down a few pixels and snaps back, repeatedly.

The mechanism, confirmed with frame-by-frame instrumentation in a real chat app:

1. When a turn is anchored, the tail spacer is sized for an **exact fit**, so the pinned `scrollTop` sits at the very bottom of the scroll range (`scrollTop === scrollHeight - clientHeight`).
2. Streamed content transiently **shrinks** all the time: incomplete markdown reflows as it completes (a closing code fence, a list merging), and pending markers (a "Thinking" row) collapse when real content arrives.
3. Any dip shrinks `scrollHeight` below the pinned `scrollTop`. The browser clamps `scrollTop` and the whole transcript shifts down.
4. The resize handler re-anchors and scrolls back, but since #11085 it is (correctly) coalesced onto `requestAnimationFrame`, so the clamped frame always paints first.

Captured trace of one wiggle (2px dip on a pending-marker swap):

```
scrollHeight 8654 -> 8652, scrollTop clamped 8004 -> 8002 (anchor moved 80 -> 82)
+75ms: content grows, reanchor restores scrollTop 8004 (anchor back to 80)
```

## The fix

Make it impossible for a dip to clamp, instead of correcting after it does:

- **Slack** (`ANCHORED_TAIL_SLACK = 128`): an anchored placement pads the tail spacer beyond the exact fit, so the pinned position is never at max scroll. The slack is blank space below the fold, invisible at the pinned position. A turn placed with **no** spacer (it already fills the viewport) stays unpadded: it has natural slack below the fold, and a padded spacer would read as "placed with spacer room" to the autoScroll handoff.
- **Grow-or-hold**: while the turn stays anchored, re-anchoring never shrinks the spacer (`max(padded, current)`), keeping `scrollHeight` monotonic for the whole stream.
- **`relaxTailSpacer`**: leaving the anchor hold via user scroll intent trims the spacer back to the exact fit, so the reader cannot scroll into blank space the stream no longer needs. The held height is always >= the exact one, so the trim itself never clamps.
- The autoScroll handoff in `handleResize` now keys off the exact remaining height (recomputed via `getTailSpacerHeight`) instead of the styled spacer hitting 0, which a held spacer never does. Same handoff timing as before.

## Tests

Two new tests: `pads and holds the anchored tail spacer so a transient dip cannot clamp the pinned turn` and `trims the held spacer slack on user scroll intent`. Full message-scroller suite passes (62/62).

Independent of #11182 (different code paths; no conflicts).

## Related

One footgun worth knowing about that this PR does not touch: putting `content-visibility: auto` + `contain-intrinsic-size` on scroller items breaks anchored placement, because a freshly inserted item is measured at its intrinsic-size placeholder before first paint, so the anchor scroll target and spacer are computed from a wrong layout. Consumers should keep those styles off the last turn's items.
