### PR TITLE
fix(react): keep the message-scroller scroll button correct under CSS zoom

### DIFF
--- a/.changeset/message-scroller-zoom-scrollable.md
+++ b/.changeset/message-scroller-zoom-scrollable.md
@@ -1,0 +1,5 @@
+---
+"@shadcn/react": patch
+---
+
+Fix MessageScroller stranding the scroll-to-end button (and dropping autoScroll's follow-bottom) under an ancestor CSS `zoom`. The scrollable-edge check derived the distance to the bottom from `getBoundingClientRect`, whose zoom-scaled on-screen pixels are not in the same coordinate space as the `scrollTop` and `clientHeight` they were subtracted against. At a zoom other than 1 the mismatch reported a phantom gap, so the button stayed visible at the bottom and follow-bottom never armed. The check now reads the viewport's own layout-pixel scroll metrics (`scrollHeight`, `scrollTop`, `clientHeight`), which `zoom` scales uniformly.

--- a/packages/react/src/message-scroller/geometry.test.ts
+++ b/packages/react/src/message-scroller/geometry.test.ts
@@ -78,6 +78,13 @@ function setClientHeight(element: HTMLElement, height: number) {
   })
 }
 
+function setOffsetHeight(element: HTMLElement, height: number) {
+  Object.defineProperty(element, "offsetHeight", {
+    configurable: true,
+    get: () => height,
+  })
+}
+
 // Build a viewport/content/items fixture. The viewport rect is anchored at
 // `viewportTop` in client space; item rects are given in viewport-relative
 // terms and offset by viewportTop so getElementTop math lines up with scrollTop.
