### PR TITLE
Add @mediadrop to the registry directory

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1771,5 +1771,12 @@
     "url": "https://shadcndashboard.dev/r/{name}.json",
     "description": "Shadcn Dashboard is a collection of modern, production-ready dashboard layouts, components, and UI patterns built on top of shadcn/ui and Tailwind CSS. It’s designed to help developers build clean, scalable, and data-driven dashboards faster—without compromising on performance, accessibility, or customization.",
     "logo": "<svg width='40' height='40' viewBox='0 0 40 40' fill='none' xmlns='http://www.w3.org/2000/svg'><rect width='40' height='40' rx='20' fill='#053B25'/><path d='M32.1327 19.501C31.5178 19.6123 30.8844 19.6705 30.2375 19.6705C24.3886 19.6705 19.6471 14.9189 19.6471 9.05765C19.6471 8.89469 19.6507 8.73258 19.658 8.57141C13.8411 9.10533 9.28516 14.0074 9.28516 19.9759C9.28516 26.301 14.4019 31.4286 20.7137 31.4286C27.0256 31.4286 32.1423 26.301 32.1423 19.9759C32.1423 19.8168 32.1391 19.6585 32.1327 19.501Z' fill='#C2FD75'/></svg>"
+  },
+  {
+    "name": "@mediadrop",
+    "homepage": "https://www.mediadrop.dev",
+    "url": "https://www.mediadrop.dev/r/{name}.json",
+    "description": "Drag-and-drop file upload blocks for React built on react-mediadrop — dropzone, avatar uploader, multi-file upload form, and direct-to-S3 upload.",
+    "logo": "<svg width='1024' height='1024' viewBox='0 0 1024 1024' fill='none' xmlns='http://www.w3.org/2000/svg'><rect width='1024' height='1024' rx='264' fill='black'/><path d='M690.68 471.521L506.92 655.283L466.282 614.646L466.283 614.644L332.918 481.278L373.555 440.642L506.921 574.007L650.044 430.885L690.68 471.521Z' fill='#00D9FF'/><path d='M690.68 267.637L506.92 451.398L466.282 410.761L466.283 410.759L332.918 277.394L373.555 236.757L506.921 370.122L650.044 227L690.68 267.637Z' fill='#0080A9'/><path d='M798.012 796.063H225.59V740.668H742.616V445.224H798.012V796.063ZM280.984 740.666H225.589V445.221H280.984V740.666Z' fill='url(#paint0_linear_220_485)'/><defs><linearGradient id='paint0_linear_220_485' x1='770.314' y1='445.221' x2='770.314' y2='740.667' gradientUnits='userSpaceOnUse'><stop/><stop offset='1' stop-color='white'/></linearGradient></defs></svg>"
   }
 ]


### PR DESCRIPTION
## Summary

Adds `@mediadrop` to `apps/v4/registry/directory.json`.

mediadrop is a small registry of file-upload blocks for React, built on [react-mediadrop](https://github.com/autorender/react-mediadrop):
- `dropzone` — drag-and-drop upload with per-file progress and cancel
- `avatar-uploader` — circular single-image avatar picker
- `multi-file-upload-form` — multi-file picker with review + explicit submit
- `s3-direct-upload` — direct-to-S3 upload via a presigned PUT URL

Registry is served at `https://www.mediadrop.dev/r/{name}.json` — flat, no nested items, `content` omitted from the source `registry.json`'s `files` arrays per the directory requirements.

## Checklist

- [x] Registry is public and publicly accessible (no auth)
- [x] `registry.json` conforms to the registry schema
- [x] Flat structure — `registry.json` and `{name}.json` files at `/r/` (verified against other directory.json entries using the same `/r/{name}.json` pattern)
- [x] `files` array in the source `registry.json` does not include a `content` property
- [x] Validated the new entry against `apps/v4/scripts/validate-registries.mts`'s zod schema (name regex, homepage URL, `{name}` placeholder in `url`, description present)
- [x] Ran `shadcn init` + `shadcn add` against the live URLs in a fresh Next.js app — installs cleanly, `tsc --noEmit` and `next build` both pass with 0 errors

## Test plan

```
npx shadcn add https://www.mediadrop.dev/r/dropzone.json \
  https://www.mediadrop.dev/r/avatar-uploader.json \
  https://www.mediadrop.dev/r/multi-file-upload-form.json \
  https://www.mediadrop.dev/r/s3-direct-upload.json
```
All 4 blocks install correctly with the `react-mediadrop` dependency resolved.
