### PR TITLE
fix(v4): size chevron icon in base breadcrumb dropdown example

### DIFF
--- a/apps/v4/examples/base/breadcrumb-dropdown.tsx
+++ b/apps/v4/examples/base/breadcrumb-dropdown.tsx
@@ -33,7 +33,7 @@ export function BreadcrumbDropdown() {
               render={<button className="flex items-center gap-1" />}
             >
               Components
-              <ChevronDownIcon data-icon="inline-end" />
+              <ChevronDownIcon data-icon="inline-end" className="size-3.5" />
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start">
               <DropdownMenuGroup>


### PR DESCRIPTION
## What changed

Added `className="size-3.5"` to the `ChevronDownIcon` inside the dropdown trigger in `apps/v4/examples/base/breadcrumb-dropdown.tsx`.

## Why

The trigger renders a plain `<button>` via Base UI's `render` prop (not the `Button` component), so nothing constrained the svg size — the chevron rendered at lucide's 24×24px default, oversized next to the breadcrumb text.

## Notes for reviewers

`size-3.5` matches the identical trigger pattern in the `breadcrumb-rtl.tsx` example. Verified in the browser at `/examples/base/breadcrumb-dropdown` — the chevron now computes to 14×14px.