@@ -398,16 +405,13 @@ describe("getMessageScrollerScrollable", () => {
   })
 
   it("treats sub-threshold gaps at both edges as not scrollable", () => {
-    stubComputedStyle()
     const { content, spacer, viewport } = createFixture({
       viewportHeight: 200,
-      viewportTop: 0,
       // scrollTop 5 <= threshold 8, so it cannot scroll toward the start.
       scrollTop: 5,
-      contentPaddingStart: 0,
-      contentPaddingEnd: 0,
-      // contentBottom 204; 204 - 5 - 200 = -1 <= 8, so it cannot scroll toward the end.
-      items: [{ messageId: "a", top: 199, height: 0 }],
+      // 205 - 200 - 5 = 0 <= 8, so it cannot scroll toward the end.
+      scrollHeight: 205,
+      items: [],
     })
 
     const scrollable = getMessageScrollerScrollable({
@@ -424,16 +428,13 @@ describe("getMessageScrollerScrollable", () => {
   })
 
   it("can scroll toward both edges past the threshold", () => {
-    stubComputedStyle()
     const { content, spacer, viewport } = createFixture({
       viewportHeight: 200,
-      viewportTop: 0,
       // scrollTop 100 > threshold 8, so it can scroll toward the start.
       scrollTop: 100,
-      contentPaddingStart: 0,
-      contentPaddingEnd: 0,
-      // contentBottom 1000; 1000 - 100 - 200 = 700 > 8, so it can scroll toward the end.
-      items: [{ messageId: "a", top: 900, height: 100 }],
+      // 1000 - 200 - 100 = 700 > 8, so it can scroll toward the end.
+      scrollHeight: 1000,
+      items: [],
     })
 
     const scrollable = getMessageScrollerScrollable({
@@ -446,6 +447,56 @@ describe("getMessageScrollerScrollable", () => {
     expect(scrollable).toMatchObject({
       start: true,
       end: true,
+    })
+  })
+
+  it("excludes the tail spacer from the end gap", () => {
+    const { content, spacer, viewport } = createFixture({
+      viewportHeight: 200,
+      scrollTop: 0,
+      // 60px of the 250px scroll height is the reserved tail spacer, so the real
+      // content bottom (190) sits inside the viewport: nothing to scroll toward.
+      scrollHeight: 250,
+      items: [],
+    })
+    setOffsetHeight(spacer, 60)
+
+    const scrollable = getMessageScrollerScrollable({
+      content,
+      scrollEdgeThreshold: 8,
+      spacer,
+      viewport,
+    })
+
+    // Without excluding the spacer, 250 - 200 - 0 = 50 would read as scrollable.
+    expect(scrollable).toMatchObject({
+      start: false,
+      end: false,
+    })
+  })
+
+  it("measures the end gap from layout metrics, not zoom-scaled client rects", () => {
+    // scrollTop/scrollHeight/clientHeight are layout px (zoom-invariant) and put
+    // the viewport exactly at the bottom: 500 - 200 - 300 = 0. An ancestor CSS
+    // zoom leaves those untouched but inflates getBoundingClientRect, so an item
+    // rect reaching far below the fold must not reintroduce a phantom end gap.
+    const { content, spacer, viewport } = createFixture({
+      viewportHeight: 200,
+      scrollTop: 300,
+      scrollHeight: 500,
+      items: [{ messageId: "a", top: 900, height: 100 }],
+    })
+
+    const scrollable = getMessageScrollerScrollable({
+      content,
+      scrollEdgeThreshold: 8,
+      spacer,
+      viewport,
+    })
+
+    expect(scrollable).toMatchObject({
+      start: true,
+      end: false,
     })
   })
 })

--- a/packages/react/src/message-scroller/geometry.test.ts
+++ b/packages/react/src/message-scroller/geometry.test.ts
@@ -476,10 +476,9 @@ describe("getMessageScrollerScrollable", () => {
   })
 
   it("measures the end gap from layout metrics, not zoom-scaled client rects", () => {
-    // scrollTop/scrollHeight/clientHeight are layout px (zoom-invariant) and put
-    // the viewport exactly at the bottom: 500 - 200 - 300 = 0. An ancestor CSS
-    // zoom leaves those untouched but inflates getBoundingClientRect, so an item
-    // rect reaching far below the fold must not reintroduce a phantom end gap.
+    // Layout metrics put the viewport exactly at the bottom (500 - 200 - 300 =
+    // 0). A zoom-inflated item rect far below the fold must not reintroduce a
+    // phantom end gap.
     const { content, spacer, viewport } = createFixture({
       viewportHeight: 200,
       scrollTop: 300,

--- a/packages/react/src/message-scroller/geometry.ts
+++ b/packages/react/src/message-scroller/geometry.ts
@@ -24,13 +24,27 @@ function getMessageScrollerScrollable({
     return EMPTY_MESSAGE_SCROLLER_SCROLLABLE
   }
 
-  const contentBottom = getContentBottom({ content, spacer, viewport })
+  // scrollTop, scrollHeight, and clientHeight all live in the viewport's
+  // layout-pixel coordinate space, which an ancestor CSS `zoom` (or scaling
+  // transform) scales uniformly, so the gap to each edge stays correct at any
+  // scale. Deriving that gap from getBoundingClientRect instead, the way the
+  // rest of this module does for element placement, would fold zoom-scaled
+  // on-screen pixels into the subtraction against scrollTop/clientHeight. At a
+  // zoom other than 1 the coordinate-space mismatch reports a phantom gap,
+  // which strands the scroll-to-end affordance on screen even though the reader
+  // is already at the bottom, and keeps autoScroll from arming follow-bottom.
+  // Subtract the tail spacer so the room it reserves below a freshly anchored
+  // turn is not counted as more content to scroll toward.
+  const tailSpacerHeight = spacer?.offsetHeight ?? 0
+  const distanceToEnd =
+    viewport.scrollHeight -
+    tailSpacerHeight -
+    viewport.clientHeight -
+    viewport.scrollTop
 
   return {
     start: viewport.scrollTop > scrollEdgeThreshold,
-    end:
-      contentBottom - viewport.scrollTop - viewport.clientHeight >
-      scrollEdgeThreshold,
+    end: distanceToEnd > scrollEdgeThreshold,
   }
 }
 

--- a/packages/react/src/message-scroller/geometry.ts
+++ b/packages/react/src/message-scroller/geometry.ts
@@ -24,17 +24,12 @@ function getMessageScrollerScrollable({
     return EMPTY_MESSAGE_SCROLLER_SCROLLABLE
   }
 
-  // scrollTop, scrollHeight, and clientHeight all live in the viewport's
-  // layout-pixel coordinate space, which an ancestor CSS `zoom` (or scaling
-  // transform) scales uniformly, so the gap to each edge stays correct at any
-  // scale. Deriving that gap from getBoundingClientRect instead, the way the
-  // rest of this module does for element placement, would fold zoom-scaled
-  // on-screen pixels into the subtraction against scrollTop/clientHeight. At a
-  // zoom other than 1 the coordinate-space mismatch reports a phantom gap,
-  // which strands the scroll-to-end affordance on screen even though the reader
-  // is already at the bottom, and keeps autoScroll from arming follow-bottom.
-  // Subtract the tail spacer so the room it reserves below a freshly anchored
-  // turn is not counted as more content to scroll toward.
+  // Derive the gap to the bottom from the viewport's own scroll metrics, which
+  // an ancestor CSS `zoom` scales uniformly. A getBoundingClientRect value would
+  // be zoom-scaled on-screen px from a different coordinate space; mixing it in
+  // misreports the gap under zoom, stranding the scroll-to-end button and
+  // blocking follow-bottom. Exclude the tail spacer so a freshly anchored turn's
+  // reserved room is not counted as content.
   const tailSpacerHeight = spacer?.offsetHeight ?? 0
   const distanceToEnd =
     viewport.scrollHeight -

--- a/packages/react/src/message-scroller/message-scroller.browser.test.tsx
+++ b/packages/react/src/message-scroller/message-scroller.browser.test.tsx
@@ -351,11 +351,9 @@ test("scroll button moves the viewport to the end", async () => {
 })
 
 test("keeps the scroll-to-end button inert at the bottom under an ancestor CSS zoom", async () => {
-  // Render inside a zoomed ancestor so the first commit measures under zoom. In
-  // Chromium `zoom` scales getBoundingClientRect (on-screen px) while leaving
-  // scrollTop/scrollHeight/clientHeight in layout px. The old geometry mixed the
-  // two and re-activated the button at the bottom; the fix reads only layout
-  // metrics, so the affordance stays inert.
+  // Under an ancestor CSS `zoom`, Chromium scales getBoundingClientRect while
+  // leaving scrollTop/clientHeight in layout px. The old geometry mixed the two
+  // and re-activated the button at the bottom; the fix reads only layout metrics.
   container = document.createElement("div")
   container.style.zoom = "1.5"
   document.body.appendChild(container)
@@ -367,10 +365,8 @@ test("keeps the scroll-to-end button inert at the bottom under an ancestor CSS z
 
   const viewport = getViewport()
 
-  // Guard the premise: this engine really does scale client rects under `zoom`
-  // (300 = 200 layout px x 1.5) while keeping scroll metrics in layout px. If a
-  // future engine stops splitting the two, this fails loudly instead of passing
-  // for the wrong reason.
+  // Guard the premise: the engine scales client rects under `zoom` (300 = 200 x
+  // 1.5) but keeps scroll metrics in layout px. Fails loudly if that changes.
   expect(Math.round(viewport.getBoundingClientRect().height)).toBe(300)
   expect(viewport.clientHeight).toBe(VIEWPORT_HEIGHT)
 

--- a/packages/react/src/message-scroller/message-scroller.browser.test.tsx
+++ b/packages/react/src/message-scroller/message-scroller.browser.test.tsx
@@ -350,6 +350,38 @@ test("scroll button moves the viewport to the end", async () => {
   expect(getDistanceToBottom(viewport)).toBeLessThanOrEqual(1)
 })
 
+test("keeps the scroll-to-end button inert at the bottom under an ancestor CSS zoom", async () => {
+  // Render inside a zoomed ancestor so the first commit measures under zoom. In
+  // Chromium `zoom` scales getBoundingClientRect (on-screen px) while leaving
+  // scrollTop/scrollHeight/clientHeight in layout px. The old geometry mixed the
+  // two and re-activated the button at the bottom; the fix reads only layout
+  // metrics, so the affordance stays inert.
+  container = document.createElement("div")
+  container.style.zoom = "1.5"
+  document.body.appendChild(container)
+  root = createRoot(container)
+  flushSync(() => {
+    root!.render(<Thread items={createItems(8)} showButton />)
+  })
+  await settle()
+
+  const viewport = getViewport()
+
+  // Guard the premise: this engine really does scale client rects under `zoom`
+  // (300 = 200 layout px x 1.5) while keeping scroll metrics in layout px. If a
+  // future engine stops splitting the two, this fails loudly instead of passing
+  // for the wrong reason.
+  expect(Math.round(viewport.getBoundingClientRect().height)).toBe(300)
+  expect(viewport.clientHeight).toBe(VIEWPORT_HEIGHT)
+
+  // Layout metrics agree the viewport is pinned to the bottom, so the button
+  // must be inert. The old rect-based gap read ~100px here and kept it active.
+  expect(getDistanceToBottom(viewport)).toBeLessThanOrEqual(1)
+  expect(
+    document.querySelector<HTMLButtonElement>("button")?.dataset.active
+  ).toBe("false")
+})
+
 test("restores the last scroll anchor when the final turn overflows", async () => {
   await renderThread({
     defaultScrollPosition: "last-anchor",


### PR DESCRIPTION
## Problem

Under an ancestor CSS [`zoom`](https://developer.mozilla.org/en-US/docs/Web/CSS/zoom), the scroll-to-end button stays active while the viewport is already pinned to the bottom (and only clears when clicked), and `autoScroll` no longer sticks to the bottom. Invisible at the default 1x zoom.

## Cause

`getMessageScrollerScrollable` measured the bottom gap as `getContentBottom(...) - scrollTop - clientHeight`. `getContentBottom` is derived from `getBoundingClientRect` (on-screen px, scaled by an ancestor `zoom`), while `scrollTop`/`clientHeight` are layout px. At zoom != 1 the mismatch over-reports the gap by ~`clientHeight * (zoom - 1)`, far past the 8px threshold: `end` never returns to `false` at the bottom, so the button stays active and `reconcileFollowMode` (which arms on `!end`) never engages.

## Fix

Measure the gap from the viewport's own layout-pixel scroll metrics, which `zoom` scales uniformly:

```ts
const tailSpacerHeight = spacer?.offsetHeight ?? 0
const distanceToEnd =
  viewport.scrollHeight - tailSpacerHeight - viewport.clientHeight - viewport.scrollTop
```

The tail spacer is subtracted to preserve the prior spacer-exclusion behavior. Identical to the old result at zoom 1. `getContentBottom` is left as-is for the anchor-placement paths, which compare rect to rect.

## Tests

- `geometry.test.ts`: moved the `getMessageScrollerScrollable` cases onto layout metrics; added tail-spacer exclusion and a case asserting zoom-scaled client rects are ignored.
- `message-scroller.browser.test.tsx`: real-Chromium regression under `zoom: 1.5` asserting the button stays `data-active="false"` at the bottom.

Both new tests fail on `main` and pass with the fix. Full package suite: 62 jsdom + 24 browser passing, typecheck clean.

---
Model: Claude Opus 4.8
