### PR TITLE
feat(react): add releaseAutoScroll to useMessageScroller

### DIFF
--- a/.changeset/message-scroller-release-auto-scroll.md
+++ b/.changeset/message-scroller-release-auto-scroll.md
@@ -1,0 +1,5 @@
+---
+"@shadcn/react": minor
+---
+
+Add `releaseAutoScroll()` to `useMessageScroller()`. It releases `autoScroll`'s follow-bottom (and any turn anchoring) exactly as a wheel/touch/keyboard scroll does, so consumers can hand scroll control back to the reader before growing content in response to a user action — expanding a collapsed section, a "show more" toggle. Without it, `autoScroll` treats that growth as new output and re-pins the viewport to the end, scrolling the just-expanded content out of view. It is a no-op when nothing is being followed.

--- a/apps/v4/content/docs/react/message-scroller.mdx
+++ b/apps/v4/content/docs/react/message-scroller.mdx
@@ -232,16 +232,24 @@ removed from the tab order when there is nothing to scroll toward.
 
 Imperative transcript controls.
 
-| Method            | Type                                       | Description                     |
-| ----------------- | ------------------------------------------ | ------------------------------- |
-| `scrollToMessage` | `(messageId: string, options?) => boolean` | Scroll to a mounted message id. |
-| `scrollToEnd`     | `(options?) => boolean`                    | Scroll to the latest message.   |
-| `scrollToStart`   | `(options?) => boolean`                    | Scroll to the top.              |
+| Method             | Type                                       | Description                                  |
+| ------------------ | ------------------------------------------ | -------------------------------------------- |
+| `scrollToMessage`  | `(messageId: string, options?) => boolean` | Scroll to a mounted message id.              |
+| `scrollToEnd`      | `(options?) => boolean`                    | Scroll to the latest message.                |
+| `scrollToStart`    | `(options?) => boolean`                    | Scroll to the top.                           |
+| `releaseAutoScroll`| `() => void`                               | Release follow-bottom / turn-anchoring.      |
 
 All commands return `false` when the command could not be applied.
 `scrollToStart` and `scrollToEnd` return `false` only when the viewport is not
 mounted yet. `scrollToMessage` returns `false` when the target is not mounted and
 cannot be queued.
+
+`releaseAutoScroll` hands scroll control back to the reader the same way a
+wheel, touch, or keyboard scroll does: it releases `autoScroll`'s follow-bottom
+(and any turn anchoring) so the viewport stays put. Call it when you grow
+content in response to a user action — expanding a collapsed section, a "show
+more" toggle — so `autoScroll` does not treat that growth as new output and
+re-pin the viewport to the end. It is a no-op when nothing is being followed.
 
 Command options:
 

--- a/packages/react/src/message-scroller/README.md
+++ b/packages/react/src/message-scroller/README.md
@@ -45,7 +45,7 @@ All from `@shadcn/react/message-scroller`.
 
 | Hook                             | Returns                                                                     |
 | -------------------------------- | --------------------------------------------------------------------------- |
-| `useMessageScroller()`           | `{ scrollToMessage, scrollToStart, scrollToEnd }`                           |
+| `useMessageScroller()`           | `{ scrollToMessage, scrollToStart, scrollToEnd, releaseAutoScroll }`         |
 | `useMessageScrollerScrollable()` | `MessageScrollerScrollable` — `{ start, end }`, the edges the viewport can scroll toward |
 | `useMessageScrollerVisibility()` | `MessageScrollerVisibilityState` — `currentAnchorId`, `visibleMessageIds`   |
 

--- a/packages/react/src/message-scroller/components.tsx
+++ b/packages/react/src/message-scroller/components.tsx
@@ -43,16 +43,22 @@ function useMessageScrollerItemContext() {
 }
 
 function useMessageScroller() {
-  const { scrollToEnd, scrollToMessage, scrollToStart } =
+  const { scrollToEnd, scrollToMessage, scrollToStart, userScrollIntent } =
     useMessageScrollerContext()
 
   return React.useMemo(
     () => ({
+      // Public name for the internal user-scroll-intent transition. Releases
+      // follow-bottom and turn-anchoring exactly as a wheel/touch/key gesture
+      // does, so content grown in response to a user action (expanding a
+      // collapsed section) is left where it is instead of being re-pinned to
+      // the end.
+      releaseAutoScroll: userScrollIntent,
       scrollToEnd,
       scrollToMessage,
       scrollToStart,
     }),
-    [scrollToEnd, scrollToMessage, scrollToStart]
+    [scrollToEnd, scrollToMessage, scrollToStart, userScrollIntent]
   )
 }
 

