### PR TITLE
feat(shadcn): migrate icons between any icon libraries

### DIFF
--- a/.changeset/twelve-stars-drum.md
+++ b/.changeset/twelve-stars-drum.md
@@ -1,0 +1,5 @@
+---
+"shadcn": minor
+---
+
+add support for icon migration

--- a/apps/v4/content/docs/(root)/cli.mdx
+++ b/apps/v4/content/docs/(root)/cli.mdx
@@ -426,11 +426,49 @@ Arguments:
   path             optional path or glob pattern to migrate.
 
 Options:
-  -c, --cwd <cwd>  the working directory. defaults to the current directory.
-  -l, --list       list all migrations. (default: false)
-  -y, --yes        skip confirmation prompt. (default: false)
-  -h, --help       display help for command
+  -c, --cwd <cwd>       the working directory. defaults to the current directory.
+  -l, --list            list all migrations. (default: false)
+  -y, --yes             skip confirmation prompt. (default: false)
+  -f, --from <library>  the icon library to migrate from (icons migration only).
+  -t, --to <library>    the icon library to migrate to (icons migration only).
+  -h, --help            display help for command
 ```
+
+---
+
+### migrate icons
+
+The `icons` migration moves your components from one icon library to another.
+
+```bash
+npx shadcn@latest migrate icons
+```
+
+This will prompt you for the source and target libraries, rewrite icon imports and JSX usage in your `ui` directory, install the target library and update `iconLibrary` in your `components.json` so future `npx shadcn add` installs use the new library.
+
+The following libraries are supported: `lucide`, `tabler`, `hugeicons`, `phosphor`, `remixicon` and `radix` (legacy).
+
+**Non-interactive**
+
+Use `--from` and `--to` to skip the prompts:
+
+```bash
+npx shadcn@latest migrate icons --from lucide --to phosphor --yes
+```
+
+**Migrate specific files**
+
+You can migrate specific files or use glob patterns. Scoped runs do not update `components.json`.
+
+```bash
+# Migrate a specific file.
+npx shadcn@latest migrate icons src/components/ui/button.tsx --from lucide --to tabler
+
+# Migrate files matching a glob pattern.
+npx shadcn@latest migrate icons "src/components/**" --from lucide --to tabler
+```
+
+Icons without an equivalent in the target library are left untouched and reported at the end of the migration.
 
 ---
 

--- a/apps/v4/public/r/icons/index.json
+++ b/apps/v4/public/r/icons/index.json
@@ -1,15 +1,27 @@
 {
   "AlertCircle": {
     "lucide": "AlertCircle",
-    "radix": "ExclamationTriangleIcon"
+    "radix": "ExclamationTriangleIcon",
+    "tabler": "IconAlertCircle",
+    "hugeicons": "AlertCircleIcon",
+    "phosphor": "WarningCircleIcon",
+    "remixicon": "RiErrorWarningLine"
   },
   "ArrowLeft": {
     "lucide": "ArrowLeft",
-    "radix": "ArrowLeftIcon"
+    "radix": "ArrowLeftIcon",
+    "tabler": "IconArrowLeft",
+    "hugeicons": "ArrowLeft02Icon",
+    "phosphor": "ArrowLeftIcon",
+    "remixicon": "RiArrowLeftLine"
   },
   "ArrowRight": {
     "lucide": "ArrowRight",
-    "radix": "ArrowRightIcon"
+    "radix": "ArrowRightIcon",
+    "tabler": "IconArrowRight",
+    "hugeicons": "ArrowRight01Icon",
+    "phosphor": "ArrowRightIcon",
+    "remixicon": "RiArrowRightLine"
   },
   "ArrowUpDown": {
     "lucide": "ArrowUpDown",
@@ -21,39 +33,75 @@
   },
   "Bold": {
     "lucide": "Bold",
-    "radix": "FontBoldIcon"
+    "radix": "FontBoldIcon",
+    "tabler": "IconBold",
+    "hugeicons": "TextBoldIcon",
+    "phosphor": "TextBIcon",
+    "remixicon": "RiBold"
   },
   "Calculator": {
     "lucide": "Calculator",
-    "radix": "ComponentPlaceholderIcon"
+    "radix": "ComponentPlaceholderIcon",
+    "tabler": "IconCalculator",
+    "hugeicons": "CalculatorIcon",
+    "phosphor": "CalculatorIcon",
+    "remixicon": "RiCalculatorLine"
   },
   "Calendar": {
     "lucide": "Calendar",
-    "radix": "CalendarIcon"
+    "radix": "CalendarIcon",
+    "tabler": "IconCalendar",
+    "hugeicons": "Calendar03Icon",
+    "phosphor": "CalendarIcon",
+    "remixicon": "RiCalendarLine"
   },
   "Check": {
     "lucide": "Check",
-    "radix": "CheckIcon"
+    "radix": "CheckIcon",
+    "tabler": "IconCheck",
+    "hugeicons": "Tick02Icon",
+    "phosphor": "CheckIcon",
+    "remixicon": "RiCheckLine"
   },
   "ChevronDown": {
     "lucide": "ChevronDown",
-    "radix": "ChevronDownIcon"
+    "radix": "ChevronDownIcon",
+    "tabler": "IconChevronDown",
+    "hugeicons": "ArrowDown01Icon",
+    "phosphor": "CaretDownIcon",
+    "remixicon": "RiArrowDownSLine"
   },
   "ChevronLeft": {
     "lucide": "ChevronLeft",
-    "radix": "ChevronLeftIcon"
+    "radix": "ChevronLeftIcon",
+    "tabler": "IconChevronLeft",
+    "hugeicons": "ArrowLeft01Icon",
+    "phosphor": "CaretLeftIcon",
+    "remixicon": "RiArrowLeftSLine"
   },
   "ChevronRight": {
     "lucide": "ChevronRight",
-    "radix": "ChevronRightIcon"
+    "radix": "ChevronRightIcon",
+    "tabler": "IconChevronRight",
+    "hugeicons": "ArrowRight01Icon",
+    "phosphor": "CaretRightIcon",
+    "remixicon": "RiArrowRightSLine"
   },
   "ChevronUp": {
     "lucide": "ChevronUp",
-    "radix": "ChevronUpIcon"
+    "radix": "ChevronUpIcon",
+    "tabler": "IconChevronUp",
+    "hugeicons": "ArrowUp01Icon",
+    "phosphor": "CaretUpIcon",
+    "remixicon": "RiArrowUpSLine"
   },
   "ChevronsUpDown": {
     "lucide": "ChevronsUpDown",
-    "radix": "CaretSortIcon"
+    "radix": "CaretSortIcon",
+    "tabler": "IconSelector",
+    "hugeicons": "UnfoldMoreIcon",
+    "phosphor": "CaretUpDownIcon",
+    "remixicon": "RiArrowUpDownLine"
   },
   "Circle": {
     "lucide": "Circle",
@@ -61,27 +109,51 @@
   },
   "Copy": {
     "lucide": "Copy",
-    "radix": "CopyIcon"
+    "radix": "CopyIcon",
+    "tabler": "IconCopy",
+    "hugeicons": "Copy01Icon",
+    "phosphor": "CopyIcon",
+    "remixicon": "RiFileCopyLine"
   },
   "CreditCard": {
     "lucide": "CreditCard",
-    "radix": "ComponentPlaceholderIcon"
+    "radix": "ComponentPlaceholderIcon",
+    "tabler": "IconCreditCard",
+    "hugeicons": "CreditCardIcon",
+    "phosphor": "CreditCardIcon",
+    "remixicon": "RiBankCardLine"
   },
   "GripVertical": {
     "lucide": "GripVertical",
-    "radix": "DragHandleDots2Icon"
+    "radix": "DragHandleDots2Icon",
+    "tabler": "IconGripVertical",
+    "hugeicons": "DragDropVerticalIcon",
+    "phosphor": "DotsSixVerticalIcon",
+    "remixicon": "RiDraggable"
   },
   "Italic": {
     "lucide": "Italic",
-    "radix": "FontItalicIcon"
+    "radix": "FontItalicIcon",
+    "tabler": "IconItalic",
+    "hugeicons": "TextItalicIcon",
+    "phosphor": "TextItalicIcon",
+    "remixicon": "RiItalic"
   },
   "Loader2": {
     "lucide": "Loader2",
-    "radix": "ReloadIcon"
+    "radix": "ReloadIcon",
+    "tabler": "IconLoader",
+    "hugeicons": "Loading03Icon",
+    "phosphor": "SpinnerIcon",
+    "remixicon": "RiLoaderLine"
   },
   "Mail": {
     "lucide": "Mail",
-    "radix": "EnvelopeClosedIcon"
+    "radix": "EnvelopeClosedIcon",
+    "tabler": "IconMail",
+    "hugeicons": "Mail01Icon",
+    "phosphor": "EnvelopeIcon",
+    "remixicon": "RiMailLine"
   },
   "MailOpen": {
     "lucide": "MailOpen",
@@ -89,35 +161,67 @@
   },
   "Minus": {
     "lucide": "Minus",
-    "radix": "MinusIcon"
+    "radix": "MinusIcon",
+    "tabler": "IconMinus",
+    "hugeicons": "MinusSignIcon",
+    "phosphor": "MinusIcon",
+    "remixicon": "RiSubtractLine"
   },
   "Moon": {
     "lucide": "Moon",
-    "radix": "MoonIcon"
+    "radix": "MoonIcon",
+    "tabler": "IconMoon",
+    "hugeicons": "MoonIcon",
+    "phosphor": "MoonIcon",
+    "remixicon": "RiMoonLine"
   },
   "MoreHorizontal": {
     "lucide": "MoreHorizontal",
-    "radix": "DotsHorizontalIcon"
+    "radix": "DotsHorizontalIcon",
+    "tabler": "IconDots",
+    "hugeicons": "MoreHorizontalCircle01Icon",
+    "phosphor": "DotsThreeOutlineIcon",
+    "remixicon": "RiMoreLine"
   },
   "PanelLeft": {
     "lucide": "PanelLeft",
-    "radix": "ViewVerticalIcon"
+    "radix": "ViewVerticalIcon",
+    "tabler": "IconLayoutSidebar",
+    "hugeicons": "SidebarLeftIcon",
+    "phosphor": "SidebarIcon",
+    "remixicon": "RiLayoutLeftLine"
   },
   "Plus": {
     "lucide": "Plus",
-    "radix": "PlusIcon"
+    "radix": "PlusIcon",
+    "tabler": "IconPlus",
+    "hugeicons": "Add01Icon",
+    "phosphor": "PlusIcon",
+    "remixicon": "RiAddLine"
   },
   "Search": {
     "lucide": "Search",
-    "radix": "MagnifyingGlassIcon"
+    "radix": "MagnifyingGlassIcon",
+    "tabler": "IconSearch",
+    "hugeicons": "SearchIcon",
+    "phosphor": "MagnifyingGlassIcon",
+    "remixicon": "RiSearchLine"
   },
   "Send": {
     "lucide": "Send",
-    "radix": "PaperPlaneIcon"
+    "radix": "PaperPlaneIcon",
+    "tabler": "IconSend",
+    "hugeicons": "SentIcon",
+    "phosphor": "PaperPlaneTiltIcon",
+    "remixicon": "RiSendPlaneLine"
   },
   "Settings": {
     "lucide": "Settings",
-    "radix": "GearIcon"
+    "radix": "GearIcon",
+    "tabler": "IconSettings",
+    "hugeicons": "SettingsIcon",
+    "phosphor": "GearIcon",
+    "remixicon": "RiSettingsLine"
   },
   "Slash": {
     "lucide": "Slash",
@@ -125,26 +229,1128 @@
   },
   "Smile": {
     "lucide": "Smile",
-    "radix": "FaceIcon"
+    "radix": "FaceIcon",
+    "tabler": "IconMoodSmile",
+    "hugeicons": "SmileIcon",
+    "phosphor": "SmileyIcon",
+    "remixicon": "RiEmotionLine"
   },
   "Sun": {
     "lucide": "Sun",
-    "radix": "SunIcon"
+    "radix": "SunIcon",
+    "tabler": "IconSun",
+    "hugeicons": "Sun03Icon",
+    "phosphor": "SunIcon",
+    "remixicon": "RiSunLine"
   },
   "Terminal": {
     "lucide": "Terminal",
-    "radix": "RocketIcon"
+    "radix": "RocketIcon",
+    "tabler": "IconTerminal",
+    "hugeicons": "ComputerTerminal01Icon",
+    "phosphor": "TerminalIcon",
+    "remixicon": "RiTerminalBoxLine"
   },
   "Underline": {
     "lucide": "Underline",
-    "radix": "UnderlineIcon"
+    "radix": "UnderlineIcon",
+    "tabler": "IconUnderline",
+    "hugeicons": "TextUnderlineIcon",
+    "phosphor": "TextUnderlineIcon",
+    "remixicon": "RiUnderline"
   },
   "User": {
     "lucide": "User",
-    "radix": "PersonIcon"
+    "radix": "PersonIcon",
+    "tabler": "IconUser",
+    "hugeicons": "UserIcon",
+    "phosphor": "UserIcon",
+    "remixicon": "RiUserLine"
   },
   "X": {
     "lucide": "X",
-    "radix": "Cross2Icon"
+    "radix": "Cross2Icon",
+    "tabler": "IconX",
+    "hugeicons": "Cancel01Icon",
+    "phosphor": "XIcon",
+    "remixicon": "RiCloseLine"
+  },
+  "ActivityIcon": {
+    "lucide": "ActivityIcon",
+    "tabler": "IconActivity",
+    "hugeicons": "ActivityIcon",
+    "phosphor": "ActivityIcon",
+    "remixicon": "RiPulseLine"
+  },
+  "AlertTriangleIcon": {
+    "lucide": "AlertTriangleIcon",
+    "tabler": "IconAlertTriangle",
+    "hugeicons": "AlertCircleIcon",
+    "phosphor": "WarningIcon",
+    "remixicon": "RiErrorWarningLine"
+  },
+  "AppWindowIcon": {
+    "lucide": "AppWindowIcon",
+    "tabler": "IconAppWindow",
+    "hugeicons": "CursorInWindowIcon",
+    "phosphor": "AppWindowIcon",
+    "remixicon": "RiWindowLine"
+  },
+  "ArchiveIcon": {
+    "lucide": "ArchiveIcon",
+    "tabler": "IconArchive",
+    "hugeicons": "Archive02Icon",
+    "phosphor": "ArchiveIcon",
+    "remixicon": "RiArchiveLine"
+  },
+  "ArchiveXIcon": {
+    "lucide": "ArchiveXIcon",
+    "tabler": "IconArchiveOff",
+    "hugeicons": "ArchiveIcon",
+    "phosphor": "ArchiveIcon",
+    "remixicon": "RiArchiveLine"
+  },
+  "ArrowDownIcon": {
+    "lucide": "ArrowDownIcon",
+    "tabler": "IconArrowDown",
+    "hugeicons": "ArrowDownIcon",
+    "phosphor": "ArrowDownIcon",
+    "remixicon": "RiArrowDownLine"
+  },
+  "ArrowLeftCircleIcon": {
+    "lucide": "ArrowLeftCircleIcon",
+    "tabler": "IconCircleArrowLeft",
+    "hugeicons": "CircleArrowLeft02Icon",
+    "phosphor": "ArrowCircleLeftIcon",
+    "remixicon": "RiArrowLeftCircleLine"
+  },
+  "ArrowLeftRightIcon": {
+    "lucide": "ArrowLeftRightIcon",
+    "tabler": "IconArrowsLeftRight",
+    "hugeicons": "ArrowDataTransferHorizontalIcon",
+    "phosphor": "ArrowsLeftRightIcon",
+    "remixicon": "RiArrowLeftRightLine"
+  },
+  "ArrowUpIcon": {
+    "lucide": "ArrowUpIcon",
+    "tabler": "IconArrowUp",
+    "hugeicons": "ArrowUpIcon",
+    "phosphor": "ArrowUpIcon",
+    "remixicon": "RiArrowUpLine"
+  },
+  "ArrowUpRightIcon": {
+    "lucide": "ArrowUpRightIcon",
+    "tabler": "IconArrowUpRight",
+    "hugeicons": "ArrowUpRightIcon",
+    "phosphor": "ArrowUpRightIcon",
+    "remixicon": "RiArrowRightUpLine"
+  },
+  "AudioLinesIcon": {
+    "lucide": "AudioLinesIcon",
+    "tabler": "IconPlayerRecordFilled",
+    "hugeicons": "AudioWave01Icon",
+    "phosphor": "RecordIcon",
+    "remixicon": "RiRecordCircleLine"
+  },
+  "BadgeCheck": {
+    "lucide": "BadgeCheck",
+    "tabler": "IconRosetteDiscountCheck",
+    "hugeicons": "CheckmarkBadge02Icon",
+    "phosphor": "CheckCircleIcon",
+    "remixicon": "RiCheckboxCircleLine"
+  },
+  "BadgeCheckIcon": {
+    "lucide": "BadgeCheckIcon",
+    "tabler": "IconRosetteDiscountCheck",
+    "hugeicons": "CheckmarkBadgeIcon",
+    "phosphor": "CheckCircleIcon",
+    "remixicon": "RiCheckboxCircleLine"
+  },
+  "BellIcon": {
+    "lucide": "BellIcon",
+    "tabler": "IconNotification",
+    "hugeicons": "Notification03Icon",
+    "phosphor": "BellIcon",
+    "remixicon": "RiNotification3Line"
+  },
+  "BlocksIcon": {
+    "lucide": "BlocksIcon",
+    "tabler": "IconCube",
+    "hugeicons": "CubeIcon",
+    "phosphor": "CubeIcon",
+    "remixicon": "RiBox3Line"
+  },
+  "BluetoothIcon": {
+    "lucide": "BluetoothIcon",
+    "tabler": "IconBluetooth",
+    "hugeicons": "BluetoothIcon",
+    "phosphor": "BluetoothIcon",
+    "remixicon": "RiBluetoothLine"
+  },
+  "BookOpen": {
+    "lucide": "BookOpen",
+    "tabler": "IconBook",
+    "hugeicons": "BookOpen02Icon",
+    "phosphor": "BookOpenIcon",
+    "remixicon": "RiBookOpenLine"
+  },
+  "BookOpenIcon": {
+    "lucide": "BookOpenIcon",
+    "tabler": "IconBook",
+    "hugeicons": "BookOpen02Icon",
+    "phosphor": "BookOpenIcon",
+    "remixicon": "RiBookOpenLine"
+  },
+  "BookmarkIcon": {
+    "lucide": "BookmarkIcon",
+    "tabler": "IconBookmark",
+    "hugeicons": "BookmarkIcon",
+    "phosphor": "BookmarkIcon",
+    "remixicon": "RiBookmarkLine"
+  },
+  "BotIcon": {
+    "lucide": "BotIcon",
+    "tabler": "IconRobot",
+    "hugeicons": "RoboticIcon",
+    "phosphor": "RobotIcon",
+    "remixicon": "RiRobotLine"
+  },
+  "BrainIcon": {
+    "lucide": "BrainIcon",
+    "tabler": "IconBrain",
+    "hugeicons": "AiBrainIcon",
+    "phosphor": "BrainIcon",
+    "remixicon": "RiBrainLine"
+  },
+  "Building2Icon": {
+    "lucide": "Building2Icon",
+    "tabler": "IconBuildingBank",
+    "hugeicons": "BankIcon",
+    "phosphor": "BankIcon",
+    "remixicon": "RiBankLine"
+  },
+  "CameraIcon": {
+    "lucide": "CameraIcon",
+    "tabler": "IconCamera",
+    "hugeicons": "Camera01Icon",
+    "phosphor": "CameraIcon",
+    "remixicon": "RiCameraLine"
+  },
+  "CaptionsIcon": {
+    "lucide": "CaptionsIcon",
+    "tabler": "IconTextCaption",
+    "hugeicons": "TextCheckIcon",
+    "phosphor": "TextTIcon",
+    "remixicon": "RiTextWrap"
+  },
+  "CarIcon": {
+    "lucide": "CarIcon",
+    "tabler": "IconCar",
+    "hugeicons": "Car01Icon",
+    "phosphor": "CarIcon",
+    "remixicon": "RiCarLine"
+  },
+  "ChartBarIcon": {
+    "lucide": "ChartBarIcon",
+    "tabler": "IconChartBar",
+    "hugeicons": "ChartHistogramIcon",
+    "phosphor": "ChartBarIcon",
+    "remixicon": "RiBarChartLine"
+  },
+  "ChartLineIcon": {
+    "lucide": "ChartLineIcon",
+    "tabler": "IconChartLine",
+    "hugeicons": "ChartIcon",
+    "phosphor": "ChartLineIcon",
+    "remixicon": "RiLineChartLine"
+  },
+  "ChartPieIcon": {
+    "lucide": "ChartPieIcon",
+    "tabler": "IconChartPie",
+    "hugeicons": "Chart03Icon",
+    "phosphor": "ChartPieIcon",
+    "remixicon": "RiPieChartLine"
+  },
+  "CheckCircle2Icon": {
+    "lucide": "CheckCircle2Icon",
+    "tabler": "IconCircleCheckFilled",
+    "hugeicons": "CheckmarkCircle02Icon",
+    "phosphor": "CheckCircleIcon",
+    "remixicon": "RiCheckboxCircleLine"
+  },
+  "ChevronsLeftIcon": {
+    "lucide": "ChevronsLeftIcon",
+    "tabler": "IconChevronsLeft",
+    "hugeicons": "ArrowLeftDoubleIcon",
+    "phosphor": "CaretDoubleLeftIcon",
+    "remixicon": "RiSkipLeftLine"
+  },
+  "ChevronsRightIcon": {
+    "lucide": "ChevronsRightIcon",
+    "tabler": "IconChevronsRight",
+    "hugeicons": "ArrowRightDoubleIcon",
+    "phosphor": "CaretDoubleRightIcon",
+    "remixicon": "RiSkipRightLine"
+  },
+  "CircleAlertIcon": {
+    "lucide": "CircleAlertIcon",
+    "tabler": "IconExclamationCircle",
+    "hugeicons": "AlertCircleIcon",
+    "phosphor": "WarningCircleIcon",
+    "remixicon": "RiErrorWarningLine"
+  },
+  "CircleCheckIcon": {
+    "lucide": "CircleCheckIcon",
+    "tabler": "IconCircleCheckFilled",
+    "hugeicons": "CheckmarkCircle01Icon",
+    "phosphor": "CheckCircleIcon",
+    "remixicon": "RiCheckboxCircleFill"
+  },
+  "CircleDashedIcon": {
+    "lucide": "CircleDashedIcon",
+    "tabler": "IconCircleDashed",
+    "hugeicons": "DashedLineCircleIcon",
+    "phosphor": "CircleDashedIcon",
+    "remixicon": "RiLoaderLine"
+  },
+  "CircleHelpIcon": {
+    "lucide": "CircleHelpIcon",
+    "tabler": "IconHelp",
+    "hugeicons": "HelpCircleIcon",
+    "phosphor": "QuestionIcon",
+    "remixicon": "RiQuestionLine"
+  },
+  "CirclePlusIcon": {
+    "lucide": "CirclePlusIcon",
+    "tabler": "IconCirclePlusFilled",
+    "hugeicons": "PlusSignCircleIcon",
+    "phosphor": "PlusCircleIcon",
+    "remixicon": "RiAddCircleFill"
+  },
+  "CircleUserIcon": {
+    "lucide": "CircleUserIcon",
+    "tabler": "IconUserCircle",
+    "hugeicons": "UserCircleIcon",
+    "phosphor": "UserCircleIcon",
+    "remixicon": "RiUserSmileLine"
+  },
+  "CircleUserRoundIcon": {
+    "lucide": "CircleUserRoundIcon",
+    "tabler": "IconUserCircle",
+    "hugeicons": "UserCircle02Icon",
+    "phosphor": "UserCircleIcon",
+    "remixicon": "RiUserLine"
+  },
+  "ClipboardPasteIcon": {
+    "lucide": "ClipboardPasteIcon",
+    "tabler": "IconClipboard",
+    "hugeicons": "ClipboardIcon",
+    "phosphor": "ClipboardIcon",
+    "remixicon": "RiClipboardLine"
+  },
+  "Clock2Icon": {
+    "lucide": "Clock2Icon",
+    "tabler": "IconClockHour2",
+    "hugeicons": "Clock03Icon",
+    "phosphor": "ClockIcon",
+    "remixicon": "RiTimeLine"
+  },
+  "ClockIcon": {
+    "lucide": "ClockIcon",
+    "tabler": "IconClock",
+    "hugeicons": "Clock01Icon",
+    "phosphor": "ClockIcon",
+    "remixicon": "RiTimeLine"
+  },
+  "CloudIcon": {
+    "lucide": "CloudIcon",
+    "tabler": "IconCloud",
+    "hugeicons": "CloudUploadIcon",
+    "phosphor": "CloudIcon",
+    "remixicon": "RiCloudLine"
+  },
+  "CodeIcon": {
+    "lucide": "CodeIcon",
+    "tabler": "IconCode",
+    "hugeicons": "CodeIcon",
+    "phosphor": "CodeIcon",
+    "remixicon": "RiCodeLine"
+  },
+  "CoffeeIcon": {
+    "lucide": "CoffeeIcon",
+    "tabler": "IconCoffee",
+    "hugeicons": "CoffeeIcon",
+    "phosphor": "CoffeeIcon",
+    "remixicon": "RiCupLine"
+  },
+  "Columns3Icon": {
+    "lucide": "Columns3Icon",
+    "tabler": "IconLayoutColumns",
+    "hugeicons": "LeftToRightListBulletIcon",
+    "phosphor": "ColumnsIcon",
+    "remixicon": "RiLayoutColumnLine"
+  },
+  "CommandIcon": {
+    "lucide": "CommandIcon",
+    "tabler": "IconInnerShadowTop",
+    "hugeicons": "CommandIcon",
+    "phosphor": "CommandIcon",
+    "remixicon": "RiCommandLine"
+  },
+  "ContainerIcon": {
+    "lucide": "ContainerIcon",
+    "tabler": "IconBox",
+    "hugeicons": "CubeIcon",
+    "phosphor": "CubeIcon",
+    "remixicon": "RiBox1Line"
+  },
+  "CornerUpLeftIcon": {
+    "lucide": "CornerUpLeftIcon",
+    "tabler": "IconCornerUpLeft",
+    "hugeicons": "UndoIcon",
+    "phosphor": "ArrowBendUpLeftIcon",
+    "remixicon": "RiCornerUpLeftLine"
+  },
+  "CornerUpRightIcon": {
+    "lucide": "CornerUpRightIcon",
+    "tabler": "IconCornerUpRight",
+    "hugeicons": "RedoIcon",
+    "phosphor": "ArrowBendUpRightIcon",
+    "remixicon": "RiCornerUpRightLine"
+  },
+  "DatabaseIcon": {
+    "lucide": "DatabaseIcon",
+    "tabler": "IconDatabase",
+    "hugeicons": "Database01Icon",
+    "phosphor": "DatabaseIcon",
+    "remixicon": "RiDatabase2Line"
+  },
+  "DownloadIcon": {
+    "lucide": "DownloadIcon",
+    "tabler": "IconDownload",
+    "hugeicons": "DownloadIcon",
+    "phosphor": "DownloadIcon",
+    "remixicon": "RiDownloadLine"
+  },
+  "EllipsisVerticalIcon": {
+    "lucide": "EllipsisVerticalIcon",
+    "tabler": "IconDotsVertical",
+    "hugeicons": "MoreVerticalCircle01Icon",
+    "phosphor": "DotsThreeVerticalIcon",
+    "remixicon": "RiMore2Line"
+  },
+  "ExternalLinkIcon": {
+    "lucide": "ExternalLinkIcon",
+    "tabler": "IconExternalLink",
+    "hugeicons": "LinkSquare02Icon",
+    "phosphor": "ArrowSquareOutIcon",
+    "remixicon": "RiExternalLinkLine"
+  },
+  "EyeIcon": {
+    "lucide": "EyeIcon",
+    "tabler": "IconEye",
+    "hugeicons": "EyeIcon",
+    "phosphor": "EyeIcon",
+    "remixicon": "RiEyeLine"
+  },
+  "EyeOffIcon": {
+    "lucide": "EyeOffIcon",
+    "tabler": "IconEyeClosed",
+    "hugeicons": "ViewOffIcon",
+    "phosphor": "EyeSlashIcon",
+    "remixicon": "RiEyeOffLine"
+  },
+  "FileArchiveIcon": {
+    "lucide": "FileArchiveIcon",
+    "tabler": "IconFileZip",
+    "hugeicons": "File01Icon",
+    "phosphor": "FileZipIcon",
+    "remixicon": "RiFileZipLine"
+  },
+  "FileBarChartIcon": {
+    "lucide": "FileBarChartIcon",
+    "tabler": "IconReportAnalytics",
+    "hugeicons": "ChartBarLineIcon",
+    "phosphor": "ChartBarIcon",
+    "remixicon": "RiBarChartLine"
+  },
+  "FileChartColumnIcon": {
+    "lucide": "FileChartColumnIcon",
+    "tabler": "IconReport",
+    "hugeicons": "Analytics01Icon",
+    "phosphor": "ChartLineIcon",
+    "remixicon": "RiFileChartLine"
+  },
+  "FileCodeIcon": {
+    "lucide": "FileCodeIcon",
+    "tabler": "IconFileCode",
+    "hugeicons": "File01Icon",
+    "phosphor": "FileCodeIcon",
+    "remixicon": "RiFileCodeLine"
+  },
+  "FileIcon": {
+    "lucide": "FileIcon",
+    "tabler": "IconFileWord",
+    "hugeicons": "File01Icon",
+    "phosphor": "FileIcon",
+    "remixicon": "RiFileLine"
+  },
+  "FileSearchIcon": {
+    "lucide": "FileSearchIcon",
+    "tabler": "IconFileSearch",
+    "hugeicons": "FileSearchIcon",
+    "phosphor": "FileSearchIcon",
+    "remixicon": "RiFileSearchLine"
+  },
+  "FileTextIcon": {
+    "lucide": "FileTextIcon",
+    "tabler": "IconFileDescription",
+    "hugeicons": "File01Icon",
+    "phosphor": "FileTextIcon",
+    "remixicon": "RiFileTextLine"
+  },
+  "FileWarningIcon": {
+    "lucide": "FileWarningIcon",
+    "tabler": "IconFileAlert",
+    "hugeicons": "FileCorruptIcon",
+    "phosphor": "FileXIcon",
+    "remixicon": "RiFileWarningLine"
+  },
+  "FlipHorizontalIcon": {
+    "lucide": "FlipHorizontalIcon",
+    "tabler": "IconFlipHorizontal",
+    "hugeicons": "FlipHorizontalIcon",
+    "phosphor": "ArrowsHorizontalIcon",
+    "remixicon": "RiArrowLeftRightLine"
+  },
+  "FlipVerticalIcon": {
+    "lucide": "FlipVerticalIcon",
+    "tabler": "IconFlipVertical",
+    "hugeicons": "FlipVerticalIcon",
+    "phosphor": "ArrowsVerticalIcon",
+    "remixicon": "RiArrowUpDownLine"
+  },
+  "FolderIcon": {
+    "lucide": "FolderIcon",
+    "tabler": "IconFolder",
+    "hugeicons": "Folder01Icon",
+    "phosphor": "FolderIcon",
+    "remixicon": "RiFolderLine"
+  },
+  "FolderOpenIcon": {
+    "lucide": "FolderOpenIcon",
+    "tabler": "IconFolderOpen",
+    "hugeicons": "FolderOpenIcon",
+    "phosphor": "FolderOpenIcon",
+    "remixicon": "RiFolderOpenLine"
+  },
+  "FolderPlusIcon": {
+    "lucide": "FolderPlusIcon",
+    "tabler": "IconFolderPlus",
+    "hugeicons": "FolderAddIcon",
+    "phosphor": "FolderPlusIcon",
+    "remixicon": "RiFolderAddLine"
+  },
+  "FolderSearchIcon": {
+    "lucide": "FolderSearchIcon",
+    "tabler": "IconFolderSearch",
+    "hugeicons": "SearchIcon",
+    "phosphor": "MagnifyingGlassIcon",
+    "remixicon": "RiSearchLine"
+  },
+  "FrameIcon": {
+    "lucide": "FrameIcon",
+    "tabler": "IconFrame",
+    "hugeicons": "CropIcon",
+    "phosphor": "CropIcon",
+    "remixicon": "RiCropLine"
+  },
+  "GalleryVerticalEndIcon": {
+    "lucide": "GalleryVerticalEndIcon",
+    "tabler": "IconLayoutRows",
+    "hugeicons": "LayoutBottomIcon",
+    "phosphor": "RowsIcon",
+    "remixicon": "RiGalleryLine"
+  },
+  "GaugeIcon": {
+    "lucide": "GaugeIcon",
+    "tabler": "IconGauge",
+    "hugeicons": "Settings01Icon",
+    "phosphor": "GaugeIcon",
+    "remixicon": "RiDashboardLine"
+  },
+  "GitBranchIcon": {
+    "lucide": "GitBranchIcon",
+    "tabler": "IconGitBranch",
+    "hugeicons": "GitBranchIcon",
+    "phosphor": "GitBranchIcon",
+    "remixicon": "RiGitBranchLine"
+  },
+  "GlobeIcon": {
+    "lucide": "GlobeIcon",
+    "tabler": "IconWorld",
+    "hugeicons": "Globe02Icon",
+    "phosphor": "GlobeIcon",
+    "remixicon": "RiGlobalLine"
+  },
+  "HeartIcon": {
+    "lucide": "HeartIcon",
+    "tabler": "IconBell",
+    "hugeicons": "Notification02Icon",
+    "phosphor": "HeartIcon",
+    "remixicon": "RiHeartLine"
+  },
+  "HelpCircleIcon": {
+    "lucide": "HelpCircleIcon",
+    "tabler": "IconHelpCircle",
+    "hugeicons": "HelpCircleIcon",
+    "phosphor": "QuestionIcon",
+    "remixicon": "RiQuestionLine"
+  },
+  "HomeIcon": {
+    "lucide": "HomeIcon",
+    "tabler": "IconHome",
+    "hugeicons": "HomeIcon",
+    "phosphor": "HouseIcon",
+    "remixicon": "RiHomeLine"
+  },
+  "ImageIcon": {
+    "lucide": "ImageIcon",
+    "tabler": "IconPhoto",
+    "hugeicons": "Image01Icon",
+    "phosphor": "ImageIcon",
+    "remixicon": "RiImageLine"
+  },
+  "InboxIcon": {
+    "lucide": "InboxIcon",
+    "tabler": "IconInbox",
+    "hugeicons": "InboxIcon",
+    "phosphor": "TrayIcon",
+    "remixicon": "RiInboxLine"
+  },
+  "InfoIcon": {
+    "lucide": "InfoIcon",
+    "tabler": "IconInfoCircle",
+    "hugeicons": "AlertCircleIcon",
+    "phosphor": "InfoIcon",
+    "remixicon": "RiInformationLine"
+  },
+  "KeyboardIcon": {
+    "lucide": "KeyboardIcon",
+    "tabler": "IconKeyboard",
+    "hugeicons": "KeyboardIcon",
+    "phosphor": "KeyboardIcon",
+    "remixicon": "RiKeyboardLine"
+  },
+  "LanguagesIcon": {
+    "lucide": "LanguagesIcon",
+    "tabler": "IconLanguage",
+    "hugeicons": "LanguageCircleIcon",
+    "phosphor": "TranslateIcon",
+    "remixicon": "RiTranslate"
+  },
+  "LayoutDashboardIcon": {
+    "lucide": "LayoutDashboardIcon",
+    "tabler": "IconDashboard",
+    "hugeicons": "DashboardSquare01Icon",
+    "phosphor": "SquaresFourIcon",
+    "remixicon": "RiDashboardLine"
+  },
+  "LayoutGridIcon": {
+    "lucide": "LayoutGridIcon",
+    "tabler": "IconLayoutGrid",
+    "hugeicons": "GridIcon",
+    "phosphor": "GridFourIcon",
+    "remixicon": "RiGridLine"
+  },
+  "LayoutIcon": {
+    "lucide": "LayoutIcon",
+    "tabler": "IconLayout",
+    "hugeicons": "LayoutIcon",
+    "phosphor": "LayoutIcon",
+    "remixicon": "RiLayoutLine"
+  },
+  "LifeBuoy": {
+    "lucide": "LifeBuoy",
+    "tabler": "IconLifebuoy",
+    "hugeicons": "ChartRingIcon",
+    "phosphor": "LifebuoyIcon",
+    "remixicon": "RiLifebuoyLine"
+  },
+  "LifeBuoyIcon": {
+    "lucide": "LifeBuoyIcon",
+    "tabler": "IconLifebuoy",
+    "hugeicons": "ChartRingIcon",
+    "phosphor": "LifebuoyIcon",
+    "remixicon": "RiLifebuoyLine"
+  },
+  "LinkIcon": {
+    "lucide": "LinkIcon",
+    "tabler": "IconLink",
+    "hugeicons": "LinkIcon",
+    "phosphor": "LinkIcon",
+    "remixicon": "RiLinksLine"
+  },
+  "ListIcon": {
+    "lucide": "ListIcon",
+    "tabler": "IconListDetails",
+    "hugeicons": "Menu01Icon",
+    "phosphor": "ListIcon",
+    "remixicon": "RiListUnordered"
+  },
+  "LoaderIcon": {
+    "lucide": "LoaderIcon",
+    "tabler": "IconLoader",
+    "hugeicons": "Loading03Icon",
+    "phosphor": "SpinnerIcon",
+    "remixicon": "RiLoader4Line"
+  },
+  "LockIcon": {
+    "lucide": "LockIcon",
+    "tabler": "IconLock",
+    "hugeicons": "SquareLock02Icon",
+    "phosphor": "LockKeyIcon",
+    "remixicon": "RiLockLine"
+  },
+  "LockKeyholeIcon": {
+    "lucide": "LockKeyholeIcon",
+    "tabler": "IconLock",
+    "hugeicons": "SquareLock02Icon",
+    "phosphor": "LockKeyIcon",
+    "remixicon": "RiLockLine"
+  },
+  "LogOutIcon": {
+    "lucide": "LogOutIcon",
+    "tabler": "IconLogout",
+    "hugeicons": "Logout01Icon",
+    "phosphor": "SignOutIcon",
+    "remixicon": "RiLogoutBoxLine"
+  },
+  "MapIcon": {
+    "lucide": "MapIcon",
+    "tabler": "IconMap",
+    "hugeicons": "MapsIcon",
+    "phosphor": "MapTrifoldIcon",
+    "remixicon": "RiMapLine"
+  },
+  "MaximizeIcon": {
+    "lucide": "MaximizeIcon",
+    "tabler": "IconMaximize",
+    "hugeicons": "PlusSignIcon",
+    "phosphor": "PlusIcon",
+    "remixicon": "RiAddLine"
+  },
+  "MenuIcon": {
+    "lucide": "MenuIcon",
+    "tabler": "IconMenu",
+    "hugeicons": "Menu09Icon",
+    "phosphor": "ListIcon",
+    "remixicon": "RiMenuLine"
+  },
+  "MessageCircleIcon": {
+    "lucide": "MessageCircleIcon",
+    "tabler": "IconMessageQuestion",
+    "hugeicons": "MessageIcon",
+    "phosphor": "ChatCircleIcon",
+    "remixicon": "RiChat1Line"
+  },
+  "MessageCircleQuestionIcon": {
+    "lucide": "MessageCircleQuestionIcon",
+    "tabler": "IconMessageQuestion",
+    "hugeicons": "MessageQuestionIcon",
+    "phosphor": "ChatCircleIcon",
+    "remixicon": "RiQuestionLine"
+  },
+  "MessageSquareIcon": {
+    "lucide": "MessageSquareIcon",
+    "tabler": "IconMessage",
+    "hugeicons": "Message01Icon",
+    "phosphor": "ChatIcon",
+    "remixicon": "RiChat1Line"
+  },
+  "MicIcon": {
+    "lucide": "MicIcon",
+    "tabler": "IconMicrophone",
+    "hugeicons": "VoiceIcon",
+    "phosphor": "MicrophoneIcon",
+    "remixicon": "RiMicLine"
+  },
+  "MinimizeIcon": {
+    "lucide": "MinimizeIcon",
+    "tabler": "IconMinimize",
+    "hugeicons": "MinusSignIcon",
+    "phosphor": "MinusIcon",
+    "remixicon": "RiSubtractLine"
+  },
+  "MonitorIcon": {
+    "lucide": "MonitorIcon",
+    "tabler": "IconDeviceDesktop",
+    "hugeicons": "ComputerIcon",
+    "phosphor": "MonitorIcon",
+    "remixicon": "RiComputerLine"
+  },
+  "MoreVerticalIcon": {
+    "lucide": "MoreVerticalIcon",
+    "tabler": "IconDotsVertical",
+    "hugeicons": "MoreVerticalCircle01Icon",
+    "phosphor": "DotsThreeVerticalIcon",
+    "remixicon": "RiMore2Line"
+  },
+  "OctagonXIcon": {
+    "lucide": "OctagonXIcon",
+    "tabler": "IconAlertOctagon",
+    "hugeicons": "MultiplicationSignCircleIcon",
+    "phosphor": "XCircleIcon",
+    "remixicon": "RiCloseCircleLine"
+  },
+  "PaintbrushIcon": {
+    "lucide": "PaintbrushIcon",
+    "tabler": "IconPalette",
+    "hugeicons": "PaintBoardIcon",
+    "phosphor": "PaletteIcon",
+    "remixicon": "RiPaletteLine"
+  },
+  "PaletteIcon": {
+    "lucide": "PaletteIcon",
+    "tabler": "IconPalette",
+    "hugeicons": "PaintBoardIcon",
+    "phosphor": "PaletteIcon",
+    "remixicon": "RiPaletteLine"
+  },
+  "PaperclipIcon": {
+    "lucide": "PaperclipIcon",
+    "tabler": "IconPaperclip",
+    "hugeicons": "AttachmentIcon",
+    "phosphor": "PaperclipIcon",
+    "remixicon": "RiAttachmentLine"
+  },
+  "PencilIcon": {
+    "lucide": "PencilIcon",
+    "tabler": "IconPencil",
+    "hugeicons": "EditIcon",
+    "phosphor": "PencilIcon",
+    "remixicon": "RiPencilLine"
+  },
+  "PieChartIcon": {
+    "lucide": "PieChartIcon",
+    "tabler": "IconChartPie",
+    "hugeicons": "PieChartIcon",
+    "phosphor": "ChartPieIcon",
+    "remixicon": "RiPieChartLine"
+  },
+  "PlusCircleIcon": {
+    "lucide": "PlusCircleIcon",
+    "tabler": "IconCirclePlus",
+    "hugeicons": "AddCircleIcon",
+    "phosphor": "PlusCircleIcon",
+    "remixicon": "RiAddCircleLine"
+  },
+  "PresentationIcon": {
+    "lucide": "PresentationIcon",
+    "tabler": "IconPresentation",
+    "hugeicons": "Presentation01Icon",
+    "phosphor": "PresentationIcon",
+    "remixicon": "RiSlideshowLine"
+  },
+  "RadioIcon": {
+    "lucide": "RadioIcon",
+    "tabler": "IconPlayerRecordFilled",
+    "hugeicons": "RecordIcon",
+    "phosphor": "RecordIcon",
+    "remixicon": "RiRecordCircleLine"
+  },
+  "RefreshCcwIcon": {
+    "lucide": "RefreshCcwIcon",
+    "tabler": "IconRefresh",
+    "hugeicons": "ReloadIcon",
+    "phosphor": "ArrowClockwiseIcon",
+    "remixicon": "RiRefreshLine"
+  },
+  "RefreshCwIcon": {
+    "lucide": "RefreshCwIcon",
+    "tabler": "IconRefresh",
+    "hugeicons": "RepeatIcon",
+    "phosphor": "ArrowsClockwiseIcon",
+    "remixicon": "RiRefreshLine"
+  },
+  "RepeatIcon": {
+    "lucide": "RepeatIcon",
+    "tabler": "IconRepeat",
+    "hugeicons": "RepeatIcon",
+    "phosphor": "RepeatIcon",
+    "remixicon": "RiRepeatLine"
+  },
+  "RotateCwIcon": {
+    "lucide": "RotateCwIcon",
+    "tabler": "IconRotateClockwise2",
+    "hugeicons": "Rotate01Icon",
+    "phosphor": "ArrowClockwiseIcon",
+    "remixicon": "RiRefreshLine"
+  },
+  "SaveIcon": {
+    "lucide": "SaveIcon",
+    "tabler": "IconDeviceFloppy",
+    "hugeicons": "FloppyDiskIcon",
+    "phosphor": "FloppyDiskIcon",
+    "remixicon": "RiSaveLine"
+  },
+  "ScissorsIcon": {
+    "lucide": "ScissorsIcon",
+    "tabler": "IconCut",
+    "hugeicons": "ScissorIcon",
+    "phosphor": "ScissorsIcon",
+    "remixicon": "RiScissorsLine"
+  },
+  "SendIcon": {
+    "lucide": "SendIcon",
+    "tabler": "IconSend",
+    "hugeicons": "SentIcon",
+    "phosphor": "PaperPlaneTiltIcon",
+    "remixicon": "RiSendPlaneLine"
+  },
+  "ServerIcon": {
+    "lucide": "ServerIcon",
+    "tabler": "IconServer",
+    "hugeicons": "ServerStackIcon",
+    "phosphor": "HardDrivesIcon",
+    "remixicon": "RiHardDriveLine"
+  },
+  "Settings2Icon": {
+    "lucide": "Settings2Icon",
+    "tabler": "IconSettings",
+    "hugeicons": "Settings05Icon",
+    "phosphor": "GearIcon",
+    "remixicon": "RiSettingsLine"
+  },
+  "ShareIcon": {
+    "lucide": "ShareIcon",
+    "tabler": "IconShare3",
+    "hugeicons": "Share01Icon",
+    "phosphor": "ShareIcon",
+    "remixicon": "RiShareLine"
+  },
+  "ShieldIcon": {
+    "lucide": "ShieldIcon",
+    "tabler": "IconShield",
+    "hugeicons": "ShieldIcon",
+    "phosphor": "ShieldIcon",
+    "remixicon": "RiShieldLine"
+  },
+  "ShoppingBagIcon": {
+    "lucide": "ShoppingBagIcon",
+    "tabler": "IconShoppingBag",
+    "hugeicons": "ShoppingBag01Icon",
+    "phosphor": "BagIcon",
+    "remixicon": "RiShoppingBagLine"
+  },
+  "ShoppingCartIcon": {
+    "lucide": "ShoppingCartIcon",
+    "tabler": "IconShoppingCart",
+    "hugeicons": "ShoppingCart01Icon",
+    "phosphor": "ShoppingCartIcon",
+    "remixicon": "RiShoppingCartLine"
+  },
+  "SparklesIcon": {
+    "lucide": "SparklesIcon",
+    "tabler": "IconSparkles",
+    "hugeicons": "SparklesIcon",
+    "phosphor": "SparkleIcon",
+    "remixicon": "RiSparklingLine"
+  },
+  "SquareIcon": {
+    "lucide": "SquareIcon",
+    "tabler": "IconPlayerStop",
+    "hugeicons": "StopCircleIcon",
+    "phosphor": "StopCircleIcon",
+    "remixicon": "RiStopCircleLine"
+  },
+  "StarIcon": {
+    "lucide": "StarIcon",
+    "tabler": "IconStar",
+    "hugeicons": "StarIcon",
+    "phosphor": "StarIcon",
+    "remixicon": "RiStarLine"
+  },
+  "StarOffIcon": {
+    "lucide": "StarOffIcon",
+    "tabler": "IconStarOff",
+    "hugeicons": "StarOffIcon",
+    "phosphor": "StarIcon",
+    "remixicon": "RiStarOffLine"
+  },
+  "StopCircleIcon": {
+    "lucide": "StopCircleIcon",
+    "tabler": "IconPlayerStop",
+    "hugeicons": "StopCircleIcon",
+    "phosphor": "StopCircleIcon",
+    "remixicon": "RiStopCircleLine"
+  },
+  "TableIcon": {
+    "lucide": "TableIcon",
+    "tabler": "IconTable",
+    "hugeicons": "TableIcon",
+    "phosphor": "TableIcon",
+    "remixicon": "RiTableLine"
+  },
+  "TargetIcon": {
+    "lucide": "TargetIcon",
+    "tabler": "IconTarget",
+    "hugeicons": "Target02Icon",
+    "phosphor": "TargetIcon",
+    "remixicon": "RiFocus3Line"
+  },
+  "TerminalSquareIcon": {
+    "lucide": "TerminalSquareIcon",
+    "tabler": "IconTerminal2",
+    "hugeicons": "ComputerTerminalIcon",
+    "phosphor": "TerminalIcon",
+    "remixicon": "RiTerminalBoxLine"
+  },
+  "ThermometerIcon": {
+    "lucide": "ThermometerIcon",
+    "tabler": "IconThermometer",
+    "hugeicons": "ThermometerWarmIcon",
+    "phosphor": "ThermometerIcon",
+    "remixicon": "RiThermometerLine"
+  },
+  "ThumbsDownIcon": {
+    "lucide": "ThumbsDownIcon",
+    "tabler": "IconThumbDown",
+    "hugeicons": "ThumbsDownIcon",
+    "phosphor": "ThumbsDownIcon",
+    "remixicon": "RiThumbDownLine"
+  },
+  "ThumbsUpIcon": {
+    "lucide": "ThumbsUpIcon",
+    "tabler": "IconThumbUp",
+    "hugeicons": "ThumbsUpIcon",
+    "phosphor": "ThumbsUpIcon",
+    "remixicon": "RiThumbUpLine"
+  },
+  "TimerIcon": {
+    "lucide": "TimerIcon",
+    "tabler": "IconClock",
+    "hugeicons": "Clock03Icon",
+    "phosphor": "TimerIcon",
+    "remixicon": "RiTimerLine"
+  },
+  "Trash2Icon": {
+    "lucide": "Trash2Icon",
+    "tabler": "IconTrash",
+    "hugeicons": "Delete02Icon",
+    "phosphor": "TrashIcon",
+    "remixicon": "RiDeleteBinLine"
+  },
+  "TrashIcon": {
+    "lucide": "TrashIcon",
+    "tabler": "IconTrash",
+    "hugeicons": "DeleteIcon",
+    "phosphor": "TrashIcon",
+    "remixicon": "RiDeleteBinLine"
+  },
+  "TrendingDownIcon": {
+    "lucide": "TrendingDownIcon",
+    "tabler": "IconTrendingDown",
+    "hugeicons": "ChartDownIcon",
+    "phosphor": "TrendDownIcon",
+    "remixicon": "RiArrowDownLine"
+  },
+  "TrendingUpIcon": {
+    "lucide": "TrendingUpIcon",
+    "tabler": "IconTrendingUp",
+    "hugeicons": "ChartUpIcon",
+    "phosphor": "TrendUpIcon",
+    "remixicon": "RiArrowUpLine"
+  },
+  "TriangleAlertIcon": {
+    "lucide": "TriangleAlertIcon",
+    "tabler": "IconAlertTriangle",
+    "hugeicons": "Alert02Icon",
+    "phosphor": "WarningIcon",
+    "remixicon": "RiErrorWarningLine"
+  },
+  "TvIcon": {
+    "lucide": "TvIcon",
+    "tabler": "IconDeviceTv",
+    "hugeicons": "Tv01Icon",
+    "phosphor": "TelevisionIcon",
+    "remixicon": "RiTvLine"
+  },
+  "UploadCloudIcon": {
+    "lucide": "UploadCloudIcon",
+    "tabler": "IconCloudUpload",
+    "hugeicons": "CloudUploadIcon",
+    "phosphor": "CloudArrowUpIcon",
+    "remixicon": "RiUploadCloudLine"
+  },
+  "UserRoundXIcon": {
+    "lucide": "UserRoundXIcon",
+    "tabler": "IconUserX",
+    "hugeicons": "UserRemove01Icon",
+    "phosphor": "UserMinusIcon",
+    "remixicon": "RiUserUnfollowLine"
+  },
+  "UsersIcon": {
+    "lucide": "UsersIcon",
+    "tabler": "IconUsers",
+    "hugeicons": "UserGroupIcon",
+    "phosphor": "UsersIcon",
+    "remixicon": "RiGroupLine"
+  },
+  "VideoIcon": {
+    "lucide": "VideoIcon",
+    "tabler": "IconVideoPlus",
+    "hugeicons": "RecordIcon",
+    "phosphor": "VideoIcon",
+    "remixicon": "RiVideoLine"
+  },
+  "Volume2Icon": {
+    "lucide": "Volume2Icon",
+    "tabler": "IconVolume",
+    "hugeicons": "VolumeHighIcon",
+    "phosphor": "SpeakerHighIcon",
+    "remixicon": "RiVolumeUpLine"
+  },
+  "VolumeOffIcon": {
+    "lucide": "VolumeOffIcon",
+    "tabler": "IconVolume",
+    "hugeicons": "VolumeOffIcon",
+    "phosphor": "SpeakerSlashIcon",
+    "remixicon": "RiVolumeMuteLine"
+  },
+  "VolumeX": {
+    "lucide": "VolumeX",
+    "tabler": "IconVolume",
+    "hugeicons": "VolumeOffIcon",
+    "phosphor": "SpeakerSlashIcon",
+    "remixicon": "RiVolumeMuteLine"
+  },
+  "WalletIcon": {
+    "lucide": "WalletIcon",
+    "tabler": "IconWallet",
+    "hugeicons": "Wallet01Icon",
+    "phosphor": "WalletIcon",
+    "remixicon": "RiWalletLine"
+  },
+  "ZapIcon": {
+    "lucide": "ZapIcon",
+    "tabler": "IconBolt",
+    "hugeicons": "ZapIcon",
+    "phosphor": "LightningIcon",
+    "remixicon": "RiFlashlightLine"
+  },
+  "ZoomInIcon": {
+    "lucide": "ZoomInIcon",
+    "tabler": "IconZoomIn",
+    "hugeicons": "ZoomInAreaIcon",
+    "phosphor": "MagnifyingGlassPlusIcon",
+    "remixicon": "RiZoomInLine"
+  },
+  "ZoomOutIcon": {
+    "lucide": "ZoomOutIcon",
+    "tabler": "IconZoomOut",
+    "hugeicons": "ZoomOutAreaIcon",
+    "phosphor": "MagnifyingGlassMinusIcon",
+    "remixicon": "RiSearchEyeLine"
   }
 }

--- a/apps/v4/registry/icons/legacy-mapping.json
+++ b/apps/v4/registry/icons/legacy-mapping.json
@@ -1,0 +1,150 @@
+{
+  "AlertCircle": {
+    "lucide": "AlertCircle",
+    "radix": "ExclamationTriangleIcon"
+  },
+  "ArrowLeft": {
+    "lucide": "ArrowLeft",
+    "radix": "ArrowLeftIcon"
+  },
+  "ArrowRight": {
+    "lucide": "ArrowRight",
+    "radix": "ArrowRightIcon"
+  },
+  "ArrowUpDown": {
+    "lucide": "ArrowUpDown",
+    "radix": "CaretSortIcon"
+  },
+  "BellRing": {
+    "lucide": "BellRing",
+    "radix": "BellIcon"
+  },
+  "Bold": {
+    "lucide": "Bold",
+    "radix": "FontBoldIcon"
+  },
+  "Calculator": {
+    "lucide": "Calculator",
+    "radix": "ComponentPlaceholderIcon"
+  },
+  "Calendar": {
+    "lucide": "Calendar",
+    "radix": "CalendarIcon"
+  },
+  "Check": {
+    "lucide": "Check",
+    "radix": "CheckIcon"
+  },
+  "ChevronDown": {
+    "lucide": "ChevronDown",
+    "radix": "ChevronDownIcon"
+  },
+  "ChevronLeft": {
+    "lucide": "ChevronLeft",
+    "radix": "ChevronLeftIcon"
+  },
+  "ChevronRight": {
+    "lucide": "ChevronRight",
+    "radix": "ChevronRightIcon"
+  },
+  "ChevronUp": {
+    "lucide": "ChevronUp",
+    "radix": "ChevronUpIcon"
+  },
+  "ChevronsUpDown": {
+    "lucide": "ChevronsUpDown",
+    "radix": "CaretSortIcon"
+  },
+  "Circle": {
+    "lucide": "Circle",
+    "radix": "DotFilledIcon"
+  },
+  "Copy": {
+    "lucide": "Copy",
+    "radix": "CopyIcon"
+  },
+  "CreditCard": {
+    "lucide": "CreditCard",
+    "radix": "ComponentPlaceholderIcon"
+  },
+  "GripVertical": {
+    "lucide": "GripVertical",
+    "radix": "DragHandleDots2Icon"
+  },
+  "Italic": {
+    "lucide": "Italic",
+    "radix": "FontItalicIcon"
+  },
+  "Loader2": {
+    "lucide": "Loader2",
+    "radix": "ReloadIcon"
+  },
+  "Mail": {
+    "lucide": "Mail",
+    "radix": "EnvelopeClosedIcon"
+  },
+  "MailOpen": {
+    "lucide": "MailOpen",
+    "radix": "EnvelopeOpenIcon"
+  },
+  "Minus": {
+    "lucide": "Minus",
+    "radix": "MinusIcon"
+  },
+  "Moon": {
+    "lucide": "Moon",
+    "radix": "MoonIcon"
+  },
+  "MoreHorizontal": {
+    "lucide": "MoreHorizontal",
+    "radix": "DotsHorizontalIcon"
+  },
+  "PanelLeft": {
+    "lucide": "PanelLeft",
+    "radix": "ViewVerticalIcon"
+  },
+  "Plus": {
+    "lucide": "Plus",
+    "radix": "PlusIcon"
+  },
+  "Search": {
+    "lucide": "Search",
+    "radix": "MagnifyingGlassIcon"
+  },
+  "Send": {
+    "lucide": "Send",
+    "radix": "PaperPlaneIcon"
+  },
+  "Settings": {
+    "lucide": "Settings",
+    "radix": "GearIcon"
+  },
+  "Slash": {
+    "lucide": "Slash",
+    "radix": "SlashIcon"
+  },
+  "Smile": {
+    "lucide": "Smile",
+    "radix": "FaceIcon"
+  },
+  "Sun": {
+    "lucide": "Sun",
+    "radix": "SunIcon"
+  },
+  "Terminal": {
+    "lucide": "Terminal",
+    "radix": "RocketIcon"
+  },
+  "Underline": {
+    "lucide": "Underline",
+    "radix": "UnderlineIcon"
+  },
+  "User": {
+    "lucide": "User",
+    "radix": "PersonIcon"
+  },
+  "X": {
+    "lucide": "X",
+    "radix": "Cross2Icon"
+  }
+}

--- a/apps/v4/scripts/build-icons.ts
+++ b/apps/v4/scripts/build-icons.ts
@@ -5,9 +5,16 @@ import { iconLibraries, type IconLibraryName } from "shadcn/icons"
 
 type IconUsage = Record<IconLibraryName, Set<string>>
 
+// Canonical (lucide) icon name -> { library: icon name }.
+type IconMapping = Record<string, Record<string, string>>
+
 function findTsxFiles(dir: string) {
   const files: string[] = []
-  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  // Sort for a deterministic scan order: mapping conflicts resolve to the
+  // first occurrence, which must not depend on filesystem enumeration order.
+  const entries = fs
+    .readdirSync(dir, { withFileTypes: true })
+    .sort((a, b) => a.name.localeCompare(b.name))
 
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name)
@@ -26,6 +33,10 @@ function scanIconUsage() {
     acc[key as IconLibraryName] = new Set()
     return acc
   }, {} as IconUsage)
+  const iconMapping: IconMapping = {}
+  // Keyed to dedupe: the same conflict shows up once per placeholder
+  // occurrence across bases, but only the first file is worth reporting.
+  const warnings = new Map<string, string>()
 
   const registryBasesDir = path.join(process.cwd(), "registry/bases")
   const files = findTsxFiles(registryBasesDir)
@@ -43,6 +54,7 @@ function scanIconUsage() {
     let match
     while ((match = iconPlaceholderRegex.exec(content)) !== null) {
       const fullMatch = match[0]
+      const placeholderIcons: Partial<Record<IconLibraryName, string>> = {}
 
       for (const [libraryName, config] of Object.entries(iconLibraries)) {
         const attrMatch = fullMatch.match(
@@ -50,12 +62,43 @@ function scanIconUsage() {
         )
         if (attrMatch) {
           iconUsage[libraryName as IconLibraryName].add(attrMatch[1])
+          placeholderIcons[libraryName as IconLibraryName] = attrMatch[1]
         }
+      }
+
+      // Lucide is the canonical key: every placeholder has a lucide prop.
+      const canonical = placeholderIcons.lucide
+      if (!canonical) {
+        const relativeFile = path.relative(process.cwd(), file)
+        warnings.set(
+          `missing-lucide|${relativeFile}`,
+          `IconPlaceholder without a lucide prop in ${relativeFile}`
+        )
+        continue
+      }
+
+      const entry = (iconMapping[canonical] ??= {})
+      for (const [libraryName, iconName] of Object.entries(placeholderIcons)) {
+        if (entry[libraryName] && entry[libraryName] !== iconName) {
+          const key = `conflict|${libraryName}|${canonical}|${iconName}`
+          if (!warnings.has(key)) {
+            warnings.set(
+              key,
+              `Conflicting ${libraryName} mapping for ${canonical}: keeping ${entry[libraryName]}, ignoring ${iconName} (first seen in ${path.relative(process.cwd(), file)})`
+            )
+          }
+          continue
+        }
+        entry[libraryName] = iconName
       }
     }
   }
 
-  return iconUsage
+  return {
+    iconUsage,
+    iconMapping,
+    warnings: Array.from(warnings.values()),
+  }
 }
 
 function generateIconFiles(iconUsage: IconUsage) {
@@ -96,12 +139,92 @@ ${icons.map((icon) => `export { ${icon} } from "${config.export}"`).join("\n")}
   }
 }
 
+function generateIconMapping(iconMapping: IconMapping, warnings: string[]) {
+  const legacyPath = path.join(
+    process.cwd(),
+    "registry/icons/legacy-mapping.json"
+  )
+  const legacy: IconMapping = JSON.parse(fs.readFileSync(legacyPath, "utf-8"))
+
+  const output: IconMapping = {}
+  const scanned: IconMapping = { ...iconMapping }
+  const libraryOrder = Object.keys(iconLibraries)
+
+  // Legacy entries come first with their lucide/radix values untouched:
+  // published CLI versions reverse-lookup this file by first match, so
+  // entry order and legacy values are a compatibility contract.
+  for (const [canonical, legacyEntry] of Object.entries(legacy)) {
+    const entry: Record<string, string> = { ...legacyEntry }
+
+    // Registry code uses lucide's suffixed aliases (e.g. CheckIcon for Check).
+    const scannedKey =
+      canonical in scanned
+        ? canonical
+        : `${canonical}Icon` in scanned
+          ? `${canonical}Icon`
+          : undefined
+
+    if (scannedKey) {
+      for (const library of libraryOrder) {
+        if (!entry[library] && scanned[scannedKey][library]) {
+          entry[library] = scanned[scannedKey][library]
+        }
+      }
+      delete scanned[scannedKey]
+    }
+
+    output[canonical] = entry
+  }
+
+  for (const canonical of Object.keys(scanned).sort()) {
+    const entry: Record<string, string> = {}
+    for (const library of libraryOrder) {
+      if (scanned[canonical][library]) {
+        entry[library] = scanned[canonical][library]
+      }
+    }
+    output[canonical] = entry
+  }
+
+  const outputPath = path.join(process.cwd(), "public/r/icons/index.json")
+  const content = JSON.stringify(output, null, 2)
+
+  if (
+    fs.existsSync(outputPath) &&
+    fs.readFileSync(outputPath, "utf-8") === content
+  ) {
+    return
+  }
+
+  fs.writeFileSync(outputPath, content)
+  console.log(
+    `✓ Generated icon mapping: ${Object.keys(output).length} icons (${
+      Object.keys(legacy).length
+    } legacy)`
+  )
+
+  // Only surface scan warnings when the mapping actually changed: they are
+  // informational (first occurrence wins) and would otherwise repeat on
+  // every rebuild in watch mode.
+  if (warnings.length > 0) {
+    if (isVerbose) {
+      warnings.forEach((warning) => console.warn(`⚠ ${warning}`))
+    } else {
+      console.warn(
+        `⚠ ${warnings.length} icon mapping conflicts (first occurrence wins). Run with --verbose for details.`
+      )
+    }
+  }
+}
+
 function main() {
-  const iconUsage = scanIconUsage()
+  const { iconUsage, iconMapping, warnings } = scanIconUsage()
   generateIconFiles(iconUsage)
+  generateIconMapping(iconMapping, warnings)
 }
 
 const isWatchMode = process.argv.includes("--watch")
+const isVerbose = process.argv.includes("--verbose")
 
 if (isWatchMode) {
   const REGISTRY_DIR = path.join(process.cwd(), "registry/bases")

--- a/packages/shadcn/src/commands/migrate.ts
+++ b/packages/shadcn/src/commands/migrate.ts
@@ -28,6 +28,8 @@ export const migrateOptionsSchema = z.object({
   cwd: z.string(),
   list: z.boolean(),
   yes: z.boolean(),
+  from: z.string().optional(),
+  to: z.string().optional(),
   migration: z
     .string()
     .refine(
@@ -54,6 +56,14 @@ export const migrate = new Command()
   )
   .option("-l, --list", "list all migrations.", false)
   .option("-y, --yes", "skip confirmation prompt.", false)
+  .option(
+    "-f, --from <library>",
+    "the icon library to migrate from (icons migration only)."
+  )
+  .option(
+    "-t, --to <library>",
+    "the icon library to migrate to (icons migration only)."
+  )
   .action(async (migration, migratePath, opts) => {
     try {
       const options = migrateOptionsSchema.parse({
@@ -62,6 +72,8 @@ export const migrate = new Command()
         path: migratePath,
         list: opts.list,
         yes: opts.yes,
+        from: opts.from,
+        to: opts.to,
       })
 
       if (options.list || !options.migration) {
@@ -96,7 +108,12 @@ export const migrate = new Command()
       }
 
       if (options.migration === "icons") {
-        await migrateIcons(config)
+        await migrateIcons(config, {
+          from: options.from,
+          to: options.to,
+          path: options.path,
+          yes: options.yes,
+        })
       }
 
       if (options.migration === "radix") {

--- a/packages/shadcn/src/icons/index.ts
+++ b/packages/shadcn/src/icons/index.ts
@@ -1,1 +1,2 @@
 export * from "./libraries"
+export * from "./templates"

--- a/packages/shadcn/src/icons/templates.ts
+++ b/packages/shadcn/src/icons/templates.ts
@@ -3,9 +3,10 @@
 //   usage:  "<HugeiconsIcon icon={ICON} strokeWidth={2} />"
 // ICON is the placeholder substituted with actual icon names.
 
-const IMPORT_REGEX = /import\s+{([^}]+)}\s+from\s+['"]([^'"]+)['"]/
-const USAGE_REGEX = /<(\w+)([^>]*)\s*\/>/
-const ATTRIBUTE_REGEX = /(\w+(?:-\w+)*)=({[^}]*}|"[^"]*"|'[^']*')/g
+// Anchored and free of overlapping quantifiers to avoid backtracking blowups.
+const IMPORT_REGEX = /^import\s+{([^}]+)}\s+from\s+['"]([^'"]+)['"]/
+const USAGE_REGEX = /<(\w+)([^>]*)\/>/
+const ATTRIBUTE_REGEX = /([\w-]+)=({[^}]*}|"[^"]*"|'[^']*')/g
 
 export interface ParsedImport {
   moduleSpecifier: string
@@ -26,7 +27,7 @@ export function parseImportTemplate(template: string): ParsedImport[] {
   const imports: ParsedImport[] = []
 
   for (const line of template.split("\n")) {
-    const match = line.match(IMPORT_REGEX)
+    const match = line.trim().match(IMPORT_REGEX)
 
     if (!match) {
       continue

--- a/packages/shadcn/src/icons/templates.ts
+++ b/packages/shadcn/src/icons/templates.ts
@@ -5,8 +5,6 @@
 
 // Anchored and free of overlapping quantifiers to avoid backtracking blowups.
 const IMPORT_REGEX = /^import\s+{([^}]+)}\s+from\s+['"]([^'"]+)['"]/
-const USAGE_REGEX = /<(\w+)([^>]*)\/>/
-const ATTRIBUTE_REGEX = /([\w-]+)=({[^}]*}|"[^"]*"|'[^']*')/g
 
 export interface ParsedImport {
   moduleSpecifier: string
@@ -49,22 +47,30 @@ export function getIconModuleSpecifier(template: string) {
   )?.moduleSpecifier
 }
 
+// The usage template is parsed with a hand-rolled scanner instead of
+// regexes: these helpers are part of the public API, so parsing must stay
+// linear on arbitrary input (no backtracking).
 export function parseUsageTemplate(usage: string): ParsedUsage {
-  const match = usage.match(USAGE_REGEX)
+  const start = usage.indexOf("<")
+  const end = usage.indexOf("/>", start)
 
-  if (!match) {
+  if (start === -1 || end === -1) {
     return { componentName: "ICON", attributes: {} }
   }
 
-  const [, componentName, rawAttributes] = match
+  const inner = usage.slice(start + 1, end).trim()
+  const nameEnd = inner.search(/[^\w]/)
+  const componentName = nameEnd === -1 ? inner : inner.slice(0, nameEnd)
+  const rawAttributes = nameEnd === -1 ? "" : inner.slice(nameEnd)
+
+  if (!componentName) {
+    return { componentName: "ICON", attributes: {} }
+  }
+
   const attributes: Record<string, string> = {}
   let iconAttribute: string | undefined
 
-  for (const attributeMatch of Array.from(
-    rawAttributes.matchAll(ATTRIBUTE_REGEX)
-  )) {
-    const [, name, value] = attributeMatch
-
+  for (const [name, value] of parseAttributeTokens(rawAttributes)) {
     if (value === "{ICON}") {
       iconAttribute = name
       continue
@@ -74,4 +80,49 @@ export function parseUsageTemplate(usage: string): ParsedUsage {
   }
 
   return { componentName, iconAttribute, attributes }
+}
+
+const NAME_CHAR = /[\w-]/
+
+// Tokenizes `name={value}` / `name="value"` / `name='value'` pairs in a
+// single linear pass.
+function parseAttributeTokens(raw: string): Array<[string, string]> {
+  const tokens: Array<[string, string]> = []
+  let index = 0
+
+  while (index < raw.length) {
+    if (!NAME_CHAR.test(raw[index])) {
+      index++
+      continue
+    }
+
+    const nameStart = index
+    while (index < raw.length && NAME_CHAR.test(raw[index])) {
+      index++
+    }
+    const name = raw.slice(nameStart, index)
+
+    if (raw[index] !== "=") {
+      continue
+    }
+
+    index++
+    const open = raw[index]
+    const close = open === "{" ? "}" : open === '"' || open === "'" ? open : ""
+
+    if (!close) {
+      continue
+    }
+
+    const closeIndex = raw.indexOf(close, index + 1)
+
+    if (closeIndex === -1) {
+      break
+    }
+
+    tokens.push([name, raw.slice(index, closeIndex + 1)])
+    index = closeIndex + 1
+  }
+
+  return tokens
 }

--- a/packages/shadcn/src/icons/templates.ts
+++ b/packages/shadcn/src/icons/templates.ts
@@ -1,0 +1,76 @@
+// Helpers for parsing icon library `import` and `usage` templates, e.g.
+//   import: "import { HugeiconsIcon } from '@hugeicons/react'\nimport { ICON } from '@hugeicons/core-free-icons';"
+//   usage:  "<HugeiconsIcon icon={ICON} strokeWidth={2} />"
+// ICON is the placeholder substituted with actual icon names.
+
+const IMPORT_REGEX = /import\s+{([^}]+)}\s+from\s+['"]([^'"]+)['"]/
+const USAGE_REGEX = /<(\w+)([^>]*)\s*\/>/
+const ATTRIBUTE_REGEX = /(\w+(?:-\w+)*)=({[^}]*}|"[^"]*"|'[^']*')/g
+
+export interface ParsedImport {
+  moduleSpecifier: string
+  namedImports: string[]
+}
+
+export interface ParsedUsage {
+  // The JSX tag icons render as. "ICON" means the icon itself is the tag
+  // (e.g. lucide); anything else is a wrapper component (e.g. HugeiconsIcon).
+  componentName: string
+  // Attribute carrying the icon when componentName is a wrapper (e.g. "icon").
+  iconAttribute?: string
+  // Remaining default attributes from the template, e.g. { strokeWidth: "{2}" }.
+  attributes: Record<string, string>
+}
+
+export function parseImportTemplate(template: string): ParsedImport[] {
+  const imports: ParsedImport[] = []
+
+  for (const line of template.split("\n")) {
+    const match = line.match(IMPORT_REGEX)
+
+    if (!match) {
+      continue
+    }
+
+    imports.push({
+      moduleSpecifier: match[2],
+      namedImports: match[1].split(",").map((name) => name.trim()),
+    })
+  }
+
+  return imports
+}
+
+// The module specifier icons (ICON) are imported from.
+export function getIconModuleSpecifier(template: string) {
+  return parseImportTemplate(template).find((parsed) =>
+    parsed.namedImports.includes("ICON")
+  )?.moduleSpecifier
+}
+
+export function parseUsageTemplate(usage: string): ParsedUsage {
+  const match = usage.match(USAGE_REGEX)
+
+  if (!match) {
+    return { componentName: "ICON", attributes: {} }
+  }
+
+  const [, componentName, rawAttributes] = match
+  const attributes: Record<string, string> = {}
+  let iconAttribute: string | undefined
+
+  for (const attributeMatch of Array.from(
+    rawAttributes.matchAll(ATTRIBUTE_REGEX)
+  )) {
+    const [, name, value] = attributeMatch
+
+    if (value === "{ICON}") {
+      iconAttribute = name
+      continue
+    }
+
+    attributes[name] = value
+  }
+
+  return { componentName, iconAttribute, attributes }
+}

--- a/packages/shadcn/src/migrations/migrate-icons.test.ts
+++ b/packages/shadcn/src/migrations/migrate-icons.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, it } from "vitest"
 
-import { migrateIconsFile } from "./migrate-icons"
+import { migrateIconsFile, migrateIconsFileWithReport } from "./migrate-icons"
+
+// A mapping fixture with full cross-library coverage.
+const FULL_MAPPING = {
+  Check: {
+    lucide: "Check",
+    radix: "CheckIcon",
+    tabler: "IconCheck",
+    hugeicons: "Tick02Icon",
+    phosphor: "CheckIcon",
+    remixicon: "RiCheckLine",
+  },
+  ChevronDown: {
+    lucide: "ChevronDown",
+    radix: "ChevronDownIcon",
+    tabler: "IconChevronDown",
+    hugeicons: "ArrowDown01Icon",
+    phosphor: "CaretDownIcon",
+    remixicon: "RiArrowDownSLine",
+  },
+}
 
 describe("migrateIconsFile", () => {
   it("should replace radix icons with lucide icons", async () => {
@@ -142,14 +162,378 @@ describe("migrateIconsFile", () => {
                   export function Component() {
               return (
                 <div>
-                  <CheckIcon
+                  <Check
                     className="w-4 h-4"
                     onClick={handleClick}
                     data-testid="check-icon"
                   >
                     <span>Child content</span>
-                  </CheckIcon>
+                  </Check>
                   <X style={{ color: 'red' }} aria-label="Close" />
+                </div>
+              )
+            }"
+    `)
+  })
+
+  it("should leave unmapped icons untouched", async () => {
+    const input = `
+      import { CheckIcon, MagicWandIcon } from "@radix-ui/react-icons"
+
+      export function Component() {
+        return (
+          <div>
+            <CheckIcon />
+            <MagicWandIcon />
+          </div>
+        )
+      }`
+
+    expect(
+      await migrateIconsFile(input, "radix", "lucide", {
+        Check: {
+          lucide: "Check",
+          radix: "CheckIcon",
+        },
+      })
+    ).toMatchInlineSnapshot(`
+      "import { MagicWandIcon } from "@radix-ui/react-icons"
+      import { Check } from "lucide-react";
+
+            export function Component() {
+              return (
+                <div>
+                  <Check />
+                  <MagicWandIcon />
+                </div>
+              )
+            }"
+    `)
+  })
+
+  it("should migrate from lucide to radix", async () => {
+    const input = `
+      import { Check, X } from "lucide-react"
+
+      export function Component() {
+        return (
+          <div>
+            <Check className="size-4" />
+            <X />
+          </div>
+        )
+      }`
+
+    expect(
+      await migrateIconsFile(input, "lucide", "radix", {
+        Check: {
+          lucide: "Check",
+          radix: "CheckIcon",
+        },
+        X: {
+          lucide: "X",
+          radix: "Cross2Icon",
+        },
+      })
+    ).toMatchInlineSnapshot(`
+      "import { CheckIcon, Cross2Icon } from "@radix-ui/react-icons";
+
+                  export function Component() {
+              return (
+                <div>
+                  <CheckIcon className="size-4" />
+                  <Cross2Icon />
+                </div>
+              )
+            }"
+    `)
+  })
+
+  it("should handle aliased imports", async () => {
+    const input = `
+      import { CheckIcon as Check } from "@radix-ui/react-icons"
+
+      export function Component() {
+        return <Check />
+      }`
+
+    expect(
+      await migrateIconsFile(input, "radix", "lucide", {
+        Check: {
+          lucide: "Check",
+          radix: "CheckIcon",
+        },
+      })
+    ).toMatchInlineSnapshot(`
+      "import { Check } from "lucide-react";
+
+                  export function Component() {
+              return <Check />
+            }"
+    `)
+  })
+
+  it("should handle icons used as prop references", async () => {
+    const input = `
+      import { CheckIcon } from "@radix-ui/react-icons"
+
+      export function Component() {
+        return <Button icon={CheckIcon} />
+      }`
+
+    expect(
+      await migrateIconsFile(input, "radix", "lucide", {
+        Check: {
+          lucide: "Check",
+          radix: "CheckIcon",
+        },
+      })
+    ).toMatchInlineSnapshot(`
+      "import { Check } from "lucide-react";
+
+                  export function Component() {
+              return <Button icon={Check} />
+            }"
+    `)
+  })
+})
+
+describe("migrateIconsFile (cross-library)", () => {
+  it("should migrate from lucide to tabler", async () => {
+    const input = `
+      import { Check, ChevronDown } from "lucide-react"
+
+      export function Component() {
+        return (
+          <div>
+            <Check className="size-4" />
+            <ChevronDown />
+          </div>
+        )
+      }`
+
+    expect(await migrateIconsFile(input, "lucide", "tabler", FULL_MAPPING))
+      .toMatchInlineSnapshot(`
+      "import { IconCheck, IconChevronDown } from "@tabler/icons-react";
+
+                  export function Component() {
+              return (
+                <div>
+                  <IconCheck className="size-4" />
+                  <IconChevronDown />
+                </div>
+              )
+            }"
+    `)
+  })
+
+  it("should migrate lucide suffixed aliases (CheckIcon)", async () => {
+    const input = `
+      import { CheckIcon } from "lucide-react"
+
+      export function Component() {
+        return <CheckIcon className="size-4" />
+      }`
+
+    expect(await migrateIconsFile(input, "lucide", "remixicon", FULL_MAPPING))
+      .toMatchInlineSnapshot(`
+      "import { RiCheckLine } from "@remixicon/react";
+
+                  export function Component() {
+              return <RiCheckLine className="size-4" />
+            }"
+    `)
+  })
+
+  it("should migrate from lucide to hugeicons (wrapper target)", async () => {
+    const input = `
+      import { Check, ChevronDown } from "lucide-react"
+
+      export function Component() {
+        return (
+          <div>
+            <Check className="size-4" />
+            <ChevronDown />
+          </div>
+        )
+      }`
+
+    expect(await migrateIconsFile(input, "lucide", "hugeicons", FULL_MAPPING))
+      .toMatchInlineSnapshot(`
+      "import { HugeiconsIcon } from "@hugeicons/react";
+      import { Tick02Icon, ArrowDown01Icon } from "@hugeicons/core-free-icons";
+
+                  export function Component() {
+              return (
+                <div>
+                  <HugeiconsIcon icon={Tick02Icon} strokeWidth={2} className="size-4" />
+                  <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={2} />
+                </div>
+              )
+            }"
+    `)
+  })
+
+  it("should migrate from hugeicons to lucide (wrapper source)", async () => {
+    const input = `
+      import { HugeiconsIcon } from "@hugeicons/react"
+      import { Tick02Icon, ArrowDown01Icon } from "@hugeicons/core-free-icons"
+
+      export function Component() {
+        return (
+          <div>
+            <HugeiconsIcon icon={Tick02Icon} strokeWidth={2} className="size-4" />
+            <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={1.5} />
+          </div>
+        )
+      }`
+
+    expect(await migrateIconsFile(input, "hugeicons", "lucide", FULL_MAPPING))
+      .toMatchInlineSnapshot(`
+      "import { Check, ChevronDown } from "lucide-react";
+
+                  export function Component() {
+              return (
+                <div>
+                  <Check className="size-4" />
+                  <ChevronDown strokeWidth={1.5} />
+                </div>
+              )
+            }"
+    `)
+  })
+
+  it("should migrate from lucide to phosphor with default props", async () => {
+    const input = `
+      import { Check } from "lucide-react"
+
+      export function Component() {
+        return <Check className="size-4" strokeWidth={3} />
+      }`
+
+    expect(await migrateIconsFile(input, "lucide", "phosphor", FULL_MAPPING))
+      .toMatchInlineSnapshot(`
+      "import { CheckIcon } from "@phosphor-icons/react";
+
+                  export function Component() {
+              return <CheckIcon className="size-4" strokeWidth={3} />
+            }"
+    `)
+  })
+
+  it("should migrate from phosphor to lucide stripping template defaults", async () => {
+    const input = `
+      import { CheckIcon, CaretDownIcon } from "@phosphor-icons/react"
+
+      export function Component() {
+        return (
+          <div>
+            <CheckIcon strokeWidth={2} className="size-4" />
+            <CaretDownIcon strokeWidth={3} />
+          </div>
+        )
+      }`
+
+    expect(await migrateIconsFile(input, "phosphor", "lucide", FULL_MAPPING))
+      .toMatchInlineSnapshot(`
+      "import { Check, ChevronDown } from "lucide-react";
+
+                  export function Component() {
+              return (
+                <div>
+                  <Check className="size-4" />
+                  <ChevronDown strokeWidth={3} />
+                </div>
+              )
+            }"
+    `)
+  })
+
+  it("should migrate from radix to phosphor via the canonical name", async () => {
+    const input = `
+      import { CheckIcon } from "@radix-ui/react-icons"
+
+      export function Component() {
+        return <CheckIcon />
+      }`
+
+    expect(await migrateIconsFile(input, "radix", "phosphor", FULL_MAPPING))
+      .toMatchInlineSnapshot(`
+      "import { CheckIcon } from "@phosphor-icons/react";
+
+                  export function Component() {
+              return <CheckIcon strokeWidth={2} />
+            }"
+    `)
+  })
+
+  it("should ignore type-only imports", async () => {
+    const input = `
+      import { Check, type LucideIcon } from "lucide-react"
+
+      export function Component({ icon }: { icon: LucideIcon }) {
+        return <Check />
+      }`
+
+    expect(
+      await migrateIconsFileWithReport(input, "lucide", "tabler", FULL_MAPPING)
+    ).toMatchInlineSnapshot(`
+        {
+          "content": "import { type LucideIcon } from "lucide-react"
+        import { IconCheck } from "@tabler/icons-react";
+
+              export function Component({ icon }: { icon: LucideIcon }) {
+                return <IconCheck />
+              }",
+          "skipped": [],
+        }
+      `)
+  })
+
+  it("should report skipped icons", async () => {
+    const input = `
+      import { Check, Banana } from "lucide-react"
+
+      export function Component() {
+        return (
+          <div>
+            <Check>
+              <title>Done</title>
+            </Check>
+            <Banana />
+          </div>
+        )
+      }`
+
+    const result = await migrateIconsFileWithReport(
+      input,
+      "lucide",
+      "hugeicons",
+      FULL_MAPPING
+    )
+
+    expect(result.skipped).toMatchInlineSnapshot(`
+      [
+        {
+          "icon": "Check",
+          "reason": "cannot be wrapped in <HugeiconsIcon />",
+        },
+        {
+          "icon": "Banana",
+          "reason": "no HugeIcons equivalent found",
+        },
+      ]
+    `)
+    expect(result.content).toMatchInlineSnapshot(`
+      "import { Check, Banana } from "lucide-react"
+
+            export function Component() {
+              return (
+                <div>
+                  <Check>
+                    <title>Done</title>
+                  </Check>
+                  <Banana />
                 </div>
               )
             }"

--- a/packages/shadcn/src/migrations/migrate-icons.ts
+++ b/packages/shadcn/src/migrations/migrate-icons.ts
@@ -2,142 +2,322 @@ import { randomBytes } from "crypto"
 import { promises as fs } from "fs"
 import { tmpdir } from "os"
 import path from "path"
+import { iconLibraries } from "@/src/icons/libraries"
+import {
+  getIconModuleSpecifier,
+  parseImportTemplate,
+  parseUsageTemplate,
+  type ParsedUsage,
+} from "@/src/icons/templates"
 import { getRegistryIcons } from "@/src/registry/api"
 import { iconsSchema } from "@/src/schema"
 import { Config } from "@/src/utils/get-config"
 import { highlighter } from "@/src/utils/highlighter"
-import { LEGACY_ICON_LIBRARIES } from "@/src/utils/legacy-icon-libraries"
 import { logger } from "@/src/utils/logger"
 import { spinner } from "@/src/utils/spinner"
 import { updateDependencies } from "@/src/utils/updaters/update-dependencies"
 import fg from "fast-glob"
+import fsExtra from "fs-extra"
 import prompts from "prompts"
-import { Project, ScriptKind, SyntaxKind } from "ts-morph"
+import {
+  JsxOpeningElement,
+  JsxSelfClosingElement,
+  Project,
+  ScriptKind,
+  SourceFile,
+  SyntaxKind,
+} from "ts-morph"
 import { z } from "zod"
 
-export async function migrateIcons(config: Config) {
-  if (!config.resolvedPaths.ui) {
-    throw new Error(
-      "We could not find a valid `ui` path in your `components.json` file. Please ensure you have a valid `ui` path in your `components.json` file."
-    )
+// Radix is a legacy icon library: still migratable (in both directions, with
+// coverage limited to the legacy mapping entries) but not offered to new
+// projects, so it lives here instead of in `iconLibraries`.
+export const MIGRATION_ICON_LIBRARIES = {
+  ...iconLibraries,
+  radix: {
+    name: "radix",
+    title: "Radix Icons",
+    packages: ["@radix-ui/react-icons"],
+    import: "import { ICON } from '@radix-ui/react-icons'",
+    usage: "<ICON />",
+    export: "@radix-ui/react-icons",
+  },
+} as const
+
+export type MigrationIconLibraryName = keyof typeof MIGRATION_ICON_LIBRARIES
+
+type IconsMapping = z.infer<typeof iconsSchema>
+
+export interface SkippedIcon {
+  icon: string
+  reason: string
+}
+
+export async function migrateIcons(
+  config: Config,
+  options: {
+    from?: string
+    to?: string
+    path?: string
+    yes?: boolean
+  } = {}
+) {
+  // Determine files to migrate.
+  let files: string[]
+  let basePath: string
+
+  if (options.path) {
+    // User provided a path/glob.
+    basePath = config.resolvedPaths.cwd
+    const isGlob = options.path.includes("*")
+
+    if (isGlob) {
+      files = await fg(options.path, {
+        cwd: basePath,
+        onlyFiles: true,
+        ignore: ["**/node_modules/**"],
+      })
+    } else {
+      const fullPath = path.resolve(basePath, options.path)
+      const stat = await fs.stat(fullPath).catch(() => null)
+
+      if (!stat) {
+        throw new Error(`File not found: ${options.path}`)
+      }
+
+      if (stat.isDirectory()) {
+        basePath = fullPath
+        files = await fg("**/*.{js,ts,jsx,tsx}", {
+          cwd: basePath,
+          onlyFiles: true,
+          ignore: ["**/node_modules/**"],
+        })
+      } else if (stat.isFile()) {
+        files = [options.path]
+      } else {
+        throw new Error(`Unsupported path type: ${options.path}`)
+      }
+    }
+
+    if (files.length === 0) {
+      throw new Error(`No files found matching: ${options.path}`)
+    }
+  } else {
+    if (!config.resolvedPaths.ui) {
+      throw new Error(
+        "We could not find a valid `ui` path in your `components.json` file. Please ensure you have a valid `ui` path in your `components.json` file."
+      )
+    }
+
+    basePath = config.resolvedPaths.ui
+    files = await fg("**/*.{js,ts,jsx,tsx}", {
+      cwd: basePath,
+    })
   }
 
-  const uiPath = config.resolvedPaths.ui
-  const [files, registryIcons] = await Promise.all([
-    fg("**/*.{js,ts,jsx,tsx}", {
-      cwd: uiPath,
-    }),
-    getRegistryIcons(),
-  ])
+  const registryIcons = await getRegistryIcons()
 
   if (Object.keys(registryIcons).length === 0) {
     throw new Error("Something went wrong fetching the registry icons.")
   }
 
-  const libraryChoices = Object.entries(LEGACY_ICON_LIBRARIES).map(
+  const libraryChoices = Object.entries(MIGRATION_ICON_LIBRARIES).map(
     ([name, iconLibrary]) => ({
-      title: iconLibrary.name,
+      title: iconLibrary.title,
       value: name,
     })
   )
 
-  const migrateOptions = await prompts([
-    {
-      type: "select",
-      name: "sourceLibrary",
-      message: `Which icon library would you like to ${highlighter.info(
-        "migrate from"
-      )}?`,
-      choices: libraryChoices,
-    },
-    {
-      type: "select",
-      name: "targetLibrary",
-      message: `Which icon library would you like to ${highlighter.info(
-        "migrate to"
-      )}?`,
-      choices: libraryChoices,
-    },
-  ])
+  for (const libraryName of [options.from, options.to]) {
+    if (libraryName && !(libraryName in MIGRATION_ICON_LIBRARIES)) {
+      throw new Error(
+        `Unknown icon library: ${libraryName}. Available libraries: ${Object.keys(
+          MIGRATION_ICON_LIBRARIES
+        ).join(", ")}.`
+      )
+    }
+  }
 
-  if (migrateOptions.sourceLibrary === migrateOptions.targetLibrary) {
+  let sourceLibraryName = options.from
+  let targetLibraryName = options.to
+
+  if (!sourceLibraryName || !targetLibraryName) {
+    const currentLibraryIndex = libraryChoices.findIndex(
+      (choice) => choice.value === config.iconLibrary
+    )
+    const migrateOptions = await prompts([
+      {
+        type: sourceLibraryName ? null : "select",
+        name: "sourceLibrary",
+        message: `Which icon library would you like to ${highlighter.info(
+          "migrate from"
+        )}?`,
+        choices: libraryChoices,
+        initial: currentLibraryIndex === -1 ? 0 : currentLibraryIndex,
+      },
+      {
+        type: targetLibraryName ? null : "select",
+        name: "targetLibrary",
+        message: `Which icon library would you like to ${highlighter.info(
+          "migrate to"
+        )}?`,
+        choices: libraryChoices,
+      },
+    ])
+
+    sourceLibraryName = sourceLibraryName ?? migrateOptions.sourceLibrary
+    targetLibraryName = targetLibraryName ?? migrateOptions.targetLibrary
+  }
+
+  if (!sourceLibraryName || !targetLibraryName) {
+    logger.info("Migration cancelled.")
+    process.exit(0)
+  }
+
+  if (sourceLibraryName === targetLibraryName) {
     throw new Error(
       "You cannot migrate to the same icon library. Please choose a different icon library."
     )
   }
 
-  if (
-    !(
-      migrateOptions.sourceLibrary in LEGACY_ICON_LIBRARIES &&
-      migrateOptions.targetLibrary in LEGACY_ICON_LIBRARIES
-    )
-  ) {
-    throw new Error("Invalid icon library. Please choose a valid icon library.")
+  const sourceLibrary =
+    MIGRATION_ICON_LIBRARIES[sourceLibraryName as MigrationIconLibraryName]
+  const targetLibrary =
+    MIGRATION_ICON_LIBRARIES[targetLibraryName as MigrationIconLibraryName]
+
+  if (!options.yes) {
+    const relativePath = options.path
+      ? options.path
+      : `./${path.relative(config.resolvedPaths.cwd, basePath)}`
+    const { confirm } = await prompts({
+      type: "confirm",
+      name: "confirm",
+      initial: true,
+      message: `We will migrate ${highlighter.info(
+        files.length
+      )} files in ${highlighter.info(relativePath)} from ${highlighter.info(
+        sourceLibrary.title
+      )} to ${highlighter.info(targetLibrary.title)}. Continue?`,
+    })
+
+    if (!confirm) {
+      logger.info("Migration cancelled.")
+      process.exit(0)
+    }
   }
 
-  const sourceLibrary =
-    LEGACY_ICON_LIBRARIES[
-      migrateOptions.sourceLibrary as keyof typeof LEGACY_ICON_LIBRARIES
-    ]
-  const targetLibrary =
-    LEGACY_ICON_LIBRARIES[
-      migrateOptions.targetLibrary as keyof typeof LEGACY_ICON_LIBRARIES
-    ]
-  const { confirm } = await prompts({
-    type: "confirm",
-    name: "confirm",
-    initial: true,
-    message: `We will migrate ${highlighter.info(
-      files.length
-    )} files in ${highlighter.info(
-      `./${path.relative(config.resolvedPaths.cwd, uiPath)}`
-    )} from ${highlighter.info(sourceLibrary.name)} to ${highlighter.info(
-      targetLibrary.name
-    )}. Continue?`,
+  await updateDependencies([...targetLibrary.packages], [], config, {
+    silent: false,
   })
 
-  if (!confirm) {
-    logger.info("Migration cancelled.")
-    process.exit(0)
-  }
-
-  if (targetLibrary.package) {
-    await updateDependencies([targetLibrary.package], [], config, {
-      silent: false,
-    })
-  }
-
   const migrationSpinner = spinner(`Migrating icons...`)?.start()
+  const skippedIcons = new Map<string, string>()
 
   await Promise.all(
     files.map(async (file) => {
       migrationSpinner.text = `Migrating ${file}...`
 
-      const filePath = path.join(uiPath, file)
+      const filePath = path.join(basePath, file)
       const fileContent = await fs.readFile(filePath, "utf-8")
 
-      const content = await migrateIconsFile(
+      const { content, skipped } = await migrateIconsFileWithReport(
         fileContent,
-        migrateOptions.sourceLibrary,
-        migrateOptions.targetLibrary,
+        sourceLibraryName as MigrationIconLibraryName,
+        targetLibraryName as MigrationIconLibraryName,
         registryIcons
       )
+
+      for (const skippedIcon of skipped) {
+        if (!skippedIcons.has(skippedIcon.icon)) {
+          skippedIcons.set(skippedIcon.icon, skippedIcon.reason)
+        }
+      }
 
       await fs.writeFile(filePath, content)
     })
   )
 
   migrationSpinner.succeed("Migration complete.")
+
+  // Keep components.json in sync so future `shadcn add` installs use the
+  // new icon library. Skip for scoped runs: a partial migration should not
+  // change project-wide config.
+  if (!options.path) {
+    await updateConfigIconLibrary(config, targetLibraryName)
+  }
+
+  if (skippedIcons.size > 0) {
+    logger.break()
+    logger.warn(
+      `Skipped ${skippedIcons.size} icon${
+        skippedIcons.size === 1 ? "" : "s"
+      }. These were left untouched:`
+    )
+    for (const [icon, reason] of Array.from(skippedIcons)) {
+      logger.warn(`  - ${icon}: ${reason}`)
+    }
+  }
+}
+
+async function updateConfigIconLibrary(config: Config, iconLibrary: string) {
+  const targetPath = path.resolve(config.resolvedPaths.cwd, "components.json")
+
+  if (!fsExtra.existsSync(targetPath)) {
+    return
+  }
+
+  const rawConfig = await fsExtra.readJson(targetPath)
+
+  if (rawConfig.iconLibrary === iconLibrary) {
+    return
+  }
+
+  rawConfig.iconLibrary = iconLibrary
+  await fsExtra.writeJson(targetPath, rawConfig, { spaces: 2 })
+  logger.info(
+    `Updated ${highlighter.info("iconLibrary")} in components.json to ${highlighter.info(
+      iconLibrary
+    )}.`
+  )
 }
 
 export async function migrateIconsFile(
   content: string,
-  sourceLibrary: keyof typeof LEGACY_ICON_LIBRARIES,
-  targetLibrary: keyof typeof LEGACY_ICON_LIBRARIES,
-  iconsMapping: z.infer<typeof iconsSchema>
+  sourceLibrary: MigrationIconLibraryName,
+  targetLibrary: MigrationIconLibraryName,
+  iconsMapping: IconsMapping
 ) {
-  const sourceLibraryImport = LEGACY_ICON_LIBRARIES[sourceLibrary]?.import
-  const targetLibraryImport = LEGACY_ICON_LIBRARIES[targetLibrary]?.import
+  const result = await migrateIconsFileWithReport(
+    content,
+    sourceLibrary,
+    targetLibrary,
+    iconsMapping
+  )
+
+  return result.content
+}
+
+export async function migrateIconsFileWithReport(
+  content: string,
+  sourceLibraryName: MigrationIconLibraryName,
+  targetLibraryName: MigrationIconLibraryName,
+  iconsMapping: IconsMapping
+): Promise<{ content: string; skipped: SkippedIcon[] }> {
+  const sourceLibrary = MIGRATION_ICON_LIBRARIES[sourceLibraryName]
+  const targetLibrary = MIGRATION_ICON_LIBRARIES[targetLibraryName]
+
+  const sourceIconModule = getIconModuleSpecifier(sourceLibrary.import)
+  const sourceUsage = parseUsageTemplate(sourceLibrary.usage)
+  const targetUsage = parseUsageTemplate(targetLibrary.usage)
+
+  if (!sourceIconModule) {
+    throw new Error(
+      `Could not resolve the icon import for ${sourceLibrary.title}.`
+    )
+  }
+
+  const reverseIndex = buildReverseIconIndex(iconsMapping, sourceLibraryName)
+  const skipped: SkippedIcon[] = []
 
   const dir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-"))
   const project = new Project({
@@ -152,54 +332,448 @@ export async function migrateIconsFile(
     scriptKind: ScriptKind.TSX,
   })
 
-  // Find all sourceLibrary imports.
-  let targetedIcons: string[] = []
+  let migratedIcons: string[] = []
+
   for (const importDeclaration of sourceFile.getImportDeclarations() ?? []) {
     if (
-      importDeclaration.getModuleSpecifier()?.getText() !==
-      `"${sourceLibraryImport}"`
+      importDeclaration.getModuleSpecifier()?.getLiteralValue() !==
+        sourceIconModule ||
+      importDeclaration.isTypeOnly()
     ) {
       continue
     }
 
-    for (const specifier of importDeclaration.getNamedImports() ?? []) {
-      const iconName = specifier.getName()
-
-      // TODO: this is O(n^2) but okay for now.
-      const targetedIcon = Object.values(iconsMapping).find(
-        (icon) => icon[sourceLibrary] === iconName
-      )?.[targetLibrary]
-
-      if (!targetedIcon || targetedIcons.includes(targetedIcon)) {
+    for (const specifier of [...(importDeclaration.getNamedImports() ?? [])]) {
+      // Type imports (e.g. LucideIcon) are not icons.
+      if (specifier.isTypeOnly()) {
         continue
       }
 
-      targetedIcons.push(targetedIcon)
+      const importedName = specifier.getName()
+      const localName = specifier.getAliasNode()?.getText() ?? importedName
 
-      // Remove the named import.
+      const canonical = reverseIndex.get(importedName)
+      const targetIcon = canonical
+        ? iconsMapping[canonical]?.[targetLibraryName]
+        : undefined
+
+      if (!targetIcon) {
+        skipped.push({
+          icon: importedName,
+          reason: `no ${targetLibrary.title} equivalent found`,
+        })
+        continue
+      }
+
+      const usages = findIconUsages(sourceFile, localName, sourceUsage)
+
+      if (usages.complex) {
+        skipped.push({
+          icon: importedName,
+          reason: "unsupported usage (e.g. referenced outside JSX)",
+        })
+        continue
+      }
+
+      const targetIsWrapper = targetUsage.componentName !== "ICON"
+      if (targetIsWrapper && (usages.references > 0 || usages.paired > 0)) {
+        skipped.push({
+          icon: importedName,
+          reason: `cannot be wrapped in <${targetUsage.componentName} />`,
+        })
+        continue
+      }
+
       specifier.remove()
+      rewriteIconUsages(
+        sourceFile,
+        localName,
+        targetIcon,
+        sourceUsage,
+        targetUsage
+      )
 
-      // Replace with the targeted icon.
-      sourceFile
-        .getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement)
-        .filter((node) => node.getTagNameNode()?.getText() === iconName)
-        .forEach((node) => node.getTagNameNode()?.replaceWithText(targetedIcon))
+      if (!migratedIcons.includes(targetIcon)) {
+        migratedIcons.push(targetIcon)
+      }
     }
 
     // If the named import is empty, remove the import declaration.
-    if (importDeclaration.getNamedImports()?.length === 0) {
+    if (
+      importDeclaration.getNamedImports()?.length === 0 &&
+      !importDeclaration.getDefaultImport() &&
+      !importDeclaration.getNamespaceImport()
+    ) {
       importDeclaration.remove()
     }
   }
 
-  if (targetedIcons.length > 0) {
-    sourceFile.addImportDeclaration({
-      moduleSpecifier: targetLibraryImport,
-      namedImports: targetedIcons.map((icon) => ({
-        name: icon,
-      })),
-    })
+  // If the source library renders through a wrapper component (e.g.
+  // HugeiconsIcon) and no usages remain, remove the wrapper import too.
+  if (sourceUsage.componentName !== "ICON" && migratedIcons.length > 0) {
+    removeUnusedWrapperImport(sourceFile, sourceLibrary.import, sourceUsage)
   }
 
-  return await sourceFile.getText()
+  if (migratedIcons.length > 0) {
+    for (const parsedImport of parseImportTemplate(targetLibrary.import)) {
+      const namedImports = parsedImport.namedImports.flatMap((name) =>
+        name === "ICON" ? migratedIcons : [name]
+      )
+
+      // Non-icon imports (e.g. the wrapper component) may already exist.
+      const alreadyImported =
+        !parsedImport.namedImports.includes("ICON") &&
+        sourceFile
+          .getImportDeclarations()
+          .some(
+            (declaration) =>
+              declaration.getModuleSpecifier()?.getLiteralValue() ===
+                parsedImport.moduleSpecifier &&
+              declaration
+                .getNamedImports()
+                .some((named) => namedImports.includes(named.getName()))
+          )
+
+      if (alreadyImported) {
+        continue
+      }
+
+      sourceFile.addImportDeclaration({
+        moduleSpecifier: parsedImport.moduleSpecifier,
+        namedImports: namedImports.map((name) => ({
+          name,
+        })),
+      })
+    }
+  }
+
+  return { content: sourceFile.getText(), skipped }
+}
+
+function buildReverseIconIndex(
+  iconsMapping: IconsMapping,
+  sourceLibraryName: MigrationIconLibraryName
+) {
+  const index = new Map<string, string>()
+
+  for (const [canonical, entry] of Object.entries(iconsMapping)) {
+    const iconName = entry[sourceLibraryName]
+    if (iconName && !index.has(iconName)) {
+      index.set(iconName, canonical)
+    }
+  }
+
+  // Lucide exports every icon under two names (e.g. Check and CheckIcon).
+  // The mapping only records one of them, so index both.
+  if (sourceLibraryName === "lucide") {
+    for (const [iconName, canonical] of Array.from(index)) {
+      const alias = iconName.endsWith("Icon")
+        ? iconName.slice(0, -"Icon".length)
+        : `${iconName}Icon`
+      if (alias && !index.has(alias)) {
+        index.set(alias, canonical)
+      }
+    }
+  }
+
+  return index
+}
+
+interface IconUsages {
+  selfClosing: number
+  paired: number
+  references: number
+  complex: boolean
+}
+
+function findIconUsages(
+  sourceFile: SourceFile,
+  localName: string,
+  sourceUsage: ParsedUsage
+): IconUsages {
+  const usages: IconUsages = {
+    selfClosing: 0,
+    paired: 0,
+    references: 0,
+    complex: false,
+  }
+
+  for (const identifier of sourceFile.getDescendantsOfKind(
+    SyntaxKind.Identifier
+  )) {
+    if (identifier.getText() !== localName) {
+      continue
+    }
+
+    if (identifier.getFirstAncestorByKind(SyntaxKind.ImportDeclaration)) {
+      continue
+    }
+
+    const parent = identifier.getParent()
+    const parentKind = parent?.getKind()
+
+    if (sourceUsage.componentName === "ICON") {
+      if (parentKind === SyntaxKind.JsxSelfClosingElement) {
+        usages.selfClosing++
+      } else if (parentKind === SyntaxKind.JsxOpeningElement) {
+        usages.paired++
+      } else if (parentKind === SyntaxKind.JsxClosingElement) {
+        // Counted via the opening element.
+      } else if (
+        parentKind === SyntaxKind.JsxExpression &&
+        parent?.getParent()?.getKind() === SyntaxKind.JsxAttribute
+      ) {
+        usages.references++
+      } else {
+        usages.complex = true
+      }
+      continue
+    }
+
+    // Wrapper-style source (e.g. <HugeiconsIcon icon={ICON} />): the icon
+    // only ever appears inside the wrapper's icon attribute.
+    const jsxAttribute = identifier.getFirstAncestorByKind(
+      SyntaxKind.JsxAttribute
+    )
+    const wrapperElement = identifier.getFirstAncestorByKind(
+      SyntaxKind.JsxSelfClosingElement
+    )
+
+    if (
+      parentKind === SyntaxKind.JsxExpression &&
+      jsxAttribute?.getNameNode().getText() === sourceUsage.iconAttribute &&
+      wrapperElement?.getTagNameNode()?.getText() === sourceUsage.componentName
+    ) {
+      usages.selfClosing++
+    } else {
+      usages.complex = true
+    }
+  }
+
+  return usages
+}
+
+function rewriteIconUsages(
+  sourceFile: SourceFile,
+  localName: string,
+  targetIcon: string,
+  sourceUsage: ParsedUsage,
+  targetUsage: ParsedUsage
+) {
+  if (sourceUsage.componentName === "ICON") {
+    // Direct-style source: the icon is the JSX tag.
+    for (const element of sourceFile.getDescendantsOfKind(
+      SyntaxKind.JsxSelfClosingElement
+    )) {
+      if (element.getTagNameNode()?.getText() !== localName) {
+        continue
+      }
+      rewriteElement(element, targetIcon, sourceUsage, targetUsage)
+    }
+
+    for (const element of sourceFile.getDescendantsOfKind(
+      SyntaxKind.JsxElement
+    )) {
+      const openingElement = element.getOpeningElement()
+      if (openingElement.getTagNameNode()?.getText() !== localName) {
+        continue
+      }
+      // Wrapper targets are filtered out before we get here.
+      applyUsageAttributes(openingElement, sourceUsage, targetUsage)
+      openingElement.getTagNameNode()?.replaceWithText(targetIcon)
+      element.getClosingElement().getTagNameNode()?.replaceWithText(targetIcon)
+    }
+
+    for (const identifier of sourceFile.getDescendantsOfKind(
+      SyntaxKind.Identifier
+    )) {
+      if (identifier.getText() !== localName) {
+        continue
+      }
+      if (identifier.getFirstAncestorByKind(SyntaxKind.ImportDeclaration)) {
+        continue
+      }
+      const parent = identifier.getParent()
+      if (
+        parent?.getKind() === SyntaxKind.JsxExpression &&
+        parent?.getParent()?.getKind() === SyntaxKind.JsxAttribute
+      ) {
+        identifier.replaceWithText(targetIcon)
+      }
+    }
+
+    return
+  }
+
+  // Wrapper-style source: rewrite each wrapper element using this icon.
+  for (const element of sourceFile.getDescendantsOfKind(
+    SyntaxKind.JsxSelfClosingElement
+  )) {
+    if (
+      element.getTagNameNode()?.getText() !== sourceUsage.componentName ||
+      !sourceUsage.iconAttribute
+    ) {
+      continue
+    }
+
+    const iconAttribute = element.getAttribute(sourceUsage.iconAttribute)
+    if (!iconAttribute || iconAttribute.getKind() !== SyntaxKind.JsxAttribute) {
+      continue
+    }
+
+    const iconExpression = iconAttribute
+      .asKindOrThrow(SyntaxKind.JsxAttribute)
+      .getInitializer()
+      ?.getText()
+
+    if (iconExpression !== `{${localName}}`) {
+      continue
+    }
+
+    rewriteElement(element, targetIcon, sourceUsage, targetUsage, {
+      excludeAttribute: sourceUsage.iconAttribute,
+    })
+  }
+}
+
+function rewriteElement(
+  element: JsxSelfClosingElement,
+  targetIcon: string,
+  sourceUsage: ParsedUsage,
+  targetUsage: ParsedUsage,
+  options: { excludeAttribute?: string } = {}
+) {
+  const sourceIsPlain =
+    sourceUsage.componentName === "ICON" &&
+    Object.keys(sourceUsage.attributes).length === 0
+  const targetIsPlain =
+    targetUsage.componentName === "ICON" &&
+    Object.keys(targetUsage.attributes).length === 0
+
+  // Plain tag to plain tag (e.g. lucide -> radix): rename in place to
+  // preserve the original formatting.
+  if (sourceIsPlain && targetIsPlain) {
+    element.getTagNameNode()?.replaceWithText(targetIcon)
+    return
+  }
+
+  const userAttributes = element
+    .getAttributes()
+    .filter((attribute) => {
+      if (attribute.getKind() !== SyntaxKind.JsxAttribute) {
+        return true
+      }
+      const jsxAttribute = attribute.asKindOrThrow(SyntaxKind.JsxAttribute)
+      const name = jsxAttribute.getNameNode().getText()
+
+      if (name === options.excludeAttribute) {
+        return false
+      }
+
+      // Drop defaults the source library's template added at install time,
+      // but only on an exact match (a customized value is user intent).
+      return (
+        sourceUsage.attributes[name] !==
+        (jsxAttribute.getInitializer()?.getText() ?? "")
+      )
+    })
+    .map((attribute) => attribute.getText())
+
+  const userAttributeNames = new Set(
+    element
+      .getAttributes()
+      .filter((attribute) => attribute.getKind() === SyntaxKind.JsxAttribute)
+      .map((attribute) =>
+        attribute.asKindOrThrow(SyntaxKind.JsxAttribute).getNameNode().getText()
+      )
+  )
+
+  const defaultAttributes = Object.entries(targetUsage.attributes)
+    .filter(([name]) => !userAttributeNames.has(name))
+    .map(([name, value]) => `${name}=${value}`)
+
+  const parts =
+    targetUsage.componentName === "ICON"
+      ? [targetIcon, ...defaultAttributes, ...userAttributes]
+      : [
+          targetUsage.componentName,
+          `${targetUsage.iconAttribute}={${targetIcon}}`,
+          ...defaultAttributes,
+          ...userAttributes,
+        ]
+
+  element.replaceWithText(`<${parts.join(" ")} />`)
+}
+
+function applyUsageAttributes(
+  element: JsxOpeningElement | JsxSelfClosingElement,
+  sourceUsage: ParsedUsage,
+  targetUsage: ParsedUsage
+) {
+  for (const [name, value] of Object.entries(sourceUsage.attributes)) {
+    const attribute = element.getAttribute(name)
+    if (
+      attribute?.getKind() === SyntaxKind.JsxAttribute &&
+      (attribute
+        .asKindOrThrow(SyntaxKind.JsxAttribute)
+        .getInitializer()
+        ?.getText() ?? "") === value
+    ) {
+      attribute.remove()
+    }
+  }
+
+  for (const [name, value] of Object.entries(targetUsage.attributes)) {
+    if (!element.getAttribute(name)) {
+      element.addAttribute({ name, initializer: value })
+    }
+  }
+}
+
+function removeUnusedWrapperImport(
+  sourceFile: SourceFile,
+  importTemplate: string,
+  sourceUsage: ParsedUsage
+) {
+  const wrapperName = sourceUsage.componentName
+
+  const wrapperStillUsed =
+    sourceFile
+      .getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement)
+      .some((element) => element.getTagNameNode()?.getText() === wrapperName) ||
+    sourceFile
+      .getDescendantsOfKind(SyntaxKind.JsxOpeningElement)
+      .some((element) => element.getTagNameNode()?.getText() === wrapperName)
+
+  if (wrapperStillUsed) {
+    return
+  }
+
+  const wrapperModules = parseImportTemplate(importTemplate)
+    .filter((parsed) => !parsed.namedImports.includes("ICON"))
+    .map((parsed) => parsed.moduleSpecifier)
+
+  for (const importDeclaration of sourceFile.getImportDeclarations() ?? []) {
+    if (
+      !wrapperModules.includes(
+        importDeclaration.getModuleSpecifier()?.getLiteralValue() ?? ""
+      )
+    ) {
+      continue
+    }
+
+    for (const specifier of [...(importDeclaration.getNamedImports() ?? [])]) {
+      if (specifier.getName() === wrapperName) {
+        specifier.remove()
+      }
+    }
+
+    if (
+      importDeclaration.getNamedImports()?.length === 0 &&
+      !importDeclaration.getDefaultImport() &&
+      !importDeclaration.getNamespaceImport()
+    ) {
+      importDeclaration.remove()
+    }
+  }
 }


### PR DESCRIPTION
```bash
npx shadcn@latest migrate icons

npx shadcn@latest migrate icons --from lucide --to phosphor --yes

npx shadcn@latest migrate icons "src/components/**" --from lucide --to tabler
```
