### PR TITLE
feat(registry): add programmatic install API

### DIFF
--- a/.changeset/clean-lions-install.md
+++ b/.changeset/clean-lions-install.md
@@ -1,0 +1,5 @@
+---
+"shadcn": minor
+---
+
+Add a public `addRegistryItems` API for installing registry items programmatically without invoking the CLI.

--- a/apps/v4/content/docs/registry/api-reference.mdx
+++ b/apps/v4/content/docs/registry/api-reference.mdx
@@ -4,8 +4,8 @@ description: Programmatic API for working with registries, schemas and presets.
 ---
 
 The `shadcn` package exposes a set of programmatic APIs in addition to the CLI.
-You can use these to fetch and resolve registry items, validate registry JSON,
-and build custom tooling on top of the registry.
+You can use these to fetch, resolve, and install registry items, validate
+registry JSON, and build custom tooling on top of the registry.
 
 Each API is available under a dedicated subpath import.
 
@@ -150,6 +150,27 @@ Returns a single merged tree:
   "docs": ""
 }
 ```
+
+### addRegistryItems
+
+Resolve and install registry items into an existing project. This is the
+programmatic equivalent of `shadcn add` and applies files, package dependencies,
+environment variables, CSS, and Tailwind configuration declared by the items.
+
+```ts showLineNumbers
+import { addRegistryItems } from "shadcn/registry"
+
+await addRegistryItems(["@acme/button", "@acme/card"], {
+  cwd: process.cwd(),
+  overwrite: false,
+  silent: true,
+})
+```
+
+A `components.json` file is required unless every requested item is universal:
+a `registry:item` or `registry:file` whose files all declare explicit targets.
+The function loads registry configuration from `components.json`, discovers
+known registry namespaces, and throws errors instead of exiting the process.
 
 ### getRegistries
 

--- a/packages/shadcn/src/registry/add.test.ts
+++ b/packages/shadcn/src/registry/add.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { addRegistryItems } from "./add"
+
+const {
+  mockAddComponents,
+  mockClearRegistryContext,
+  mockCreateConfig,
+  mockEnsureRegistriesInConfig,
+  mockGetConfig,
+  mockGetRegistryItems,
+  mockLoadEnvFiles,
+} = vi.hoisted(() => ({
+  mockAddComponents: vi.fn(),
+  mockClearRegistryContext: vi.fn(),
+  mockCreateConfig: vi.fn(),
+  mockEnsureRegistriesInConfig: vi.fn(),
+  mockGetConfig: vi.fn(),
+  mockGetRegistryItems: vi.fn(),
+  mockLoadEnvFiles: vi.fn(),
+}))
+
+vi.mock("@/src/registry/api", () => ({
+  getRegistryItems: mockGetRegistryItems,
+}))
+
+vi.mock("@/src/registry/context", () => ({
+  clearRegistryContext: mockClearRegistryContext,
+}))
+
+vi.mock("@/src/utils/add-components", () => ({
+  addComponents: mockAddComponents,
+}))
+
+vi.mock("@/src/utils/env-loader", () => ({
+  loadEnvFiles: mockLoadEnvFiles,
+}))
+
+vi.mock("@/src/utils/get-config", () => ({
+  createConfig: mockCreateConfig,
+  getConfig: mockGetConfig,
+}))
+
+vi.mock("@/src/utils/registries", () => ({
+  ensureRegistriesInConfig: mockEnsureRegistriesInConfig,
+}))
+
+describe("addRegistryItems", () => {
+  const projectConfig = { resolvedPaths: { cwd: "/project" } }
+  const updatedConfig = { ...projectConfig, registries: { "@acme": "url" } }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetConfig.mockResolvedValue(projectConfig)
+    mockEnsureRegistriesInConfig.mockResolvedValue({
+      config: updatedConfig,
+      newRegistries: [],
+    })
+  })
+
+  it("loads project configuration and installs registry items", async () => {
+    await addRegistryItems(["@acme/button"], {
+      cwd: "/project",
+      overwrite: true,
+      silent: true,
+    })
+
+    expect(mockLoadEnvFiles).toHaveBeenCalledWith("/project")
+    expect(mockEnsureRegistriesInConfig).toHaveBeenCalledWith(
+      ["@acme/button"],
+      projectConfig,
+      { silent: true, writeFile: true }
+    )
+    expect(mockAddComponents).toHaveBeenCalledWith(
+      ["@acme/button"],
+      updatedConfig,
+      expect.objectContaining({ overwrite: true, silent: true })
+    )
+    expect(mockClearRegistryContext).toHaveBeenCalledOnce()
+  })
+
+  it("installs universal items without components.json", async () => {
+    const universalConfig = { resolvedPaths: { cwd: "/project" } }
+    mockGetConfig.mockResolvedValue(null)
+    mockCreateConfig.mockReturnValue(universalConfig)
+    mockEnsureRegistriesInConfig.mockResolvedValue({
+      config: universalConfig,
+      newRegistries: [],
+    })
+    mockGetRegistryItems.mockResolvedValue([
+      {
+        name: "agent",
+        type: "registry:file",
+        files: [
+          {
+            path: "agent.ts",
+            target: "agent/extensions/agent.ts",
+            type: "registry:file",
+          },
+        ],
+      },
+    ])
+
+    await addRegistryItems(["https://example.com/agent.json"], {
+      cwd: "/project",
+    })
+
+    expect(mockEnsureRegistriesInConfig).toHaveBeenCalledWith(
+      ["https://example.com/agent.json"],
+      universalConfig,
+      { silent: undefined, writeFile: false }
+    )
+    expect(mockAddComponents).toHaveBeenCalledWith(
+      ["https://example.com/agent.json"],
+      universalConfig,
+      expect.any(Object)
+    )
+  })
+
+  it("rejects non-universal items without components.json", async () => {
+    const universalConfig = { resolvedPaths: { cwd: "/project" } }
+    mockGetConfig.mockResolvedValue(null)
+    mockCreateConfig.mockReturnValue(universalConfig)
+    mockEnsureRegistriesInConfig.mockResolvedValue({
+      config: universalConfig,
+      newRegistries: [],
+    })
+    mockGetRegistryItems.mockResolvedValue([
+      { name: "button", type: "registry:ui" },
+    ])
+
+    await expect(
+      addRegistryItems(["@acme/button"], { cwd: "/project" })
+    ).rejects.toThrow("A components.json file is required")
+
+    expect(mockAddComponents).not.toHaveBeenCalled()
+    expect(mockClearRegistryContext).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/shadcn/src/registry/add.ts
+++ b/packages/shadcn/src/registry/add.ts
@@ -1,0 +1,72 @@
+import path from "path"
+import { getRegistryItems } from "@/src/registry/api"
+import { clearRegistryContext } from "@/src/registry/context"
+import { isUniversalRegistryItem } from "@/src/registry/utils"
+import {
+  addComponents,
+  type AddComponentsOptions,
+} from "@/src/utils/add-components"
+import { loadEnvFiles } from "@/src/utils/env-loader"
+import { createConfig, getConfig } from "@/src/utils/get-config"
+import { ensureRegistriesInConfig } from "@/src/utils/registries"
+
+export interface AddRegistryItemsOptions
+  extends Pick<
+    AddComponentsOptions,
+    "overwrite" | "overwriteCssVars" | "silent" | "skipFonts" | "path"
+  > {
+  /** The project directory. Defaults to the current working directory. */
+  cwd?: string
+}
+
+/**
+ * Resolve and install registry items into a project.
+ *
+ * This is the programmatic equivalent of `shadcn add` for an existing project.
+ * Universal registry items with explicit file targets can also be installed
+ * without a components.json file.
+ */
+export async function addRegistryItems(
+  items: string[],
+  options: AddRegistryItemsOptions = {}
+): Promise<void> {
+  if (items.length === 0) {
+    return
+  }
+
+  const cwd = path.resolve(options.cwd ?? process.cwd())
+
+  try {
+    await loadEnvFiles(cwd)
+
+    const projectConfig = await getConfig(cwd)
+    let config =
+      projectConfig ??
+      createConfig({
+        resolvedPaths: { cwd },
+      })
+
+    const { config: configWithRegistries } = await ensureRegistriesInConfig(
+      items,
+      config,
+      {
+        silent: options.silent,
+        writeFile: projectConfig !== null,
+      }
+    )
+    config = configWithRegistries
+
+    if (!projectConfig) {
+      const registryItems = await getRegistryItems(items, { config })
+      if (!registryItems.every(isUniversalRegistryItem)) {
+        throw new Error(
+          "A components.json file is required to add non-universal registry items."
+        )
+      }
+    }
+
+    await addComponents(items, config, options)
+  } finally {
+    clearRegistryContext()
+  }
+}

--- a/packages/shadcn/src/registry/index.ts
+++ b/packages/shadcn/src/registry/index.ts
@@ -6,6 +6,8 @@ export {
   getRegistriesIndex,
 } from "./api"
 
+export { addRegistryItems, type AddRegistryItemsOptions } from "./add"
+
 export { searchRegistries } from "./search"
 
 export {

--- a/packages/shadcn/src/utils/add-components.test.ts
+++ b/packages/shadcn/src/utils/add-components.test.ts
@@ -95,10 +95,6 @@ vi.mock("@/src/utils/spinner", () => ({
   spinner: vi.fn(() => spinnerInstance),
 }))
 
-vi.mock("@/src/utils/handle-error", () => ({
-  handleError: vi.fn(),
-}))
-
 vi.mock("@/src/utils/logger", () => ({
   logger: {
     info: vi.fn(),
@@ -126,6 +122,20 @@ describe("addComponents", () => {
       filesSkipped: [],
     })
     mockUpdateCss.mockResolvedValue(undefined)
+  })
+
+  it("throws when registry items cannot be resolved", async () => {
+    mockResolveRegistryTree.mockResolvedValue(null)
+
+    await expect(
+      addComponents(
+        ["missing"],
+        { resolvedPaths: { cwd: "/test/project" } } as any,
+        { silent: true }
+      )
+    ).rejects.toThrow("Failed to fetch components from registry.")
+
+    expect(spinnerInstance.fail).toHaveBeenCalledOnce()
   })
 
   it("passes pending heading font markers into updateFiles before CSS is written", async () => {

--- a/packages/shadcn/src/utils/add-components.ts
+++ b/packages/shadcn/src/utils/add-components.ts
@@ -16,7 +16,6 @@ import {
   type Config,
 } from "@/src/utils/get-config"
 import { getProjectTailwindVersionFromConfig } from "@/src/utils/get-project-info"
-import { handleError } from "@/src/utils/handle-error"
 import { isSafeTarget } from "@/src/utils/is-safe-target"
 import { logger } from "@/src/utils/logger"
 import { spinner } from "@/src/utils/spinner"
@@ -31,18 +30,20 @@ import {
 import { updateTailwindConfig } from "@/src/utils/updaters/update-tailwind-config"
 import { z } from "zod"
 
+export interface AddComponentsOptions {
+  overwrite?: boolean
+  overwriteCssVars?: boolean
+  silent?: boolean
+  isNewProject?: boolean
+  skipFonts?: boolean
+  registryHeaders?: Record<string, Record<string, string>>
+  path?: string
+}
+
 export async function addComponents(
   components: string[],
   config: Config,
-  options: {
-    overwrite?: boolean
-    overwriteCssVars?: boolean
-    silent?: boolean
-    isNewProject?: boolean
-    skipFonts?: boolean
-    registryHeaders?: Record<string, Record<string, string>>
-    path?: string
-  }
+  options: AddComponentsOptions
 ) {
   options = {
     overwrite: false,
@@ -93,14 +94,14 @@ async function addProjectComponents(
 
   if (!tree) {
     registrySpinner?.fail()
-    return handleError(new Error("Failed to fetch components from registry."))
+    throw new Error("Failed to fetch components from registry.")
   }
 
   try {
     validateFilesTarget(tree.files ?? [], config.resolvedPaths.cwd)
   } catch (error) {
     registrySpinner?.fail()
-    return handleError(error)
+    throw error
   }
 
   registrySpinner?.succeed()
@@ -183,14 +184,14 @@ async function addWorkspaceComponents(
 
   if (!tree) {
     registrySpinner?.fail()
-    return handleError(new Error("Failed to fetch components from registry."))
+    throw new Error("Failed to fetch components from registry.")
   }
 
   try {
     validateFilesTarget(tree.files ?? [], config.resolvedPaths.cwd)
   } catch (error) {
     registrySpinner?.fail()
-    return handleError(error)
+    throw error
   }
 
   registrySpinner?.succeed()


### PR DESCRIPTION
## Summary

- export `addRegistryItems` from `shadcn/registry` as a programmatic installation API
- load project and registry configuration before applying files, dependencies, environment variables, CSS, and Tailwind configuration
- support universal registry items without `components.json`
- make the underlying add pipeline throw errors rather than exiting the embedding process
- document and test the new API

## Motivation

Registry consumers currently have public APIs for fetching, resolving, and searching items, but applying an item requires spawning the shadcn CLI. This API allows tools embedding shadcn to install registry items without depending on `npx` or undocumented CLI internals.

## Validation

- `pnpm --filter shadcn typecheck`
- `pnpm --filter shadcn build`
- `pnpm --filter shadcn test` (80 files, 1,665 tests)