### PR TITLE
feat(registry): expose project config APIs

### DIFF
--- a/.changeset/brave-bags-configure.md
+++ b/.changeset/brave-bags-configure.md
@@ -1,0 +1,5 @@
+---
+"shadcn": minor
+---
+
+Expose project registry configuration APIs for reading namespace mappings and adding registries without invoking the CLI.

--- a/apps/v4/content/docs/registry/api-reference.mdx
+++ b/apps/v4/content/docs/registry/api-reference.mdx
@@ -65,6 +65,33 @@ can change between requests and you need fresh data each time.
 const fresh = await getRegistry("@shadcn", { useCache: false })
 ```
 
+### getRegistriesConfig
+
+Read registry namespace mappings from a project's `components.json`. Built-in
+registries are included even when the project has no configuration file.
+
+```ts showLineNumbers
+import { getRegistriesConfig } from "shadcn/registry"
+
+const config = await getRegistriesConfig(process.cwd())
+```
+
+### addRegistriesToConfig
+
+Add registry namespace mappings to an existing `components.json`. Pass either an
+explicit URL template or a namespace listed in the shadcn registry directory.
+The function does not prompt or write output, and reports mappings that were
+added or skipped.
+
+```ts showLineNumbers
+import { addRegistriesToConfig } from "shadcn/registry"
+
+const result = await addRegistriesToConfig(
+  ["@acme=https://acme.com/r/{name}.json"],
+  { cwd: process.cwd() }
+)
+```
+
 ### getRegistry
 
 Fetch a single registry by name.

--- a/packages/shadcn/src/commands/registry/add.test.ts
+++ b/packages/shadcn/src/commands/registry/add.test.ts
@@ -1,47 +1,39 @@
+import { parseRegistryArgument } from "@/src/registry/project-config"
 import { describe, expect, it } from "vitest"
 
-import { parseRegistryArg } from "./add"
-
-describe("parseRegistryArg", () => {
+describe("parseRegistryArgument", () => {
   it("should parse namespace without URL", () => {
-    expect(parseRegistryArg("@magicui")).toEqual({ namespace: "@magicui" })
-    expect(parseRegistryArg("@aceternity")).toEqual({
+    expect(parseRegistryArgument("@magicui")).toEqual({
+      namespace: "@magicui",
+    })
+    expect(parseRegistryArgument("@aceternity")).toEqual({
       namespace: "@aceternity",
     })
   })
 
   it("should parse namespace with URL", () => {
     expect(
-      parseRegistryArg("@mycompany=https://example.com/r/{name}.json")
+      parseRegistryArgument("@mycompany=https://example.com/r/{name}.json")
     ).toEqual({
       namespace: "@mycompany",
       url: "https://example.com/r/{name}.json",
     })
   })
 
-  it("should handle URL with query params containing =", () => {
+  it("should preserve URL query parameters containing =", () => {
     expect(
-      parseRegistryArg("@foo=https://example.com/r/{name}.json?token=abc")
-    ).toEqual({
-      namespace: "@foo",
-      url: "https://example.com/r/{name}.json?token=abc",
-    })
-  })
-
-  it("should handle URL with multiple = in query params", () => {
-    expect(
-      parseRegistryArg(
-        "@bar=https://example.com/r/{name}.json?token=abc&key=xyz"
+      parseRegistryArgument(
+        "@foo=https://example.com/r/{name}.json?token=abc&key=xyz"
       )
     ).toEqual({
-      namespace: "@bar",
+      namespace: "@foo",
       url: "https://example.com/r/{name}.json?token=abc&key=xyz",
     })
   })
 
   it("should handle URL with port number", () => {
     expect(
-      parseRegistryArg("@local=http://localhost:8080/r/{name}.json")
+      parseRegistryArgument("@local=http://localhost:8080/r/{name}.json")
     ).toEqual({
       namespace: "@local",
       url: "http://localhost:8080/r/{name}.json",
@@ -49,10 +41,9 @@ describe("parseRegistryArg", () => {
   })
 
   it("should throw for namespace without @", () => {
-    expect(() => parseRegistryArg("foo")).toThrow("must start with @")
-    expect(() => parseRegistryArg("magicui")).toThrow("must start with @")
+    expect(() => parseRegistryArgument("foo")).toThrow("must start with @")
     expect(() =>
-      parseRegistryArg("mycompany=https://example.com/r/{name}.json")
+      parseRegistryArgument("mycompany=https://example.com/r/{name}.json")
     ).toThrow("must start with @")
   })
 })

--- a/packages/shadcn/src/commands/registry/add.ts
+++ b/packages/shadcn/src/commands/registry/add.ts
@@ -1,12 +1,11 @@
 import path from "path"
 import { getRegistries } from "@/src/registry/api"
-import { BUILTIN_REGISTRIES } from "@/src/registry/constants"
+import { addRegistriesToConfig } from "@/src/registry/project-config"
 import { handleError } from "@/src/utils/handle-error"
 import { highlighter } from "@/src/utils/highlighter"
 import { logger } from "@/src/utils/logger"
 import { spinner } from "@/src/utils/spinner"
 import { Command } from "commander"
-import fs from "fs-extra"
 import prompts from "prompts"
 import { z } from "zod"
 
@@ -34,179 +33,75 @@ export const add = new Command()
         cwd: path.resolve(opts.cwd),
         silent: opts.silent,
       })
-
-      const registryArgs =
+      const registryArguments =
         registries.length > 0
           ? registries
           : await promptForRegistries({ silent: options.silent })
-
-      await addRegistriesToConfig(registryArgs, options.cwd, {
-        silent: options.silent,
+      const result = await addRegistriesToConfig(registryArguments, {
+        cwd: options.cwd,
       })
+      if (result.addedRegistries.length > 0) {
+        spinner("Updated components.json.", {
+          silent: options.silent,
+        }).succeed()
+      }
+      printResult(result, options)
     } catch (error) {
       logger.break()
       handleError(error)
     }
   })
 
-export function parseRegistryArg(arg: string): {
-  namespace: string
-  url?: string
-} {
-  const [namespace, ...rest] = arg.split("=")
-  const url = rest.length > 0 ? rest.join("=") : undefined
-
-  if (!namespace.startsWith("@")) {
-    throw new Error(
-      `Invalid registry namespace: ${highlighter.info(namespace)}. ` +
-        `Registry names must start with @ (e.g., @acme).`
-    )
-  }
-
-  return { namespace, url }
-}
-
 function pluralize(count: number, singular: string, plural: string) {
   return `${count} ${count === 1 ? singular : plural}`
 }
 
-async function addRegistriesToConfig(
-  registryArgs: string[],
-  cwd: string,
+function printResult(
+  result: Awaited<ReturnType<typeof addRegistriesToConfig>>,
   options: { silent?: boolean }
 ) {
-  const configPath = path.resolve(cwd, "components.json")
-  if (!fs.existsSync(configPath)) {
-    throw new Error(
-      `No ${highlighter.info("components.json")} found. Run ${highlighter.info(
-        "shadcn init"
-      )} first.`
-    )
-  }
-
-  const parsed = registryArgs.map(parseRegistryArg)
-  const needsLookup = parsed.filter((p) => !p.url)
-  let registriesIndex: { name: string; url: string }[] = []
-  if (needsLookup.length > 0) {
-    const fetchSpinner = spinner("Fetching registries.", {
-      silent: options.silent,
-    }).start()
-    const registries = await getRegistries()
-    if (!registries) {
-      fetchSpinner.fail()
-      throw new Error("Failed to fetch registries.")
-    }
-    fetchSpinner.succeed()
-    registriesIndex = registries
-  }
-
-  const registriesToAdd: Record<string, string> = {}
-  for (const { namespace, url } of parsed) {
-    if (namespace in BUILTIN_REGISTRIES) {
-      logger.warn(
-        `${highlighter.info(
-          namespace
-        )} is a built-in registry and cannot be added.`
-      )
-      continue
-    }
-
-    if (url) {
-      if (!url.includes("{name}")) {
-        throw new Error(
-          `Invalid registry URL for ${highlighter.info(
-            namespace
-          )}. URL must include {name} placeholder. Example: ${highlighter.info(
-            `${namespace}=https://example.com/r/{name}.json`
-          )}`
-        )
-      }
-      registriesToAdd[namespace] = url
-    } else {
-      const registry = registriesIndex.find((r) => r.name === namespace)
-      if (!registry) {
-        throw new Error(
-          `Registry ${highlighter.info(namespace)} not found. ` +
-            `Provide a URL: ${highlighter.info(
-              `${namespace}=https://.../{name}.json`
-            )}`
-        )
-      }
-      registriesToAdd[namespace] = registry.url
-    }
-  }
-
-  if (Object.keys(registriesToAdd).length === 0) {
-    return { addedRegistries: [] }
-  }
-
-  const existingConfig = await fs.readJson(configPath)
-  const existingRegistries = existingConfig.registries || {}
-  const newRegistries: Record<string, string> = {}
-  const skipped: string[] = []
-  for (const [ns, url] of Object.entries(registriesToAdd)) {
-    if (existingRegistries[ns]) {
-      skipped.push(ns)
-    } else {
-      newRegistries[ns] = url
-    }
-  }
-
-  if (Object.keys(newRegistries).length === 0) {
-    if (skipped.length > 0 && !options.silent) {
-      spinner(
-        `Skipped ${pluralize(
-          skipped.length,
-          "registry",
-          "registries"
-        )}: (already configured)`,
-        { silent: options.silent }
-      )?.info()
-      for (const name of skipped) {
-        logger.log(`  - ${name}`)
-      }
-    } else if (!options.silent) {
-      logger.info("No new registries to add.")
-    }
+  if (options.silent) {
     return
   }
 
-  const updatedConfig = {
-    ...existingConfig,
-    registries: {
-      ...existingRegistries,
-      ...newRegistries,
-    },
+  if (result.addedRegistries.length > 0) {
+    spinner(
+      `Added ${pluralize(
+        result.addedRegistries.length,
+        "registry",
+        "registries"
+      )}:`
+    )?.succeed()
+    for (const namespace of result.addedRegistries) {
+      logger.log(`  - ${namespace}`)
+    }
+  } else if (result.skippedRegistries.length === 0) {
+    logger.info("No new registries to add.")
   }
 
-  const writeSpinner = spinner("Updating components.json.", {
-    silent: options.silent,
-  }).start()
-  await fs.writeJson(configPath, updatedConfig, { spaces: 2 })
-  writeSpinner.succeed()
-
-  if (!options.silent) {
-    const newRegistryNames = Object.keys(newRegistries)
-    spinner(
-      `Added ${pluralize(newRegistryNames.length, "registry", "registries")}:`,
-      { silent: options.silent }
-    )?.succeed()
-    for (const name of newRegistryNames) {
-      logger.log(`  - ${name}`)
+  for (const skipped of result.skippedRegistries) {
+    if (skipped.reason === "built-in") {
+      logger.warn(
+        `${highlighter.info(
+          skipped.namespace
+        )} is a built-in registry and cannot be added.`
+      )
     }
+  }
 
-    if (skipped.length > 0) {
-      spinner(
-        `Skipped ${pluralize(
-          skipped.length,
-          "registry",
-          "registries"
-        )}: (already configured)`,
-        { silent: options.silent }
-      )?.info()
-      for (const name of skipped) {
-        logger.log(`  - ${name}`)
-      }
+  const alreadyConfigured = result.skippedRegistries
+    .filter((entry) => entry.reason === "already-configured")
+    .map((entry) => entry.namespace)
+  if (alreadyConfigured.length > 0) {
+    spinner(
+      `Skipped ${pluralize(
+        alreadyConfigured.length,
+        "registry",
+        "registries"
+      )}: (already configured)`
+    )?.info()
+    for (const namespace of alreadyConfigured) {
+      logger.log(`  - ${namespace}`)
     }
   }
 }
@@ -216,24 +111,19 @@ async function promptForRegistries(options: { silent?: boolean }) {
     silent: options.silent,
   }).start()
   const registries = await getRegistries()
-  if (!registries) {
-    fetchSpinner.fail()
-    throw new Error("Failed to fetch registries.")
-  }
   fetchSpinner.succeed()
 
   const sorted = [...registries].sort((a, b) => a.name.localeCompare(b.name))
-
   const { selected } = await prompts({
     type: "autocompleteMultiselect",
     name: "selected",
     message: "Which registries would you like to add?",
     hint: "Space to select. A to toggle all. Enter to submit.",
     instructions: false,
-    choices: sorted.map((r) => ({
-      title: r.name,
-      description: r.description,
-      value: r.name,
+    choices: sorted.map((registry) => ({
+      title: registry.name,
+      description: registry.description,
+      value: registry.name,
     })),
   })
 

--- a/packages/shadcn/src/registry/index.ts
+++ b/packages/shadcn/src/registry/index.ts
@@ -4,9 +4,16 @@ export {
   resolveRegistryItems,
   getRegistry,
   getRegistriesIndex,
+  getRegistriesConfig,
 } from "./api"
 
 export { addRegistryItems, type AddRegistryItemsOptions } from "./add"
+
+export {
+  addRegistriesToConfig,
+  type AddRegistriesToConfigOptions,
+  type AddRegistriesToConfigResult,
+} from "./project-config"
 
 export { searchRegistries } from "./search"
 

--- a/packages/shadcn/src/registry/project-config.test.ts
+++ b/packages/shadcn/src/registry/project-config.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { addRegistriesToConfig } from "./project-config"
+
+const { getRegistries, getRegistriesConfig, pathExists, readJson, writeJson } =
+  vi.hoisted(() => ({
+    getRegistries: vi.fn(),
+    getRegistriesConfig: vi.fn(),
+    pathExists: vi.fn(),
+    readJson: vi.fn(),
+    writeJson: vi.fn(),
+  }))
+
+vi.mock("@/src/registry/api", () => ({
+  getRegistries,
+  getRegistriesConfig,
+}))
+
+vi.mock("fs-extra", () => ({
+  default: { pathExists, readJson, writeJson },
+}))
+
+describe("addRegistriesToConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    pathExists.mockResolvedValue(true)
+    getRegistriesConfig.mockResolvedValue({ registries: { "@shadcn": "url" } })
+    readJson.mockResolvedValue({ style: "new-york", registries: {} })
+  })
+
+  it("adds an explicit namespace mapping", async () => {
+    const result = await addRegistriesToConfig(
+      ["@acme=https://example.com/r/{name}.json"],
+      { cwd: "/project" }
+    )
+
+    expect(result).toEqual({
+      addedRegistries: ["@acme"],
+      skippedRegistries: [],
+    })
+    expect(getRegistries).not.toHaveBeenCalled()
+    expect(writeJson).toHaveBeenCalledWith(
+      "/project/components.json",
+      {
+        style: "new-york",
+        registries: { "@acme": "https://example.com/r/{name}.json" },
+      },
+      { spaces: 2 }
+    )
+  })
+
+  it("resolves a namespace through the registry directory", async () => {
+    getRegistries.mockResolvedValue([
+      { name: "@acme", url: "https://example.com/r/{name}.json" },
+    ])
+
+    const result = await addRegistriesToConfig(["@acme"], {
+      cwd: "/project",
+      useCache: false,
+    })
+
+    expect(getRegistries).toHaveBeenCalledWith({ useCache: false })
+    expect(result.addedRegistries).toEqual(["@acme"])
+  })
+
+  it("reports built-in and existing namespaces as skipped", async () => {
+    getRegistriesConfig.mockResolvedValue({
+      registries: {
+        "@shadcn": "built-in",
+        "@acme": "https://example.com/r/{name}.json",
+      },
+    })
+
+    const result = await addRegistriesToConfig(
+      [
+        "@shadcn=https://other.example/r/{name}.json",
+        "@acme=https://other.example/r/{name}.json",
+      ],
+      { cwd: "/project" }
+    )
+
+    expect(result).toEqual({
+      addedRegistries: [],
+      skippedRegistries: [
+        { namespace: "@shadcn", reason: "built-in" },
+        { namespace: "@acme", reason: "already-configured" },
+      ],
+    })
+    expect(writeJson).not.toHaveBeenCalled()
+  })
+
+  it("requires an existing components.json", async () => {
+    pathExists.mockResolvedValue(false)
+
+    await expect(
+      addRegistriesToConfig(["@acme=https://example.com/r/{name}.json"], {
+        cwd: "/project",
+      })
+    ).rejects.toThrow("No components.json found at /project")
+  })
+})

--- a/packages/shadcn/src/registry/project-config.ts
+++ b/packages/shadcn/src/registry/project-config.ts
@@ -1,0 +1,109 @@
+import path from "path"
+import { getRegistries, getRegistriesConfig } from "@/src/registry/api"
+import { BUILTIN_REGISTRIES } from "@/src/registry/constants"
+import fs from "fs-extra"
+
+export interface AddRegistriesToConfigOptions {
+  /** The project directory. Defaults to the current working directory. */
+  cwd?: string
+  /** Whether registry directory requests may use the in-memory cache. */
+  useCache?: boolean
+}
+
+export interface AddRegistriesToConfigResult {
+  addedRegistries: string[]
+  skippedRegistries: Array<{
+    namespace: string
+    reason: "built-in" | "already-configured"
+  }>
+}
+
+export function parseRegistryArgument(argument: string): {
+  namespace: string
+  url?: string
+} {
+  const [namespace, ...rest] = argument.split("=")
+  const url = rest.length > 0 ? rest.join("=") : undefined
+
+  if (!namespace.startsWith("@")) {
+    throw new Error(
+      `Invalid registry namespace: ${namespace}. Registry names must start with @ (e.g., @acme).`
+    )
+  }
+
+  return { namespace, url }
+}
+
+/**
+ * Add registry namespace mappings to an existing components.json file.
+ *
+ * Namespace-only arguments are resolved through the shadcn registry directory.
+ * Existing and built-in namespaces are left unchanged and reported as skipped.
+ */
+export async function addRegistriesToConfig(
+  registryArguments: string[],
+  options: AddRegistriesToConfigOptions = {}
+): Promise<AddRegistriesToConfigResult> {
+  const cwd = path.resolve(options.cwd ?? process.cwd())
+  const configPath = path.resolve(cwd, "components.json")
+  if (!(await fs.pathExists(configPath))) {
+    throw new Error(`No components.json found at ${cwd}.`)
+  }
+
+  const parsed = registryArguments.map(parseRegistryArgument)
+  const directory = parsed.some((entry) => !entry.url)
+    ? await getRegistries({ useCache: options.useCache })
+    : []
+  const { registries: configuredRegistries } = await getRegistriesConfig(cwd, {
+    useCache: false,
+  })
+  const registriesToAdd: Record<string, string> = {}
+  const skippedRegistries: AddRegistriesToConfigResult["skippedRegistries"] = []
+
+  for (const { namespace, url } of parsed) {
+    if (namespace in BUILTIN_REGISTRIES) {
+      skippedRegistries.push({ namespace, reason: "built-in" })
+      continue
+    }
+    if (configuredRegistries[namespace]) {
+      skippedRegistries.push({ namespace, reason: "already-configured" })
+      continue
+    }
+
+    if (url) {
+      if (!url.includes("{name}")) {
+        throw new Error(
+          `Invalid registry URL for ${namespace}. URL must include {name} placeholder. Example: ${namespace}=https://example.com/r/{name}.json`
+        )
+      }
+      registriesToAdd[namespace] = url
+      continue
+    }
+
+    const registry = directory.find((entry) => entry.name === namespace)
+    if (!registry) {
+      throw new Error(
+        `Registry ${namespace} not found. Provide a URL: ${namespace}=https://.../{name}.json`
+      )
+    }
+    registriesToAdd[namespace] = registry.url
+  }
+
+  const addedRegistries = Object.keys(registriesToAdd)
+  if (addedRegistries.length > 0) {
+    const document = await fs.readJson(configPath)
+    await fs.writeJson(
+      configPath,
+      {
+        ...document,
+        registries: {
+          ...(document.registries || {}),
+          ...registriesToAdd,
+        },
+      },
+      { spaces: 2 }
+    )
+  }
+
+  return { addedRegistries, skippedRegistries }
+}


