### PR TITLE
chore(templates): move Docker templates off end-of-life node:20-alpine

### DIFF
--- a/templates/react-router-app/Dockerfile
+++ b/templates/react-router-app/Dockerfile
@@ -1,20 +1,20 @@
-FROM node:20-alpine AS development-dependencies-env
+FROM node:22-alpine AS development-dependencies-env
 COPY . /app
 WORKDIR /app
 RUN npm ci
 
-FROM node:20-alpine AS production-dependencies-env
+FROM node:22-alpine AS production-dependencies-env
 COPY ./package.json package-lock.json /app/
 WORKDIR /app
 RUN npm ci --omit=dev
 
-FROM node:20-alpine AS build-env
+FROM node:22-alpine AS build-env
 COPY . /app/
 COPY --from=development-dependencies-env /app/node_modules /app/node_modules
 WORKDIR /app
 RUN npm run build
 
-FROM node:20-alpine
+FROM node:22-alpine
 COPY ./package.json package-lock.json /app/
 COPY --from=production-dependencies-env /app/node_modules /app/node_modules
 COPY --from=build-env /app/build /app/build

--- a/templates/react-router-monorepo/apps/web/Dockerfile
+++ b/templates/react-router-monorepo/apps/web/Dockerfile
@@ -1,20 +1,20 @@
-FROM node:20-alpine AS development-dependencies-env
+FROM node:22-alpine AS development-dependencies-env
 COPY . /app
 WORKDIR /app
 RUN npm ci
 
-FROM node:20-alpine AS production-dependencies-env
+FROM node:22-alpine AS production-dependencies-env
 COPY ./package.json package-lock.json /app/
 WORKDIR /app
 RUN npm ci --omit=dev
 
-FROM node:20-alpine AS build-env
+FROM node:22-alpine AS build-env
 COPY . /app/
 COPY --from=development-dependencies-env /app/node_modules /app/node_modules
 WORKDIR /app
 RUN npm run build
 
-FROM node:20-alpine
+FROM node:22-alpine
 COPY ./package.json package-lock.json /app/
 COPY --from=production-dependencies-env /app/node_modules /app/node_modules
 COPY --from=build-env /app/build /app/build


### PR DESCRIPTION
Node 20 reached end-of-life on **2026-04-30** and no longer receives security releases. Both Docker templates still build on it, runtime stage included.

```diff
-FROM node:20-alpine AS development-dependencies-env
-FROM node:20-alpine AS production-dependencies-env
-FROM node:20-alpine AS build-env
-FROM node:20-alpine
+FROM node:22-alpine AS development-dependencies-env
+FROM node:22-alpine AS production-dependencies-env
+FROM node:22-alpine AS build-env
+FROM node:22-alpine
```

`+4/-4` in each of `templates/react-router-app/` and `templates/react-router-monorepo/apps/web/`.

### Why templates are a slightly different case

These aren't shipped as an image by this repo — they're copied into other people's projects when someone scaffolds, and built and deployed from there. So the consequence isn't one stale image; it's a default that keeps propagating to teams who reasonably assume a widely-used template starts them on a supported runtime.

It also ages in a particular way: a template committed while Node 20 was current becomes a liability the day that line goes EOL, and nothing about the template announces the change. That's what makes it worth a PR despite being four lines — it stops future propagation, which no downstream consumer can do for themselves.

### What that EOL actually means

Node states it directly:

> "It's important to note that **End-of-Life versions are always affected** when a security release occurs."

The June 2026 release fixed twelve CVEs into 22.x/24.x/26.x with 20.x excluded, including **CVE-2026-48933** (HIGH, WebCrypto AES integer overflow → remote process abort) and **CVE-2026-48618** (HIGH, Unicode dot separator → TLS wildcard-depth authentication bypass). July 2026, published this week, again patched only 26/24/22.

I've gone to **22** rather than 24 as the conservative step — it's the oldest currently-supported line, so it's the smallest change that gets off EOL. Happy to make it 24 if you'd prefer.

### Filed as a PR rather than an issue

`blank_issues_enabled: false`, and neither the bug-report nor feature-request template fits this well — a four-line fix seemed more useful than trying to squeeze it into one.

### Not changed

I didn't touch any other template or example, and I haven't verified whether the templates build cleanly on 22 in CI — worth a look before merge if there's no coverage for them.

*Disclosure: AI-assisted (Claude Opus 5). I verified the Dockerfile contents, the Node EOL dates from endoflife.date and the CVE list from nodejs.org myself.*
