### PR TITLE
fix(shadcn): drop custom registry headers on cross-origin redirects

### DIFF
--- a/.changeset/fix-registry-header-redirect-leak.md
+++ b/.changeset/fix-registry-header-redirect-leak.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Drop custom registry headers on cross-origin redirects to prevent credential leakage.

--- a/packages/shadcn/src/registry/proxy.test.ts
+++ b/packages/shadcn/src/registry/proxy.test.ts
@@ -24,9 +24,12 @@ describe("fetchWithProxy", () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(okResponse())
     vi.stubGlobal("fetch", fetchMock)
 
-    const response = await fetchWithProxy("https://registry.example.com/a.json", {
-      headers: { "X-API-Key": "secret" },
-    })
+    const response = await fetchWithProxy(
+      "https://registry.example.com/a.json",
+      {
+        headers: { "X-API-Key": "secret" },
+      }
+    )
 
     expect(response.status).toBe(200)
     expect(fetchMock).toHaveBeenCalledTimes(1)

--- a/packages/shadcn/src/registry/proxy.test.ts
+++ b/packages/shadcn/src/registry/proxy.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { fetchWithProxy } from "./proxy"
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+function redirectResponse(status: number, location: string) {
+  return new Response(null, { status, headers: { location } })
+}
+
+function okResponse() {
+  return new Response("ok", { status: 200 })
+}
+
+function headersForCall(mock: ReturnType<typeof vi.fn>, index: number) {
+  return mock.mock.calls[index][1].headers as Headers
+}
+
+describe("fetchWithProxy", () => {
+  it("returns a direct (non-redirect) response as-is", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(okResponse())
+    vi.stubGlobal("fetch", fetchMock)
+
+    const response = await fetchWithProxy("https://registry.example.com/a.json", {
+      headers: { "X-API-Key": "secret" },
+    })
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(headersForCall(fetchMock, 0).get("x-api-key")).toBe("secret")
+  })
+
+  it("keeps custom headers on a same-origin redirect", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        redirectResponse(302, "https://registry.example.com/final.json")
+      )
+      .mockResolvedValueOnce(okResponse())
+    vi.stubGlobal("fetch", fetchMock)
+
+    const response = await fetchWithProxy(
+      "https://registry.example.com/start.json",
+      {
+        headers: {
+          "X-API-Key": "secret",
+          Accept: "application/json",
+        },
+      }
+    )
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const second = headersForCall(fetchMock, 1)
+    expect(second.get("x-api-key")).toBe("secret")
+    expect(second.get("accept")).toBe("application/json")
+  })
+
+  it("keeps custom headers on a relative (path-only) same-origin redirect", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse(307, "/final.json"))
+      .mockResolvedValueOnce(okResponse())
+    vi.stubGlobal("fetch", fetchMock)
+
+    await fetchWithProxy("https://registry.example.com/start.json", {
+      headers: { "X-API-Key": "secret" },
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(headersForCall(fetchMock, 1).get("x-api-key")).toBe("secret")
+  })
+
+  it("drops custom headers on a cross-origin redirect", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        redirectResponse(302, "https://attacker.example/steal")
+      )
+      .mockResolvedValueOnce(okResponse())
+    vi.stubGlobal("fetch", fetchMock)
+
+    const response = await fetchWithProxy(
+      "https://registry.example.com/start.json",
+      {
+        headers: {
+          "X-API-Key": "secret",
+          Accept: "application/json",
+          "User-Agent": "shadcn",
+        },
+      }
+    )
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const second = headersForCall(fetchMock, 1)
+    // Sensitive custom header must not be forwarded to the new origin.
+    expect(second.get("x-api-key")).toBeNull()
+    // Non-sensitive headers may be kept.
+    expect(second.get("accept")).toBe("application/json")
+    expect(second.get("user-agent")).toBe("shadcn")
+  })
+
+  it("throws when the redirect chain exceeds the limit", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        redirectResponse(302, "https://registry.example.com/loop")
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    await expect(
+      fetchWithProxy("https://registry.example.com/start", {
+        headers: { "X-API-Key": "secret" },
+      })
+    ).rejects.toThrow(/Too many redirects/)
+  })
+})

