### PR TITLE
Add @mediadrop to the registry directory

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1813,5 +1813,12 @@
     "url": "https://www.atelier-ui.com/r/{name}.json",
     "description": "A WebGL and Motion system for React that runs many effects on one shared canvas. Shader, cursor, scroll and text effects, 3D galleries, plus page transitions for Next.js. Built with Three.js, React Three Fiber, Motion, and Lenis smooth scroll.",
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48' fill='var(--foreground)' width='24' height='24'><path d='M22 8h9v13h10v18H26V24l-9.5 15H7V28z'/></svg>"
+  },
+  {
+    "name": "@mediadrop",
+    "homepage": "https://www.mediadrop.dev",
+    "url": "https://www.mediadrop.dev/r/{name}.json",
+    "description": "Drag-and-drop file upload blocks for React built on react-mediadrop — dropzone, avatar uploader, multi-file upload form, and direct-to-S3 upload.",
+    "logo": "<svg width='1024' height='1024' viewBox='0 0 1024 1024' fill='none' xmlns='http://www.w3.org/2000/svg'><rect width='1024' height='1024' rx='264' fill='black'/><path d='M690.68 471.521L506.92 655.283L466.282 614.646L466.283 614.644L332.918 481.278L373.555 440.642L506.921 574.007L650.044 430.885L690.68 471.521Z' fill='#00D9FF'/><path d='M690.68 267.637L506.92 451.398L466.282 410.761L466.283 410.759L332.918 277.394L373.555 236.757L506.921 370.122L650.044 227L690.68 267.637Z' fill='#0080A9'/><path d='M798.012 796.063H225.59V740.668H742.616V445.224H798.012V796.063ZM280.984 740.666H225.589V445.221H280.984V740.666Z' fill='url(#paint0_linear_220_485)'/><defs><linearGradient id='paint0_linear_220_485' x1='770.314' y1='445.221' x2='770.314' y2='740.667' gradientUnits='userSpaceOnUse'><stop/><stop offset='1' stop-color='white'/></linearGradient></defs></svg>"
   }
 ]


### PR DESCRIPTION
## Summary

Adds `@mediadrop` to `apps/v4/registry/directory.json`.

mediadrop is a small registry of file-upload blocks for React, built on [react-mediadrop](https://github.com/autorender/react-mediadrop):
- `dropzone` — drag-and-drop upload with per-file progress and cancel
- `avatar-uploader` — circular single-image avatar picker
- `multi-file-upload-form` — multi-file picker with review + explicit submit
- `s3-direct-upload` — direct-to-S3 upload via a presigned PUT URL

Registry is served at `https://www.mediadrop.dev/r/{name}.json` — flat, no nested items, `content` omitted from the source `registry.json`'s `files` arrays per the directory requirements.

## Checklist

- [x] Registry is public and publicly accessible (no auth)
- [x] `registry.json` conforms to the registry schema
- [x] Flat structure — `registry.json` and `{name}.json` files at `/r/` (verified against other directory.json entries using the same `/r/{name}.json` pattern)
- [x] `files` array in the source `registry.json` does not include a `content` property
- [x] Validated the new entry against `apps/v4/scripts/validate-registries.mts`'s zod schema (name regex, homepage URL, `{name}` placeholder in `url`, description present)
- [x] Ran `shadcn init` + `shadcn add` against the live URLs in a fresh Next.js app — installs cleanly, `tsc --noEmit` and `next build` both pass with 0 errors

## Test plan

```
npx shadcn add https://www.mediadrop.dev/r/dropzone.json \
  https://www.mediadrop.dev/r/avatar-uploader.json \
  https://www.mediadrop.dev/r/multi-file-upload-form.json \
  https://www.mediadrop.dev/r/s3-direct-upload.json
```
All 4 blocks install correctly with the `react-mediadrop` dependency resolved.