### PR TITLE
feat(registry): add @usva to the registry directory

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1790,7 +1790,7 @@
     "name": "@usva",
     "homepage": "https://usva.build",
     "url": "https://usva.build/r/{name}.json",
-    "description": "A React design language in three themes, where kajo is atmospheric and dark, sisu is dense and quick, and savi is the light ground. 79 components over 25 semantic role tokens, including WebGL atmospheres that honour reduced-motion. Every component installs from npm or copies in from this registry.",
+    "description": "A React design language in three themes, where kajo is atmospheric and dark, sisu is dense and quick, and savi is the light ground. One token vocabulary underneath, including WebGL atmospheres that honour reduced-motion. Every component installs from npm or copies in from this registry.",
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='7 19 88 62' width='24' height='24'><path fill-rule='evenodd' fill='var(--foreground)' d='M7,50a31,31 0 1,0 62,0a31,31 0 1,0 -62,0M33,50a31,31 0 1,0 62,0a31,31 0 1,0 -62,0'/></svg>"
   }
 ]

--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1785,5 +1785,12 @@
     "url": "https://shadcndashboard.dev/r/{name}.json",
     "description": "Shadcn Dashboard is a collection of modern, production-ready dashboard layouts, components, and UI patterns built on top of shadcn/ui and Tailwind CSS. It’s designed to help developers build clean, scalable, and data-driven dashboards faster—without compromising on performance, accessibility, or customization.",
     "logo": "<svg width='40' height='40' viewBox='0 0 40 40' fill='none' xmlns='http://www.w3.org/2000/svg'><rect width='40' height='40' rx='20' fill='#053B25'/><path d='M32.1327 19.501C31.5178 19.6123 30.8844 19.6705 30.2375 19.6705C24.3886 19.6705 19.6471 14.9189 19.6471 9.05765C19.6471 8.89469 19.6507 8.73258 19.658 8.57141C13.8411 9.10533 9.28516 14.0074 9.28516 19.9759C9.28516 26.301 14.4019 31.4286 20.7137 31.4286C27.0256 31.4286 32.1423 26.301 32.1423 19.9759C32.1423 19.8168 32.1391 19.6585 32.1327 19.501Z' fill='#C2FD75'/></svg>"
+  },
+  {
+    "name": "@usva",
+    "homepage": "https://usva.build",
+    "url": "https://usva.build/r/{name}.json",
+    "description": "A React design language in three themes, where kajo is atmospheric and dark, sisu is dense and quick, and savi is the light ground. 79 components over 25 semantic role tokens, including WebGL atmospheres that honour reduced-motion. Every component installs from npm or copies in from this registry.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='7 19 88 62' width='24' height='24'><path fill-rule='evenodd' fill='var(--foreground)' d='M7,50a31,31 0 1,0 62,0a31,31 0 1,0 -62,0M33,50a31,31 0 1,0 62,0a31,31 0 1,0 -62,0'/></svg>"
   }
 ]


### PR DESCRIPTION
Adds `@usva` to the registry directory.

usva. is a React design language in three themes, built on Base UI and Tailwind v4 and installable with the shadcn CLI. One token vocabulary sits under all three: kajo is atmospheric and dark, sisu is dense and quick, savi is the light ground.

Every component ships two ways from one source: as the `usva` npm package, and as registry JSON you copy the source in from.

- **Homepage:** https://usva.build
- **Registry:** `https://usva.build/r/{name}.json`
- **Source:** https://github.com/matt-pasek/usva
- **Licence:** MIT + Commons Clause (source-available)

Verified with `npx shadcn@latest add https://usva.build/r/button.json` into a clean Vite + React 19 app.
