### PR TITLE
fix(shadcn): handle empty css file when adding v4 css variables

### DIFF
--- a/.changeset/fix-empty-css-file-init.md
+++ b/.changeset/fix-empty-css-file-init.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Fix a crash when adding Tailwind v4 CSS variables to an empty CSS file.

--- a/packages/shadcn/src/utils/updaters/update-css-vars.ts
+++ b/packages/shadcn/src/utils/updaters/update-css-vars.ts
@@ -542,9 +542,12 @@ function addCustomVariant({ params }: { params: string }) {
           // Insert after the last import
           const lastImport = importNodes[importNodes.length - 1]
           root.insertAfter(lastImport, variantNode)
-        } else {
+        } else if (root.nodes.length > 0) {
           // If no imports, insert after the first node
           root.insertAfter(root.nodes[0], variantNode)
+        } else {
+          // If the file is empty, there is no node to anchor to.
+          root.append(variantNode)
         }
 
         root.insertBefore(variantNode, postcss.comment({ text: "---break---" }))

--- a/packages/shadcn/test/utils/updaters/update-css-vars.test.ts
+++ b/packages/shadcn/test/utils/updaters/update-css-vars.test.ts
@@ -1192,6 +1192,76 @@ describe("transformCssVarsV4", () => {
               "
     `)
   })
+
+  test("should add css vars to an empty css file", async () => {
+    expect(
+      await transformCssVars(
+        ``,
+        {
+          light: {
+            background: "0 0% 100%",
+          },
+          dark: {
+            background: "240 10% 3.9%",
+          },
+        },
+        { tailwind: { cssVariables: true } },
+        { tailwindVersion: "v4" }
+      )
+    ).toMatchInlineSnapshot(`
+      "
+      @custom-variant dark (&:is(.dark *));
+
+      :root {
+          --background: hsl(0 0% 100%);
+      }
+
+      .dark {
+          --background: hsl(240 10% 3.9%);
+      }
+
+      @theme inline {
+          --color-background: var(--background);
+      }"
+    `)
+  })
+
+  test("should add css vars to a css file with only whitespace", async () => {
+    expect(
+      await transformCssVars(
+        `
+
+        `,
+        {
+          light: {
+            background: "0 0% 100%",
+          },
+          dark: {
+            background: "240 10% 3.9%",
+          },
+        },
+        { tailwind: { cssVariables: true } },
+        { tailwindVersion: "v4" }
+      )
+    ).toMatchInlineSnapshot(`
+      "
+      @custom-variant dark (&:is(.dark *));
+
+      :root {
+          --background: hsl(0 0% 100%);
+      }
+
+      .dark {
+          --background: hsl(240 10% 3.9%);
+      }
+
+      @theme inline {
+          --color-background: var(--background);
+      }
+
+              "
+    `)
+  })
 })
 
 describe("isLocalHSLValue", () => {


### PR DESCRIPTION
Fixes #10856

### Problem

`init` fails with `Cannot read properties of undefined (reading 'proxyOf')` when the target CSS file is empty. Putting `@import "tailwindcss";` back into the file works around it, which is why this only shows up on projects that start from a blank `globals.css`.

The v4 branch of `transformCssVars` always runs the `add-custom-variant` plugin. When the stylesheet has no `@import` at-rules, the plugin anchors the new `@custom-variant` node to the first node:

```ts
} else {
  // If no imports, insert after the first node
  root.insertAfter(root.nodes[0], variantNode)
}
```

On an empty stylesheet `root.nodes` is empty, so `root.nodes[0]` is `undefined`. postcss dereferences it in `Container.index()`:

```js
index(child) {
  if (typeof child === 'number') return child
  if (child.proxyOf) child = child.proxyOf   // TypeError
  return this.nodes.indexOf(child)
}
```

which surfaces as the `proxyOf` error right after the `Updating app/globals.css` step.

### Fix

Append the at-rule when there is no node to anchor to. Files that already have content keep their current behavior — insert after the last `@import`, or after the first node.

### Tests

Added two cases to `transformCssVarsV4`: an empty file and a whitespace-only file. Both reproduce the crash on `main` and pass with this change.

### Notes

- The two sibling `root.nodes[0]` reads in this file (`updateTailwindConfigPlugin` and `getQuoteType`) are not reachable on an empty stylesheet: `add-custom-variant` runs first in the v4 plugin list and always leaves a node behind, so they are left alone here.
- This only stops the crash. Whether `init` should also write `@import "tailwindcss";` into a stylesheet that is completely empty felt like a separate call, so I left it out — happy to add it if you'd prefer that.
