### PR TITLE
feat(registry): add @sf-fleet-hud to registry directory

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1163,6 +1163,13 @@
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 24 24' fill='none'><path d='M5.999 17a3 3 0 0 1-1.873-.658a2.98 2.98 0 0 1-1.107-2.011a2.98 2.98 0 0 1 .639-2.206l4-5c.978-1.225 2.883-1.471 4.143-.523l1.674 1.254l2.184-2.729a3 3 0 1 1 4.682 3.747l-4 5c-.977 1.226-2.882 1.471-4.143.526l-1.674-1.256l-2.184 2.729A2.98 2.98 0 0 1 5.999 17M10 8a1 1 0 0 0-.781.374l-4 5.001a1 1 0 0 0-.213.734c.03.266.161.504.369.67a.996.996 0 0 0 1.406-.155l3.395-4.244L13.4 12.8c.42.316 1.056.231 1.381-.176l4-5.001a1 1 0 0 0 .213-.734a1 1 0 0 0-.369-.67a.996.996 0 0 0-1.406.156l-3.395 4.242L10.6 8.2A1 1 0 0 0 10 8m9 13H5a1 1 0 1 1 0-2h14a1 1 0 1 1 0 2' fill='var(--foreground)'/></svg>"
   },
   {
+    "name": "@sf-fleet-hud",
+    "homepage": "https://sf-fleet-hud.vercel.app",
+    "url": "https://sf-fleet-hud.vercel.app/r/{name}.json",
+    "description": "A dark sci-fi fleet-ops UI kit. Restyled primitives plus HUD widgets: radar, gauges, telemetry bars, an interactive dot globe and dependency-free charts. Dark-only, radius 0.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'><path d='M2 8V2h6' fill='none' stroke='var(--foreground)' stroke-width='2'/><path d='M22 16v6h-6' fill='none' stroke='var(--foreground)' stroke-width='2'/><rect x='9' y='9' width='6' height='6' fill='var(--foreground)' transform='rotate(45 12 12)'/></svg>"
+  },
+  {
     "name": "@shadcn-editor",
     "homepage": "https://shadcn-editor.vercel.app",
     "url": "https://raw.githubusercontent.com/htmujahid/shadcn-editor/refs/heads/main/public/r/{name}.json",


### PR DESCRIPTION
## Summary

Adds [SF Fleet HUD](https://sf-fleet-hud.vercel.app) to the registry directory.

A dark sci-fi fleet-ops UI kit — 47 items covering restyled primitives plus widgets a stock kit doesn't have.

- Restyled primitives: button, input, select, dialog, sheet, command palette, table, pagination, calendar, input-otp, sonner, and the rest of the usual set
- HUD widgets: radar scope, ring gauges, telemetry bars, segment bars, heatmap, timeline, tree, dropzone, stepper, crew card
- Dot globe: interactive canvas earth with drag-to-rotate inertia and incident markers. Land dots are precomputed from Natural Earth (public domain) and embedded, so it has no fetches, no image assets and no runtime dependencies
- Charts: line and bar drawn as plain SVG, with no charting dependency. Series separate by lightness and dash pattern rather than hue, validated for colour-vision deficiency
- Optional cyan accent as a second `registry:theme` item
- Demo doubles as a seven-screen dashboard, so every component appears in a working screen rather than as a swatch

Dark-only by design, radius 0, 10px minimum font size. Decorative motion respects `prefers-reduced-motion`.

Registry: https://sf-fleet-hud.vercel.app/r/registry.json
GitHub: https://github.com/m-nagasaka-singleorigin/sf-fleet-hud
License: MIT

## Checks

- [x] `pnpm validate:registries` passes
- [x] Entry inserted in alphabetical order
- [x] Registry is open source and publicly accessible
- [x] `url` resolves — verified `hud-button`, `radar` and `theme-hud` all return 200
- [x] Logo is inline SVG using `var(--foreground)`