### PR DESCRIPTION
## Summary

- export the existing `getRegistriesConfig` helper from `shadcn/registry`
- add a non-interactive `addRegistriesToConfig` API for adding explicit URL templates or directory-listed namespaces to `components.json`
- return structured added/skipped results so embedding tools can own their output and UX
- refactor `shadcn registry add` to use the same public implementation
- document and test the new APIs

## Rationale

The registry SDK can now fetch, search, inspect, resolve, and install items programmatically, but registry source configuration is still implemented inside the CLI command. Tools embedding shadcn must either spawn the CLI or duplicate shadcn’s `components.json` parsing, built-in namespace handling, registry-directory lookup, URL-template validation, and write behavior.

Exposing the configuration layer completes the programmatic consumer workflow:

```ts
import {
  addRegistriesToConfig,
  addRegistryItems,
  getRegistriesConfig,
  searchRegistries,
} from "shadcn/registry"

await addRegistriesToConfig(
  ["@acme=https://example.com/r/{name}.json"],
  { cwd: process.cwd() }
)

const config = await getRegistriesConfig(process.cwd())
const results = await searchRegistries(["@acme"], { config })
await addRegistryItems(["@acme/my-item"], { cwd: process.cwd() })
```

The API itself does not prompt or print. It reports added namespaces and skips with reasons (`built-in` or `already-configured`), while the existing CLI remains responsible for spinners and user-facing output.

There is ongoing work in [vercel/eve#1154](https://github.com/vercel/eve/pull/1154) to consume shadcn programmatically. That integration currently has to carry temporary local `components.json` handling; these APIs would let it defer registry configuration semantics to shadcn as well.

## Validation

- `pnpm --filter shadcn typecheck`
- `pnpm --filter shadcn build`
- `pnpm --filter shadcn test` (83 files, 1,686 tests)