### PR TITLE
fix(v4): validate create-flow item param against allowed items

### DIFF
--- a/apps/v4/app/(app)/(create)/lib/v0.test.ts
+++ b/apps/v4/app/(app)/(create)/lib/v0.test.ts
@@ -40,6 +40,10 @@ vi.mock("@/registry/bases/__index__", () => ({
   },
 }))
 
+vi.mock("@/app/(app)/(create)/lib/api", () => ({
+  getItemsForBase: vi.fn(async () => [{ name: "button", type: "registry:ui" }]),
+}))
+
 describe("buildV0Payload", () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_APP_URL = "http://example.test"
@@ -111,5 +115,23 @@ describe("buildV0Payload", () => {
 
     expect(cardFile?.content).toContain("font-heading")
     expect(cardFile?.content).not.toContain("cn-font-heading")
+  })
+
+  it("rejects an item that is not in the base's allowed set", async () => {
+    await expect(
+      buildV0Payload({
+        ...DEFAULT_CONFIG,
+        item: "../../evil",
+      })
+    ).rejects.toThrow(/Unknown item/)
+  })
+
+  it("does not reject a valid item as unknown", async () => {
+    await expect(
+      buildV0Payload({
+        ...DEFAULT_CONFIG,
+        item: "button",
+      })
+    ).resolves.toBeDefined()
   })
 })

--- a/apps/v4/app/(app)/(create)/lib/v0.ts
+++ b/apps/v4/app/(app)/(create)/lib/v0.ts
@@ -21,6 +21,7 @@ import {
   getInheritedHeadingFontValue,
   type DesignSystemConfig,
 } from "@/registry/config"
+import { getItemsForBase } from "@/app/(app)/(create)/lib/api"
 
 const { Index } = await import("@/registry/bases/__index__")
 
@@ -178,6 +179,16 @@ function getStyle(designSystemConfig: DesignSystemConfig) {
 }
 
 export async function buildV0Payload(designSystemConfig: DesignSystemConfig) {
+  if (designSystemConfig.item) {
+    const allowedItems = await getItemsForBase(designSystemConfig.base)
+    const isAllowed = allowedItems.some(
+      (allowed) => allowed?.name === designSystemConfig.item
+    )
+    if (!isAllowed) {
+      throw new Error(`Unknown item: "${designSystemConfig.item}".`)
+    }
+  }
+
   const registryBase = buildRegistryBase(designSystemConfig)
   const normalizedFontHeading =
     designSystemConfig.fontHeading === designSystemConfig.font


### PR DESCRIPTION
## What

Validates the create-flow `item` query param against the per-base allowed item set before it is used server-side.

## Why

In `designSystemConfigSchema`, every field is a strict `z.enum` except `item` (`z.string().optional()`). On the server that raw value is interpolated into a `fetch` URL (`.../r/styles/<style>/<item>.json`) and reflected into generated project code (an import path and a component filename). An unexpected `item` value could redirect the server-side fetch and inject arbitrary strings into the generated scaffold. The sibling helpers (`getBaseItem`/`getItemsForBase`) already enforce an allow-set; this path did not.

## Changes

- `buildV0Payload` now checks `item` against `getItemsForBase(base)` and throws (surfaced by the route as an error response) if it is not in the allowed set — before any use of the value.
- Regression tests: an unexpected `item` is rejected; a valid one is accepted.

## Reviewer notes

- The valid item set is per-base and computed at runtime, so the schema field is intentionally left as-is (a static `z.enum` can't express it); validation happens at the server boundary.
- No changeset — `v4` is in the changeset `ignore` list.