### PR TITLE
docs(contributing): clarify local development setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,13 @@ packages
 
 ## Development
 
+### Install prerequisites
+
+This repository requires [Node.js](https://nodejs.org),
+[pnpm](https://pnpm.io/installation), and [Bun](https://bun.sh). The pnpm
+version is pinned in `package.json` and can be managed with Corepack. Bun is
+required by the registry build and app test scripts.
+
 ### Fork this repo
 
 You can fork this repo by clicking the fork button in the top right corner of this page.
@@ -68,6 +75,14 @@ git checkout -b my-new-branch
 
 ```bash
 pnpm install
+```
+
+### Configure the website environment
+
+Before running the `v4` website, copy its example environment file:
+
+```bash
+cp apps/v4/.env.example apps/v4/.env.local
 ```
 
 ### Run a workspace


### PR DESCRIPTION
## What

- Documents Node.js, pnpm/Corepack, and Bun as local development prerequisites.
- Adds the command to create `apps/v4/.env.local` from the checked-in example.

## Why

Fresh clones can fail during registry generation when Bun is unavailable, and the v4 website crashes when `NEXT_PUBLIC_APP_URL` is undefined. The contribution guide did not document either setup requirement.

## Verification

- `pnpm exec prettier --check CONTRIBUTING.md`
- `pnpm --filter=v4 registry:build --style all`

Closes #7537