### PR TITLE
feat(registry): accept config in addRegistryItems

### DIFF
--- a/.changeset/calm-tools-load.md
+++ b/.changeset/calm-tools-load.md
@@ -1,0 +1,5 @@
+---
+"shadcn": minor
+---
+
+make addRegistryItems accept explicit registry configuration instead of loading components.json

--- a/apps/v4/content/docs/registry/api-reference.mdx
+++ b/apps/v4/content/docs/registry/api-reference.mdx
@@ -32,9 +32,10 @@ omit it to use the built-in registries.
 - **Type:** `Partial<Config>`
 - **Default:** built-in registries only
 
-The resolved contents of your `components.json` file. Its `registries` field
-maps a namespace (e.g. `@acme`) to a URL and any authentication headers or
-environment variables required to reach it.
+The registry configuration to use. Its `registries` field maps a namespace
+(e.g. `@acme`) to a URL and any authentication headers or environment
+variables required to reach it. Use
+[`getRegistriesConfig`](#getregistriesconfig) to load it from your project.
 
 ```ts showLineNumbers
 import { getRegistryItems } from "shadcn/registry"
@@ -63,6 +64,18 @@ can change between requests and you need fresh data each time.
 
 ```ts
 const fresh = await getRegistry("@shadcn", { useCache: false })
+```
+
+### getRegistriesConfig
+
+Load registry configuration from a project directory. The function reads
+`components.json` when present; otherwise it reads the top-level `registries`
+field from `package.json`.
+
+```ts showLineNumbers
+import { getRegistriesConfig } from "shadcn/registry"
+
+const config = await getRegistriesConfig(process.cwd())
 ```
 
 ### getRegistry
@@ -158,22 +171,30 @@ programmatic equivalent of `shadcn add` and applies files, package dependencies,
 environment variables, CSS, and Tailwind configuration declared by the items.
 
 ```ts showLineNumbers
-import { addRegistryItems } from "shadcn/registry"
+import { addRegistryItems, getRegistriesConfig } from "shadcn/registry"
 
-await addRegistryItems(["@acme/button", "@acme/card"], {
-  cwd: process.cwd(),
+const cwd = process.cwd()
+const config = await getRegistriesConfig(cwd)
+
+await addRegistryItems(["@acme/agent"], {
+  cwd,
+  config,
   overwrite: false,
   silent: true,
 })
 ```
 
-A `components.json` file is required unless every requested item and dependency
-is universal: a `registry:item` or `registry:file` whose files all declare
-explicit targets. The function loads registry configuration from
-`components.json`, discovers known registry namespaces, and throws errors
-instead of exiting the process. It never prompts: existing files are skipped
-unless `overwrite` is enabled, and npm uses `--force` for React 19 peer
-dependency conflicts.
+`addRegistryItems` does not read project configuration files itself. Pass the
+result of [`getRegistriesConfig`](#getregistriesconfig), or provide `config`
+directly. A config containing only `registries` is enough when every requested
+item and dependency is universal: a `registry:item` or `registry:file` whose
+files all declare explicit targets. Other items require a full resolved project
+config, including its aliases and `resolvedPaths`. Every custom registry
+namespace referenced by an item or dependency must be present in `config`.
+
+The function throws errors instead of exiting the process and never prompts.
+Existing files are skipped unless `overwrite` is enabled, and npm uses
+`--force` for React 19 peer dependency conflicts.
 
 ### getRegistries
 

--- a/packages/shadcn/src/registry/add.integration.test.ts
+++ b/packages/shadcn/src/registry/add.integration.test.ts
@@ -1,0 +1,201 @@
+import { promises as fs } from "fs"
+import { createServer } from "http"
+import { tmpdir } from "os"
+import path from "path"
+import { createConfig } from "@/src/utils/get-config"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { addRegistryItems } from "./add"
+import { getRegistriesConfig } from "./api"
+import { RegistryNotConfiguredError } from "./errors"
+
+describe("addRegistryItems package.json registries", () => {
+  let tempDir: string | undefined
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true })
+      tempDir = undefined
+    }
+  })
+
+  it("installs a universal item with a registries-only config", async () => {
+    const registryItem = {
+      name: "agent",
+      type: "registry:file",
+      files: [
+        {
+          path: "agent.ts",
+          type: "registry:file",
+          target: "generated/agent.ts",
+          content: "export const agent = true\n",
+        },
+      ],
+    }
+    const server = createServer((request, response) => {
+      if (request.url === "/agent.json") {
+        if (request.headers.authorization !== "Bearer project-token") {
+          response.writeHead(401)
+          response.end()
+          return
+        }
+
+        response.writeHead(200, { "content-type": "application/json" })
+        response.end(JSON.stringify(registryItem))
+        return
+      }
+
+      response.writeHead(404)
+      response.end()
+    })
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve)
+    })
+
+    try {
+      const address = server.address()
+      if (!address || typeof address === "string") {
+        throw new Error("Failed to start test registry server.")
+      }
+
+      tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-add-registry-"))
+      await fs.writeFile(
+        path.join(tempDir, "package.json"),
+        JSON.stringify({
+          name: "registry-consumer",
+          private: true,
+          registries: {
+            "@acme": {
+              url: `http://127.0.0.1:${address.port}/{name}.json`,
+              headers: {
+                Authorization: "Bearer ${REGISTRY_TOKEN}",
+              },
+            },
+          },
+        })
+      )
+      await fs.writeFile(
+        path.join(tempDir, ".env"),
+        "REGISTRY_TOKEN=project-token\n"
+      )
+
+      const config = await getRegistriesConfig(tempDir)
+
+      await addRegistryItems(["@acme/agent"], {
+        cwd: tempDir,
+        config,
+        silent: true,
+      })
+
+      await expect(
+        fs.readFile(path.join(tempDir, "generated/agent.ts"), "utf8")
+      ).resolves.toBe("export const agent = true\n")
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+            return
+          }
+
+          resolve()
+        })
+      })
+    }
+  })
+
+  it("installs a non-universal item with a full project config", async () => {
+    const registryItem = {
+      name: "button",
+      type: "registry:ui",
+      files: [
+        {
+          path: "button.tsx",
+          type: "registry:ui",
+          content: "export function Button() {}\n",
+        },
+      ],
+    }
+    const server = createServer((request, response) => {
+      if (request.url === "/button.json") {
+        response.writeHead(200, { "content-type": "application/json" })
+        response.end(JSON.stringify(registryItem))
+        return
+      }
+
+      response.writeHead(404)
+      response.end()
+    })
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve)
+    })
+
+    try {
+      const address = server.address()
+      if (!address || typeof address === "string") {
+        throw new Error("Failed to start test registry server.")
+      }
+
+      tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-add-registry-"))
+      await fs.writeFile(
+        path.join(tempDir, "package.json"),
+        JSON.stringify({
+          name: "registry-consumer",
+          private: true,
+        })
+      )
+
+      const config = createConfig({
+        registries: {
+          "@acme": `http://127.0.0.1:${address.port}/{name}.json`,
+        },
+        resolvedPaths: {
+          cwd: tempDir,
+          components: path.join(tempDir, "components"),
+          hooks: path.join(tempDir, "hooks"),
+          lib: path.join(tempDir, "lib"),
+          ui: path.join(tempDir, "components/ui"),
+          utils: path.join(tempDir, "lib/utils"),
+        },
+      })
+
+      await addRegistryItems(["@acme/button"], {
+        cwd: tempDir,
+        config,
+        silent: true,
+        skipFonts: true,
+      })
+
+      await expect(
+        fs.readFile(path.join(tempDir, "components/ui/button.tsx"), "utf8")
+      ).resolves.toBe("export function Button() {}\n")
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+            return
+          }
+
+          resolve()
+        })
+      })
+    }
+  })
+
+  it("requires custom registry namespaces to be configured", async () => {
+    tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-add-registry-"))
+
+    await expect(
+      addRegistryItems(["@missing/agent"], {
+        cwd: tempDir,
+        config: {
+          registries: {},
+        },
+        silent: true,
+      })
+    ).rejects.toBeInstanceOf(RegistryNotConfiguredError)
+  })
+})

