### PR TITLE
fix(scroll-fade): clamp the Firefox fallback to the ScrollArea overflow distance (#11291)

### DIFF
--- a/.changeset/tidy-moons-shave.md
+++ b/.changeset/tidy-moons-shave.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Fix `scroll-fade` applying a permanent fade in browsers without scroll-driven animations. The fallback now clamps to the overflow distance published by a Base UI `ScrollArea` viewport, so the fade stays scroll-aware in Firefox and resolves to none on a container that does not overflow.

--- a/apps/v4/content/docs/utils/scroll-fade.mdx
+++ b/apps/v4/content/docs/utils/scroll-fade.mdx
@@ -159,7 +159,11 @@ Use `scroll-fade-none` to remove the fade. It works in any class order, so the t
 
 ## Fallback
 
-The scroll-aware behavior is implemented with [CSS scroll-driven animations](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scroll-driven_animations), with no JavaScript and no scroll listeners. In browsers that do not support scroll-driven animations, `scroll-fade` falls back to a static fade on both edges, and edge utilities fall back to a static fade on the selected edge.
+The scroll-aware behavior is implemented with [CSS scroll-driven animations](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scroll-driven_animations), with no JavaScript and no scroll listeners. Firefox has not shipped scroll-driven animations yet, so it needs a fallback.
+
+Inside a [`ScrollArea`](/docs/components/scroll-area), there is nothing to do: the viewport publishes how far the content extends past each edge as `--scroll-area-overflow-{x,y}-{start,end}`, and `scroll-fade` reads those variables when scroll-driven animations are unavailable. The fade stays fully scroll-aware, and "no overflow, no fade" still holds.
+
+On a bare scroll container the fade is simply not shown, because there is no way to measure overflow in CSS alone. Reach for `ScrollArea` if you want the fade in every browser.
 
 Since the mask is applied to the scroll container itself, a visible scrollbar fades with the content at the edges. Pair `scroll-fade` with `no-scrollbar`, which ships in the same package, if you want to hide the scrollbar entirely.
 

--- a/apps/v4/content/docs/utils/scroll-fade.mdx
+++ b/apps/v4/content/docs/utils/scroll-fade.mdx
@@ -161,7 +161,7 @@ Use `scroll-fade-none` to remove the fade. It works in any class order, so the t
 
 The scroll-aware behavior is implemented with [CSS scroll-driven animations](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_scroll-driven_animations), with no JavaScript and no scroll listeners. Firefox has not shipped scroll-driven animations yet, so it needs a fallback.
 
-Inside a [`ScrollArea`](/docs/components/scroll-area), there is nothing to do: the viewport publishes how far the content extends past each edge as `--scroll-area-overflow-{x,y}-{start,end}`, and `scroll-fade` reads those variables when scroll-driven animations are unavailable. The fade stays fully scroll-aware, and "no overflow, no fade" still holds.
+Inside a [`ScrollArea`](/docs/components/scroll-area), apply `scroll-fade` to the viewport. It publishes how far the content extends past each edge as `--scroll-area-overflow-{x,y}-{start,end}`, and `scroll-fade` reads those variables when scroll-driven animations are unavailable. The fade stays fully scroll-aware there, and "no overflow, no fade" still holds. Those variables are registered with `inherits: false`, so they resolve on the viewport itself and not on its descendants.
 
 On a bare scroll container the fade is simply not shown, because there is no way to measure overflow in CSS alone. Reach for `ScrollArea` if you want the fade in every browser.
 

--- a/packages/shadcn/src/tailwind.css
+++ b/packages/shadcn/src/tailwind.css
@@ -190,8 +190,14 @@
   }
 
   @supports not (animation-timeline: scroll()) {
-    --scroll-fade-t: var(--_scroll-fade-size-t);
-    --scroll-fade-b: var(--_scroll-fade-size-b);
+    --scroll-fade-t: min(
+      var(--_scroll-fade-size-t),
+      var(--scroll-area-overflow-y-start, 0px)
+    );
+    --scroll-fade-b: min(
+      var(--_scroll-fade-size-b),
+      var(--scroll-area-overflow-y-end, 0px)
+    );
   }
 }
 
@@ -230,8 +236,14 @@
   }
 
   @supports not (animation-timeline: scroll()) {
-    --scroll-fade-t: var(--_scroll-fade-size-t);
-    --scroll-fade-b: var(--_scroll-fade-size-b);
+    --scroll-fade-t: min(
+      var(--_scroll-fade-size-t),
+      var(--scroll-area-overflow-y-start, 0px)
+    );
+    --scroll-fade-b: min(
+      var(--_scroll-fade-size-b),
+      var(--scroll-area-overflow-y-end, 0px)
+    );
   }
 }
 
