### PR TITLE
fix(registry): remove unused React imports across base UI components

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/scroll-area.tsx
+++ b/apps/v4/registry/new-york-v4/ui/scroll-area.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import * as React from "react"
 import { ScrollArea as ScrollAreaPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"


### PR DESCRIPTION
Fixes: #11274


Summary: Remove unused import * as React from "react" from the new-york-v4 scroll-area registry component. JSX uses the automatic runtime; React.ComponentProps remains valid via global types.

Test plan: pnpm typecheck in apps/v4

