### PR TITLE
feat(registry): add dkmediaviewer

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -364,6 +364,13 @@
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' class='fill-none!' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' aria-hidden='true' viewBox='0 0 24 24'><rect width='18' height='18' x='3' y='3' rx='2' ry='2'/><path d='M16 8h.01M8 8h.01M8 16h.01M16 16h.01'/></svg>"
   },
   {
+    "name": "@dkmediaviewer",
+    "homepage": "https://diklein.com/dkmediaviewer",
+    "url": "https://diklein.com/r/{name}.json",
+    "description": "A minimalist, performant, and elegant photo and video viewer for React. Masonry grid, fly-in lightbox, a crossfading carousel, captions and camera EXIF data.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 96 96' width='24' height='24'><circle cx='62' cy='38' r='28' fill='#e10000'/><rect x='12' y='32' width='56' height='56' fill='var(--foreground)'/></svg>"
+  },
+  {
     "name": "@dominik-ui",
     "homepage": "https://dominikkoch.dev/ui",
     "url": "https://dominikkoch.dev/r/{name}.json",


### PR DESCRIPTION
Adds **DKMediaViewer** to the registry directory. It is a minimalist, performant, and elegant photo and video viewer for React, extracted from [diklein.com](https://diklein.com). Masonry grid, fly-in lightbox, a crossfading carousel, captions and camera EXIF data, light and dark modes, reduced-motion support, and full keyboard and focus handling.

- Registry: https://diklein.com/r/registry.json (flat, no `content` in `files`)
- Item: `npx shadcn add https://diklein.com/r/dk-media-viewer.json`
- Docs and live demo: https://diklein.com/dkmediaviewer
- Source: https://github.com/diklein/dkmediaviewer (open source, MIT)

### Checklist

- [x] Added entry to `apps/v4/registry/directory.json`
- [x] `pnpm validate:registries` passes
- [x] Registry is publicly accessible and conforms to the registry schema