--- a/packages/shadcn/src/registry/proxy.ts
+++ b/packages/shadcn/src/registry/proxy.ts
@@ -11,12 +11,70 @@ const proxyDispatcher =
     ? new EnvHttpProxyAgent()
     : undefined
 
+// Standard fetch strips Authorization/Cookie/Proxy-Authorization on
+// cross-origin redirects, but preserves custom-named headers. Since private
+// registries can carry secrets in arbitrary header names (e.g. X-API-Key), we
+// follow redirects manually and only re-attach the caller's headers when the
+// next hop stays on the original origin. Accept/User-Agent are not secrets and
+// are kept across origins.
+const MAX_REDIRECTS = 5
+const SAFE_HEADER_NAMES = new Set(["accept", "user-agent"])
+
 export async function fetchWithProxy(url: string | URL, init?: RequestInit) {
+  const originalOrigin = new URL(url).origin
+  const originalHeaders = new Headers(init?.headers)
+  let currentUrl = new URL(url).toString()
+  let headers = originalHeaders
+
+  for (let i = 0; i <= MAX_REDIRECTS; i++) {
+    const response = await fetchOnce(currentUrl, init, headers)
+
+    const isRedirect =
+      response.status >= 300 &&
+      response.status < 400 &&
+      response.headers.has("location")
+
+    if (!isRedirect) {
+      return response
+    }
+
+    const location = response.headers.get("location")!
+    const nextUrl = new URL(location, currentUrl)
+
+    if (nextUrl.origin !== originalOrigin) {
+      // Cross-origin hop: drop every caller-supplied header except the
+      // non-sensitive Accept/User-Agent.
+      const stripped = new Headers()
+      originalHeaders.forEach((value, key) => {
+        if (SAFE_HEADER_NAMES.has(key.toLowerCase())) {
+          stripped.set(key, value)
+        }
+      })
+      headers = stripped
+    } else {
+      headers = originalHeaders
+    }
+
+    currentUrl = nextUrl.toString()
+  }
+
+  throw new Error(`Too many redirects while fetching ${url}`)
+}
+
+async function fetchOnce(
+  url: string,
+  init: RequestInit | undefined,
+  headers: Headers
+) {
   try {
     // The `dispatcher` option is supported by Node's fetch at runtime but
-    // missing from the ambient RequestInit type, hence the cast.
+    // missing from the ambient RequestInit type, hence the cast. Redirects are
+    // followed manually (see fetchWithProxy) so headers can be re-scoped per
+    // hop, hence `redirect: "manual"`.
     return await fetch(url, {
       ...init,
+      headers,
+      redirect: "manual",
       dispatcher: proxyDispatcher,
     } as RequestInit)
   } catch (error) {


### PR DESCRIPTION
## What

Makes the registry fetcher follow redirects manually and re-attach configured request headers only when a redirect stays on the original origin.

## Why

Private/third-party registries can be configured (in `components.json`) with auth headers whose values come from environment variables, under arbitrary header names (e.g. `X-API-Key`). `fetchWithProxy` used the default `redirect: "follow"`. On a cross-origin redirect, `fetch` strips only the standard sensitive headers (`Authorization`/`Cookie`/`Proxy-Authorization`) — custom-named headers are preserved and sent to the redirect target, so a registry that redirects to another origin would receive the configured credential.

## Changes

- `fetchWithProxy` now issues requests with `redirect: "manual"` and follows redirects in a bounded loop (max 5). On a hop to a different origin than the original request, it drops all caller-supplied headers except the non-sensitive `Accept`/`User-Agent`; same-origin hops keep the full header set.
- Proxy dispatcher and the existing network-error enrichment are preserved (factored into a small `fetchOnce` helper).
- New tests: same-origin redirect keeps custom headers; relative (path-only) redirect keeps them; cross-origin redirect drops the sensitive header; redirect chains beyond the limit throw.

## Reviewer notes

- The origin comparison is against the **original** request origin, so an A→A→B chain still strips at B.
- Behavior change applies to every `fetchWithProxy` caller; the same-origin and relative-path tests are the guard that legitimate redirect-based registries keep working.
- Patch changeset included.