### PR TITLE
feat(v4): apply theme changes on hover in create and typeset

### DIFF
--- a/apps/v4/app/(app)/(create)/components/accent-picker.tsx
+++ b/apps/v4/app/(app)/(create)/components/accent-picker.tsx
@@ -10,6 +10,7 @@ import {
   PickerRadioItem,
   PickerTrigger,
 } from "@/app/(app)/(create)/components/picker"
+import { usePreviewOverride } from "@/app/(app)/(create)/components/preview-override"
 import { useDesignSystemSearchParams } from "@/app/(app)/(create)/lib/search-params"
 
 export function MenuAccentPicker({
@@ -20,6 +21,7 @@ export function MenuAccentPicker({
   anchorRef: React.RefObject<HTMLDivElement | null>
 }) {
   const [params, setParams] = useDesignSystemSearchParams()
+  const { setOverride, clearOverride } = usePreviewOverride()
 
   const currentAccent = MENU_ACCENTS.find(
     (accent) => accent.value === params.menuAccent
@@ -27,7 +29,13 @@ export function MenuAccentPicker({
 
   return (
     <div className="group/picker relative pr-3 md:pr-0">
-      <Picker>
+      <Picker
+        onOpenChange={(open) => {
+          if (!open) {
+            clearOverride()
+          }
+        }}
+      >
         <PickerTrigger>
           <div className="flex flex-col justify-start text-left">
             <div className="text-xs text-muted-foreground">Menu Accent</div>
@@ -69,12 +77,19 @@ export function MenuAccentPicker({
           anchor={isMobile ? anchorRef : undefined}
           side={isMobile ? "top" : "right"}
           align={isMobile ? "center" : "start"}
+          onMouseLeave={clearOverride}
         >
           <PickerRadioGroup
             value={currentAccent?.value}
             onValueChange={(value) => {
               setParams({ menuAccent: value as MenuAccentValue })
             }}
+            onItemPreview={
+              isMobile
+                ? undefined
+                : (value) =>
+                    setOverride({ menuAccent: value as MenuAccentValue })
+            }
           >
             <PickerGroup>
               {MENU_ACCENTS.map((accent) => (

--- a/apps/v4/app/(app)/(create)/components/base-color-picker.tsx
+++ b/apps/v4/app/(app)/(create)/components/base-color-picker.tsx
@@ -13,6 +13,7 @@ import {
   PickerRadioItem,
   PickerTrigger,
 } from "@/app/(app)/(create)/components/picker"
+import { usePreviewOverride } from "@/app/(app)/(create)/components/preview-override"
 import { useDesignSystemSearchParams } from "@/app/(app)/(create)/lib/search-params"
 
 export function BaseColorPicker({
@@ -24,6 +25,7 @@ export function BaseColorPicker({
 }) {
   const mounted = useMounted()
   const [params, setParams] = useDesignSystemSearchParams()
+  const { setOverride, clearOverride } = usePreviewOverride()
 
   const currentBaseColor = React.useMemo(
     () => BASE_COLORS.find((baseColor) => baseColor.name === params.baseColor),
@@ -32,7 +34,13 @@ export function BaseColorPicker({
 
   return (
     <div className="group/picker relative">
-      <Picker>
+      <Picker
+        onOpenChange={(open) => {
+          if (!open) {
+            clearOverride()
+          }
+        }}
+      >
         <PickerTrigger>
           <div className="flex flex-col justify-start text-left">
             <div className="text-xs text-muted-foreground">Base Color</div>
@@ -56,12 +64,18 @@ export function BaseColorPicker({
           anchor={isMobile ? anchorRef : undefined}
           side={isMobile ? "top" : "right"}
           align={isMobile ? "center" : "start"}
+          onMouseLeave={clearOverride}
         >
           <PickerRadioGroup
             value={currentBaseColor?.name}
             onValueChange={(value) => {
               setParams({ baseColor: value as BaseColorName })
             }}
+            onItemPreview={
+              isMobile
+                ? undefined
+                : (value) => setOverride({ baseColor: value as BaseColorName })
+            }
           >
             <PickerGroup>
               {BASE_COLORS.map((baseColor) => (

--- a/apps/v4/app/(app)/(create)/components/chart-color-picker.tsx
+++ b/apps/v4/app/(app)/(create)/components/chart-color-picker.tsx
@@ -18,6 +18,7 @@ import {
   PickerSeparator,
   PickerTrigger,
 } from "@/app/(app)/(create)/components/picker"
+import { usePreviewOverride } from "@/app/(app)/(create)/components/preview-override"
 import { useDesignSystemSearchParams } from "@/app/(app)/(create)/lib/search-params"
 
 export function ChartColorPicker({
@@ -29,6 +30,7 @@ export function ChartColorPicker({
 }) {
   const mounted = useMounted()
   const [params, setParams] = useDesignSystemSearchParams()
+  const { setOverride, clearOverride } = usePreviewOverride()
 
   const availableChartColors = React.useMemo(
     () => getThemesForBaseColor(params.baseColor),
@@ -48,7 +50,13 @@ export function ChartColorPicker({
 
   return (
     <div className="group/picker relative">
-      <Picker>
+      <Picker
+        onOpenChange={(open) => {
+          if (!open) {
+            clearOverride()
+          }
+        }}
+      >
         <PickerTrigger>
           <div className="flex flex-col justify-start text-left">
             <div className="text-xs text-muted-foreground">Chart Color</div>
@@ -77,12 +85,19 @@ export function ChartColorPicker({
           side={isMobile ? "top" : "right"}
           align={isMobile ? "center" : "start"}
           className="max-h-92"
+          onMouseLeave={clearOverride}
         >
           <PickerRadioGroup
             value={currentChartColor?.name}
             onValueChange={(value) => {
               setParams({ chartColor: value as ChartColorName })
             }}
+            onItemPreview={
+              isMobile
+                ? undefined
+                : (value) =>
+                    setOverride({ chartColor: value as ChartColorName })
+            }
           >
             <PickerGroup>
               {availableChartColors

--- a/apps/v4/app/(app)/(create)/components/font-picker.tsx
+++ b/apps/v4/app/(app)/(create)/components/font-picker.tsx
@@ -13,6 +13,7 @@ import {
   PickerSeparator,
   PickerTrigger,
 } from "@/app/(app)/(create)/components/picker"
+import { usePreviewOverride } from "@/app/(app)/(create)/components/preview-override"
 import { FONTS } from "@/app/(app)/(create)/lib/fonts"
 import {
   useDesignSystemSearchParams,
@@ -44,6 +45,7 @@ export function FontPicker({
   anchorRef: React.RefObject<HTMLDivElement | null>
 }) {
   const [params, setParams] = useDesignSystemSearchParams()
+  const { setOverride, clearOverride } = usePreviewOverride()
   const currentValue = param === "font" ? params.font : params.fontHeading
   const handleFontChange = React.useCallback(
     (value: string) => {
@@ -93,7 +95,13 @@ export function FontPicker({
 
   return (
     <div className="group/picker relative">
-      <Picker>
+      <Picker
+        onOpenChange={(open) => {
+          if (!open) {
+            clearOverride()
+          }
+        }}
+      >
         <PickerTrigger>
           <div className="flex flex-col justify-start text-left">
             <div className="text-xs text-muted-foreground">{label}</div>
@@ -117,10 +125,19 @@ export function FontPicker({
           side={isMobile ? "top" : "right"}
           align={isMobile ? "center" : "start"}
           className="max-h-96"
+          onMouseLeave={clearOverride}
         >
           <PickerRadioGroup
             value={currentValue}
             onValueChange={handleFontChange}
+            onItemPreview={
+              isMobile
+                ? undefined
+                : (value) =>
+                    setOverride({
+                      [param]: value,
+                    } as Partial<DesignSystemSearchParams>)
+            }
           >
             {param === "fontHeading" ? (
               <>

--- a/apps/v4/app/(app)/(create)/components/icon-library-picker.tsx
+++ b/apps/v4/app/(app)/(create)/components/icon-library-picker.tsx
@@ -12,6 +12,7 @@ import {
   PickerRadioItem,
   PickerTrigger,
 } from "@/app/(app)/(create)/components/picker"
+import { usePreviewOverride } from "@/app/(app)/(create)/components/preview-override"
 import { useDesignSystemSearchParams } from "@/app/(app)/(create)/lib/search-params"
 
 const logos = {
@@ -117,6 +118,7 @@ export function IconLibraryPicker({
   anchorRef: React.RefObject<HTMLDivElement | null>
 }) {
   const [params, setParams] = useDesignSystemSearchParams()
+  const { setOverride, clearOverride } = usePreviewOverride()
 
   const currentIconLibrary = React.useMemo(
     () => iconLibraries[params.iconLibrary as keyof typeof iconLibraries],
@@ -125,7 +127,13 @@ export function IconLibraryPicker({
 
   return (
     <div className="group/picker relative">
-      <Picker>
+      <Picker
+        onOpenChange={(open) => {
+          if (!open) {
+            clearOverride()
+          }
+        }}
+      >
         <PickerTrigger>
           <div className="flex flex-col justify-start text-left">
             <div className="text-xs text-muted-foreground">Icon Library</div>
@@ -141,12 +149,19 @@ export function IconLibraryPicker({
           anchor={isMobile ? anchorRef : undefined}
           side={isMobile ? "top" : "right"}
           align={isMobile ? "center" : "start"}
+          onMouseLeave={clearOverride}
         >
           <PickerRadioGroup
             value={currentIconLibrary?.name}
             onValueChange={(value) => {
               setParams({ iconLibrary: value as IconLibraryName })
             }}
+            onItemPreview={
+              isMobile
+                ? undefined
+                : (value) =>
+                    setOverride({ iconLibrary: value as IconLibraryName })
+            }
           >
             <PickerGroup>
               {Object.values(iconLibraries).map((iconLibrary) => (

--- a/apps/v4/app/(app)/(create)/components/menu-picker.tsx
+++ b/apps/v4/app/(app)/(create)/components/menu-picker.tsx
@@ -18,6 +18,7 @@ import {
   PickerSeparator,
   PickerTrigger,
 } from "@/app/(app)/(create)/components/picker"
+import { usePreviewOverride } from "@/app/(app)/(create)/components/preview-override"
 import {
   isTranslucentMenuColor,
   useDesignSystemSearchParams,
@@ -52,6 +53,7 @@ export function MenuColorPicker({
   anchorRef: React.RefObject<HTMLDivElement | null>
 }) {
   const [params, setParams] = useDesignSystemSearchParams()
+  const { setOverride, clearOverride } = usePreviewOverride()
   const { resolvedTheme } = useTheme()
   const mounted = useMounted()
   const lastSolidMenuAccentRef = React.useRef(params.menuAccent)
@@ -98,9 +100,40 @@ export function MenuColorPicker({
     })
   }
 
+  // Hover previews mirror setColor/setSurface, including the menuAccent
+  // coupling, so the previewed state matches what a click would commit.
+  const previewColor = (color: ColorChoice) => {
+    const nextMenuColor = getMenuColorValue(
+      color,
+      surfaceChoice === "translucent"
+    )
+
+    setOverride({
+      menuColor: nextMenuColor,
+      ...(isTranslucentMenuColor(nextMenuColor) && {
+        menuAccent: "subtle" as const,
+      }),
+    })
+  }
+
+  const previewSurface = (choice: SurfaceChoice) => {
+    const isTranslucent = choice === "translucent"
+
+    setOverride({
+      menuColor: getMenuColorValue(colorChoice, isTranslucent),
+      menuAccent: isTranslucent ? "subtle" : lastSolidMenuAccentRef.current,
+    })
+  }
+
   return (
     <div className="group/picker relative">
-      <Picker>
+      <Picker
+        onOpenChange={(open) => {
+          if (!open) {
+            clearOverride()
+          }
+        }}
+      >
         <PickerTrigger>
           <div className="flex flex-col justify-start text-left">
             <div className="text-xs text-muted-foreground">Menu</div>
@@ -120,6 +153,7 @@ export function MenuColorPicker({
           anchor={isMobile ? anchorRef : undefined}
           side={isMobile ? "top" : "right"}
           align={isMobile ? "center" : "start"}
+          onMouseLeave={clearOverride}
         >
           <PickerGroup>
             <PickerLabel>Color</PickerLabel>
@@ -128,6 +162,11 @@ export function MenuColorPicker({
               onValueChange={(value) => {
                 setColor(value as ColorChoice)
               }}
+              onItemPreview={
+                isMobile
+                  ? undefined
+                  : (value) => previewColor(value as ColorChoice)
+              }
             >
               <PickerRadioItem value="default" closeOnClick={isMobile}>
                 Default
@@ -149,6 +188,11 @@ export function MenuColorPicker({
               onValueChange={(value) => {
                 setSurface(value as SurfaceChoice)
               }}
+              onItemPreview={
+                isMobile
+                  ? undefined
+                  : (value) => previewSurface(value as SurfaceChoice)
+              }
             >
               <PickerRadioItem value="solid" closeOnClick={isMobile}>
                 Solid

--- a/apps/v4/app/(app)/(create)/components/picker.tsx
+++ b/apps/v4/app/(app)/(create)/components/picker.tsx
@@ -202,23 +202,54 @@ function PickerCheckboxItem({
   )
 }
 
-function PickerRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+// Lets pickers preview an item's value on hover/highlight by declaring a
+// single onItemPreview on the group instead of wiring every radio item.
+const PickerPreviewContext = React.createContext<
+  ((value: string) => void) | null
+>(null)
+
+function PickerRadioGroup({
+  onItemPreview,
+  ...props
+}: MenuPrimitive.RadioGroup.Props & {
+  onItemPreview?: (value: string) => void
+}) {
   return (
-    <MenuPrimitive.RadioGroup
-      data-slot="dropdown-menu-radio-group"
-      {...props}
-    />
+    <PickerPreviewContext.Provider value={onItemPreview ?? null}>
+      <MenuPrimitive.RadioGroup
+        data-slot="dropdown-menu-radio-group"
+        {...props}
+      />
+    </PickerPreviewContext.Provider>
   )
 }
 
 function PickerRadioItem({
   className,
   children,
+  value,
+  onMouseMove,
+  onFocus,
   ...props
 }: MenuPrimitive.RadioItem.Props) {
+  const onItemPreview = React.useContext(PickerPreviewContext)
+
   return (
     <MenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
+      value={value}
+      // Previews apply when the pointer settles: every mousemove re-arms the
+      // provider's trailing timer, so nothing applies while the cursor is in
+      // motion. Base UI moves DOM focus to the highlighted item, so onFocus
+      // covers keyboard (arrow key) browsing.
+      onMouseMove={(event) => {
+        onMouseMove?.(event)
+        onItemPreview?.(value as string)
+      }}
+      onFocus={(event) => {
+        onFocus?.(event)
+        onItemPreview?.(value as string)
+      }}
       className={cn(
         "relative flex cursor-default items-center gap-2 rounded-lg py-1.5 pr-8 pl-2 text-sm font-medium outline-hidden select-none **:text-neutral-100 focus:bg-neutral-600 focus:text-neutral-100 focus:**:text-neutral-100 data-inset:pl-8 dark:focus:bg-neutral-700/80 pointer-coarse:gap-3 pointer-coarse:py-2.5 pointer-coarse:pl-3 pointer-coarse:text-base data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className

--- a/apps/v4/app/(app)/(create)/components/preview-override.tsx
+++ b/apps/v4/app/(app)/(create)/components/preview-override.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import * as React from "react"
+
+import type { DesignSystemSearchParams } from "@/app/(app)/(create)/lib/search-params"
+
+// Uncommitted params applied to the preview while hovering a picker item.
+// Kept out of the URL on purpose: committing to the URL would re-encode the
+// preset code and push a history entry for every hovered item, polluting
+// undo/redo and shareable links. The preview iframe receives these via the
+// same postMessage channel as committed params and reverts when cleared.
+type PreviewOverride = Partial<DesignSystemSearchParams> | null
+
+// How long the pointer must settle before a preview applies. Every mousemove
+// over a picker item re-arms this trailing timer, so nothing applies while
+// the cursor is in motion — each application is a full theme rewrite in the
+// iframe. Clears are never debounced: reverting on leave/Escape must feel
+// instant.
+const PREVIEW_OVERRIDE_DEBOUNCE_MS = 50
+
+// The value and the actions live in separate contexts so pickers (which only
+// call the stable setters) never re-render while a preview is applied. Only
+// the preview iframe host subscribes to the value.
+const PreviewOverrideValueContext = React.createContext<PreviewOverride>(null)
+
+const PreviewOverrideActionsContext = React.createContext<{
+  setOverride: (override: Partial<DesignSystemSearchParams>) => void
+  clearOverride: () => void
+} | null>(null)
+
+function isSameOverride(a: PreviewOverride, b: PreviewOverride) {
+  if (a === b) {
+    return true
+  }
+
+  if (!a || !b) {
+    return false
+  }
+
+  const aKeys = Object.keys(a) as (keyof DesignSystemSearchParams)[]
+  const bKeys = Object.keys(b) as (keyof DesignSystemSearchParams)[]
+
+  return (
+    aKeys.length === bKeys.length && aKeys.every((key) => a[key] === b[key])
+  )
+}
+
+export function PreviewOverrideProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [override, setOverrideState] = React.useState<PreviewOverride>(null)
+  const timeoutRef = React.useRef<number | null>(null)
+
+  const cancelPendingOverride = React.useCallback(() => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current)
+      timeoutRef.current = null
+    }
+  }, [])
+
+  React.useEffect(() => cancelPendingOverride, [cancelPendingOverride])
+
+  const setOverride = React.useCallback(
+    (next: Partial<DesignSystemSearchParams>) => {
+      cancelPendingOverride()
+      timeoutRef.current = window.setTimeout(() => {
+        timeoutRef.current = null
+        // Skip identical updates: mouseenter and focus both fire for the
+        // hovered item, and hovering the committed value is a no-op.
+        setOverrideState((current) =>
+          isSameOverride(current, next) ? current : next
+        )
+      }, PREVIEW_OVERRIDE_DEBOUNCE_MS)
+    },
+    [cancelPendingOverride]
+  )
+
+  const clearOverride = React.useCallback(() => {
+    cancelPendingOverride()
+    setOverrideState(null)
+  }, [cancelPendingOverride])
+
+  const actions = React.useMemo(
+    () => ({ setOverride, clearOverride }),
+    [setOverride, clearOverride]
+  )
+
+  return (
+    <PreviewOverrideActionsContext.Provider value={actions}>
+      <PreviewOverrideValueContext.Provider value={override}>
+        {children}
+      </PreviewOverrideValueContext.Provider>
+    </PreviewOverrideActionsContext.Provider>
+  )
+}
+
+// For pickers: stable setters only, never re-renders on override changes.
+export function usePreviewOverride() {
+  const context = React.useContext(PreviewOverrideActionsContext)
+
+  if (!context) {
+    throw new Error(
+      "usePreviewOverride must be used within a PreviewOverrideProvider."
+    )
+  }
+
+  return context
+}
+
+// For the preview iframe host: the current override value.
+export function usePreviewOverrideValue() {
+  return React.useContext(PreviewOverrideValueContext)
+}

--- a/apps/v4/app/(app)/(create)/components/preview.tsx
+++ b/apps/v4/app/(app)/(create)/components/preview.tsx
@@ -9,6 +9,7 @@ import {
   UNDO_FORWARD_TYPE,
 } from "@/app/(app)/(create)/components/history-buttons"
 import { DARK_MODE_FORWARD_TYPE } from "@/app/(app)/(create)/components/mode-switcher"
+import { usePreviewOverrideValue } from "@/app/(app)/(create)/components/preview-override"
 import { PreviewSwitcher } from "@/app/(app)/(create)/components/preview-switcher"
 import { RANDOMIZE_FORWARD_TYPE } from "@/app/(app)/(create)/components/random-button"
 import { sendToIframe } from "@/app/(app)/(create)/hooks/use-iframe-sync"
@@ -22,9 +23,31 @@ import {
 // Hoisted — avoids recreating on every message event. (js-hoist-regexp)
 const MAC_REGEX = /Mac|iPhone|iPad|iPod/
 
+function isSameParams(
+  a: ReturnType<typeof useDesignSystemSearchParams>[0] | null,
+  b: ReturnType<typeof useDesignSystemSearchParams>[0]
+) {
+  if (!a) {
+    return false
+  }
+
+  return Object.keys(b).every(
+    (key) => a[key as keyof typeof b] === b[key as keyof typeof b]
+  )
+}
+
 export function Preview() {
   const [params] = useDesignSystemSearchParams()
+  const override = usePreviewOverrideValue()
   const iframeRef = React.useRef<HTMLIFrameElement>(null)
+  const lastSentParamsRef = React.useRef<typeof params | null>(null)
+
+  // Hover previews overlay the committed params without touching the URL —
+  // clearing the override re-sends the committed params, reverting the preview.
+  const mergedParams = React.useMemo(
+    () => (override ? { ...params, ...override } : params),
+    [params, override]
+  )
 
   React.useEffect(() => {
     const iframe = iframeRef.current
@@ -33,10 +56,16 @@ export function Preview() {
     }
 
     const sendParams = () => {
-      sendToIframe(iframe, "design-system-params", params)
+      sendToIframe(iframe, "design-system-params", mergedParams)
+      lastSentParamsRef.current = mergedParams
     }
 
-    if (iframe.contentWindow) {
+    // Skip content-identical re-sends (e.g. an override matching the committed
+    // params) — each message triggers a full param sync in the iframe.
+    if (
+      iframe.contentWindow &&
+      !isSameParams(lastSentParamsRef.current, mergedParams)
+    ) {
       sendParams()
     }
 
@@ -44,7 +73,7 @@ export function Preview() {
     return () => {
       iframe.removeEventListener("load", sendParams)
     }
-  }, [params])
+  }, [mergedParams])
 
   React.useEffect(() => {
     const handleMessage = (event: MessageEvent) => {

--- a/apps/v4/app/(app)/(create)/components/radius-picker.tsx
+++ b/apps/v4/app/(app)/(create)/components/radius-picker.tsx
@@ -13,6 +13,7 @@ import {
   PickerSeparator,
   PickerTrigger,
 } from "@/app/(app)/(create)/components/picker"
+import { usePreviewOverride } from "@/app/(app)/(create)/components/preview-override"
 import { useDesignSystemSearchParams } from "@/app/(app)/(create)/lib/search-params"
 
 export function RadiusPicker({
@@ -23,6 +24,7 @@ export function RadiusPicker({
   anchorRef: React.RefObject<HTMLDivElement | null>
 }) {
   const [params, setParams] = useDesignSystemSearchParams()
+  const { setOverride, clearOverride } = usePreviewOverride()
   const isRadiusLocked = params.style === "lyra" || params.style === "sera"
   const selectedRadiusName = isRadiusLocked ? "none" : params.radius
 
@@ -34,7 +36,13 @@ export function RadiusPicker({
 
   return (
     <div className="group/picker relative">
-      <Picker>
+      <Picker
+        onOpenChange={(open) => {
+          if (!open) {
+            clearOverride()
+          }
+        }}
+      >
         <PickerTrigger disabled={isRadiusLocked}>
           <div className="flex flex-col justify-start text-left">
             <div className="text-xs text-muted-foreground">Radius</div>
@@ -65,6 +73,7 @@ export function RadiusPicker({
           anchor={isMobile ? anchorRef : undefined}
           side={isMobile ? "top" : "right"}
           align={isMobile ? "center" : "start"}
+          onMouseLeave={clearOverride}
         >
           <PickerRadioGroup
             value={currentRadius?.name}
@@ -74,6 +83,11 @@ export function RadiusPicker({
               }
               setParams({ radius: value as RadiusValue })
             }}
+            onItemPreview={
+              isMobile || isRadiusLocked
+                ? undefined
+                : (value) => setOverride({ radius: value as RadiusValue })
+            }
           >
             <PickerGroup>
               {defaultRadius && (

--- a/apps/v4/app/(app)/(create)/components/style-picker.tsx
+++ b/apps/v4/app/(app)/(create)/components/style-picker.tsx
@@ -12,6 +12,7 @@ import {
   PickerRadioItem,
   PickerTrigger,
 } from "@/app/(app)/(create)/components/picker"
+import { usePreviewOverride } from "@/app/(app)/(create)/components/preview-override"
 import { useDesignSystemSearchParams } from "@/app/(app)/(create)/lib/search-params"
 
 export function StylePicker({
@@ -24,12 +25,19 @@ export function StylePicker({
   anchorRef: React.RefObject<HTMLDivElement | null>
 }) {
   const [params, setParams] = useDesignSystemSearchParams()
+  const { setOverride, clearOverride } = usePreviewOverride()
 
   const currentStyle = styles.find((style) => style.name === params.style)
 
   return (
     <div className="group/picker relative">
-      <Picker>
+      <Picker
+        onOpenChange={(open) => {
+          if (!open) {
+            clearOverride()
+          }
+        }}
+      >
         <PickerTrigger>
           <div className="flex flex-col justify-start text-left">
             <div className="text-xs text-muted-foreground">Style</div>
@@ -49,12 +57,18 @@ export function StylePicker({
           anchor={isMobile ? anchorRef : undefined}
           side={isMobile ? "top" : "right"}
           align={isMobile ? "center" : "start"}
+          onMouseLeave={clearOverride}
         >
           <PickerRadioGroup
             value={currentStyle?.name}
             onValueChange={(value) => {
               setParams({ style: value as StyleName })
             }}
+            onItemPreview={
+              isMobile
+                ? undefined
+                : (value) => setOverride({ style: value as StyleName })
+            }
           >
             <PickerGroup>
               {styles.map((style) => (

--- a/apps/v4/app/(app)/(create)/components/theme-picker.tsx
+++ b/apps/v4/app/(app)/(create)/components/theme-picker.tsx
@@ -14,6 +14,7 @@ import {
   PickerSeparator,
   PickerTrigger,
 } from "@/app/(app)/(create)/components/picker"
+import { usePreviewOverride } from "@/app/(app)/(create)/components/preview-override"
 import { useDesignSystemSearchParams } from "@/app/(app)/(create)/lib/search-params"
 
 export function ThemePicker({
@@ -27,6 +28,7 @@ export function ThemePicker({
 }) {
   const mounted = useMounted()
   const [params, setParams] = useDesignSystemSearchParams()
+  const { setOverride, clearOverride } = usePreviewOverride()
 
   const currentTheme = React.useMemo(
     () => themes.find((theme) => theme.name === params.theme),
@@ -40,7 +42,13 @@ export function ThemePicker({
 
   return (
     <div className="group/picker relative">
-      <Picker>
+      <Picker
+        onOpenChange={(open) => {
+          if (!open) {
+            clearOverride()
+          }
+        }}
+      >
         <PickerTrigger>
           <div className="flex flex-col justify-start text-left">
             <div className="text-xs text-muted-foreground">Theme</div>
@@ -67,12 +75,18 @@ export function ThemePicker({
           side={isMobile ? "top" : "right"}
           align={isMobile ? "center" : "start"}
           className="max-h-92"
+          onMouseLeave={clearOverride}
         >
           <PickerRadioGroup
             value={currentTheme?.name}
             onValueChange={(value) => {
               setParams({ theme: value as ThemeName })
             }}
+            onItemPreview={
+              isMobile
+                ? undefined
+                : (value) => setOverride({ theme: value as ThemeName })
+            }
           >
             <PickerGroup>
               {themes

--- a/apps/v4/app/(app)/(create)/create/page.tsx
+++ b/apps/v4/app/(app)/(create)/create/page.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from "@/styles/base-nova/ui/skeleton"
 import { Customizer } from "@/app/(app)/(create)/components/customizer"
 import { PresetHandler } from "@/app/(app)/(create)/components/preset-handler"
 import { Preview } from "@/app/(app)/(create)/components/preview"
+import { PreviewOverrideProvider } from "@/app/(app)/(create)/components/preview-override"
 import { getAllItems } from "@/app/(app)/(create)/lib/api"
 
 // Only shown on first visit (checks localStorage).
@@ -53,14 +54,16 @@ export default function CreatePage() {
         data-slot="designer"
         className="flex min-h-0 flex-1 flex-col gap-(--gap) p-(--gap) pt-[calc(var(--gap)*0.25)] md:flex-row-reverse"
       >
-        <Preview />
-        <Suspense
-          fallback={
-            <Skeleton className="isolate min-h-[151px] w-full self-start rounded-2xl md:h-full md:max-h-full md:min-h-0 md:w-(--customizer-width)" />
-          }
-        >
-          <CustomizerLoader />
-        </Suspense>
+        <PreviewOverrideProvider>
+          <Preview />
+          <Suspense
+            fallback={
+              <Skeleton className="isolate min-h-[151px] w-full self-start rounded-2xl md:h-full md:max-h-full md:min-h-0 md:w-(--customizer-width)" />
+            }
+          >
+            <CustomizerLoader />
+          </Suspense>
+        </PreviewOverrideProvider>
       </div>
       <PresetHandler />
       <WelcomeDialog />

--- a/apps/v4/app/(app)/(typeset)/components/font-picker.tsx
+++ b/apps/v4/app/(app)/(typeset)/components/font-picker.tsx
@@ -11,6 +11,7 @@ import {
   PickerSeparator,
   PickerTrigger,
 } from "@/app/(app)/(typeset)/components/picker"
+import { usePreviewOverride } from "@/app/(app)/(typeset)/components/preview-override"
 import { findFont, FONTS } from "@/app/(app)/(typeset)/lib/fonts"
 import {
   coerceTypesetValue,
@@ -29,6 +30,7 @@ export function FontPicker({
   anchorRef: React.RefObject<HTMLDivElement | null>
 }) {
   const [params, setParams] = useTypesetSearchParams()
+  const { setOverride, clearOverride } = usePreviewOverride()
   const currentValue =
     param === "body"
       ? params.body
@@ -50,7 +52,13 @@ export function FontPicker({
 
   return (
     <div className="group/picker relative">
-      <Picker>
+      <Picker
+        onOpenChange={(open) => {
+          if (!open) {
+            clearOverride()
+          }
+        }}
+      >
         <PickerTrigger>
           <div className="flex flex-col justify-start text-left">
             <div className="text-xs text-muted-foreground">{label}</div>
@@ -70,6 +78,7 @@ export function FontPicker({
           side={isMobile ? "top" : "right"}
           align={isMobile ? "center" : "start"}
           className="max-h-96"
+          onMouseLeave={clearOverride}
         >
           <PickerRadioGroup
             value={currentValue}
@@ -85,6 +94,16 @@ export function FontPicker({
                 if (value !== null) setParams({ mono: value })
               }
             }}
+            onItemPreview={
+              isMobile
+                ? undefined
+                : (next) => {
+                    const value = coerceTypesetValue(param, next)
+                    if (value !== null) {
+                      setOverride({ [param]: value })
+                    }
+                  }
+            }
           >
             {param === "heading" ? (
               <>

--- a/apps/v4/app/(app)/(typeset)/components/option-picker.tsx
+++ b/apps/v4/app/(app)/(typeset)/components/option-picker.tsx
@@ -11,7 +11,9 @@ import {
   PickerRadioItem,
   PickerTrigger,
 } from "@/app/(app)/(typeset)/components/picker"
+import { usePreviewOverride } from "@/app/(app)/(typeset)/components/preview-override"
 import { type LockableParam } from "@/app/(app)/(typeset)/hooks/use-locks"
+import { coerceTypesetValue } from "@/app/(app)/(typeset)/lib/search-params"
 
 export function OptionPicker<T extends string>({
   label,
@@ -34,11 +36,18 @@ export function OptionPicker<T extends string>({
   anchorRef: React.RefObject<HTMLDivElement | null>
   className?: string
 }) {
+  const { setOverride, clearOverride } = usePreviewOverride()
   const current = options.find((option) => option.value === value)
 
   return (
     <div className={cn("group/picker relative", className)}>
-      <Picker>
+      <Picker
+        onOpenChange={(open) => {
+          if (!open) {
+            clearOverride()
+          }
+        }}
+      >
         <PickerTrigger>
           <div className="flex min-w-0 flex-col justify-start pr-8 text-left">
             <div className="text-xs text-muted-foreground">{label}</div>
@@ -56,10 +65,21 @@ export function OptionPicker<T extends string>({
           anchor={isMobile ? anchorRef : undefined}
           side={isMobile ? "top" : "right"}
           align={isMobile ? "center" : "start"}
+          onMouseLeave={clearOverride}
         >
           <PickerRadioGroup
             value={value}
             onValueChange={(next) => onChange(next as T)}
+            onItemPreview={
+              isMobile || !param
+                ? undefined
+                : (next) => {
+                    const coerced = coerceTypesetValue(param, next)
+                    if (coerced !== null) {
+                      setOverride({ [param]: coerced })
+                    }
+                  }
+            }
           >
             {options.map((option) => (
               <PickerRadioItem key={option.value} value={option.value}>

--- a/apps/v4/app/(app)/(typeset)/components/picker.tsx
+++ b/apps/v4/app/(app)/(typeset)/components/picker.tsx
@@ -111,23 +111,54 @@ function PickerItem({
   )
 }
 
-function PickerRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+// Lets pickers preview an item's value on hover/highlight by declaring a
+// single onItemPreview on the group instead of wiring every radio item.
+const PickerPreviewContext = React.createContext<
+  ((value: string) => void) | null
+>(null)
+
+function PickerRadioGroup({
+  onItemPreview,
+  ...props
+}: MenuPrimitive.RadioGroup.Props & {
+  onItemPreview?: (value: string) => void
+}) {
   return (
-    <MenuPrimitive.RadioGroup
-      data-slot="dropdown-menu-radio-group"
-      {...props}
-    />
+    <PickerPreviewContext.Provider value={onItemPreview ?? null}>
+      <MenuPrimitive.RadioGroup
+        data-slot="dropdown-menu-radio-group"
+        {...props}
+      />
+    </PickerPreviewContext.Provider>
   )
 }
 
 function PickerRadioItem({
   className,
   children,
+  value,
+  onMouseMove,
+  onFocus,
   ...props
 }: MenuPrimitive.RadioItem.Props) {
+  const onItemPreview = React.useContext(PickerPreviewContext)
+
   return (
     <MenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
+      value={value}
+      // Previews apply when the pointer settles: every mousemove re-arms the
+      // provider's trailing timer, so nothing applies while the cursor is in
+      // motion. Base UI moves DOM focus to the highlighted item, so onFocus
+      // covers keyboard (arrow key) browsing.
+      onMouseMove={(event) => {
+        onMouseMove?.(event)
+        onItemPreview?.(value as string)
+      }}
+      onFocus={(event) => {
+        onFocus?.(event)
+        onItemPreview?.(value as string)
+      }}
       className={cn(
         "relative flex cursor-default items-center gap-2 rounded-lg py-1.5 pr-8 pl-2 text-sm font-medium outline-hidden select-none **:text-neutral-100 focus:bg-neutral-600 focus:text-neutral-100 focus:**:text-neutral-100 data-inset:pl-8 dark:focus:bg-neutral-700/80 pointer-coarse:gap-3 pointer-coarse:py-2.5 pointer-coarse:pl-3 pointer-coarse:text-base data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className

--- a/apps/v4/app/(app)/(typeset)/components/preview-override.tsx
+++ b/apps/v4/app/(app)/(typeset)/components/preview-override.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import * as React from "react"
+
+import type { TypesetSearchParams } from "@/app/(app)/(typeset)/lib/search-params"
+
+// Uncommitted params applied to the preview while hovering a picker item.
+// Kept out of the URL on purpose: the URL is what the custom typeset history
+// snapshots, so committing hovers would record a phantom undo entry for every
+// hovered item. The preview iframe receives these via the same postMessage
+// channel as committed params and reverts when cleared. Mirrors create's
+// preview-override.
+type PreviewOverride = Partial<TypesetSearchParams> | null
+
+// How long the pointer must settle before a preview applies. Every mousemove
+// over a picker item re-arms this trailing timer, so nothing applies while
+// the cursor is in motion. Clears are never debounced: reverting on
+// leave/Escape must feel instant.
+const PREVIEW_OVERRIDE_DEBOUNCE_MS = 50
+
+// The value and the actions live in separate contexts so pickers (which only
+// call the stable setters) never re-render while a preview is applied. Only
+// the preview iframe host subscribes to the value.
+const PreviewOverrideValueContext = React.createContext<PreviewOverride>(null)
+
+const PreviewOverrideActionsContext = React.createContext<{
+  setOverride: (override: Partial<TypesetSearchParams>) => void
+  clearOverride: () => void
+} | null>(null)
+
+function isSameOverride(a: PreviewOverride, b: PreviewOverride) {
+  if (a === b) {
+    return true
+  }
+
+  if (!a || !b) {
+    return false
+  }
+
+  const aKeys = Object.keys(a) as (keyof TypesetSearchParams)[]
+  const bKeys = Object.keys(b) as (keyof TypesetSearchParams)[]
+
+  return (
+    aKeys.length === bKeys.length && aKeys.every((key) => a[key] === b[key])
+  )
+}
+
+export function TypesetPreviewOverrideProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [override, setOverrideState] = React.useState<PreviewOverride>(null)
+  const timeoutRef = React.useRef<number | null>(null)
+
+  const cancelPendingOverride = React.useCallback(() => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current)
+      timeoutRef.current = null
+    }
+  }, [])
+
+  React.useEffect(() => cancelPendingOverride, [cancelPendingOverride])
+
+  const setOverride = React.useCallback(
+    (next: Partial<TypesetSearchParams>) => {
+      cancelPendingOverride()
+      timeoutRef.current = window.setTimeout(() => {
+        timeoutRef.current = null
+        // Skip identical updates: mouseenter and focus both fire for the
+        // hovered item, and hovering the committed value is a no-op.
+        setOverrideState((current) =>
+          isSameOverride(current, next) ? current : next
+        )
+      }, PREVIEW_OVERRIDE_DEBOUNCE_MS)
+    },
+    [cancelPendingOverride]
+  )
+
+  const clearOverride = React.useCallback(() => {
+    cancelPendingOverride()
+    setOverrideState(null)
+  }, [cancelPendingOverride])
+
+  const actions = React.useMemo(
+    () => ({ setOverride, clearOverride }),
+    [setOverride, clearOverride]
+  )
+
+  return (
+    <PreviewOverrideActionsContext.Provider value={actions}>
+      <PreviewOverrideValueContext.Provider value={override}>
+        {children}
+      </PreviewOverrideValueContext.Provider>
+    </PreviewOverrideActionsContext.Provider>
+  )
+}
+
+// For pickers: stable setters only, never re-renders on override changes.
+export function usePreviewOverride() {
+  const context = React.useContext(PreviewOverrideActionsContext)
+
+  if (!context) {
+    throw new Error(
+      "usePreviewOverride must be used within a TypesetPreviewOverrideProvider."
+    )
+  }
+
+  return context
+}
+
+// For the preview iframe host: the current override value.
+export function usePreviewOverrideValue() {
+  return React.useContext(PreviewOverrideValueContext)
+}

--- a/apps/v4/app/(app)/(typeset)/components/preview.tsx
+++ b/apps/v4/app/(app)/(typeset)/components/preview.tsx
@@ -6,6 +6,7 @@ import {
   TYPESET_COMMAND_MESSAGE,
   type TypesetCommand,
 } from "@/app/(app)/(typeset)/components/forward-scripts"
+import { usePreviewOverrideValue } from "@/app/(app)/(typeset)/components/preview-override"
 import { TypesetToolbar } from "@/app/(app)/(typeset)/components/toolbar"
 import { useHistory } from "@/app/(app)/(typeset)/hooks/use-history"
 import { useShuffle } from "@/app/(app)/(typeset)/hooks/use-shuffle"
@@ -14,10 +15,22 @@ import {
   serializeTypesetSearchParams,
   TYPESET_PARAMS_MESSAGE,
   useTypesetSearchParams,
+  type TypesetSearchParams,
 } from "@/app/(app)/(typeset)/lib/search-params"
+
+function isSameParams(a: TypesetSearchParams | null, b: TypesetSearchParams) {
+  if (!a) {
+    return false
+  }
+
+  return Object.keys(b).every(
+    (key) => a[key as keyof typeof b] === b[key as keyof typeof b]
+  )
+}
 
 export function TypesetPreview() {
   const [params] = useTypesetSearchParams()
+  const override = usePreviewOverrideValue()
   const { shuffle, reset } = useShuffle()
   const { goBack, goForward } = useHistory()
   const { toggleTheme } = useThemeToggle({ shortcut: false })
@@ -26,6 +39,16 @@ export function TypesetPreview() {
     serializeTypesetSearchParams(`/preview/typeset/${params.item}`, params)
   )
   const itemRef = React.useRef(params.item)
+  const lastSentParamsRef = React.useRef<TypesetSearchParams | null>(null)
+
+  // Hover previews overlay the committed params without touching the URL —
+  // clearing the override re-sends the committed params, reverting the
+  // preview. Overrides never contain `item`, so the reload branch below is
+  // only ever driven by committed changes.
+  const mergedParams = React.useMemo(
+    () => (override ? { ...params, ...override } : params),
+    [params, override]
+  )
 
   React.useEffect(() => {
     const iframe = iframeRef.current
@@ -33,28 +56,38 @@ export function TypesetPreview() {
       return
     }
 
-    if (params.item !== itemRef.current) {
-      itemRef.current = params.item
+    if (mergedParams.item !== itemRef.current) {
+      itemRef.current = mergedParams.item
       setPreviewUrl(
-        serializeTypesetSearchParams(`/preview/typeset/${params.item}`, params)
+        serializeTypesetSearchParams(
+          `/preview/typeset/${mergedParams.item}`,
+          mergedParams
+        )
       )
       return
     }
 
     const sendParams = () => {
       iframe.contentWindow?.postMessage(
-        { type: TYPESET_PARAMS_MESSAGE, data: params },
+        { type: TYPESET_PARAMS_MESSAGE, data: mergedParams },
         window.location.origin
       )
+      lastSentParamsRef.current = mergedParams
     }
 
-    sendParams()
+    // Skip content-identical re-sends (e.g. an override matching the
+    // committed params) — each message triggers a full param sync in the
+    // iframe.
+    if (!isSameParams(lastSentParamsRef.current, mergedParams)) {
+      sendParams()
+    }
+
     iframe.addEventListener("load", sendParams)
 
     return () => {
       iframe.removeEventListener("load", sendParams)
     }
-  }, [params])
+  }, [mergedParams])
 
   // The iframe forwards its keyboard shortcuts as typed commands; handle them
   // here by calling the real actions.

--- a/apps/v4/app/(app)/(typeset)/typeset/page.tsx
+++ b/apps/v4/app/(app)/(typeset)/typeset/page.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils"
 import { TypesetCustomizer } from "@/app/(app)/(typeset)/components/customizer"
 import { TypesetDocsPanel } from "@/app/(app)/(typeset)/components/docs-panel"
 import { TypesetPreview } from "@/app/(app)/(typeset)/components/preview"
+import { TypesetPreviewOverrideProvider } from "@/app/(app)/(typeset)/components/preview-override"
 import { previewFontVariables } from "@/app/(view)/preview/fonts"
 
 export const metadata: Metadata = {
@@ -24,8 +25,10 @@ export default function TypesetPage() {
         className="flex min-h-0 flex-1 flex-col items-start gap-(--gap) p-(--gap) pt-[calc(var(--gap)*0.25)] md:flex-row-reverse"
       >
         <TypesetDocsPanel />
-        <TypesetPreview />
-        <TypesetCustomizer />
+        <TypesetPreviewOverrideProvider>
+          <TypesetPreview />
+          <TypesetCustomizer />
+        </TypesetPreviewOverrideProvider>
       </div>
     </div>
   )


### PR DESCRIPTION
Hovering a picker item temporarily applies it to the preview, reverting on mouse leave, Escape, or menu close. Previews apply when the pointer settles and never touch the URL, so history, undo/redo, and preset codes only reflect committed changes.