### PR TITLE
fix: resolve tsconfig paths from TypeScript project references (Vite scaffold on Windows)

### DIFF
--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -6,7 +6,7 @@ import {
   rawConfigSchema,
   workspaceConfigSchema,
 } from "@/src/schema"
-import { getProjectInfo } from "@/src/utils/get-project-info"
+import { getProjectInfo, getTsConfig } from "@/src/utils/get-project-info"
 import { highlighter } from "@/src/utils/highlighter"
 import { resolveImportWithMetadata } from "@/src/utils/resolve-import"
 import { cosmiconfig } from "cosmiconfig"
@@ -63,6 +63,20 @@ export async function resolveConfigPaths(
         tsConfig.message ?? ""
       }`.trim()
     )
+  }
+
+  // Fallback: if loadConfig didn't find paths (e.g. Vite's project-references
+  // pattern), try reading tsconfig directly from alternative file names.
+  if (!Object.keys(tsConfig.paths).length) {
+    const customPaths = (await getTsConfig(cwd))?.compilerOptions.paths
+    if (customPaths && Object.keys(customPaths).length) {
+      tsConfig.paths = Object.fromEntries(
+        Object.entries(customPaths).map(([key, value]) => [
+          key,
+          Array.isArray(value) ? value : [value],
+        ])
+      )
+    }
   }
 
   // Resolve the primary aliases first so fallbacks can reuse their results.


### PR DESCRIPTION
## Description

Fixes #11044. The Vite scaffold template uses TypeScript [project references](\eferences\ in \	sconfig.json\) instead of \xtends\ to reference \	sconfig.app.json\. The \	sconfig-paths\ library's \loadConfig()\ does not follow \eferences\, so path aliases like \@/*\ defined only in \	sconfig.app.json\ were never found.

This caused \esolveConfigPaths\ to fail silently on Windows, creating a physical \@\ directory with components written to \@/components/ui/button.tsx\ instead of \src/components/ui/button.tsx\.

## Fix

Added a fallback in \esolveConfigPaths\ that mirrors the existing logic in \getTsConfigAliasPrefix\: when \loadConfig\ returns empty paths, try \getTsConfig()\ which manually checks alternative tsconfig filenames (\	sconfig.json\, \	sconfig.web.json\, \	sconfig.app.json\). Path values are normalized to the \string[]\ format expected by \createMatchPath\.

## Test

The existing \ite\ test fixture already uses the project-references pattern. This change makes \esolveConfigPaths\ consistent with \getProjectConfig\ → \getTsConfigAliasPrefix\ which already handled this case correctly.