### PR TITLE
fix: remove unused React import in base scroll-area component

### DIFF
--- a/apps/v4/registry/bases/base/ui/scroll-area.tsx
+++ b/apps/v4/registry/bases/base/ui/scroll-area.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import * as React from "react"
 import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area"
 
 import { cn } from "@/registry/bases/base/lib/utils"


### PR DESCRIPTION
Removes unused `import * as React from "react"` from the Base UI `scroll-area` component.

This fixes `TS6133: 'React' is declared but its value is never read` when using `"noUnusedLocals": true` with the automatic JSX runtime.
