### PR TITLE
docs(message-scroller): remove autoScroll from usage

### DIFF
--- a/apps/v4/content/docs/components/aria/message-scroller.mdx
+++ b/apps/v4/content/docs/components/aria/message-scroller.mdx
@@ -119,7 +119,7 @@ import {
 ```
 
 ```tsx
-<MessageScrollerProvider autoScroll>
+<MessageScrollerProvider>
   <MessageScroller>
     <MessageScrollerViewport>
       <MessageScrollerContent>

--- a/apps/v4/content/docs/components/base/message-scroller.mdx
+++ b/apps/v4/content/docs/components/base/message-scroller.mdx
@@ -119,7 +119,7 @@ import {
 ```
 
 ```tsx
-<MessageScrollerProvider autoScroll>
+<MessageScrollerProvider>
   <MessageScroller>
     <MessageScrollerViewport>
       <MessageScrollerContent>

--- a/apps/v4/content/docs/components/radix/message-scroller.mdx
+++ b/apps/v4/content/docs/components/radix/message-scroller.mdx
@@ -119,7 +119,7 @@ import {
 ```
 
 ```tsx
-<MessageScrollerProvider autoScroll>
+<MessageScrollerProvider>
   <MessageScroller>
     <MessageScrollerViewport>
       <MessageScrollerContent>


### PR DESCRIPTION
Removes the autoScroll prop from the primary message scroller usage example for the Base UI, Radix, and ARIA docs.