### PR TITLE
fix: validate postMessage origins across iframe communication layer

### DIFF
--- a/apps/v4/app/(app)/(create)/components/action-menu.tsx
+++ b/apps/v4/app/(app)/(create)/components/action-menu.tsx
@@ -75,7 +75,7 @@ export function ActionMenuScript() {
                     window.parent.postMessage({
                       type: '${CMD_K_FORWARD_TYPE}',
                       key: e.key
-                    }, '*');
+                    }, window.location.origin);
                   }
                 }
               });

--- a/apps/v4/app/(app)/(create)/components/history-buttons.tsx
+++ b/apps/v4/app/(app)/(create)/components/history-buttons.tsx
@@ -61,12 +61,12 @@ export function HistoryScript() {
                 if ((key === 'z' && e.shiftKey) || (key === 'y' && e.ctrlKey)) {
                   e.preventDefault();
                   if (window.parent && window.parent !== window) {
-                    window.parent.postMessage({ type: '${REDO_FORWARD_TYPE}' }, '*');
+                    window.parent.postMessage({ type: '${REDO_FORWARD_TYPE}' }, window.location.origin);
                   }
                 } else if (key === 'z') {
                   e.preventDefault();
                   if (window.parent && window.parent !== window) {
-                    window.parent.postMessage({ type: '${UNDO_FORWARD_TYPE}' }, '*');
+                    window.parent.postMessage({ type: '${UNDO_FORWARD_TYPE}' }, window.location.origin);
                   }
                 }
               });

--- a/apps/v4/app/(app)/(create)/components/mode-switcher.tsx
+++ b/apps/v4/app/(app)/(create)/components/mode-switcher.tsx
@@ -74,7 +74,7 @@ export function DarkModeScript() {
                     window.parent.postMessage({
                       type: '${DARK_MODE_FORWARD_TYPE}',
                       key: e.key
-                    }, '*');
+                    }, window.location.origin);
                   }
                 }
               });

--- a/apps/v4/app/(app)/(create)/components/open-preset.tsx
+++ b/apps/v4/app/(app)/(create)/components/open-preset.tsx
@@ -190,7 +190,7 @@ export function OpenPresetScript() {
                     window.parent.postMessage({
                       type: '${OPEN_PRESET_FORWARD_TYPE}',
                       key: e.key
-                    }, '*');
+                    }, window.location.origin);
                   }
                 }
               });

--- a/apps/v4/app/(app)/(create)/components/random-button.tsx
+++ b/apps/v4/app/(app)/(create)/components/random-button.tsx
@@ -60,7 +60,7 @@ export function RandomizeScript() {
                     window.parent.postMessage({
                       type: type,
                       key: e.key
-                    }, '*');
+                    }, window.location.origin);
                   }
                 }
               });

--- a/apps/v4/app/(app)/(create)/hooks/use-iframe-sync.tsx
+++ b/apps/v4/app/(app)/(create)/hooks/use-iframe-sync.tsx
@@ -35,6 +35,10 @@ export function useIframeMessageListener<
     }
 
     const handleMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) {
+        return
+      }
+
       if (event.data.type === messageType) {
         onMessageRef.current(event.data.data)
       }
@@ -64,6 +68,6 @@ export function sendToIframe<
       type: messageType,
       data,
     },
-    "*"
+    window.location.origin
   )
 }

--- a/apps/v4/app/(app)/(typeset)/components/preview-provider.tsx
+++ b/apps/v4/app/(app)/(typeset)/components/preview-provider.tsx
@@ -37,6 +37,10 @@ export function TypesetPreviewProvider({
 
   React.useEffect(() => {
     function onMessage(event: MessageEvent) {
+      if (event.origin !== window.location.origin) {
+        return
+      }
+
       if (event.data?.type === TYPESET_PARAMS_MESSAGE && event.data.data) {
         setParams(event.data.data)
       }

--- a/apps/v4/components/mode-switcher.tsx
+++ b/apps/v4/components/mode-switcher.tsx
@@ -84,7 +84,7 @@ export function DarkModeScript() {
                     window.parent.postMessage({
                       type: '${DARK_MODE_FORWARD_TYPE}',
                       key: e.key
-                    }, '*');
+                    }, window.location.origin);
                   }
                 }
               });


### PR DESCRIPTION
## Description

The `(create)` section's iframe communication layer accepts and sends `postMessage` events without origin validation, while the `(typeset)` section already validates origins correctly. This PR brings the entire iframe communication layer to the same security standard.

### Problem

**Unvalidated listeners** — Two message listeners accept events from any origin:

- `useIframeMessageListener` in `use-iframe-sync.tsx` — the shared, reusable hook that downstream developers are most likely to copy — checks only `event.data.type` before calling `onMessageRef.current(event.data.data)`.
- `TypesetPreviewProvider` in `preview-provider.tsx` — accepts any origin and calls `setParams(event.data.data)`, mutating internal React state.

**Wildcard target origin** — `sendToIframe()` in `use-iframe-sync.tsx` broadcasts messages using `postMessage({…}, "*")`, and all six iframe-to-parent forward scripts in the `(create)` section do the same.

The `(typeset)` section already uses `window.location.origin` everywhere (e.g. `forward-scripts.tsx`, `preview.tsx`), confirming this was an intentional pattern that the `(create)` side was not yet aligned with.

### Changes

**Core fixes (unvalidated listeners):**
- `use-iframe-sync.tsx` — Added `event.origin !== window.location.origin` guard in `handleMessage`; changed `sendToIframe` target from `"*"` to `window.location.origin`.
- `preview-provider.tsx` — Added `event.origin !== window.location.origin` guard in `onMessage`.

**Consistency fixes (wildcard target origins):**
- `action-menu.tsx`, `history-buttons.tsx`, `mode-switcher.tsx` (create), `open-preset.tsx`, `random-button.tsx`, `components/mode-switcher.tsx` — Replaced `'*'` with `window.location.origin` in `postMessage` calls, matching the pattern already used in the typeset forward scripts.

### What is NOT changed

`create/preview.tsx` and `typeset/preview.tsx` parent-side listeners already validate both `event.origin` and `event.source` — no changes needed there.

### Testing

Verified locally with `pnpm --filter=v4 dev` — iframe sync for both the create (design system) and typeset preview flows works correctly since parent and iframe share the same origin. Cross-origin messages are now blocked as expected.