@@ -279,8 +291,14 @@
   }
 
   @supports not (animation-timeline: scroll()) {
-    --scroll-fade-s: var(--_scroll-fade-size-s);
-    --scroll-fade-e: var(--_scroll-fade-size-e);
+    --scroll-fade-s: min(
+      var(--_scroll-fade-size-s),
+      var(--scroll-area-overflow-x-start, 0px)
+    );
+    --scroll-fade-e: min(
+      var(--_scroll-fade-size-e),
+      var(--scroll-area-overflow-x-end, 0px)
+    );
   }
 }
 
@@ -310,7 +328,10 @@
   }
 
   @supports not (animation-timeline: scroll()) {
-    --scroll-fade-t: var(--_scroll-fade-size-t);
+    --scroll-fade-t: min(
+      var(--_scroll-fade-size-t),
+      var(--scroll-area-overflow-y-start, 0px)
+    );
   }
 }
 
@@ -343,7 +364,10 @@
   }
 
   @supports not (animation-timeline: scroll()) {
-    --scroll-fade-b: var(--_scroll-fade-size-b);
+    --scroll-fade-b: min(
+      var(--_scroll-fade-size-b),
+      var(--scroll-area-overflow-y-end, 0px)
+    );
   }
 }
 
@@ -373,7 +397,10 @@
   }
 
   @supports not (animation-timeline: scroll()) {
-    --scroll-fade-s: var(--_scroll-fade-size-s);
+    --scroll-fade-s: min(
+      var(--_scroll-fade-size-s),
+      var(--scroll-area-overflow-x-start, 0px)
+    );
   }
 }
 
@@ -406,7 +433,10 @@
   }
 
   @supports not (animation-timeline: scroll()) {
-    --scroll-fade-e: var(--_scroll-fade-size-e);
+    --scroll-fade-e: min(
+      var(--_scroll-fade-size-e),
+      var(--scroll-area-overflow-x-end, 0px)
+    );
   }
 }
 
@@ -444,7 +474,10 @@
   }
 
   @supports not (animation-timeline: scroll()) {
-    --scroll-fade-s: var(--_scroll-fade-size-s);
+    --scroll-fade-s: min(
+      var(--_scroll-fade-size-s),
+      var(--scroll-area-overflow-x-start, 0px)
+    );
   }
 }
 
@@ -485,7 +518,10 @@
   }
 
   @supports not (animation-timeline: scroll()) {
-    --scroll-fade-e: var(--_scroll-fade-size-e);
+    --scroll-fade-e: min(
+      var(--_scroll-fade-size-e),
+      var(--scroll-area-overflow-x-end, 0px)
+    );
   }
 }
 


### PR DESCRIPTION
Fixes #11291.

## Problem

Firefox has not shipped scroll-driven animations, so it always takes the `@supports not (animation-timeline: scroll())` branch in all nine `scroll-fade` utilities. That branch applies the fade unconditionally, so every `scroll-fade` element renders a permanent fade on both edges, including containers that never overflow. It is visible on the docs site itself: the sidebar, the On This Page nav and MDX tables are all masked on every page. The issue has screenshots and a per-browser breakdown.

This also contradicts the documented guarantee that "if the content does not overflow, no fade is shown".

## Fix

The fallback now clamps each fade to the overflow distance that Base UI's `ScrollArea.Viewport` already publishes as `--scroll-area-overflow-{x,y}-{start,end}`:

```css
--scroll-fade-t: min(
  var(--_scroll-fade-size-t),
  var(--scroll-area-overflow-y-start, 0px)
);
```

- Inside a `ScrollArea`, when `scroll-fade` is applied to the viewport itself, the variables exist and the fade stays fully scroll-aware in Firefox: crisp at the start, fading at the end, and nothing at all on a list that does not overflow. Base UI registers these properties with `inherits: false`, so they are readable on `ScrollArea.Viewport` and not on its descendants or on `ScrollArea.Root`.
- On a bare scroll container the variables are absent, `min(size, 0px)` resolves to `0px`, and no fade is shown.

The `@supports (animation-timeline: scroll())` branch used by Chrome and Safari is untouched.

## Docs

The second case is a documented behavior change, so this also updates the Fallback section of `scroll-fade.mdx`, which currently promises a static fade on both edges. A changeset is included.

## Testing

Verified in Firefox 153, Chrome 149 and Safari 26.3.1 on macOS 26.3.1. `pnpm shadcn:test` passes: 82 files, 1683 tests.

Note: #11293 proposes the same CSS clamp, taken from the patch in the issue, without the docs correction or the changeset.
