### PR TITLE
fix(shadcn): validate file paths for registry items without an explicit target

### DIFF
--- a/.changeset/fix-registry-path-traversal.md
+++ b/.changeset/fix-registry-path-traversal.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Validate file paths for registry items without an explicit target to prevent path traversal.

--- a/packages/shadcn/src/utils/add-components.test.ts
+++ b/packages/shadcn/src/utils/add-components.test.ts
@@ -208,7 +208,7 @@ describe("validateFilesTarget", () => {
   type File = Parameters<typeof validateFilesTarget>[0][number]
   const cwd = "/project"
 
-  it.each([
+  const rejectedCases = [
     [
       "rejects target-less file whose path escapes root",
       { type: "registry:ui", path: "ui/../../../../etc/evil.tsx" },
@@ -221,13 +221,13 @@ describe("validateFilesTarget", () => {
       "still rejects unsafe target",
       { type: "registry:file", path: "x", target: "../../etc/evil" },
     ],
-  ])("%s", (_name, file) => {
-    expect(() => validateFilesTarget([file as File], cwd)).toThrow(
-      /unsafe file path/
-    )
+  ] satisfies Array<[string, File]>
+
+  it.each(rejectedCases)("%s", (_name, file) => {
+    expect(() => validateFilesTarget([file], cwd)).toThrow(/unsafe file path/)
   })
 
-  it.each([
+  const allowedCases = [
     [
       "allows normal target-less file",
       { type: "registry:ui", path: "ui/button.tsx" },
@@ -240,7 +240,9 @@ describe("validateFilesTarget", () => {
       "allows safe target",
       { type: "registry:file", path: "x", target: "components/ui/x.tsx" },
     ],
-  ])("%s", (_name, file) => {
-    expect(() => validateFilesTarget([file as File], cwd)).not.toThrow()
+  ] satisfies Array<[string, File]>
+
+  it.each(allowedCases)("%s", (_name, file) => {
+    expect(() => validateFilesTarget([file], cwd)).not.toThrow()
   })
 })

--- a/packages/shadcn/src/utils/add-components.test.ts
+++ b/packages/shadcn/src/utils/add-components.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { addComponents } from "./add-components"
+import { addComponents, validateFilesTarget } from "./add-components"
 
 const {
   mockResolveRegistryTree,
@@ -201,5 +201,46 @@ describe("addComponents", () => {
     expect(mockUpdateFiles.mock.invocationCallOrder[0]).toBeLessThan(
       mockUpdateCss.mock.invocationCallOrder[0]
     )
+  })
+})
+
+describe("validateFilesTarget", () => {
+  type File = Parameters<typeof validateFilesTarget>[0][number]
+  const cwd = "/project"
+
+  it.each([
+    [
+      "rejects target-less file whose path escapes root",
+      { type: "registry:ui", path: "ui/../../../../etc/evil.tsx" },
+    ],
+    [
+      "rejects target-less file with absolute escaping path",
+      { type: "registry:lib", path: "/etc/evil.ts" },
+    ],
+    [
+      "still rejects unsafe target",
+      { type: "registry:file", path: "x", target: "../../etc/evil" },
+    ],
+  ])("%s", (_name, file) => {
+    expect(() => validateFilesTarget([file as File], cwd)).toThrow(
+      /unsafe file path/
+    )
+  })
+
+  it.each([
+    [
+      "allows normal target-less file",
+      { type: "registry:ui", path: "ui/button.tsx" },
+    ],
+    [
+      "allows normal nested target-less path",
+      { type: "registry:ui", path: "registry/new-york-v4/ui/button.tsx" },
+    ],
+    [
+      "allows safe target",
+      { type: "registry:file", path: "x", target: "components/ui/x.tsx" },
+    ],
+  ])("%s", (_name, file) => {
+    expect(() => validateFilesTarget([file as File], cwd)).not.toThrow()
   })
 })

--- a/packages/shadcn/src/utils/add-components.ts
+++ b/packages/shadcn/src/utils/add-components.ts
@@ -444,18 +444,22 @@ async function shouldOverwriteCssVars(
   )
 }
 
-function validateFilesTarget(
+export function validateFilesTarget(
   files: z.infer<typeof registryItemFileSchema>[],
   cwd: string
 ) {
   for (const file of files) {
-    if (!file?.target) {
+    // `target` decides the write location when present; otherwise the path is
+    // derived from `file.path` (see resolveFilePath in update-files.ts). Both
+    // are registry-controlled, so validate whichever one is used.
+    const locationField = file?.target ?? file?.path
+    if (!locationField) {
       continue
     }
 
-    if (!isSafeTarget(file.target, cwd)) {
+    if (!isSafeTarget(locationField, cwd)) {
       throw new Error(
-        `We found an unsafe file path "${file.target} in the registry item. Installation aborted.`
+        `We found an unsafe file path "${locationField}" in the registry item. Installation aborted.`
       )
     }
   }


### PR DESCRIPTION
## What

Extends the CLI's path-traversal guard (`validateFilesTarget` in `packages/shadcn/src/utils/add-components.ts`) to validate a registry file's `path` when it has no explicit `target`, not just the `target` field.

## Why

`shadcn add` writes files onto the user's machine using locations supplied by registry JSON. The guard `isSafeTarget` existed but was only applied to `file.target`. For the most common item types (`registry:ui`, `registry:component`, `registry:hook`, `registry:lib`, `registry:block`) `target` is optional and usually absent — and when it is absent, `resolveFilePath` derives the write location from the registry-controlled `file.path` instead (via `resolveNestedFilePath`), which was never validated. A file whose `path` escapes the project root could therefore be written outside it.

The fix validates the field that actually determines the destination: `file.target` when present, `file.path` otherwise. Legitimate items use in-tree relative paths (`ui/button.tsx`, `registry/new-york-v4/ui/button.tsx`), which pass; only escaping paths are rejected.

## Changes

- `validateFilesTarget` now checks `file?.target ?? file?.path` against `isSafeTarget`, and is exported for testing.
- Added regression tests in `add-components.test.ts`: rejects target-less traversal and absolute-escape paths, still rejects unsafe `target`, and allows normal target-less paths and safe targets.
- Patch changeset for `shadcn`.

## Reviewer notes

- `isSafeTarget` is unchanged; the fix is purely at the input boundary.
- The user-supplied `--path` flow (`resolveFilePath` `options.path`) is intentionally not affected.
- A defense-in-depth check of the final resolved path right before `fs.writeFile` in `update-files.ts` was deliberately deferred — it must exempt the legitimate absolute `--path` case, so it belongs in a separate hardening pass.

## Verification

- `pnpm --filter=shadcn typecheck` — exit 0
- `pnpm --filter=shadcn test` — 1531 passed (79 files), including the new `validateFilesTarget` cases