### PR TITLE
fix(shadcn): use icon-specific props for Spinner

### DIFF
--- a/.changeset/fifty-papayas-sleep.md
+++ b/.changeset/fifty-papayas-sleep.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+fix(spinner): use icon-specific props type

--- a/apps/v4/registry/bases/aria/ui/spinner.tsx
+++ b/apps/v4/registry/bases/aria/ui/spinner.tsx
@@ -1,7 +1,9 @@
 import { cn } from "@/registry/bases/aria/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+type SpinnerProps = Omit<React.ComponentProps<"svg">, "children">
+
+function Spinner({ className, ...props }: SpinnerProps) {
   return (
     <IconPlaceholder
       lucide="Loader2Icon"

--- a/apps/v4/registry/bases/base/ui/spinner.tsx
+++ b/apps/v4/registry/bases/base/ui/spinner.tsx
@@ -1,7 +1,9 @@
 import { cn } from "@/registry/bases/base/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+type SpinnerProps = Omit<React.ComponentProps<"svg">, "children">
+
+function Spinner({ className, ...props }: SpinnerProps) {
   return (
     <IconPlaceholder
       lucide="Loader2Icon"

--- a/apps/v4/registry/bases/radix/ui/spinner.tsx
+++ b/apps/v4/registry/bases/radix/ui/spinner.tsx
@@ -1,7 +1,9 @@
 import { cn } from "@/registry/bases/radix/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+type SpinnerProps = Omit<React.ComponentProps<"svg">, "children">
+
+function Spinner({ className, ...props }: SpinnerProps) {
   return (
     <IconPlaceholder
       lucide="Loader2Icon"

--- a/apps/v4/registry/new-york-v4/ui/spinner.tsx
+++ b/apps/v4/registry/new-york-v4/ui/spinner.tsx
@@ -2,7 +2,9 @@ import { Loader2Icon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+type SpinnerProps = Omit<React.ComponentProps<typeof Loader2Icon>, "children">
+
+function Spinner({ className, ...props }: SpinnerProps) {
   return (
     <Loader2Icon
       role="status"

--- a/packages/shadcn/src/utils/transformers/transform-icons.test.ts
+++ b/packages/shadcn/src/utils/transformers/transform-icons.test.ts
@@ -684,4 +684,53 @@ export function Component() {
       }"
     `)
   })
+
+  describe("remixicon library", () => {
+    test("updates svg props type when spreading props to icon", async () => {
+      expect(
+        await transform(
+          {
+            filename: "spinner.tsx",
+            raw: `import { cn } from "@/lib/utils"
+import { IconPlaceholder } from "@/app/(create)/create/components/icon-placeholder"
+
+type SpinnerProps = Omit<React.ComponentProps<"svg">, "children">
+
+function Spinner({ className, ...props }: SpinnerProps) {
+  return (
+    <IconPlaceholder
+      remixicon="RiLoaderLine"
+      data-slot="spinner"
+      role="status"
+      aria-label="Loading"
+      className={cn("size-4 animate-spin", className)}
+      {...props}
+    />
+  )
+}
+
+export { Spinner }`,
+            config: {
+              ...testConfig,
+              iconLibrary: "remixicon",
+            },
+          },
+          [transformIcons]
+        )
+      ).toMatchInlineSnapshot(`
+        "import { cn } from "@/lib/utils"
+        import { RiLoaderLine } from "@remixicon/react"
+
+        type SpinnerProps = Omit<React.ComponentProps<typeof RiLoaderLine>, "children">
+
+        function Spinner({ className, ...props }: SpinnerProps) {
+          return (
+            <RiLoaderLine data-slot="spinner" role="status" aria-label="Loading" className={cn("size-4 animate-spin", className)} {...props} />
+          )
+        }
+
+        export { Spinner }"
+      `)
+    })
+  })
 })

--- a/packages/shadcn/src/utils/transformers/transform-icons.ts
+++ b/packages/shadcn/src/utils/transformers/transform-icons.ts
@@ -1,6 +1,10 @@
 import { iconLibraries, type IconLibraryName } from "@/src/icons/libraries"
 import { Transformer } from "@/src/utils/transformers"
-import { SourceFile, SyntaxKind } from "ts-morph"
+import {
+  JsxSelfClosingElement,
+  SourceFile,
+  SyntaxKind,
+} from "ts-morph"
 
 export const transformIcons: Transformer = async ({ sourceFile, config }) => {
   const iconLibrary = config.iconLibrary
@@ -69,11 +73,16 @@ export const transformIcons: Transformer = async ({ sourceFile, config }) => {
     }
 
     if (!usageMatch) {
+      updateSvgPropsType(element, targetIconName)
       element.getTagNameNode()?.replaceWithText(targetIconName)
       continue
     }
 
     const [, componentName, defaultPropsStr] = usageMatch
+    const propsComponentName =
+      componentName === "ICON" ? targetIconName : componentName
+
+    updateSvgPropsType(element, propsComponentName)
 
     if (componentName === "ICON") {
       // Get remaining user attributes (non-library props)
@@ -201,6 +210,91 @@ export const transformIcons: Transformer = async ({ sourceFile, config }) => {
   }
 
   return sourceFile
+}
+
+function updateSvgPropsType(
+  element: JsxSelfClosingElement,
+  targetComponentName: string
+) {
+  const spreadNames = element
+    .getAttributes()
+    .filter((attr) => attr.getKind() === SyntaxKind.JsxSpreadAttribute)
+    .map((attr) =>
+      attr.asKindOrThrow(SyntaxKind.JsxSpreadAttribute).getExpression().getText()
+    )
+
+  if (spreadNames.length === 0) {
+    return
+  }
+
+  const func =
+    element.getFirstAncestorByKind(SyntaxKind.FunctionDeclaration) ??
+    element.getFirstAncestorByKind(SyntaxKind.FunctionExpression) ??
+    element.getFirstAncestorByKind(SyntaxKind.ArrowFunction)
+
+  if (!func) {
+    return
+  }
+
+  const newType = `Omit<React.ComponentProps<typeof ${targetComponentName}>, "children">`
+
+  for (const param of func.getParameters()) {
+    const nameNode = param.getNameNode()
+    if (nameNode.getKind() !== SyntaxKind.ObjectBindingPattern) {
+      continue
+    }
+
+    const hasMatchingRest = nameNode
+      .asKindOrThrow(SyntaxKind.ObjectBindingPattern)
+      .getElements()
+      .some((bindingElement) => {
+        if (bindingElement.getKind() !== SyntaxKind.BindingElement) {
+          return false
+        }
+
+        const binding = bindingElement.asKindOrThrow(SyntaxKind.BindingElement)
+        const bindingNameNode = binding.getNameNode()
+        const bindingName =
+          bindingNameNode.getKind() === SyntaxKind.Identifier
+            ? bindingNameNode.getText()
+            : binding.getName()
+
+        return (
+          binding.getDotDotDotToken() !== undefined &&
+          bindingName !== undefined &&
+          spreadNames.includes(bindingName)
+        )
+      })
+
+    if (!hasMatchingRest) {
+      continue
+    }
+
+    const typeNode = param.getTypeNode()
+    if (!typeNode) {
+      continue
+    }
+
+    const typeText = typeNode.getText()
+
+    if (typeText.includes('ComponentProps<"svg">')) {
+      param.setType(newType)
+      continue
+    }
+
+    if (typeText === "SpinnerProps") {
+      updateSpinnerPropsTypeAlias(func.getSourceFile(), newType)
+    }
+  }
+}
+
+function updateSpinnerPropsTypeAlias(sourceFile: SourceFile, newType: string) {
+  for (const typeAlias of sourceFile.getTypeAliases()) {
+    if (typeAlias.getName() === "SpinnerProps") {
+      typeAlias.setType(newType)
+      return
+    }
+  }
 }
 
 function _useSemicolon(sourceFile: SourceFile) {


### PR DESCRIPTION
This fixes the generated Spinner component’s prop type when using Remix Icon.

Previously, Spinner templates declared their props as SVG-native props:

```tsx
React.ComponentProps<"svg">
```
During generation, IconPlaceholder is replaced with the configured icon component for Remix Icon, RiLoaderLine. That means
the generated component was forwarding props to a React icon component while still being typed as a plain `<svg>`. The prop
type should instead come from the actual generated icon component.

In a Next.js project using the Base UI style with Remix Icon, this mismatch caused the production build's TypeScript check to fail after generating the Spinner component.

The fix changes Spinner’s base template to use a named SpinnerProps type and enhances the icon transformer to update that
type during icon replacement. For Remix Icon, generated output now becomes:

```tsx
type SpinnerProps = Omit<
    React.ComponentProps<typeof RiLoaderLine>,
    "children"
>
```
This preserves the Spinner wrapper’s existing API while accurately reflecting the selected icon library’s props. Excluding children also matches the self-closing icon usage.

### What changed

- Updated all Spinner registry templates to declare a reusable `SpinnerProps` type.
- Enhanced `transformIcons` to detect when an `IconPlaceholder` forwards `...props`.
- Located the surrounding component’s matching rest parameter and changed its SVG prop type to the selected icon component’s prop type.

- Supports both inline `React.ComponentProps<"svg">` annotations and the `SpinnerProps` type alias.
- Added a Remix Icon regression test that verifies the transformed Spinner imports `RiLoaderLine` and uses `ComponentProps<typeof RiLoaderLine>`.

### Validation

- `pnpm --filter shadcn test` - passed: 79 files, 1,650 tests.
- `pnpm --filter shadcn typecheck` - passed with no TypeScript errors.
