### PR TITLE
fix(v4): make directory View button navigate to registry homepage

### DIFF
--- a/apps/v4/components/directory-list.tsx
+++ b/apps/v4/components/directory-list.tsx
@@ -258,7 +258,17 @@ function DirectoryListContent() {
                 <DirectoryAddButton registry={registry} />
               </ItemActions>
               <ItemFooter className="justify-start pl-16 sm:hidden">
-                <Button size="sm" variant="outline">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  render={
+                    <a
+                      href={getHomepageUrl(registry.homepage)}
+                      target="_blank"
+                      rel="noopener noreferrer external"
+                    />
+                  }
+                >
                   View <IconArrowUpRight />
                 </Button>
                 <DirectoryAddButton registry={registry} />


### PR DESCRIPTION
The View button rendered on each registry directory entry was an inert <Button> with no href and no onClick, so tapping it did nothing.

The button is only shown below the sm breakpoint (its ItemFooter wrapper is sm:hidden), so this affected mobile users exclusively. On desktop the registry title anchor provides navigation, which is why the bug went unnoticed there.

Render the button as an anchor pointing at the same UTM-tagged homepage URL used by the title link, with matching target and rel attributes.