### PR TITLE
fix(shadcn): prevent flag injection via registry dependency strings

### DIFF
--- a/.changeset/guard-dependency-flag-injection.md
+++ b/.changeset/guard-dependency-flag-injection.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Prevent flag injection from registry-supplied dependency strings during install.

--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -244,7 +244,9 @@ async function installWithPackageManager(
   }
 
   if (devDependencies?.length) {
-    await execa(packageManager, ["add", "-D", "--", ...devDependencies], { cwd })
+    await execa(packageManager, ["add", "-D", "--", ...devDependencies], {
+      cwd,
+    })
   }
 }
 

--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -195,6 +195,24 @@ async function getUpdateDependenciesPackageManager(config: Config) {
   return getPackageManager(config.resolvedPaths.cwd)
 }
 
+/**
+ * Registry-supplied dependency strings are forwarded directly into the package
+ * manager's argument list. A specifier beginning with "-" would be interpreted
+ * as a flag rather than a package name, letting a malicious registry alter the
+ * install source/behavior (argument injection). Reject those before they reach
+ * `execa`; the `--` end-of-options separator added at each call site is the
+ * second layer of defense.
+ */
+export function assertSafeDependencies(deps: string[]) {
+  for (const dep of deps) {
+    if (dep.trim().startsWith("-")) {
+      throw new Error(
+        `Invalid dependency "${dep}": dependency names cannot start with "-".`
+      )
+    }
+  }
+}
+
 async function installWithPackageManager(
   packageManager: Awaited<
     ReturnType<typeof getUpdateDependenciesPackageManager>
@@ -216,14 +234,17 @@ async function installWithPackageManager(
     return installWithExpo(dependencies, devDependencies, cwd)
   }
 
+  assertSafeDependencies(dependencies)
+  assertSafeDependencies(devDependencies)
+
   if (dependencies?.length) {
-    await execa(packageManager, ["add", ...dependencies], {
+    await execa(packageManager, ["add", "--", ...dependencies], {
       cwd,
     })
   }
 
   if (devDependencies?.length) {
-    await execa(packageManager, ["add", "-D", ...devDependencies], { cwd })
+    await execa(packageManager, ["add", "-D", "--", ...devDependencies], { cwd })
   }
 }
 
@@ -233,10 +254,13 @@ async function installWithNpm(
   cwd: string,
   flag?: string
 ) {
+  assertSafeDependencies(dependencies)
+  assertSafeDependencies(devDependencies)
+
   if (dependencies.length) {
     await execa(
       "npm",
-      ["install", ...(flag ? [`--${flag}`] : []), ...dependencies],
+      ["install", ...(flag ? [`--${flag}`] : []), "--", ...dependencies],
       { cwd }
     )
   }
@@ -244,7 +268,13 @@ async function installWithNpm(
   if (devDependencies.length) {
     await execa(
       "npm",
-      ["install", ...(flag ? [`--${flag}`] : []), "-D", ...devDependencies],
+      [
+        "install",
+        ...(flag ? [`--${flag}`] : []),
+        "-D",
+        "--",
+        ...devDependencies,
+      ],
       { cwd }
     )
   }
@@ -275,12 +305,15 @@ async function installWithExpo(
   devDependencies: string[],
   cwd: string
 ) {
+  assertSafeDependencies(dependencies)
+  assertSafeDependencies(devDependencies)
+
   if (dependencies.length) {
-    await execa("npx", ["expo", "install", ...dependencies], { cwd })
+    await execa("npx", ["expo", "install", "--", ...dependencies], { cwd })
   }
 
   if (devDependencies.length) {
-    await execa("npx", ["expo", "install", "-- -D", ...devDependencies], {
+    await execa("npx", ["expo", "install", "-- -D", "--", ...devDependencies], {
       cwd,
     })
   }

--- a/packages/shadcn/test/utils/updaters/update-dependencies.test.ts
+++ b/packages/shadcn/test/utils/updaters/update-dependencies.test.ts
@@ -3,7 +3,10 @@ import { execa } from "execa"
 import prompts from "prompts"
 import { afterEach, describe, expect, test, vi } from "vitest"
 
-import { updateDependencies } from "../../../src/utils/updaters/update-dependencies"
+import {
+  assertSafeDependencies,
+  updateDependencies,
+} from "../../../src/utils/updaters/update-dependencies"
 
 vi.mock("execa")
 vi.mock("prompts")
@@ -26,8 +29,8 @@ describe("updateDependencies", () => {
         },
       },
       expectedPackageManager: "npm",
-      expectedArgs: ["install", "first", "second", "third"],
-      expectedDevArgs: ["install", "-D", "fourth"],
+      expectedArgs: ["install", "--", "first", "second", "third"],
+      expectedDevArgs: ["install", "-D", "--", "fourth"],
     },
     {
       description:
@@ -41,8 +44,8 @@ describe("updateDependencies", () => {
         },
       },
       expectedPackageManager: "npm",
-      expectedArgs: ["install", "--force", "first", "second", "third"],
-      expectedDevArgs: ["install", "--force", "-D", "fourth"],
+      expectedArgs: ["install", "--force", "--", "first", "second", "third"],
+      expectedDevArgs: ["install", "--force", "-D", "--", "fourth"],
     },
     {
       description:
@@ -59,11 +62,12 @@ describe("updateDependencies", () => {
       expectedArgs: [
         "install",
         "--legacy-peer-deps",
+        "--",
         "first",
         "second",
         "third",
       ],
-      expectedDevArgs: ["install", "--legacy-peer-deps", "-D", "fourth"],
+      expectedDevArgs: ["install", "--legacy-peer-deps", "-D", "--", "fourth"],
     },
     {
       description: "deno uses npm: package prefix",
@@ -88,8 +92,8 @@ describe("updateDependencies", () => {
         },
       },
       expectedPackageManager: "bun",
-      expectedArgs: ["add", "first", "second", "third"],
-      expectedDevArgs: ["add", "-D", "fourth"],
+      expectedArgs: ["add", "--", "first", "second", "third"],
+      expectedDevArgs: ["add", "-D", "--", "fourth"],
     },
     {
       description: "pnpm uses pnpm",
@@ -101,8 +105,8 @@ describe("updateDependencies", () => {
         },
       },
       expectedPackageManager: "pnpm",
-      expectedArgs: ["add", "first", "second", "third"],
-      expectedDevArgs: ["add", "-D", "fourth"],
+      expectedArgs: ["add", "--", "first", "second", "third"],
+      expectedDevArgs: ["add", "-D", "--", "fourth"],
     },
     {
       description: "deduplicates input dependencies",
@@ -115,8 +119,8 @@ describe("updateDependencies", () => {
         },
       },
       expectedPackageManager: "npm",
-      expectedArgs: ["install", "first"],
-      expectedDevArgs: ["install", "-D", "second"],
+      expectedArgs: ["install", "--", "first"],
+      expectedDevArgs: ["install", "-D", "--", "second"],
     },
   ])(
     "$description",
@@ -179,12 +183,16 @@ describe("updateDependencies", () => {
     expect(execa).toHaveBeenCalledTimes(2)
     expect(execa).toHaveBeenCalledWith(
       "pnpm",
-      ["add", "react-is", "recharts@3.8.0"],
+      ["add", "--", "react-is", "recharts@3.8.0"],
       { cwd }
     )
-    expect(execa).toHaveBeenCalledWith("pnpm", ["add", "-D", "typescript"], {
-      cwd,
-    })
+    expect(execa).toHaveBeenCalledWith(
+      "pnpm",
+      ["add", "-D", "--", "typescript"],
+      {
+        cwd,
+      }
+    )
   })
 
   test("prefers explicit specs over duplicate bare requests", async () => {
@@ -200,7 +208,7 @@ describe("updateDependencies", () => {
     expect(execa).toHaveBeenCalledTimes(1)
     expect(execa).toHaveBeenCalledWith(
       "pnpm",
-      ["add", "recharts@3.8.0", "@base-ui/react@1.4.1"],
+      ["add", "--", "recharts@3.8.0", "@base-ui/react@1.4.1"],
       { cwd }
     )
   })
@@ -222,8 +230,45 @@ describe("updateDependencies", () => {
 
     expect(execa).toHaveBeenCalledWith(
       "npx",
-      ["expo", "install", "recharts", "react-is"],
+      ["expo", "install", "--", "recharts", "react-is"],
       { cwd }
     )
+  })
+
+  test("rejects registry dependencies that begin with a dash (flag injection)", async () => {
+    const cwd = path.resolve(__dirname, "../../fixtures/project-pnpm")
+
+    await expect(
+      updateDependencies(
+        ["--registry=http://malicious"],
+        [],
+        { resolvedPaths: { cwd } } as any,
+        { silent: true }
+      )
+    ).rejects.toThrow(/cannot start with/)
+
+    expect(execa).not.toHaveBeenCalledWith(
+      "pnpm",
+      expect.arrayContaining(["--registry=http://malicious"]),
+      expect.anything()
+    )
+  })
+})
+
+describe("assertSafeDependencies", () => {
+  test("does not throw for normal names and specifiers", () => {
+    expect(() =>
+      assertSafeDependencies(["zod", "recharts@3.8.0", "@base-ui/react"])
+    ).not.toThrow()
+  })
+
+  test("throws for a specifier starting with a dash", () => {
+    expect(() => assertSafeDependencies(["--registry=http://x"])).toThrow(
+      /cannot start with/
+    )
+  })
+
+  test("throws when a dash follows leading whitespace", () => {
+    expect(() => assertSafeDependencies(["  -D"])).toThrow(/cannot start with/)
   })
 })


### PR DESCRIPTION
## What

Hardens the dependency-install path so registry-supplied dependency strings can only be treated as package specifiers, never as package-manager flags.

## Why

Registry item `dependencies`/`devDependencies` (arbitrary strings from registry JSON) were spread directly into the package manager's argument list with no end-of-options separator and no check for leading dashes. Executing installs is intended CLI behavior; a dependency entry acting as a *flag* is not. The `deno` path was already safe via its `npm:` prefix; npm/pnpm/yarn/bun/expo were not.

## Changes

- New `assertSafeDependencies` guard rejects any specifier beginning with `-`, applied on the npm, generic (pnpm/yarn/bun), and expo install paths.
- A `--` end-of-options separator is inserted before the package list on each of those paths (after option flags like `-D`/`--flag`), so everything after it is treated as positional package args.
- Tests: a dash-leading dependency is rejected before `execa` runs; existing exact-arg assertions updated for the new `--`; unit tests for the guard (including a leading-whitespace case).

## Reviewer notes

- `installWithDeno` unchanged (already safe by construction).
- Pre-existing follow-up (out of scope, filed separately): `installWithExpo`'s devDependencies branch passes a malformed `"-- -D"` token; the guard protects the path regardless, but that token predates this change and deserves its own fix.
- Patch changeset included.