--- a/packages/shadcn/src/registry/add.test.ts
+++ b/packages/shadcn/src/registry/add.test.ts
@@ -1,25 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { addRegistryItems } from "./add"
+import { ConfigParseError } from "./errors"
 
 const {
   mockAddComponents,
-  mockClearRegistryContext,
-  mockCreateConfig,
-  mockEnsureRegistriesInConfig,
-  mockGetConfig,
+  mockConfigWithDefaults,
   mockLoadEnvFiles,
   mockResolveRegistryTree,
   mockWithRegistryContext,
 } = vi.hoisted(() => ({
   mockAddComponents: vi.fn(),
-  mockClearRegistryContext: vi.fn(),
-  mockCreateConfig: vi.fn(),
-  mockEnsureRegistriesInConfig: vi.fn(),
-  mockGetConfig: vi.fn(),
+  mockConfigWithDefaults: vi.fn(),
   mockLoadEnvFiles: vi.fn(),
   mockResolveRegistryTree: vi.fn(),
   mockWithRegistryContext: vi.fn(),
+}))
+
+vi.mock("@/src/registry/config", () => ({
+  configWithDefaults: mockConfigWithDefaults,
 }))
 
 vi.mock("@/src/registry/resolver", () => ({
@@ -27,7 +26,6 @@ vi.mock("@/src/registry/resolver", () => ({
 }))
 
 vi.mock("@/src/registry/context", () => ({
-  clearRegistryContext: mockClearRegistryContext,
   withRegistryContext: mockWithRegistryContext,
 }))
 
@@ -39,37 +37,56 @@ vi.mock("@/src/utils/env-loader", () => ({
   loadEnvFiles: mockLoadEnvFiles,
 }))
 
-vi.mock("@/src/utils/get-config", () => ({
-  createConfig: mockCreateConfig,
-  getConfig: mockGetConfig,
-}))
-
-vi.mock("@/src/utils/registries", () => ({
-  ensureRegistriesInConfig: mockEnsureRegistriesInConfig,
-}))
-
 describe("addRegistryItems", () => {
-  const projectConfig = { resolvedPaths: { cwd: "/project" } }
-  const updatedConfig = { ...projectConfig, registries: { "@acme": "url" } }
+  const projectConfig = {
+    style: "new-york",
+    rsc: false,
+    tsx: true,
+    tailwind: {
+      config: "tailwind.config.ts",
+      css: "app/globals.css",
+      baseColor: "neutral",
+      cssVariables: true,
+    },
+    aliases: {
+      components: "@/components",
+      utils: "@/lib/utils",
+    },
+    registries: {
+      "@acme": "https://acme.com/{name}.json",
+    },
+    resolvedPaths: {
+      cwd: "/project",
+      tailwindConfig: "/project/tailwind.config.ts",
+      tailwindCss: "/project/app/globals.css",
+      utils: "/project/lib/utils",
+      components: "/project/components",
+      ui: "/project/components/ui",
+      lib: "/project/lib",
+      hooks: "/project/hooks",
+    },
+  }
   const projectEnv = { REGISTRY_TOKEN: "project-token" }
 
   beforeEach(() => {
     vi.clearAllMocks()
     mockLoadEnvFiles.mockResolvedValue(projectEnv)
     mockWithRegistryContext.mockImplementation((callback) => callback())
-    mockGetConfig.mockResolvedValue(projectConfig)
-    mockEnsureRegistriesInConfig.mockResolvedValue({
-      config: updatedConfig,
-      newRegistries: [],
-    })
+    mockConfigWithDefaults.mockImplementation((config) => config)
     mockResolveRegistryTree.mockResolvedValue({ files: [] })
   })
 
-  it("loads project configuration and installs registry items", async () => {
+  it("uses a full project config to install registry items", async () => {
+    const resolvedTree = { files: [] }
+    mockResolveRegistryTree.mockResolvedValueOnce(resolvedTree)
+
     await addRegistryItems(["@acme/button"], {
       cwd: "/project",
+      config: projectConfig,
       overwrite: true,
       silent: true,
+      skipFonts: true,
+      path: "src/components",
     })
 
     expect(mockLoadEnvFiles).toHaveBeenCalledWith("/project", {
@@ -79,51 +96,41 @@ describe("addRegistryItems", () => {
     expect(mockWithRegistryContext).toHaveBeenCalledWith(expect.any(Function), {
       env: projectEnv,
     })
-    expect(mockEnsureRegistriesInConfig).toHaveBeenCalledWith(
+    expect(mockConfigWithDefaults).toHaveBeenCalledWith(projectConfig)
+    expect(mockResolveRegistryTree).toHaveBeenCalledWith(
       ["@acme/button"],
       projectConfig,
-      { silent: true, writeFile: true }
+      { requireUniversal: false, useCache: true }
     )
     expect(mockAddComponents).toHaveBeenCalledWith(
       ["@acme/button"],
-      updatedConfig,
-      expect.objectContaining({
+      projectConfig,
+      {
         overwrite: true,
         silent: true,
+        skipFonts: true,
+        path: "src/components",
         interactive: false,
-      })
+        overwriteCssVars: undefined,
+        resolvedTree,
+      }
     )
-    expect(mockClearRegistryContext).toHaveBeenCalledOnce()
   })
 
-  it("defaults cwd to process.cwd()", async () => {
-    const cwd = "/default/project"
-    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(cwd)
-
-    try {
-      await addRegistryItems(["@acme/button"])
-    } finally {
-      cwdSpy.mockRestore()
+  it("uses a registries-only config for universal items", async () => {
+    const inputConfig = {
+      registries: {
+        "@acme": "https://acme.com/{name}.json",
+      },
     }
-
-    expect(mockLoadEnvFiles).toHaveBeenCalledWith(cwd, {
-      processEnv: expect.any(Object),
-    })
-    expect(mockGetConfig).toHaveBeenCalledWith(cwd)
-  })
-
-  it("propagates installation errors to the caller", async () => {
-    mockAddComponents.mockRejectedValueOnce(new Error("Installation failed."))
-
-    await expect(
-      addRegistryItems(["@acme/button"], { cwd: "/project" })
-    ).rejects.toThrow("Installation failed.")
-
-    expect(mockClearRegistryContext).toHaveBeenCalledOnce()
-  })
-
-  it("installs universal items without components.json", async () => {
-    const universalConfig = { resolvedPaths: { cwd: "/project" } }
+    const universalConfig = {
+      ...projectConfig,
+      resolvedPaths: {
+        ...projectConfig.resolvedPaths,
+        cwd: "/project",
+      },
+      registries: inputConfig.registries,
+    }
     const resolvedTree = {
       files: [
         {
@@ -133,27 +140,61 @@ describe("addRegistryItems", () => {
         },
       ],
     }
-    mockGetConfig.mockResolvedValue(null)
-    mockCreateConfig.mockReturnValue(universalConfig)
-    mockEnsureRegistriesInConfig.mockResolvedValue({
-      config: universalConfig,
-      newRegistries: [],
+    mockConfigWithDefaults.mockReturnValueOnce(universalConfig)
+    mockResolveRegistryTree.mockResolvedValueOnce(resolvedTree)
+
+    await addRegistryItems(["@acme/agent"], {
+      cwd: "/project",
+      config: inputConfig,
     })
-    mockResolveRegistryTree.mockResolvedValue(resolvedTree)
+
+    expect(mockConfigWithDefaults).toHaveBeenCalledWith({
+      registries: inputConfig.registries,
+      resolvedPaths: { cwd: "/project" },
+    })
+    expect(mockResolveRegistryTree).toHaveBeenCalledWith(
+      ["@acme/agent"],
+      universalConfig,
+      { requireUniversal: true, useCache: true }
+    )
+    expect(mockAddComponents).toHaveBeenCalledWith(
+      ["@acme/agent"],
+      universalConfig,
+      {
+        interactive: false,
+        overwriteCssVars: false,
+        resolvedTree,
+      }
+    )
+  })
+
+  it("uses default config for universal URL items", async () => {
+    const universalConfig = {
+      ...projectConfig,
+      resolvedPaths: {
+        ...projectConfig.resolvedPaths,
+        cwd: "/project",
+      },
+    }
+    const resolvedTree = {
+      files: [
+        {
+          path: "agent.ts",
+          target: "agent/extensions/agent.ts",
+          type: "registry:file",
+        },
+      ],
+    }
+    mockConfigWithDefaults.mockReturnValueOnce(universalConfig)
+    mockResolveRegistryTree.mockResolvedValueOnce(resolvedTree)
 
     await addRegistryItems(["https://example.com/agent.json"], {
       cwd: "/project",
     })
 
-    expect(mockCreateConfig).toHaveBeenCalledWith({
-      style: "new-york",
+    expect(mockConfigWithDefaults).toHaveBeenCalledWith({
       resolvedPaths: { cwd: "/project" },
     })
-    expect(mockEnsureRegistriesInConfig).toHaveBeenCalledWith(
-      ["https://example.com/agent.json"],
-      universalConfig,
-      { silent: undefined, writeFile: false }
-    )
     expect(mockResolveRegistryTree).toHaveBeenCalledWith(
       ["https://example.com/agent.json"],
       universalConfig,
@@ -162,48 +203,192 @@ describe("addRegistryItems", () => {
     expect(mockAddComponents).toHaveBeenCalledWith(
       ["https://example.com/agent.json"],
       universalConfig,
-      expect.objectContaining({
+      {
         interactive: false,
         overwriteCssVars: false,
         resolvedTree,
-      })
+      }
     )
   })
 
-  it("rejects non-universal dependencies without components.json", async () => {
-    const universalConfig = { resolvedPaths: { cwd: "/project" } }
-    mockGetConfig.mockResolvedValue(null)
-    mockCreateConfig.mockReturnValue(universalConfig)
-    mockEnsureRegistriesInConfig.mockResolvedValue({
-      config: universalConfig,
-      newRegistries: [],
+  it("uses the config cwd when cwd is omitted", async () => {
+    await addRegistryItems(["@acme/button"], {
+      config: projectConfig,
     })
-    mockResolveRegistryTree.mockRejectedValue(
+
+    expect(mockLoadEnvFiles).toHaveBeenCalledWith("/project", {
+      processEnv: expect.any(Object),
+    })
+  })
+
+  it("defaults cwd to process.cwd()", async () => {
+    const cwd = "/default/project"
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(cwd)
+
+    try {
+      await addRegistryItems(["https://example.com/agent.json"])
+    } finally {
+      cwdSpy.mockRestore()
+    }
+
+    expect(mockLoadEnvFiles).toHaveBeenCalledWith(cwd, {
+      processEnv: expect.any(Object),
+    })
+    expect(mockConfigWithDefaults).toHaveBeenCalledWith({
+      resolvedPaths: { cwd },
+    })
+  })
+
+  it("rejects a cwd that conflicts with a full project config", async () => {
+    await expect(
+      addRegistryItems(["@acme/button"], {
+        cwd: "/other-project",
+        config: projectConfig,
+      })
+    ).rejects.toThrow("The provided cwd must match config.resolvedPaths.cwd.")
+
+    expect(mockLoadEnvFiles).not.toHaveBeenCalled()
+    expect(mockResolveRegistryTree).not.toHaveBeenCalled()
+    expect(mockAddComponents).not.toHaveBeenCalled()
+  })
+
+  it("rejects empty cwd values that conflict with a full project config", async () => {
+    await expect(
+      addRegistryItems(["@acme/button"], {
+        cwd: "",
+        config: projectConfig,
+      })
+    ).rejects.toThrow("The provided cwd must match config.resolvedPaths.cwd.")
+
+    await expect(
+      addRegistryItems(["@acme/button"], {
+        cwd: "/project",
+        config: {
+          ...projectConfig,
+          resolvedPaths: {
+            ...projectConfig.resolvedPaths,
+            cwd: "",
+          },
+        },
+      })
+    ).rejects.toThrow("The provided cwd must match config.resolvedPaths.cwd.")
+
+    expect(mockLoadEnvFiles).not.toHaveBeenCalled()
+    expect(mockResolveRegistryTree).not.toHaveBeenCalled()
+    expect(mockAddComponents).not.toHaveBeenCalled()
+  })
+
+  it("reports partial configs with resolvedPaths as invalid", async () => {
+    await expect(
+      addRegistryItems(["@acme/agent"], {
+        cwd: "/other-project",
+        config: {
+          registries: projectConfig.registries,
+          resolvedPaths: projectConfig.resolvedPaths,
+        },
+      })
+    ).rejects.toBeInstanceOf(ConfigParseError)
+
+    expect(mockLoadEnvFiles).not.toHaveBeenCalled()
+    expect(mockResolveRegistryTree).not.toHaveBeenCalled()
+    expect(mockAddComponents).not.toHaveBeenCalled()
+  })
+
+  it("reports invalid attempted full configs", async () => {
+    const invalidConfig = {
+      ...projectConfig,
+      unexpected: true,
+    }
+
+    await expect(
+      addRegistryItems(["@acme/button"], {
+        cwd: "/project",
+        config: invalidConfig,
+      })
+    ).rejects.toBeInstanceOf(ConfigParseError)
+
+    expect(mockConfigWithDefaults).not.toHaveBeenCalled()
+    expect(mockLoadEnvFiles).not.toHaveBeenCalled()
+    expect(mockResolveRegistryTree).not.toHaveBeenCalled()
+    expect(mockAddComponents).not.toHaveBeenCalled()
+  })
+
+  it("reports missing fields in attempted full configs", async () => {
+    const invalidConfig = {
+      ...projectConfig,
+      tailwind: {
+        config: "tailwind.config.ts",
+        css: "app/globals.css",
+        cssVariables: true,
+      },
+    }
+
+    await expect(
+      addRegistryItems(["@acme/button"], {
+        cwd: "/project",
+        config: invalidConfig as never,
+      })
+    ).rejects.toThrow("tailwind.baseColor")
+  })
+
+  it("reports invalid resolvedPaths cwd values", async () => {
+    const invalidConfig = {
+      ...projectConfig,
+      resolvedPaths: {
+        ...projectConfig.resolvedPaths,
+        cwd: 42,
+      },
+    }
+
+    await expect(
+      addRegistryItems(["@acme/button"], {
+        config: invalidConfig as never,
+      })
+    ).rejects.toBeInstanceOf(ConfigParseError)
+
+    expect(mockLoadEnvFiles).not.toHaveBeenCalled()
+    expect(mockResolveRegistryTree).not.toHaveBeenCalled()
+    expect(mockAddComponents).not.toHaveBeenCalled()
+  })
+
+  it("rejects non-universal items without a full project config", async () => {
+    const universalConfig = {
+      ...projectConfig,
+      resolvedPaths: {
+        ...projectConfig.resolvedPaths,
+        cwd: "/project",
+      },
+    }
+    mockConfigWithDefaults.mockReturnValueOnce(universalConfig)
+    mockResolveRegistryTree.mockRejectedValueOnce(
       new Error(
-        "A components.json file is required to add non-universal registry items or dependencies."
+        "A full project config is required to add non-universal registry items or dependencies."
       )
     )
 
     await expect(
-      addRegistryItems(["https://example.com/agent.json"], {
+      addRegistryItems(["@acme/button"], {
         cwd: "/project",
+        config: {
+          registries: projectConfig.registries,
+        },
       })
-    ).rejects.toThrow("non-universal registry items or dependencies")
+    ).rejects.toThrow("A full project config is required")
 
     expect(mockAddComponents).not.toHaveBeenCalled()
   })
 
-  it("rejects unresolved target aliases without components.json", async () => {
+  it("rejects unresolved target aliases without a full project config", async () => {
     const universalConfig = {
-      resolvedPaths: { cwd: "/project", ui: "" },
+      ...projectConfig,
+      resolvedPaths: {
+        ...projectConfig.resolvedPaths,
+        cwd: "/project",
+        ui: "",
+      },
     }
-    mockGetConfig.mockResolvedValue(null)
-    mockCreateConfig.mockReturnValue(universalConfig)
-    mockEnsureRegistriesInConfig.mockResolvedValue({
-      config: universalConfig,
-      newRegistries: [],
-    })
-    mockResolveRegistryTree.mockResolvedValue({
+    mockConfigWithDefaults.mockReturnValueOnce(universalConfig)
+    mockResolveRegistryTree.mockResolvedValueOnce({
       files: [
         {
           path: "agent.ts",
@@ -217,20 +402,23 @@ describe("addRegistryItems", () => {
       addRegistryItems(["https://example.com/agent.json"], {
         cwd: "/project",
       })
-    ).rejects.toThrow("resolve target aliases")
+    ).rejects.toThrow(
+      "A full project config is required to resolve target aliases."
+    )
 
     expect(mockAddComponents).not.toHaveBeenCalled()
   })
 
-  it("reports unresolved registry items without components.json", async () => {
-    const universalConfig = { resolvedPaths: { cwd: "/project" } }
-    mockGetConfig.mockResolvedValue(null)
-    mockCreateConfig.mockReturnValue(universalConfig)
-    mockEnsureRegistriesInConfig.mockResolvedValue({
-      config: universalConfig,
-      newRegistries: [],
-    })
-    mockResolveRegistryTree.mockResolvedValue(null)
+  it("reports unresolved registry items without a full project config", async () => {
+    const universalConfig = {
+      ...projectConfig,
+      resolvedPaths: {
+        ...projectConfig.resolvedPaths,
+        cwd: "/project",
+      },
+    }
+    mockConfigWithDefaults.mockReturnValueOnce(universalConfig)
+    mockResolveRegistryTree.mockResolvedValueOnce(null)
 
     await expect(
       addRegistryItems(["https://example.com/missing.json"], {
@@ -241,25 +429,24 @@ describe("addRegistryItems", () => {
     expect(mockAddComponents).not.toHaveBeenCalled()
   })
 
-  it("rejects non-universal items without components.json", async () => {
-    const universalConfig = { resolvedPaths: { cwd: "/project" } }
-    mockGetConfig.mockResolvedValue(null)
-    mockCreateConfig.mockReturnValue(universalConfig)
-    mockEnsureRegistriesInConfig.mockResolvedValue({
-      config: universalConfig,
-      newRegistries: [],
-    })
-    mockResolveRegistryTree.mockRejectedValue(
-      new Error(
-        "A components.json file is required to add non-universal registry items or dependencies."
-      )
-    )
+  it("propagates installation errors", async () => {
+    mockAddComponents.mockRejectedValueOnce(new Error("Installation failed."))
 
     await expect(
-      addRegistryItems(["@acme/button"], { cwd: "/project" })
-    ).rejects.toThrow("A components.json file is required")
+      addRegistryItems(["@acme/button"], {
+        cwd: "/project",
+        config: projectConfig,
+      })
+    ).rejects.toThrow("Installation failed.")
+  })
 
+  it("does nothing when no items are provided", async () => {
+    await addRegistryItems([], {
+      cwd: "/project",
+      config: projectConfig,
+    })
+
+    expect(mockLoadEnvFiles).not.toHaveBeenCalled()
     expect(mockAddComponents).not.toHaveBeenCalled()
-    expect(mockClearRegistryContext).toHaveBeenCalledOnce()
   })
 })

--- a/packages/shadcn/src/registry/add.ts
+++ b/packages/shadcn/src/registry/add.ts
@@ -1,110 +1,110 @@
 import path from "path"
-import {
-  clearRegistryContext,
-  withRegistryContext,
-} from "@/src/registry/context"
+import { configWithDefaults } from "@/src/registry/config"
+import { withRegistryContext } from "@/src/registry/context"
+import { ConfigParseError } from "@/src/registry/errors"
 import { resolveRegistryTree } from "@/src/registry/resolver"
-import {
-  addComponents,
-  type AddComponentsOptions,
-} from "@/src/utils/add-components"
+import { configSchema } from "@/src/schema"
+import { addComponents } from "@/src/utils/add-components"
 import { loadEnvFiles } from "@/src/utils/env-loader"
-import { createConfig, getConfig, type Config } from "@/src/utils/get-config"
-import { ensureRegistriesInConfig } from "@/src/utils/registries"
+import { type Config } from "@/src/utils/get-config"
 import { getTargetAliasKey } from "@/src/utils/target-aliases"
 
-export interface AddRegistryItemsOptions
-  extends Pick<
-    AddComponentsOptions,
-    "overwrite" | "overwriteCssVars" | "silent" | "skipFonts" | "path"
-  > {
-  /** The project directory. Defaults to the current working directory. */
-  cwd?: string
-}
-
-/**
- * Resolve and install registry items into a project.
- *
- * This is the programmatic equivalent of `shadcn add` for an existing project.
- * Universal registry items with explicit file targets can also be installed
- * without a components.json file.
- */
 export async function addRegistryItems(
   items: string[],
-  options: AddRegistryItemsOptions = {}
+  options: {
+    cwd?: string
+    config?: Partial<Config>
+    overwrite?: boolean
+    overwriteCssVars?: boolean
+    silent?: boolean
+    skipFonts?: boolean
+    path?: string
+  } = {}
 ): Promise<void> {
   if (items.length === 0) {
     return
   }
 
-  const cwd = path.resolve(options.cwd ?? process.cwd())
+  const {
+    config: inputConfig,
+    cwd: inputCwd,
+    ...addComponentsOptions
+  } = options
+  const parsedConfig = configSchema.safeParse(inputConfig)
+  if (!parsedConfig.success && inputConfig && "resolvedPaths" in inputConfig) {
+    const configCwd =
+      typeof inputConfig.resolvedPaths?.cwd === "string"
+        ? inputConfig.resolvedPaths.cwd
+        : undefined
+    throw new ConfigParseError(
+      path.resolve(inputCwd ?? configCwd ?? process.cwd()),
+      parsedConfig.error,
+      "config"
+    )
+  }
+
+  const configCwd = parsedConfig.success
+    ? parsedConfig.data.resolvedPaths.cwd
+    : undefined
+  const cwd = path.resolve(inputCwd ?? configCwd ?? process.cwd())
+  if (
+    inputCwd !== undefined &&
+    configCwd !== undefined &&
+    cwd !== path.resolve(configCwd)
+  ) {
+    throw new Error("The provided cwd must match config.resolvedPaths.cwd.")
+  }
+
+  const config = configWithDefaults(
+    parsedConfig.success
+      ? parsedConfig.data
+      : {
+          ...inputConfig,
+          resolvedPaths: {
+            ...inputConfig?.resolvedPaths,
+            cwd,
+          },
+        }
+  )
   const env = await loadEnvFiles(cwd, {
     processEnv: { ...process.env },
   })
 
   return withRegistryContext(
     async () => {
-      try {
-        const projectConfig = await getConfig(cwd)
-        let config =
-          projectConfig ??
-          createConfig({
-            style: "new-york",
-            resolvedPaths: { cwd },
-          })
-        let resolvedTree:
-          | NonNullable<Awaited<ReturnType<typeof resolveRegistryTree>>>
-          | undefined
-
-        const { config: configWithRegistries } = await ensureRegistriesInConfig(
-          items,
-          config,
-          {
-            silent: options.silent,
-            writeFile: projectConfig !== null,
-          }
-        )
-        config = configWithRegistries
-
-        if (!projectConfig) {
-          const registryTree = await resolveRegistryTree(items, config, {
-            useCache: true,
-            requireUniversal: true,
-          })
-          if (!registryTree) {
-            throw new Error("Failed to fetch components from registry.")
-          }
-          if (!hasResolvedTargetAliases(registryTree, config)) {
-            throw new Error(
-              "A components.json file is required to resolve target aliases."
-            )
-          }
-          resolvedTree = registryTree
-        }
-
-        await addComponents(items, config, {
-          ...options,
-          interactive: false,
-          overwriteCssVars:
-            options.overwriteCssVars ?? (projectConfig ? undefined : false),
-          resolvedTree,
-        })
-      } finally {
-        clearRegistryContext()
+      const resolvedTree = await resolveRegistryTree(items, config, {
+        useCache: true,
+        requireUniversal: !parsedConfig.success,
+      })
+      if (!resolvedTree) {
+        throw new Error("Failed to fetch components from registry.")
       }
+      if (
+        !parsedConfig.success &&
+        !hasResolvedTargetAliases(resolvedTree, config)
+      ) {
+        throw new Error(
+          "A full project config is required to resolve target aliases."
+        )
+      }
+
+      await addComponents(items, config, {
+        ...addComponentsOptions,
+        interactive: false,
+        overwriteCssVars:
+          options.overwriteCssVars ??
+          (parsedConfig.success ? undefined : false),
+        resolvedTree,
+      })
     },
     { env }
   )
 }
 
 function hasResolvedTargetAliases(
-  registryTree: Awaited<ReturnType<typeof resolveRegistryTree>>,
+  registryTree: NonNullable<Awaited<ReturnType<typeof resolveRegistryTree>>>,
   config: Config
 ) {
-  if (!registryTree) {
-    return false
-  }
-
   return (registryTree.files ?? []).every((file) => {
     const aliasKey = getTargetAliasKey(file.target)
 

--- a/packages/shadcn/src/registry/errors.ts
+++ b/packages/shadcn/src/registry/errors.ts
@@ -385,12 +385,17 @@ export class ConfigParseError extends RegistryError {
   constructor(
     public readonly cwd: string,
     parseError: unknown,
-    public readonly configFile = "components.json"
+    public readonly configFile:
+      | "components.json"
+      | "package.json"
+      | "config" = "components.json"
   ) {
     const configName =
       configFile === "package.json"
         ? 'package.json "registries"'
-        : "components.json"
+        : configFile === "config"
+          ? "provided config"
+          : "components.json"
     let message = `Invalid ${configName} configuration in ${cwd}.`
 
     if (parseError instanceof z.ZodError) {
@@ -406,7 +411,9 @@ export class ConfigParseError extends RegistryError {
       suggestion:
         configFile === "package.json"
           ? 'Check the "registries" field in your package.json file for invalid configuration.'
-          : "Check your components.json file for syntax errors or invalid configuration. Run 'npx shadcn@latest init' to regenerate a valid configuration.",
+          : configFile === "config"
+            ? "Pass a valid full project config, or omit resolvedPaths and provide only registry configuration."
+            : "Check your components.json file for syntax errors or invalid configuration. Run 'npx shadcn@latest init' to regenerate a valid configuration.",
     })
     this.name = "ConfigParseError"
   }

--- a/packages/shadcn/src/registry/index.ts
+++ b/packages/shadcn/src/registry/index.ts
@@ -7,7 +7,7 @@ export {
   getRegistriesIndex,
 } from "./api"
 
-export { addRegistryItems, type AddRegistryItemsOptions } from "./add"
+export { addRegistryItems } from "./add"
 
 export { searchRegistries } from "./search"
 

--- a/packages/shadcn/src/registry/resolver.ts
+++ b/packages/shadcn/src/registry/resolver.ts
@@ -287,7 +287,7 @@ export async function resolveRegistryTree(
     !payload.every((item) => isUniversalRegistryItem(item))
   ) {
     throw new Error(
-      "A components.json file is required to add non-universal registry items or dependencies."
+      "A full project config is required to add non-universal registry items or dependencies."
     )
   }
 

--- a/packages/shadcn/src/registry/utils.ts
+++ b/packages/shadcn/src/registry/utils.ts
@@ -279,7 +279,7 @@ export function isLocalFile(path: string) {
  * A universal registry item must:
  * 1. Have type "registry:item" or "registry:file"
  * 2. If it has files, all files must have explicit targets and be type "registry:file" or "registry:item"
- * It can be installed without framework detection or components.json.
+ * It can be installed without framework detection or a full project config.
  */
 export function isUniversalRegistryItem(
   registryItem:


### PR DESCRIPTION
Allow addRegistryItems to consume explicit registry configuration, including registries loaded from package.json.