### PR TITLE
docs(data-table): use render prop for Base UI DropdownMenuTrigger

### DIFF
--- a/apps/v4/content/docs/components/base/data-table.mdx
+++ b/apps/v4/content/docs/components/base/data-table.mdx
@@ -349,11 +349,11 @@ export const columns: ColumnDef<Payment>[] = [
 
       return (
         <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" className="h-8 w-8 p-0">
-              <span className="sr-only">Open menu</span>
-              <MoreHorizontal className="h-4 w-4" />
-            </Button>
+          <DropdownMenuTrigger
+            render={<Button variant="ghost" className="h-8 w-8 p-0" />}
+          >
+            <span className="sr-only">Open menu</span>
+            <MoreHorizontal className="h-4 w-4" />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuLabel>Actions</DropdownMenuLabel>
@@ -694,10 +694,10 @@ export function DataTable<TData, TValue>({
           className="max-w-sm"
         />
         <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" className="ml-auto">
-              Columns
-            </Button>
+          <DropdownMenuTrigger
+            render={<Button variant="outline" className="ml-auto" />}
+          >
+            Columns
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             {table


### PR DESCRIPTION
The Base UI data-table page documents `DropdownMenuTrigger` with Radix's `asChild` pattern, so
copying the snippet into a Base UI project doesn't work.

`bases/base/ui/dropdown-menu.tsx` wraps `@base-ui/react/menu` and types the trigger as
`MenuPrimitive.Trigger.Props`, which takes `render` rather than `asChild`. The `asChild` prop
appears nowhere in the base registry. This aligns the two snippets with the pattern already used
in `apps/v4/examples/base/table-actions.tsx` and in the base `dropdown-menu` docs:

```tsx
<DropdownMenuTrigger render={<Button variant="ghost" className="h-8 w-8 p-0" />}>
  <span className="sr-only">Open menu</span>
  <MoreHorizontal className="h-4 w-4" />
</DropdownMenuTrigger>
```

Docs-only, scoped to the `base` page. The `radix` and `aria` pages are untouched, since
`asChild` is correct for Radix.

### Context

Found while looking at #11264, which reports the opposite: that the `render` prop in the
table-actions example is wrong and should be `asChild`. That example lives under
`examples/base/`, so `render` is correct there, and the mismatch is on the docs page. Worth
noting the confusion is easy to hit now that the same component is documented across three
primitive bases.
