### PR TITLE
fix(create): match native color scheme in inverted menus

### DIFF
--- a/.changeset/bright-scrollbars-glow.md
+++ b/.changeset/bright-scrollbars-glow.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Ensure native controls use the dark color scheme in inverted menus.

--- a/apps/v4/app/(app)/(create)/components/design-system-provider.tsx
+++ b/apps/v4/app/(app)/(create)/components/design-system-provider.tsx
@@ -227,7 +227,7 @@ export function DesignSystemProvider({
     styleElement.textContent = buildThemeCssText(registryTheme.cssVars, pointer)
   }, [registryTheme, pointer])
 
-  // Handle menu color inversion by adding/removing dark class to elements with cn-menu-target.
+  // Handle menu color inversion by updating the theme and native color scheme.
   // useLayoutEffect to apply classes synchronously before paint, avoiding flash.
   React.useLayoutEffect(() => {
     if (!menuColor) {
@@ -258,9 +258,9 @@ export function DesignSystemProvider({
       allElements.forEach((element) => {
         if (element.classList.contains("cn-menu-target")) {
           if (isInvertedMenu) {
-            element.classList.add("dark")
+            element.classList.add("dark", "[color-scheme:dark]")
           } else {
-            element.classList.remove("dark")
+            element.classList.remove("dark", "[color-scheme:dark]")
           }
         }
 

--- a/packages/shadcn/src/utils/transformers/transform-menu.test.ts
+++ b/packages/shadcn/src/utils/transformers/transform-menu.test.ts
@@ -32,7 +32,7 @@ const testConfig: Config = {
 
 describe("transformMenu", () => {
   describe("menuColor is inverted", () => {
-    test("replaces cn-menu-target with dark in string literal", async () => {
+    test("replaces cn-menu-target with inverted menu classes in string literal", async () => {
       expect(
         await transform(
           {
@@ -53,12 +53,12 @@ export function Component() {
         "import * as React from "react"
 
         export function Component() {
-          return <div className="dark p-4">Content</div>
+          return <div className="dark [color-scheme:dark] p-4">Content</div>
         }"
       `)
     })
 
-    test("replaces cn-menu-target with dark in cn() call", async () => {
+    test("replaces cn-menu-target with inverted menu classes in cn() call", async () => {
       expect(
         await transform(
           {
@@ -79,7 +79,7 @@ export function Component() {
         "import * as React from "react"
 
         export function Component() {
-          return <div className={cn("dark", "p-4")}>Content</div>
+          return <div className={cn("dark [color-scheme:dark]", "p-4")}>Content</div>
         }"
       `)
     })
@@ -112,8 +112,8 @@ export function Component() {
         export function Component() {
           return (
             <div>
-              <div className="dark p-4">First</div>
-              <div className={cn("dark", "mt-2")}>Second</div>
+              <div className="dark [color-scheme:dark] p-4">First</div>
+              <div className={cn("dark [color-scheme:dark]", "mt-2")}>Second</div>
             </div>
           )
         }"
@@ -367,7 +367,7 @@ export function Component() {
   })
 
   describe("menuColor is inverted-translucent", () => {
-    test("replaces cn-menu-target with dark and inlines cn-menu-translucent", async () => {
+    test("replaces cn-menu-target with inverted menu classes and inlines cn-menu-translucent", async () => {
       expect(
         await transform(
           {
@@ -388,12 +388,12 @@ export function Component() {
         "import * as React from "react"
 
         export function Component() {
-          return <div className="dark p-4 animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!">Content</div>
+          return <div className="dark [color-scheme:dark] p-4 animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!">Content</div>
         }"
       `)
     })
 
-    test("replaces cn-menu-target with dark and inlines cn-menu-translucent in cn() call", async () => {
+    test("replaces cn-menu-target with inverted menu classes and inlines cn-menu-translucent in cn() call", async () => {
       expect(
         await transform(
           {
@@ -414,14 +414,14 @@ export function Component() {
         "import * as React from "react"
 
         export function Component() {
-          return <div className={cn("dark animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!", "p-4")}>Content</div>
+          return <div className={cn("dark [color-scheme:dark] animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!", "p-4")}>Content</div>
         }"
       `)
     })
   })
 
   describe("menuColor is inverted removes cn-menu-translucent", () => {
-    test("replaces cn-menu-target with dark and removes cn-menu-translucent", async () => {
+    test("replaces cn-menu-target with inverted menu classes and removes cn-menu-translucent", async () => {
       expect(
         await transform(
           {
@@ -442,7 +442,7 @@ export function Component() {
         "import * as React from "react"
 
         export function Component() {
-          return <div className="dark p-4">Content</div>
+          return <div className="dark [color-scheme:dark] p-4">Content</div>
         }"
       `)
     })
@@ -497,7 +497,7 @@ export function Component() {
       "import * as React from "react";
 
       export function Component() {
-        return <div className="dark p-4">Content</div>;
+        return <div className="dark [color-scheme:dark] p-4">Content</div>;
       }"
     `)
   })

--- a/packages/shadcn/src/utils/transformers/transform-menu.ts
+++ b/packages/shadcn/src/utils/transformers/transform-menu.ts
@@ -7,9 +7,9 @@ const TRANSLUCENT_CLASSES =
   "animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!"
 
 // Transforms cn-menu-target and cn-menu-translucent classes based on config.menuColor.
-// If menuColor is "inverted", replaces cn-menu-target with "dark" and removes cn-menu-translucent.
+// If menuColor is "inverted", replaces cn-menu-target with inverted menu classes and removes cn-menu-translucent.
 // If menuColor is "default-translucent", removes cn-menu-target and inlines cn-menu-translucent styles.
-// If menuColor is "inverted-translucent", replaces cn-menu-target with "dark" and inlines cn-menu-translucent styles.
+// If menuColor is "inverted-translucent", replaces cn-menu-target with inverted menu classes and inlines cn-menu-translucent styles.
 // Otherwise, removes both cn-menu-target and cn-menu-translucent.
 export const transformMenu: Transformer = async ({ sourceFile, config }) => {
   const menuColor = config.menuColor
@@ -39,8 +39,8 @@ export const transformMenu: Transformer = async ({ sourceFile, config }) => {
     let needsCleanup = false
 
     if (menuColor === "inverted" || menuColor === "inverted-translucent") {
-      // Replace cn-menu-target with "dark".
-      newText = newText.replace(/cn-menu-target/g, "dark")
+      // Match native controls, including scrollbars, to the inverted menu.
+      newText = newText.replace(/cn-menu-target/g, "dark [color-scheme:dark]")
     } else {
       // Remove cn-menu-target for both "default-translucent" and "default".
       newText = newText.replace(/cn-menu-target/g, "")


### PR DESCRIPTION
## Summary

- apply a dark native color scheme to inverted menus
- keep the Create preview and generated component output aligned
- add transformer coverage for solid and translucent inverted menus

## Root cause

The `dark` class scopes Tailwind's dark theme styles, but it does not update the browser's native `color-scheme`. In light mode, native controls such as scrollbars could therefore keep their light appearance inside a dark inverted menu and blend into its background.

## Testing

- `pnpm exec vitest run src/utils/transformers/transform-menu.test.ts`
- `pnpm typecheck` in `packages/shadcn`
- targeted ESLint and Prettier checks
- verified in Chrome that a nested scrollable element inherits `color-scheme: dark`

Closes #9137
