### PR TITLE
feat(registry): add @kinetic to the registry directory

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -785,6 +785,13 @@
     "logo": "<svg fill='none' viewBox='0 0 116 116' xmlns='http://www.w3.org/2000/svg'><title>Kibo UI</title><g fill='currentColor'><path clip-rule='evenodd' d='m29.3378 0h87.0002v87l-29.0002 29v-87h-87.000031zm-29.000031 95.7389v-37.7389h37.738831zm58.000031 20.2611h-37.249l37.249-37.2488z' fill-rule='evenodd'></path></g></svg>"
   },
   {
+    "name": "@kinetic",
+    "homepage": "https://kinetic.itsjay.in",
+    "url": "https://kinetic.itsjay.in/r/{name}.json",
+    "description": "A Figma-like scrub number field for shadcn/ui (base-nova). Digit animation by Calligraph.",
+    "logo": "<svg width='40' height='40' viewBox='0 0 40 40' fill='none' xmlns='http://www.w3.org/2000/svg'><rect width='40' height='40' rx='10' fill='#eef1f4'/><g transform='translate(8 8)' stroke='#1e2a3a' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'><path d='M8 13v-8.5a1.5 1.5 0 0 1 3 0v7.5'/><path d='M11 11.5v-2a1.5 1.5 0 0 1 3 0v2.5'/><path d='M14 10.5a1.5 1.5 0 0 1 3 0v1.5'/><path d='M17 11.5a1.5 1.5 0 0 1 3 0v4.5a6 6 0 0 1 -6 6h-2h.208a6 6 0 0 1 -5.012 -2.7l-.196 -.3c-.312 -.479 -1.407 -2.388 -3.286 -5.728a1.5 1.5 0 0 1 .536 -2.022a1.867 1.867 0 0 1 2.28 .28l1.47 1.47'/><path d='M2.541 5.594a13.487 13.487 0 0 1 2.46 -1.427'/><path d='M14 3.458c1.32 .354 2.558 .902 3.685 1.612'/></g></svg>"
+  },
+  {
     "name": "@kokonutui",
     "homepage": "https://kokonutui.com",
     "url": "https://kokonutui.com/r/{name}.json",


### PR DESCRIPTION
Adds `@kinetic` to `apps/v4/registry/directory.json`.

Closes #11153

**Registry:** https://kinetic.itsjay.in/r/{name}.json  
**Homepage:** https://kinetic.itsjay.in  
**Source:** https://github.com/jay15git/Kinetic (MIT)

### What it is

A Figma-like scrub number field for shadcn/ui (base-nova). Drag to scrub, click to edit, Up/Down to nudge, with digit animation by [Calligraph](https://calligraph.raphaelsalaja.com/).

### Requirements checklist

- [x] **Open source and publicly accessible** — source at [jay15git/Kinetic](https://github.com/jay15git/Kinetic) under MIT; endpoint served without auth
- [x] **Valid JSON conforming to the registry schema** — items declare `$schema: https://ui.shadcn.com/schema/registry-item.json`
- [x] **Flat registry** — `/r/registry.json` plus `/r/{name}.json`, no nesting
- [x] **No `content` in the index** — built via `pnpm registry:build`; file entries omit inlined content

`pnpm validate:registries` passes locally.

### Install (after merge)

```bash
pnpm dlx shadcn@latest add @kinetic/scrub-number-field
```

Direct URL also works today:

```bash
pnpm dlx shadcn@latest add https://kinetic.itsjay.in/r/scrub-number-field.json
```

Made with [Cursor](https://cursor.com)