### PR TITLE
feat(registry): add @brainless to the registry directory

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -231,6 +231,13 @@
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' fill='none'><rect x='5' y='5' width='90' height='90' fill='var(--background)' stroke='var(--foreground)' stroke-width='6'/><rect x='20' y='20' width='25' height='25' fill='var(--foreground)'/><rect x='55' y='20' width='25' height='25' fill='var(--foreground)'/><rect x='20' y='55' width='25' height='25' fill='var(--foreground)'/><rect x='55' y='55' width='25' height='25' fill='var(--foreground)'/></svg>"
   },
   {
+    "name": "@brainless",
+    "homepage": "https://brainless.swerdlow.dev",
+    "url": "https://brainless.swerdlow.dev/r/{name}.json",
+    "description": "Claude Code, Codex, and Grok interfaces as shadcn components — accessible React terminal-agent UI for docs, demos, and product surfaces.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24' fill='var(--foreground)'><rect x='5' y='5' width='14' height='14'/></svg>"
+  },
+  {
     "name": "@bundui",
     "homepage": "https://bundui.io",
     "url": "https://bundui.io/r/{name}.json",


### PR DESCRIPTION
Adds `@brainless` to the registry directory, as requested in #11135.

**brainless** is an open-source registry of terminal-agent UI components — Claude Code, Codex, and Grok style interfaces built as accessible shadcn components for docs, demos, and product surfaces.

- Homepage: https://brainless.swerdlow.dev
- Repo: https://github.com/theswerd/brainless (open source)
- Flat registry: https://brainless.swerdlow.dev/r/registry.json
- Item URL pattern: `https://brainless.swerdlow.dev/r/{name}.json`

Checked against the registry directory requirements:

- [x] Registry is open source and publicly accessible
- [x] `registry.json` conforms to the registry schema (40 items, validated)
- [x] No `content` property in any `files` array
- [x] Square SVG logo included (taken from the issue)
- [x] Entry inserted in alphabetical order (between `@boldkit` and `@bundui`)

Closes #11135