--- a/packages/react/src/message-scroller/message-scroller.browser.test.tsx
+++ b/packages/react/src/message-scroller/message-scroller.browser.test.tsx
@@ -62,6 +62,7 @@ function Thread({
   scrollPreviousItemPeek,
   showButton = false,
   showJumpButton = false,
+  showReleaseButton = false,
   showVisibility = false,
 }: {
   autoScroll?: boolean
@@ -72,6 +73,7 @@ function Thread({
   scrollPreviousItemPeek?: number
   showButton?: boolean
   showJumpButton?: boolean
+  showReleaseButton?: boolean
   showVisibility?: boolean
 }) {
   return (
@@ -109,6 +111,7 @@ function Thread({
           </MessageScrollerButton>
         ) : null}
         {showJumpButton ? <JumpButton messageId="m5" /> : null}
+        {showReleaseButton ? <ReleaseButton /> : null}
         {showVisibility ? <VisibilityProbe /> : null}
       </MessageScroller>
     </MessageScrollerProvider>
@@ -156,6 +159,22 @@ function JumpButton({ messageId }: { messageId: string }) {
       }}
     >
       Jump to message
+    </button>
+  )
+}
+
+function ReleaseButton() {
+  const { releaseAutoScroll } = useMessageScroller()
+
+  return (
+    <button
+      data-testid="release"
+      type="button"
+      onClick={() => {
+        releaseAutoScroll()
+      }}
+    >
+      Release auto scroll
     </button>
   )
 }
@@ -281,6 +300,45 @@ test("keeps auto-scroll pinned when the final message grows", async () => {
   await settle()
 
   expect(getDistanceToBottom(viewport)).toBeLessThanOrEqual(1)
+})
+
+test("releaseAutoScroll stops the final message growth from re-pinning to the end", async () => {
+  const initial = createItems(6)
+
+  await renderThread({
+    autoScroll: true,
+    items: initial,
+    showReleaseButton: true,
+  })
+
+  const viewport = getViewport()
+
+  expect(getDistanceToBottom(viewport)).toBeLessThanOrEqual(1)
+
+  const scrollTopBefore = getScrollTop(viewport)
+
+  // Model a consumer that grows content in response to a user action (e.g.
+  // expanding a collapsed section): hand scroll control back first, then grow
+  // the final message in the same commit.
+  document.querySelector<HTMLButtonElement>('[data-testid="release"]')!.click()
+
+  flushSync(() => {
+    root!.render(
+      <Thread
+        autoScroll
+        showReleaseButton
+        items={initial.map((item, index) =>
+          index === initial.length - 1 ? { ...item, height: 240 } : item
+        )}
+      />
+    )
+  })
+  await settle()
+
+  // The growth stays below the fold instead of yanking the viewport to the end,
+  // so the reader keeps looking at what they expanded.
+  expect(getScrollTop(viewport)).toBe(scrollTopBefore)
+  expect(getDistanceToBottom(viewport)).toBeGreaterThan(0)
 })
 
 test("keeps the end pinned when bulk appending anchored turns with autoScroll", async () => {


### PR DESCRIPTION
## Summary

`useMessageScroller()` gains `releaseAutoScroll()`, an imperative escape hatch that releases `autoScroll`'s follow-bottom (and any turn anchoring) exactly as a wheel/touch/keyboard scroll already does. It lets a consumer hand scroll control back to the reader *before* growing content in response to a user action, so `autoScroll` doesn't treat that growth as streamed output.

## Why

When `autoScroll` is engaged and the viewport is pinned to the bottom, the scroller re-pins to the end on *any* content height growth — it can't tell "the model streamed more" from "the user expanded a collapsed section." So a UI that grows a message in place (a "show more" file grid, an expandable tool result) yanks the viewport to the end on click, scrolling the just-expanded content up and out of view.

It only happens while pinned: once the reader scrolls up (follow released), native scroll anchoring holds the expanded block's top steady and the growth reads as a natural accordion. The existing `keeps auto-scroll pinned when the final message grows` test locks in the pinned-side behavior; there was no way to opt a *user-driven* growth out of it.

The scroller can't infer intent from a resize, so this is an imperative signal rather than a heuristic. The transition already exists internally as `userScrollIntent` (wired to wheel/touch/key) — this just exposes it under a public, intent-named command.

## Usage

```tsx
const { releaseAutoScroll } = useMessageScroller()

<button
  onClick={() => {
    releaseAutoScroll() // hand control back before the height change
    setExpanded((v) => !v)
  }}
>
  Show more
</button>
```

`releaseAutoScroll()` is a no-op when nothing is being followed, so it's safe to call unconditionally on the toggle.

## Changes

- **`src/message-scroller/components.tsx`**: `useMessageScroller()` now returns `releaseAutoScroll`, mapped to the controller's existing `userScrollIntent` (the same transition the viewport's wheel/touch/key handlers use). No controller change — it was already on the context.
- **`src/message-scroller/message-scroller.browser.test.tsx`**: adds `releaseAutoScroll stops the final message growth from re-pinning to the end`. Mirrors the existing grow-the-final-message test but releases first, then asserts `scrollTop` is unchanged and the viewport is no longer at the end (the paired tests are the before/after).
- **`src/message-scroller/README.md`**, **`content/docs/react/message-scroller.mdx`**: document the new command.
- **changeset**: `@shadcn/react` minor (additive API).

## Testing

- `pnpm --filter @shadcn/react typecheck` / `build` clean.
- `pnpm --filter @shadcn/react test` — 60 jsdom tests pass.
- `pnpm --filter @shadcn/react test:browser` — 24 chromium tests pass (18 message-scroller incl. the new one, 6 perf).

No existing issue for this; happy to file one first if you'd prefer. `minor` vs `patch`: purely additive so `minor` per feat/semver — happy to drop to `patch` for 0.x.

_Written with Opus 4.8._
