### PR TITLE
fix(shadcn): create nested output directories in build

### DIFF
--- a/.changeset/build-nested-output-dirs.md
+++ b/.changeset/build-nested-output-dirs.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+fix `shadcn build` failing with ENOENT when registry item names contain path segments (e.g. `extension/foo`) by creating nested output directories before writing

--- a/packages/shadcn/src/commands/build.test.ts
+++ b/packages/shadcn/src/commands/build.test.ts
@@ -83,6 +83,51 @@ describe("build command", () => {
       ],
     })
   })
+
+  it("creates nested output directories for item names with path segments", async () => {
+    const cwd = await createFixture({
+      "registry.json": JSON.stringify({
+        name: "example",
+        homepage: "https://example.com",
+        items: [
+          {
+            name: "extension/foo",
+            type: "registry:item",
+            files: [
+              {
+                path: "registry/extensions/foo.tsx",
+                type: "registry:file",
+                target: "extensions/foo.tsx",
+              },
+            ],
+          },
+        ],
+      }),
+      "registry/extensions/foo.tsx": "export function Foo() {}",
+    })
+
+    await build.parseAsync(
+      ["node", "shadcn", "registry.json", "--cwd", cwd, "--output", "public/r"],
+      { from: "node" }
+    )
+
+    const item = JSON.parse(
+      await fs.readFile(
+        path.join(cwd, "public/r/extension/foo.json"),
+        "utf-8"
+      )
+    )
+
+    expect(item).toMatchObject({
+      name: "extension/foo",
+      files: [
+        {
+          path: "registry/extensions/foo.tsx",
+          content: "export function Foo() {}",
+        },
+      ],
+    })
+  })
 })
 
 async function createFixture(files: Record<string, string>) {

--- a/packages/shadcn/src/commands/build.test.ts
+++ b/packages/shadcn/src/commands/build.test.ts
@@ -112,10 +112,7 @@ describe("build command", () => {
     )
 
     const item = JSON.parse(
-      await fs.readFile(
-        path.join(cwd, "public/r/extension/foo.json"),
-        "utf-8"
-      )
+      await fs.readFile(path.join(cwd, "public/r/extension/foo.json"), "utf-8")
     )
 
     expect(item).toMatchObject({

--- a/packages/shadcn/src/commands/build.ts
+++ b/packages/shadcn/src/commands/build.ts
@@ -69,11 +69,15 @@ export const build = new Command()
         )
 
         // Write the registry item to the output directory.
+        // Item names can contain path segments (e.g. "extension/foo"), so
+        // ensure the nested output directory exists before writing.
+        const outputPath = path.resolve(
+          resolvePaths.outputDir,
+          `${registryItemForBuild.name}.json`
+        )
+        await fs.mkdir(path.dirname(outputPath), { recursive: true })
         await fs.writeFile(
-          path.resolve(
-            resolvePaths.outputDir,
-            `${registryItemForBuild.name}.json`
-          ),
+          outputPath,
           JSON.stringify(registryItemForBuild, null, 2)
         )
       }

--- a/packages/shadcn/src/commands/registry/build.ts
+++ b/packages/shadcn/src/commands/registry/build.ts
@@ -149,10 +149,14 @@ async function buildRegistry(opts: z.infer<typeof buildOptionsSchema>) {
       }
 
       // Write the registry item to the output directory.
-      await fs.writeFile(
-        path.resolve(resolvePaths.outputDir, `${result.data.name}.json`),
-        JSON.stringify(result.data, null, 2)
+      // Item names can contain path segments (e.g. "extension/foo"), so
+      // ensure the nested output directory exists before writing.
+      const outputPath = path.resolve(
+        resolvePaths.outputDir,
+        `${result.data.name}.json`
       )
+      await fs.mkdir(path.dirname(outputPath), { recursive: true })
+      await fs.writeFile(outputPath, JSON.stringify(result.data, null, 2))
     }
 
     // Copy registry.json to the output directory.


### PR DESCRIPTION
## Description

`shadcn build` (and the experimental `registry:build`) write each item to `<outputDir>/<item.name>.json`, but only the output root is created during preflight. Item names with path segments (e.g. `"name": "extension/foo"`) fail with:

```
ENOENT: no such file or directory, open '.../public/r/extension/foo.json'
```

This only reproduces when the nested directories don't already exist — fresh clones and CI where generated output is gitignored — so it's easy to miss locally.

Fixes #11321

## Changes

- `commands/build.ts` and `commands/registry/build.ts`: `mkdir` the item's parent directory (`recursive: true`) before writing
- Added a test covering an item name with a path segment
- Changeset (patch)

## Testing

`pnpm --filter shadcn exec vitest run src/commands/build.test.ts` — 2 passed