### PR TITLE
fix(cli): clarify missing package manager errors

### DIFF
--- a/packages/shadcn/src/utils/updaters/update-dependencies.test.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { MockExecaError, mockExeca, mockGetPackageInfo, mockGetPackageManager } =
+  vi.hoisted(() => {
+    class MockExecaError extends Error {
+      cause?: { code?: string }
+
+      constructor(message: string, cause?: { code?: string }) {
+        super(message)
+        this.name = "ExecaError"
+        this.cause = cause
+      }
+    }
+
+    return {
+      MockExecaError,
+      mockExeca: vi.fn(),
+      mockGetPackageInfo: vi.fn(),
+      mockGetPackageManager: vi.fn(),
+    }
+  })
+
+vi.mock("execa", () => ({
+  ExecaError: MockExecaError,
+  execa: mockExeca,
+}))
+
+vi.mock("@/src/utils/get-package-info", () => ({
+  getPackageInfo: mockGetPackageInfo,
+}))
+
+vi.mock("@/src/utils/get-package-manager", () => ({
+  getPackageManager: mockGetPackageManager,
+}))
+
+vi.mock("@/src/utils/spinner", () => ({
+  spinner: () => ({
+    start() {
+      return this
+    },
+    succeed: vi.fn(),
+    stopAndPersist: vi.fn(),
+  }),
+}))
+
+vi.mock("prompts", () => ({
+  default: vi.fn(),
+}))
+
+import { updateDependencies } from "./update-dependencies"
+
+const config = {
+  resolvedPaths: {
+    cwd: "/test/project",
+  },
+} as any
+
+describe("updateDependencies", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetPackageInfo.mockReturnValue({ dependencies: {} })
+    mockGetPackageManager.mockResolvedValue("pnpm")
+  })
+
+  it("adds a package-manager install hint when the detected executable is missing", async () => {
+    mockExeca.mockRejectedValueOnce(
+      new MockExecaError("spawn pnpm ENOENT", { code: "ENOENT" })
+    )
+
+    await expect(
+      updateDependencies(["radix-ui"], [], config, { silent: true })
+    ).rejects.toThrow(
+      "Detected pnpm for this project, but the pnpm executable was not found. Install it first, for example: npm install -g pnpm"
+    )
+  })
+
+  it("keeps non-ENOENT package manager errors unchanged", async () => {
+    mockExeca.mockRejectedValueOnce(
+      new MockExecaError("Command failed with exit code 1", { code: "EPERM" })
+    )
+
+    await expect(
+      updateDependencies(["radix-ui"], [], config, { silent: true })
+    ).rejects.toThrow("Command failed with exit code 1")
+  })
+})

--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -5,7 +5,7 @@ import { getPackageInfo } from "@/src/utils/get-package-info"
 import { getPackageManager } from "@/src/utils/get-package-manager"
 import { logger } from "@/src/utils/logger"
 import { spinner } from "@/src/utils/spinner"
-import { execa } from "execa"
+import { ExecaError, execa } from "execa"
 import prompts from "prompts"
 
 export async function updateDependencies(
@@ -222,6 +222,29 @@ async function installWithPackageManager(
   cwd: string,
   flag?: string
 ) {
+  try {
+    return await runInstallWithPackageManager(
+      packageManager,
+      dependencies,
+      devDependencies,
+      cwd,
+      flag
+    )
+  } catch (error) {
+    handlePackageManagerNotFound(error, packageManager)
+    throw error
+  }
+}
+
+async function runInstallWithPackageManager(
+  packageManager: Awaited<
+    ReturnType<typeof getUpdateDependenciesPackageManager>
+  >,
+  dependencies: string[],
+  devDependencies: string[],
+  cwd: string,
+  flag?: string
+) {
   if (packageManager === "npm") {
     return installWithNpm(dependencies, devDependencies, cwd, flag)
   }
@@ -319,4 +342,37 @@ async function installWithExpo(
       cwd,
     })
   }
+}
+
+function handlePackageManagerNotFound(
+  error: unknown,
+  packageManager: Awaited<ReturnType<typeof getUpdateDependenciesPackageManager>>
+) {
+  if (
+    !(error instanceof ExecaError) ||
+    (error.cause as NodeJS.ErrnoException | undefined)?.code !== "ENOENT"
+  ) {
+    return
+  }
+
+  if (packageManager === "expo") {
+    return
+  }
+
+  const installCommand =
+    packageManager === "pnpm"
+      ? "npm install -g pnpm"
+      : packageManager === "yarn"
+        ? "corepack enable yarn"
+        : packageManager === "bun"
+          ? "npm install -g bun"
+          : packageManager === "deno"
+            ? "npm install -g deno"
+            : null
+
+  const hint = installCommand
+    ? ` Install it first, for example: ${installCommand}`
+    : " Install it first or remove the lockfile/config that selects it."
+
+  error.message = `Detected ${packageManager} for this project, but the ${packageManager} executable was not found.${hint} You can also run shadcn from the same package manager you use for this project.`
 }


### PR DESCRIPTION
## Summary

- Adds a targeted ENOENT handler for dependency installation when the detected package manager executable is missing.
- Rewrites the raw `spawn pnpm ENOENT` style error into an actionable message with the detected package manager and install hint.
- Adds regression coverage for missing package manager errors while preserving non-ENOENT install failures unchanged.

## Why

Issue #11234 reports `npx shadcn@latest add dialog` failing with:

```txt
Command failed with ENOENT: pnpm add -- radix-ui
spawn pnpm ENOENT
```

That means the CLI correctly detected `pnpm` from the project, but the `pnpm` executable was not available on PATH. The current error exposes the low-level spawn failure without telling the user how to recover.

## Test Plan

- `pnpm --filter=shadcn exec vitest run src/utils/updaters/update-dependencies.test.ts`
- `pnpm --filter=shadcn typecheck`
- `git diff --check`

Closes #11234
