### PR TITLE
feat(registry): load registries from package.json

### DIFF
--- a/.changeset/two-teeth-fry.md
+++ b/.changeset/two-teeth-fry.md
@@ -1,0 +1,5 @@
+---
+"shadcn": minor
+---
+
+add getRegistriesConfig and registries in package.json support

--- a/packages/shadcn/src/registry/api.test.ts
+++ b/packages/shadcn/src/registry/api.test.ts
@@ -1303,16 +1303,189 @@ describe("getRegistry", () => {
 })
 
 describe("getRegistriesConfig", () => {
-  it("should return built-in registries when no components.json exists", async () => {
+  it("should return no registries when no registry config exists", async () => {
     const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
 
     try {
       const result = await getRegistriesConfig(tempDir)
 
       expect(result).toEqual({
-        registries: BUILTIN_REGISTRIES,
+        registries: {},
       })
     } finally {
+      await fs.rmdir(tempDir)
+    }
+  })
+
+  it("should parse registries from package.json", async () => {
+    const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
+    const packageJsonFile = path.join(tempDir, "package.json")
+
+    await fs.writeFile(
+      packageJsonFile,
+      JSON.stringify(
+        {
+          name: "test-package",
+          version: "1.0.0",
+          registries: {
+            "@acme": "https://acme.com/{name}.json",
+            "@private": {
+              url: "https://private.com/{name}.json",
+              headers: {
+                Authorization: "Bearer ${REGISTRY_TOKEN}",
+              },
+            },
+          },
+        },
+        null,
+        2
+      )
+    )
+
+    try {
+      const result = await getRegistriesConfig(tempDir)
+
+      expect(result.registries).toEqual({
+        "@acme": "https://acme.com/{name}.json",
+        "@private": {
+          url: "https://private.com/{name}.json",
+          headers: {
+            Authorization: "Bearer ${REGISTRY_TOKEN}",
+          },
+        },
+      })
+    } finally {
+      await fs.unlink(packageJsonFile)
+      await fs.rmdir(tempDir)
+    }
+  })
+
+  it("should prefer components.json over package.json", async () => {
+    const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
+    const componentsJsonFile = path.join(tempDir, "components.json")
+    const packageJsonFile = path.join(tempDir, "package.json")
+
+    await fs.writeFile(
+      componentsJsonFile,
+      JSON.stringify({
+        registries: {
+          "@components": "https://components.com/{name}.json",
+        },
+      })
+    )
+    await fs.writeFile(
+      packageJsonFile,
+      JSON.stringify({
+        registries: {
+          "@package": "https://package.com/{name}.json",
+        },
+      })
+    )
+
+    try {
+      const result = await getRegistriesConfig(tempDir)
+
+      expect(result.registries).toEqual({
+        ...BUILTIN_REGISTRIES,
+        "@components": "https://components.com/{name}.json",
+      })
+      expect(result.registries["@package"]).toBeUndefined()
+    } finally {
+      await fs.unlink(componentsJsonFile)
+      await fs.unlink(packageJsonFile)
+      await fs.rmdir(tempDir)
+    }
+  })
+
+  it("should not fall back to package.json when components.json has no registries", async () => {
+    const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
+    const componentsJsonFile = path.join(tempDir, "components.json")
+    const packageJsonFile = path.join(tempDir, "package.json")
+
+    await fs.writeFile(
+      componentsJsonFile,
+      JSON.stringify({
+        style: "new-york",
+      })
+    )
+    await fs.writeFile(
+      packageJsonFile,
+      JSON.stringify({
+        registries: {
+          "@package": "https://package.com/{name}.json",
+        },
+      })
+    )
+
+    try {
+      const result = await getRegistriesConfig(tempDir)
+
+      expect(result.registries).toEqual(BUILTIN_REGISTRIES)
+    } finally {
+      await fs.unlink(componentsJsonFile)
+      await fs.unlink(packageJsonFile)
+      await fs.rmdir(tempDir)
+    }
+  })
+
+  it("should only read registry config from the provided cwd", async () => {
+    const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
+    const childDir = path.join(tempDir, "child")
+    const componentsJsonFile = path.join(tempDir, "components.json")
+
+    await fs.mkdir(childDir)
+    await fs.writeFile(
+      componentsJsonFile,
+      JSON.stringify({
+        registries: {
+          "@parent": "https://parent.com/{name}.json",
+        },
+      })
+    )
+
+    try {
+      const result = await getRegistriesConfig(childDir)
+
+      expect(result.registries).toEqual({})
+    } finally {
+      await fs.rm(tempDir, { recursive: true })
+    }
+  })
+
+  it("should throw ConfigParseError for invalid package.json registries", async () => {
+    const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
+    const packageJsonFile = path.join(tempDir, "package.json")
+
+    await fs.writeFile(
+      packageJsonFile,
+      JSON.stringify({
+        registries: {
+          "@invalid": {
+            headers: {
+              Authorization: "Bearer token",
+            },
+          },
+        },
+      })
+    )
+
+    try {
+      await getRegistriesConfig(tempDir)
+      expect.fail("Should have thrown ConfigParseError")
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConfigParseError)
+      if (error instanceof ConfigParseError) {
+        expect(error.cwd).toBe(tempDir)
+        expect(error.configFile).toBe("package.json")
+        expect(error.message).toContain(
+          'Invalid package.json "registries" configuration'
+        )
+        expect(error.suggestion).toContain(
+          'Check the "registries" field in your package.json'
+        )
+      }
+    } finally {
+      await fs.unlink(packageJsonFile)
       await fs.rmdir(tempDir)
     }
   })
@@ -1524,6 +1697,51 @@ describe("getRegistriesConfig", () => {
   })
 
   describe("caching behavior", () => {
+    it("should cache package.json registries and clear them when requested", async () => {
+      const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
+      const packageJsonFile = path.join(tempDir, "package.json")
+
+      await fs.writeFile(
+        packageJsonFile,
+        JSON.stringify({
+          registries: {
+            "@cached": "https://cached.com/{name}.json",
+          },
+        })
+      )
+
+      try {
+        const result1 = await getRegistriesConfig(tempDir)
+        expect(result1.registries["@cached"]).toBe(
+          "https://cached.com/{name}.json"
+        )
+
+        await fs.writeFile(
+          packageJsonFile,
+          JSON.stringify({
+            registries: {
+              "@fresh": "https://fresh.com/{name}.json",
+            },
+          })
+        )
+
+        const result2 = await getRegistriesConfig(tempDir)
+        expect(result2.registries["@cached"]).toBe(
+          "https://cached.com/{name}.json"
+        )
+        expect(result2.registries["@fresh"]).toBeUndefined()
+
+        const result3 = await getRegistriesConfig(tempDir, { useCache: false })
+        expect(result3.registries["@cached"]).toBeUndefined()
+        expect(result3.registries["@fresh"]).toBe(
+          "https://fresh.com/{name}.json"
+        )
+      } finally {
+        await fs.unlink(packageJsonFile)
+        await fs.rmdir(tempDir)
+      }
+    })
+
     it("should use cache by default", async () => {
       const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
       const configFile = path.join(tempDir, "components.json")
@@ -1713,15 +1931,15 @@ describe("getRegistriesConfig", () => {
       try {
         // With cache enabled (default)
         const result1 = await getRegistriesConfig(tempDir)
-        expect(result1.registries).toEqual(BUILTIN_REGISTRIES)
+        expect(result1.registries).toEqual({})
 
         // With cache explicitly enabled
         const result2 = await getRegistriesConfig(tempDir, { useCache: true })
-        expect(result2.registries).toEqual(BUILTIN_REGISTRIES)
+        expect(result2.registries).toEqual({})
 
         // With cache disabled
         const result3 = await getRegistriesConfig(tempDir, { useCache: false })
-        expect(result3.registries).toEqual(BUILTIN_REGISTRIES)
+        expect(result3.registries).toEqual({})
       } finally {
         await fs.rmdir(tempDir)
       }

--- a/packages/shadcn/src/registry/api.ts
+++ b/packages/shadcn/src/registry/api.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "fs"
 import path from "path"
 import { resolveGitHubRegistrySource } from "@/src/registry/address"
 import { buildUrlAndHeadersForRegistryItem } from "@/src/registry/builder"
@@ -38,7 +39,17 @@ import {
 import { Config, explorer } from "@/src/utils/get-config"
 import { handleError } from "@/src/utils/handle-error"
 import { logger } from "@/src/utils/logger"
+import { cosmiconfig } from "cosmiconfig"
 import { z } from "zod"
+
+const packageRegistriesExplorer = cosmiconfig("registries", {
+  packageProp: "registries",
+  searchPlaces: ["package.json"],
+})
+
+const registriesConfigFileSchema = z.object({
+  registries: registryConfigSchema.optional(),
+})
 
 type RegistryApiOptions = {
   config?: Partial<Config>
@@ -154,38 +165,58 @@ export async function getRegistriesConfig(
 ) {
   const { useCache = true } = options || {}
 
-  // Clear cache if requested
   if (!useCache) {
     explorer.clearCaches()
+    packageRegistriesExplorer.clearCaches()
   }
 
-  const configResult = await explorer.search(cwd)
+  const componentsJsonPath = path.resolve(cwd, "components.json")
+  if (existsSync(componentsJsonPath)) {
+    const configResult = await explorer.load(componentsJsonPath)
+    const config = parseRegistriesConfig(
+      cwd,
+      configResult?.config,
+      "components.json"
+    )
 
-  if (!configResult) {
-    // Do not throw an error if the config is missing.
-    // We still have access to the built-in registries.
     return {
-      registries: BUILTIN_REGISTRIES,
+      registries: {
+        ...BUILTIN_REGISTRIES,
+        ...config.registries,
+      },
     }
   }
 
-  // Parse just the registries field from the config
-  const registriesConfig = z
-    .object({
-      registries: registryConfigSchema.optional(),
-    })
-    .safeParse(configResult.config)
-
-  if (!registriesConfig.success) {
-    throw new ConfigParseError(cwd, registriesConfig.error)
+  const packageJsonPath = path.resolve(cwd, "package.json")
+  if (existsSync(packageJsonPath)) {
+    const configResult = await packageRegistriesExplorer.load(packageJsonPath)
+    return parseRegistriesConfig(
+      cwd,
+      {
+        registries: configResult?.config,
+      },
+      "package.json"
+    )
   }
 
-  // Merge built-in registries with user registries
   return {
-    registries: {
-      ...BUILTIN_REGISTRIES,
-      ...(registriesConfig.data.registries || {}),
-    },
+    registries: {},
+  }
+}
+
+function parseRegistriesConfig(
+  cwd: string,
+  config: unknown,
+  configFile: "components.json" | "package.json"
+) {
+  const result = registriesConfigFileSchema.safeParse(config)
+
+  if (!result.success) {
+    throw new ConfigParseError(cwd, result.error, configFile)
+  }
+
+  return {
+    registries: result.data.registries || {},
   }
 }
 

--- a/packages/shadcn/src/registry/builder.test.ts
+++ b/packages/shadcn/src/registry/builder.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
 
 import { REGISTRY_URL } from "@/src/registry/constants"
+import { RegistryNotConfiguredError } from "@/src/registry/errors"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
 import {
@@ -353,9 +354,20 @@ describe("buildUrlAndHeadersForRegistryItem", () => {
   })
 
   it("should throw error for unknown registry", () => {
-    expect(() => {
+    try {
       buildUrlAndHeadersForRegistryItem("@unknown/button", {} as any)
-    }).toThrow('Unknown registry "@unknown"')
+      expect.fail("Should have thrown RegistryNotConfiguredError")
+    } catch (error) {
+      expect(error).toBeInstanceOf(RegistryNotConfiguredError)
+      if (error instanceof RegistryNotConfiguredError) {
+        expect(error.message).toContain(
+          'defined under "registries" in your components.json or package.json file'
+        )
+        expect(error.suggestion).toBe(
+          'Add the registry configuration under "registries" in your components.json or package.json file.'
+        )
+      }
+    }
   })
 
   it("should resolve registry items with string config", () => {

--- a/packages/shadcn/src/registry/errors.ts
+++ b/packages/shadcn/src/registry/errors.ts
@@ -193,19 +193,19 @@ export class RegistryFetchError extends RegistryError {
 export class RegistryNotConfiguredError extends RegistryError {
   constructor(public readonly registryName: string | null) {
     const message = registryName
-      ? `Unknown registry "${registryName}". Make sure it is defined in components.json as follows:
+      ? `Unknown registry "${registryName}". Make sure it is defined under "registries" in your components.json or package.json file:
 {
   "registries": {
     "${registryName}": "[URL_TO_REGISTRY]"
   }
 }`
-      : `Unknown registry. Make sure it is defined in components.json under "registries".`
+      : `Unknown registry. Make sure it is defined under "registries" in your components.json or package.json file.`
 
     super(message, {
       code: RegistryErrorCode.NOT_CONFIGURED,
       context: { registryName },
       suggestion:
-        "Add the registry configuration to your components.json file. Consult the registry documentation for the correct format.",
+        'Add the registry configuration under "registries" in your components.json or package.json file.',
     })
     this.name = "RegistryNotConfiguredError"
   }
@@ -384,12 +384,17 @@ export class ConfigMissingError extends RegistryError {
 export class ConfigParseError extends RegistryError {
   constructor(
     public readonly cwd: string,
-    parseError: unknown
+    parseError: unknown,
+    public readonly configFile = "components.json"
   ) {
-    let message = `Invalid components.json configuration in ${cwd}.`
+    const configName =
+      configFile === "package.json"
+        ? 'package.json "registries"'
+        : "components.json"
+    let message = `Invalid ${configName} configuration in ${cwd}.`
 
     if (parseError instanceof z.ZodError) {
-      message = `Invalid components.json configuration in ${cwd}:\n${parseError.errors
+      message = `Invalid ${configName} configuration in ${cwd}:\n${parseError.errors
         .map((e) => `  - ${e.path.join(".")}: ${e.message}`)
         .join("\n")}`
     }
@@ -397,9 +402,11 @@ export class ConfigParseError extends RegistryError {
     super(message, {
       code: RegistryErrorCode.INVALID_CONFIG,
       cause: parseError,
-      context: { cwd },
+      context: { cwd, configFile },
       suggestion:
-        "Check your components.json file for syntax errors or invalid configuration. Run 'npx shadcn@latest init' to regenerate a valid configuration.",
+        configFile === "package.json"
+          ? 'Check the "registries" field in your package.json file for invalid configuration.'
+          : "Check your components.json file for syntax errors or invalid configuration. Run 'npx shadcn@latest init' to regenerate a valid configuration.",
     })
     this.name = "ConfigParseError"
   }

--- a/packages/shadcn/src/registry/index.ts
+++ b/packages/shadcn/src/registry/index.ts
@@ -3,6 +3,7 @@ export {
   getRegistryItems,
   resolveRegistryItems,
   getRegistry,
+  getRegistriesConfig,
   getRegistriesIndex,
 } from "./api"
 


### PR DESCRIPTION
Allows registry API consumers to load registries from package.json when components.json is not present.