### PR TITLE
fix(registry): add pointer-events-none to collapsed sidebar-group-label & reduce transition duration to 100

### DIFF
--- a/apps/v4/registry/bases/aria/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/aria/ui/sidebar.tsx
@@ -234,7 +234,7 @@ function Sidebar({
         data-slot="sidebar-container"
         data-side={side}
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-100 ease-linear group-data-[collapsible=icon]:pointer-events-none data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
           // Adjust the padding for floating and inset variants.
           variant === "floating" || variant === "inset"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"

--- a/apps/v4/registry/bases/base/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/base/ui/sidebar.tsx
@@ -230,7 +230,7 @@ function Sidebar({
         data-slot="sidebar-container"
         data-side={side}
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-100 ease-linear group-data-[collapsible=icon]:pointer-events-none data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
           // Adjust the padding for floating and inset variants.
           variant === "floating" || variant === "inset"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"

--- a/apps/v4/registry/bases/radix/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/radix/ui/sidebar.tsx
@@ -229,7 +229,7 @@ function Sidebar({
         data-slot="sidebar-container"
         data-side={side}
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-100 ease-linear group-data-[collapsible=icon]:pointer-events-none data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
           // Adjust the padding for floating and inset variants.
           variant === "floating" || variant === "inset"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"

--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -229,7 +229,7 @@ function Sidebar({
       <div
         data-slot="sidebar-container"
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-100 ease-linear group-data-[collapsible=icon]:pointer-events-none md:flex",
           side === "left"
             ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
             : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",


### PR DESCRIPTION
### Description
Fixes hit-testing overlap bug where the hidden `SidebarGroupLabel` blocks hover and click interactions on the bottom half of the last menu item in the preceding group when the sidebar is collapsed to `icon` mode.

Also reduces transition duration of `SidebarGroupLabel` to `100ms` to sync better with the sidebar collapse animation.

### Nuance (Why I think only some items are blocked)
In CSS stacking context, elements appearing later in the DOM tree render on top of earlier elements by default. Thus, the `SidebarGroupLabel` at the start of a group overlaps the last item of the group above it. The switcher at the top is not blocked because of DOM order and spacing.

### Changes
- Added `group-data-[collapsible=icon]:pointer-events-none` to `SidebarGroupLabel` to pass pointer events through when hidden.
- Adjusted transition duration on the label to `duration-100` to prevent delayed floating visual artifacts during collapse.

### Attachment & Example

Nuance: This Issue was not happening at the [Official Example Sidebar](https://ui.shadcn.com/docs/components/base/sidebar) Team switcher (Or The org switcher in my project) example even when I can see with select element browser-dev-tool that SidebarGroupLabel was covering half of space. But it was not half disabled. i dont know the reason. 

SS from https://ui.shadcn.com/docs/components/base/sidebar:
<img width="386" height="683" alt="image" src="https://github.com/user-attachments/assets/7da69b5e-b2d5-4047-8f4f-0baaf8a7b83d" />

SS Example from my Project: (Nuance, working properly but i can see SidebarGroupLabel was covering bottom half of it)
<img width="386" height="683" alt="image" src="https://github.com/user-attachments/assets/9a435a65-3a2a-40ef-9be0-c4ed03009722" />

Issue Example from my Project: (The Half covered by the hidden SidebarGroupLabel is unresponsive to cllick or hover)
<img width="386" height="683" alt="image" src="https://github.com/user-attachments/assets/3bbac0e1-500e-41c3-83ad-f6cd7b4aea0e" />

Same issue here as well:
<img width="386" height="683" alt="image" src="https://github.com/user-attachments/assets/dc71c69d-dea5-457e-8431-8f8636da12b3" />

For ref my app sidebar un-collapsed:
<img width="386" height="683" alt="image" src="https://github.com/user-attachments/assets/d906f220-6a98-4235-b7dc-58502b9651ae" />


### My first PR to this repo. tried best to follow contribution guidline. tell me if there is some changes needed in this.
