### PR TITLE
fix(shadcn): preserve Expo SDK dependency resolution

### DIFF
--- a/.changeset/fix-expo-sdk-dependency-resolution.md
+++ b/.changeset/fix-expo-sdk-dependency-resolution.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Preserve Expo SDK-aware version selection when installing registry dependencies.

--- a/packages/shadcn/src/utils/updaters/update-dependencies.test.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.test.ts
@@ -228,7 +228,7 @@ describe("updateDependencies", () => {
     )
   })
 
-  it("does not skip already declared deps for expo projects", async () => {
+  it("passes dependencies to Expo for SDK-aware version resolution", async () => {
     const cwd = getFixturesDir("project-expo-existing-deps")
 
     // recharts is already declared, but `expo install` must still see it so it
@@ -242,9 +242,21 @@ describe("updateDependencies", () => {
 
     expect(execa).toHaveBeenCalledWith(
       "npx",
-      ["expo", "install", "--", "recharts", "react-is"],
+      ["expo", "install", "recharts", "react-is"],
       { cwd }
     )
+  })
+
+  it("rejects Expo dependencies that could be interpreted as flags", async () => {
+    const cwd = getFixturesDir("project-expo-existing-deps")
+
+    await expect(
+      updateDependencies(["--fix"], [], { resolvedPaths: { cwd } } as any, {
+        silent: true,
+      })
+    ).rejects.toThrow(/cannot start with/)
+
+    expect(execa).not.toHaveBeenCalled()
   })
 
   it("rejects registry dependencies that begin with a dash (flag injection)", async () => {

--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -202,8 +202,8 @@ async function getUpdateDependenciesPackageManager(config: Config) {
  * manager's argument list. A specifier beginning with "-" would be interpreted
  * as a flag rather than a package name, letting a malicious registry alter the
  * install source/behavior (argument injection). Reject those before they reach
- * `execa`; the `--` end-of-options separator added at each call site is the
- * second layer of defense.
+ * `execa`; package manager calls also use an end-of-options separator where
+ * the CLI's argument semantics support it.
  */
 export function assertSafeDependencies(deps: string[]) {
   for (const dep of deps) {
@@ -313,7 +313,10 @@ async function installWithExpo(
   assertSafeDependencies(devDependencies)
 
   if (dependencies.length) {
-    await execa("npx", ["expo", "install", "--", ...dependencies], { cwd })
+    // Expo treats arguments after `--` as package-manager arguments, bypassing
+    // its SDK-compatible version resolution. assertSafeDependencies prevents
+    // dependency strings from being interpreted as Expo CLI flags.
+    await execa("npx", ["expo", "install", ...dependencies], { cwd })
   }
 
   if (devDependencies.length) {


### PR DESCRIPTION
## What

Restores Expo's SDK-aware version selection when installing registry dependencies.

Expo treats arguments after `--` as package-manager arguments. This means:

```sh
npx expo install -- <dependencies>
```

bypasses Expo's version resolution. In an Expo SDK 56 project, a bare `@expo/ui` dependency was installed as `^57.0.7` instead of the compatible `~56.0.23`.

## Fix

Remove `--` only from Expo's normal dependency install path:

```sh
npx expo install <dependencies>
```

The `assertSafeDependencies` guard added in #11195 remains in place and rejects dependency strings beginning with `-` before `execa` runs. npm, pnpm, Yarn, and Bun still use their end-of-options separators.

The Expo dev dependency path is unchanged. Its pre-existing `"-- -D"` argument was already noted in #11195 and is outside the scope of this fix.

## Tests

- Added regression coverage for the Expo command arguments.
- Added an Expo-specific test proving flag-like dependencies are rejected before a process starts.
- `pnpm --filter=shadcn exec vitest run src/utils/updaters/update-dependencies.test.ts`
- `pnpm --filter=shadcn typecheck`
- Full shadcn test suite: 82 files, 1,684 tests passed.
- Built the CLI and verified the fix in Expo SDK 56: `@expo/ui` resolved to `56.0.23` and `expo install --check` passed.

Reproduction: https://github.com/brilliantinsane/shadcn-expo-sdk-resolution-repro/tree/6ca2bece27dea2ecbe81fadd463148aec0935132

Fixes #11275
