### PR TITLE
fix(shadcn): fix three bugs surfaced by the test audit

### DIFF
--- a/packages/shadcn/src/commands/add.ts
+++ b/packages/shadcn/src/commands/add.ts
@@ -94,16 +94,11 @@ export const add = new Command()
       }
 
       let itemType: z.infer<typeof registryItemTypeSchema> | undefined
-      let shouldInstallStyleIndex = true
       if (components.length > 0) {
         const [registryItem] = await getRegistryItems([components[0]], {
           config: initialConfig,
         })
         itemType = registryItem?.type
-        shouldInstallStyleIndex =
-          itemType !== "registry:theme" &&
-          itemType !== "registry:style" &&
-          itemType !== "registry:base"
 
         if (isUniversalRegistryItem(registryItem) && !isDryRun) {
           await addComponents(components, initialConfig, options)

--- a/packages/shadcn/src/mcp/index.ts
+++ b/packages/shadcn/src/mcp/index.ts
@@ -291,10 +291,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: "text",
               text:
-                formatSearchResultsWithPagination(results, {
+                (await formatSearchResultsWithPagination(results, {
                   query: args.query,
                   registries,
-                }) + skippedNote,
+                })) + skippedNote,
             },
           ],
         }
@@ -367,9 +367,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: "text",
               text:
-                formatSearchResultsWithPagination(results, {
+                (await formatSearchResultsWithPagination(results, {
                   registries,
-                }) + skippedNote,
+                })) + skippedNote,
             },
           ],
         }

