### PR TITLE
feat(dialog): forward overlay props from content

### DIFF
--- a/apps/v4/content/docs/components/base/alert-dialog.mdx
+++ b/apps/v4/content/docs/components/base/alert-dialog.mdx
@@ -161,6 +161,18 @@ Use the `AlertDialogAction` component to add a destructive action button to the 
   previewClassName="h-56"
 />
 
+## Nested Alert Dialog Backdrops
+
+Base UI does not render backdrops for nested alert dialogs by default. Pass
+`forceRender` through `overlayProps` to render a backdrop for a nested alert
+dialog.
+
+```tsx showLineNumbers
+<AlertDialogContent overlayProps={{ forceRender: true }}>
+  {/* Nested alert dialog content */}
+</AlertDialogContent>
+```
+
 ## RTL
 
 To enable RTL support in shadcn/ui, see the [RTL configuration guide](/docs/rtl).

--- a/apps/v4/content/docs/components/base/dialog.mdx
+++ b/apps/v4/content/docs/components/base/dialog.mdx
@@ -123,6 +123,17 @@ Long content can scroll while the header stays in view.
 
 <ComponentPreview styleName="base-nova" name="dialog-scrollable-content" />
 
+## Nested Dialog Backdrops
+
+Base UI does not render backdrops for nested dialogs by default. Pass
+`forceRender` through `overlayProps` to render a backdrop for a nested dialog.
+
+```tsx showLineNumbers
+<DialogContent overlayProps={{ forceRender: true }}>
+  {/* Nested dialog content */}
+</DialogContent>
+```
+
 ## RTL
 
 To enable RTL support in shadcn/ui, see the [RTL configuration guide](/docs/rtl).

--- a/apps/v4/registry/bases/base/ui/alert-dialog.tsx
+++ b/apps/v4/registry/bases/base/ui/alert-dialog.tsx
@@ -41,13 +41,15 @@ function AlertDialogOverlay({
 function AlertDialogContent({
   className,
   size = "default",
+  overlayProps,
   ...props
 }: AlertDialogPrimitive.Popup.Props & {
   size?: "default" | "sm"
+  overlayProps?: AlertDialogPrimitive.Backdrop.Props
 }) {
   return (
     <AlertDialogPortal>
-      <AlertDialogOverlay />
+      <AlertDialogOverlay {...overlayProps} />
       <AlertDialogPrimitive.Popup
         data-slot="alert-dialog-content"
         data-size={size}

--- a/apps/v4/registry/bases/base/ui/dialog.tsx
+++ b/apps/v4/registry/bases/base/ui/dialog.tsx
@@ -40,13 +40,15 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  overlayProps,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
+  overlayProps?: DialogPrimitive.Backdrop.Props
 }) {
   return (
     <DialogPortal>
-      <DialogOverlay />
+      <DialogOverlay {...overlayProps} />
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(

--- a/apps/v4/registry/bases/radix/ui/alert-dialog.tsx
+++ b/apps/v4/registry/bases/radix/ui/alert-dialog.tsx
@@ -44,13 +44,15 @@ function AlertDialogOverlay({
 function AlertDialogContent({
   className,
   size = "default",
+  overlayProps,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
   size?: "default" | "sm"
+  overlayProps?: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>
 }) {
   return (
     <AlertDialogPortal>
-      <AlertDialogOverlay />
+      <AlertDialogOverlay {...overlayProps} />
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         data-size={size}

--- a/apps/v4/registry/bases/radix/ui/dialog.tsx
+++ b/apps/v4/registry/bases/radix/ui/dialog.tsx
@@ -48,13 +48,15 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  overlayProps,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
+  overlayProps?: React.ComponentProps<typeof DialogPrimitive.Overlay>
 }) {
   return (
     <DialogPortal>
-      <DialogOverlay />
+      <DialogOverlay {...overlayProps} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(

--- a/apps/v4/registry/dialog.test.tsx
+++ b/apps/v4/registry/dialog.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import * as React from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+} from "./bases/base/ui/alert-dialog"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "./bases/base/ui/dialog"
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true })
+
+describe("Base UI dialog registry item", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    await React.act(async () => root.unmount())
+    container.remove()
+  })
+
+  it("forwards forceRender to a nested dialog overlay", async () => {
+    await React.act(async () => {
+      root.render(
+        <Dialog open>
+          <DialogContent showCloseButton={false}>
+            <DialogTitle>Parent dialog</DialogTitle>
+            <DialogDescription>Parent dialog description</DialogDescription>
+            <Dialog open>
+              <DialogContent
+                showCloseButton={false}
+                overlayProps={{ forceRender: true }}
+              >
+                <DialogTitle>Nested dialog</DialogTitle>
+                <DialogDescription>Nested dialog description</DialogDescription>
+              </DialogContent>
+            </Dialog>
+          </DialogContent>
+        </Dialog>
+      )
+    })
+
+    expect(
+      document.querySelectorAll('[data-slot="dialog-overlay"]')
+    ).toHaveLength(2)
+  })
+
+  it("forwards forceRender to a nested alert dialog overlay", async () => {
+    await React.act(async () => {
+      root.render(
+        <AlertDialog open>
+          <AlertDialogContent>
+            <AlertDialogTitle>Parent alert dialog</AlertDialogTitle>
+            <AlertDialogDescription>
+              Parent alert dialog description
+            </AlertDialogDescription>
+            <AlertDialog open>
+              <AlertDialogContent overlayProps={{ forceRender: true }}>
+                <AlertDialogTitle>Nested alert dialog</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Nested alert dialog description
+                </AlertDialogDescription>
+              </AlertDialogContent>
+            </AlertDialog>
+          </AlertDialogContent>
+        </AlertDialog>
+      )
+    })
+
+    expect(
+      document.querySelectorAll('[data-slot="alert-dialog-overlay"]')
+    ).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## What

Adds an `overlayProps` escape hatch to `DialogContent` and `AlertDialogContent` in the current Base UI and Radix registry sources.

## Why

Base UI intentionally omits backdrops for nested dialogs. Its `Backdrop` supports `forceRender`, but the shadcn convenience content components hardcoded their overlays, so consumers could not reach that prop without recomposing the portal and content.

Before this change, passing `overlayProps` leaked the unknown prop to the popup DOM node and a nested dialog still rendered only one backdrop. After the change, `overlayProps={{ forceRender: true }}` renders the nested backdrop while preserving Base UI's default behavior when the prop is omitted.

## Changes

- forward `overlayProps` from Base UI Dialog and AlertDialog content to their overlays
- mirror the content API in the Radix registry sources to preserve base parity
- add jsdom regressions for nested Base UI Dialog and AlertDialog backdrops
- document the opt-in on the Base UI component pages

## Verification

- `pnpm exec vitest run apps/v4/registry/dialog.test.tsx` (2 passed)
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter=v4 typecheck`
- `pnpm --filter=v4 exec eslint registry/dialog.test.tsx registry/bases/base/ui/dialog.tsx registry/bases/base/ui/alert-dialog.tsx registry/bases/radix/ui/dialog.tsx registry/bases/radix/ui/alert-dialog.tsx`
- `pnpm exec prettier --check` on all touched files
- `pnpm --filter=v4 registry:build`
- `pnpm --filter=v4 postinstall`

## Reviewer notes

- Nested backdrop rendering remains opt-in; no default behavior changes.
- Related PR #8732 targets the legacy `new-york-v4`/deprecated registries for overlay styling and also includes app bootstrap changes. This PR targets the current Base/Radix source registries, covers AlertDialog, and validates Base UI `forceRender` with tests and docs.

Closes #11214