### PR TITLE
feat(registry): add @1st-pouf

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1,5 +1,12 @@
 [
   {
+    "name": "@1st-pouf",
+    "homepage": "https://1st-pouf.worksonmy.dev",
+    "url": "https://1st-pouf.worksonmy.dev/r/{name}.json",
+    "description": "Puffy, pastel claymorphism components and app blocks for React, built with Tailwind CSS v4 and Radix UI.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='3' y='3' width='26' height='26' rx='9' fill='#c9a8ff'/><path d='M5 12c5-5 17-5 22 0v8c-5 5-17 5-22 0z' fill='var(--foreground)' fill-opacity='.16'/></svg>"
+  },
+  {
     "name": "@7ovr",
     "homepage": "https://7ovr.com",
     "url": "https://7ovr.com/r/{name}.json",


### PR DESCRIPTION
Adds @1st-pouf to the registry directory. 1st-Pouf provides puffy pastel claymorphism components and app blocks for React, Tailwind CSS v4, and Radix UI.

Validation completed before submission:
- `pnpm validate:registries` passes in this repository
- the live registry catalog exposes 71 flat items
- `button.json` installs and builds in fresh Vite React and Next.js App Router projects
- both production builds were runtime-checked in Chrome, including styles and Nunito Variable loading

Registry: https://1st-pouf.worksonmy.dev/r/registry.json
Source: https://github.com/moji2002/1st-pouf