--- a/packages/shadcn/src/mcp/utils.test.ts
+++ b/packages/shadcn/src/mcp/utils.test.ts
@@ -32,43 +32,34 @@ const minimalResults: SearchResults = {
 }
 
 describe("formatSearchResultsWithPagination", () => {
-  // KNOWN BUG (plans/005): npxShadcn is async but interpolated without await
-  // at src/mcp/utils.ts:49, so output contains "[object Promise]" instead of
-  // a runnable command. When someone fixes the bug, this it.fails test will
-  // start failing — flip it to a plain it() at that point.
-  it.fails("renders a runnable add command (currently broken)", () => {
-    const output = formatSearchResultsWithPagination(minimalResults)
+  it("renders a runnable add command", async () => {
+    const output = await formatSearchResultsWithPagination(minimalResults)
     expect(output).toContain(
       "Add command: `npx shadcn@latest add @shadcn/button`"
     )
   })
 
-  it("pins the current broken output (contains [object Promise])", () => {
-    const output = formatSearchResultsWithPagination(minimalResults)
-    expect(output).toContain("Add command: `[object Promise]`")
-  })
-
-  it("includes a header without query or registries", () => {
-    const output = formatSearchResultsWithPagination(minimalResults)
+  it("includes a header without query or registries", async () => {
+    const output = await formatSearchResultsWithPagination(minimalResults)
     expect(output).toContain("Found 1 items:")
   })
 
-  it("includes the query in the header when provided", () => {
-    const output = formatSearchResultsWithPagination(minimalResults, {
+  it("includes the query in the header when provided", async () => {
+    const output = await formatSearchResultsWithPagination(minimalResults, {
       query: "button",
     })
     expect(output).toContain('Found 1 items matching "button":')
   })
 
-  it("includes registries in the header when provided", () => {
-    const output = formatSearchResultsWithPagination(minimalResults, {
+  it("includes registries in the header when provided", async () => {
+    const output = await formatSearchResultsWithPagination(minimalResults, {
       registries: ["@shadcn", "@acme"],
     })
     expect(output).toContain("Found 1 items in registries @shadcn, @acme:")
   })
 
-  it("includes both query and registries in the header when provided", () => {
-    const output = formatSearchResultsWithPagination(minimalResults, {
+  it("includes both query and registries in the header when provided", async () => {
+    const output = await formatSearchResultsWithPagination(minimalResults, {
       query: "button",
       registries: ["@shadcn"],
     })
@@ -77,42 +68,42 @@ describe("formatSearchResultsWithPagination", () => {
     )
   })
 
-  it("clamps the showing range to the total", () => {
+  it("clamps the showing range to the total", async () => {
     const results: SearchResults = {
       items: [],
       pagination: { total: 25, offset: 20, limit: 10, hasMore: false },
     }
-    const output = formatSearchResultsWithPagination(results)
+    const output = await formatSearchResultsWithPagination(results)
     expect(output).toContain("Showing items 21-25 of 25:")
   })
 
-  it("shows the full range when there is no clamping needed", () => {
-    const output = formatSearchResultsWithPagination(minimalResults)
+  it("shows the full range when there is no clamping needed", async () => {
+    const output = await formatSearchResultsWithPagination(minimalResults)
     expect(output).toContain("Showing items 1-1 of 1:")
   })
 
-  it("adds an offset hint when hasMore is true", () => {
+  it("adds an offset hint when hasMore is true", async () => {
     const results: SearchResults = {
       items: [],
       pagination: { total: 25, offset: 0, limit: 10, hasMore: true },
     }
-    const output = formatSearchResultsWithPagination(results)
+    const output = await formatSearchResultsWithPagination(results)
     expect(output).toContain(
       "More items available. Use offset: 10 to see the next page."
     )
   })
 
-  it("does not add an offset hint when hasMore is false", () => {
-    const output = formatSearchResultsWithPagination(minimalResults)
+  it("does not add an offset hint when hasMore is false", async () => {
+    const output = await formatSearchResultsWithPagination(minimalResults)
     expect(output).not.toContain("More items available")
   })
 
-  it("includes type, description, and registry in item lines", () => {
-    const output = formatSearchResultsWithPagination(minimalResults)
+  it("includes type, description, and registry in item lines", async () => {
+    const output = await formatSearchResultsWithPagination(minimalResults)
     expect(output).toContain("- button (registry:ui) - A button. [@shadcn]")
   })
 
-  it("omits the registry bracket when registry is not present", () => {
+  it("omits the registry bracket when registry is not present", async () => {
     const results: SearchResults = {
       items: [
         {
@@ -123,7 +114,7 @@ describe("formatSearchResultsWithPagination", () => {
       ],
       pagination: { total: 1, offset: 0, limit: 10, hasMore: false },
     }
-    const output = formatSearchResultsWithPagination(results)
+    const output = await formatSearchResultsWithPagination(results)
     expect(output).not.toContain("[]")
     expect(output).toContain("- button")
   })

--- a/packages/shadcn/src/mcp/utils.ts
+++ b/packages/shadcn/src/mcp/utils.ts
@@ -21,7 +21,7 @@ export async function getMcpConfig(cwd = process.cwd()) {
   }
 }
 
-export function formatSearchResultsWithPagination(
+export async function formatSearchResultsWithPagination(
   results: z.infer<typeof searchResultsSchema>,
   options?: {
     query?: string
@@ -30,27 +30,31 @@ export function formatSearchResultsWithPagination(
 ) {
   const { query, registries } = options || {}
 
-  const formattedItems = results.items.map((item) => {
-    const parts: string[] = [`- ${item.name}`]
+  const formattedItems = await Promise.all(
+    results.items.map(async (item) => {
+      const parts: string[] = [`- ${item.name}`]
 
-    if (item.type) {
-      parts.push(`(${item.type})`)
-    }
+      if (item.type) {
+        parts.push(`(${item.type})`)
+      }
 
-    if (item.description) {
-      parts.push(`- ${item.description}`)
-    }
+      if (item.description) {
+        parts.push(`- ${item.description}`)
+      }
 
-    if (item.registry) {
-      parts.push(`[${item.registry}]`)
-    }
+      if (item.registry) {
+        parts.push(`[${item.registry}]`)
+      }
 
-    parts.push(
-      `\n  Add command: \`${npxShadcn(`add ${item.addCommandArgument}`)}\``
-    )
+      parts.push(
+        `\n  Add command: \`${await npxShadcn(
+          `add ${item.addCommandArgument}`
+        )}\``
+      )
 
-    return parts.join(" ")
-  })
+      return parts.join(" ")
+    })
+  )
 
   let header = `Found ${results.pagination.total} items`
   if (query) {

--- a/packages/shadcn/src/registry/source.test.ts
+++ b/packages/shadcn/src/registry/source.test.ts
@@ -305,6 +305,30 @@ describe("include guards", () => {
     ).rejects.toThrow(/stay inside the source registry root/)
   })
 
+  it("rejects a root registry file that resolves outside the source root when the registry has no include array", async () => {
+    // Same containment guard as above, but exercised on the include-less path:
+    // a root registry.json with no `include` array skips the include-walking
+    // branch entirely, so this confirms containment is still enforced there.
+    const reader = createReader({
+      "../outside/registry.json": JSON.stringify({
+        name: "example",
+        homepage: "https://example.com",
+        items: [{ name: "button", type: "registry:ui" }],
+      }),
+    })
+
+    await expect(
+      loadRegistryCatalogFromSource(reader, {
+        registryFile: "../outside/registry.json",
+      })
+    ).rejects.toThrow(RegistryValidationError)
+    await expect(
+      loadRegistryCatalogFromSource(reader, {
+        registryFile: "../outside/registry.json",
+      })
+    ).rejects.toThrow(/stay inside the source registry root/)
+  })
+
   it("rejects an include cycle", async () => {
     // A genuine two-distinct-file cycle (A includes B, B includes A) is not
     // reachable through the exported functions: include paths can never

--- a/packages/shadcn/src/registry/source.ts
+++ b/packages/shadcn/src/registry/source.ts
@@ -80,6 +80,8 @@ async function readSourceRegistryWithIncludes(
     source?: string
   } = {}
 ) {
+  validateRegistryFileWithinRoot(registryFile)
+
   const content = await readRegistryJson(registryFile, reader, options)
   const rootRegistry = parseRegistry(content, registryFile)
   validateRootRegistry(rootRegistry, registryFile)


### PR DESCRIPTION
Fixes the three bugs found (and test-pinned) in #11247:

- `npxShadcn` was interpolated without `await` in the MCP search results formatter, so `search_items_in_registries` output rendered `[object Promise]` instead of an add command. Formatter is now async; the `it.fails` marker test is flipped to a regular test.
- `shouldInstallStyleIndex` in the `add` command was computed but never read (superseded by `resolveRegistryBaseConfig`). Removed.
- `shadcn build` registries without an `include` array skipped root containment validation on the registry file path. The guard now runs for both paths; new test covers the include-less case.

Full suite (1649 tests), typecheck, and build pass.