### PR TITLE
feat(skills): add /shadcn-ui slash commands for all major agents

### DIFF
--- a/skills/shadcn/agents/README.md
+++ b/skills/shadcn/agents/README.md
@@ -1,0 +1,67 @@
+# Agent integrations for the shadcn/ui skill
+
+This directory ships per-agent entry points for the shadcn/ui skill. Each
+file loads the same underlying context (`../SKILL.md`, `../rules/*.md`,
+`../cli.md`, `../mcp.md`) — only the frontmatter and format differ so the
+file speaks its host agent's dialect.
+
+## Install matrix
+
+Copy the file from this directory into the shown location in **your
+project root** (the folder inside each agent's subdirectory already
+mirrors the target path, so `cp -R claude/. <your-project>/` works).
+
+> **Note on the name:** the command is `/shadcn-ui`, not `/shadcn`.
+> The bare `shadcn` name is reserved by the auto-invocable shadcn skill
+> (`skills/shadcn/SKILL.md`, `user-invocable: false`), and using it as a
+> slash command collides with the skill router on Claude Code and Codex
+> CLI. `shadcn-ui` matches the package name and is unambiguous
+> everywhere.
+
+| Agent                    | File in this repo                                   | Copy to (in your project)              | Invoke as        |
+| ------------------------ | --------------------------------------------------- | -------------------------------------- | ---------------- |
+| Claude Code              | `claude/.claude/commands/shadcn-ui.md`              | `.claude/commands/shadcn-ui.md`        | `/shadcn-ui`     |
+| Cursor                   | `cursor/.cursor/commands/shadcn-ui.md`              | `.cursor/commands/shadcn-ui.md`        | `/shadcn-ui`     |
+| Windsurf                 | `windsurf/.windsurf/workflows/shadcn-ui.md`         | `.windsurf/workflows/shadcn-ui.md`     | `/shadcn-ui`     |
+| Cline                    | `cline/.clinerules/workflows/shadcn-ui.md`          | `.clinerules/workflows/shadcn-ui.md`   | `/shadcn-ui.md`  |
+| Continue.dev             | `continue/.continue/prompts/shadcn-ui.prompt`       | `.continue/prompts/shadcn-ui.prompt`   | `/shadcn-ui`     |
+| GitHub Copilot (VS Code) | `copilot/.github/prompts/shadcn-ui.prompt.md`       | `.github/prompts/shadcn-ui.prompt.md`  | `/shadcn-ui`     |
+| Gemini CLI               | `gemini/.gemini/commands/shadcn-ui.toml`            | `.gemini/commands/shadcn-ui.toml`      | `/shadcn-ui`     |
+| OpenCode                 | `opencode/.opencode/command/shadcn-ui.md`           | `.opencode/command/shadcn-ui.md`       | `/shadcn-ui`     |
+
+## Special cases
+
+Not every agent supports project-local slash commands. These three are
+best-effort equivalents:
+
+- **Codex CLI** — Custom prompts are user-scoped only. Copy
+  `codex/prompts/shadcn-ui.md` to `~/.codex/prompts/shadcn-ui.md`
+  (globally available across all your Codex sessions). Invoke as
+  `/shadcn-ui`.
+- **Aider** — No slash-command extension surface. Copy
+  `aider/CONVENTIONS.md` into your project root and load it per session
+  with `aider --read CONVENTIONS.md` (or add `read: CONVENTIONS.md` to
+  `.aider.conf.yml`).
+- **Zed** — No project-local slash commands without a Rust/WASM
+  extension. Copy `zed/prompts/shadcn-ui.md` into Zed's Prompt Library
+  via the UI (`assistant: prompt library` action), then invoke with
+  `/prompt shadcn-ui`.
+
+## Why one file per agent
+
+Each agent has its own frontmatter shape (Claude uses
+`description`/`allowed-tools`, Windsurf uses `auto_execute_steps`,
+Copilot uses `mode`/`tools`, Gemini uses TOML, etc.). A single
+"one file fits all" wouldn't parse correctly for most of them.
+
+All the bodies are near-identical — they delegate to
+`skills/shadcn/SKILL.md` and the `rules/` files rather than duplicating
+content, so updates to the skill flow through automatically.
+
+## Related
+
+- The OpenAI-hosted skill interface config lives at `openai.yml` in this
+  directory.
+- The shadcn MCP server has its own installation flow — see
+  `../mcp.md` and the `shadcn mcp init --client <agent>` command in the
+  main shadcn CLI.

--- a/skills/shadcn/agents/aider/CONVENTIONS.md
+++ b/skills/shadcn/agents/aider/CONVENTIONS.md
@@ -1,0 +1,75 @@
+# shadcn/ui project conventions (for Aider)
+
+Aider does not support user-defined slash commands, so this file is the
+Aider-equivalent entry point for the shadcn/ui skill. Load it per
+session with:
+
+    aider --read CONVENTIONS.md
+
+or add it to `.aider.conf.yml`:
+
+    read: CONVENTIONS.md
+
+---
+
+You are working in a shadcn/ui project. Follow the shadcn/ui skill context
+and enforce its patterns for the rest of the session.
+
+## 1. The full skill
+
+If these files exist in the current project, treat them as authoritative:
+
+- `skills/shadcn/SKILL.md` — master skill definition
+- `skills/shadcn/rules/styling.md` — Tailwind rules
+- `skills/shadcn/rules/forms.md` — form composition
+- `skills/shadcn/rules/composition.md` — component structure
+- `skills/shadcn/rules/icons.md` — icon usage
+- `skills/shadcn/rules/base-vs-radix.md` — Base UI vs Radix API differences
+- `skills/shadcn/rules/chat.md` — chat primitives
+- `skills/shadcn/cli.md` — full CLI reference
+- `skills/shadcn/mcp.md` — MCP tools reference
+
+Add them to the Aider chat with `/read skills/shadcn/SKILL.md` (and the
+other files as needed).
+
+If the skill files are not present, install the skill:
+
+    npx skills add shadcn/ui
+
+or see https://ui.shadcn.com/docs/skills.
+
+## 2. Detect the project
+
+If `components.json` is missing at the project root, run `npx shadcn@latest init` before continuing. Get current project context with:
+
+    npx shadcn@latest info --json
+
+## 3. Composition rules — always enforced
+
+- Semantic colors only (`bg-primary`, `text-muted-foreground`) — never raw values like `bg-blue-500`.
+- Use `flex` + `gap-*` for layout — never `space-x-*` / `space-y-*`.
+- Forms use `FieldGroup` + `Field` — never raw `div` with `space-y-*` or `grid gap-*`.
+- Icons in `Button` use `data-icon`; no sizing classes on icons inside components.
+- `Dialog`, `Sheet`, `Drawer` always need a `Title` (use `className="sr-only"` if visually hidden).
+- Use full `Card` composition (`CardHeader` / `CardTitle` / `CardDescription` / `CardContent` / `CardFooter`).
+- Use `asChild` (Radix) or `render` (Base UI) for custom triggers — check the `base` field from `shadcn info`.
+- For chat UI use `MessageScroller`, `Message`, `Bubble` — not hand-rolled markup.
+
+Full Correct/Incorrect examples live in `skills/shadcn/rules/`.
+
+## 4. Prefer the CLI over hand-rolled work
+
+Substitute the runner that matches the project's `packageManager`:
+
+- `npx shadcn@latest search <query>` — search registries before writing custom UI
+- `npx shadcn@latest view <item>` — inspect a component before adding
+- `npx shadcn@latest add <item>` — add a component
+- `npx shadcn@latest docs <component>` — component docs URL
+
+If the shadcn MCP server is configured, prefer these tools:
+
+- `shadcn:get_project_registries`
+- `shadcn:search_items_in_registries`
+- `shadcn:view_items_in_registries`
+- `shadcn:get_add_command_for_items`
+- `shadcn:get_audit_checklist`

--- a/skills/shadcn/agents/claude/.claude/commands/shadcn-ui.md
+++ b/skills/shadcn/agents/claude/.claude/commands/shadcn-ui.md
@@ -1,0 +1,65 @@
+---
+description: Load the shadcn/ui skill — composition rules, CLI, and MCP tools — and follow them for the rest of the session.
+argument-hint: "[optional: what you want to build]"
+allowed-tools: Bash(npx shadcn@latest *), Bash(pnpm dlx shadcn@latest *), Bash(bunx --bun shadcn@latest *)
+---
+
+You are working in a shadcn/ui project. Load the shadcn/ui skill context and enforce its patterns for the rest of the session.
+
+## 1. Load the skill
+
+Read these files if they exist in the current project:
+
+- `skills/shadcn/SKILL.md` — master skill definition
+- `skills/shadcn/rules/styling.md` — Tailwind rules
+- `skills/shadcn/rules/forms.md` — form composition
+- `skills/shadcn/rules/composition.md` — component structure
+- `skills/shadcn/rules/icons.md` — icon usage
+- `skills/shadcn/rules/base-vs-radix.md` — Base UI vs Radix API differences
+- `skills/shadcn/rules/chat.md` — chat primitives
+- `skills/shadcn/cli.md` — full CLI reference
+- `skills/shadcn/mcp.md` — MCP tools reference
+
+If the skill files are not present, tell the user to install the skill:
+
+    npx skills add shadcn/ui
+
+or see https://ui.shadcn.com/docs/skills.
+
+## 2. Detect the project
+
+If `components.json` is missing at the project root, run `npx shadcn@latest init` before continuing. Get current project context with:
+
+    npx shadcn@latest info --json
+
+## 3. Enforce the composition rules
+
+- Semantic colors only (`bg-primary`, `text-muted-foreground`) — never raw values like `bg-blue-500`.
+- Use `flex` + `gap-*` for layout — never `space-x-*` / `space-y-*`.
+- Forms use `FieldGroup` + `Field` — never raw `div` with `space-y-*` or `grid gap-*`.
+- Icons in `Button` use `data-icon`; no sizing classes on icons inside components.
+- `Dialog`, `Sheet`, `Drawer` always need a `Title` (use `className="sr-only"` if visually hidden).
+- Use full `Card` composition (`CardHeader` / `CardTitle` / `CardDescription` / `CardContent` / `CardFooter`).
+- Use `asChild` (Radix) or `render` (Base UI) for custom triggers — check the `base` field from `shadcn info`.
+- For chat UI use `MessageScroller`, `Message`, `Bubble` — not hand-rolled markup.
+
+Full Correct/Incorrect examples live in `skills/shadcn/rules/`.
+
+## 4. Prefer the CLI or MCP over hand-rolled work
+
+**CLI** (substitute the runner that matches the project's `packageManager`):
+
+- `npx shadcn@latest search <query>` — search registries before writing custom UI
+- `npx shadcn@latest view <item>` — inspect a component before adding
+- `npx shadcn@latest add <item>` — add a component
+- `npx shadcn@latest docs <component>` — component docs URL
+
+**MCP tools** (if the shadcn MCP server is configured):
+
+- `shadcn:get_project_registries`
+- `shadcn:search_items_in_registries`
+- `shadcn:view_items_in_registries`
+- `shadcn:get_add_command_for_items`
+- `shadcn:get_audit_checklist`
+
+If arguments were provided ($ARGUMENTS), proceed with that task using the rules above. Otherwise ask the user what they want to build.

--- a/skills/shadcn/agents/cline/.clinerules/workflows/shadcn-ui.md
+++ b/skills/shadcn/agents/cline/.clinerules/workflows/shadcn-ui.md
@@ -1,0 +1,57 @@
+You are working in a shadcn/ui project. Load the shadcn/ui skill context and enforce its patterns for the rest of the session.
+
+## 1. Load the skill
+
+Read these files if they exist in the current project:
+
+- `skills/shadcn/SKILL.md` — master skill definition
+- `skills/shadcn/rules/styling.md` — Tailwind rules
+- `skills/shadcn/rules/forms.md` — form composition
+- `skills/shadcn/rules/composition.md` — component structure
+- `skills/shadcn/rules/icons.md` — icon usage
+- `skills/shadcn/rules/base-vs-radix.md` — Base UI vs Radix API differences
+- `skills/shadcn/rules/chat.md` — chat primitives
+- `skills/shadcn/cli.md` — full CLI reference
+- `skills/shadcn/mcp.md` — MCP tools reference
+
+If the skill files are not present, tell the user to install the skill:
+
+    npx skills add shadcn/ui
+
+or see https://ui.shadcn.com/docs/skills.
+
+## 2. Detect the project
+
+If `components.json` is missing at the project root, run `npx shadcn@latest init` before continuing. Get current project context with:
+
+    npx shadcn@latest info --json
+
+## 3. Enforce the composition rules
+
+- Semantic colors only (`bg-primary`, `text-muted-foreground`) — never raw values like `bg-blue-500`.
+- Use `flex` + `gap-*` for layout — never `space-x-*` / `space-y-*`.
+- Forms use `FieldGroup` + `Field` — never raw `div` with `space-y-*` or `grid gap-*`.
+- Icons in `Button` use `data-icon`; no sizing classes on icons inside components.
+- `Dialog`, `Sheet`, `Drawer` always need a `Title` (use `className="sr-only"` if visually hidden).
+- Use full `Card` composition (`CardHeader` / `CardTitle` / `CardDescription` / `CardContent` / `CardFooter`).
+- Use `asChild` (Radix) or `render` (Base UI) for custom triggers — check the `base` field from `shadcn info`.
+- For chat UI use `MessageScroller`, `Message`, `Bubble` — not hand-rolled markup.
+
+Full Correct/Incorrect examples live in `skills/shadcn/rules/`.
+
+## 4. Prefer the CLI or MCP over hand-rolled work
+
+**CLI** (substitute the runner that matches the project's `packageManager`):
+
+- `npx shadcn@latest search <query>` — search registries before writing custom UI
+- `npx shadcn@latest view <item>` — inspect a component before adding
+- `npx shadcn@latest add <item>` — add a component
+- `npx shadcn@latest docs <component>` — component docs URL
+
+**MCP tools** (if the shadcn MCP server is configured):
+
+- `shadcn:get_project_registries`
+- `shadcn:search_items_in_registries`
+- `shadcn:view_items_in_registries`
+- `shadcn:get_add_command_for_items`
+- `shadcn:get_audit_checklist`

--- a/skills/shadcn/agents/codex/prompts/shadcn-ui.md
+++ b/skills/shadcn/agents/codex/prompts/shadcn-ui.md
@@ -1,0 +1,64 @@
+---
+description: Load the shadcn/ui skill — composition rules, CLI, and MCP tools — and follow them for the rest of the session.
+argument-hint: "[optional: what you want to build]"
+---
+
+You are working in a shadcn/ui project. Load the shadcn/ui skill context and enforce its patterns for the rest of the session.
+
+## 1. Load the skill
+
+Read these files if they exist in the current project:
+
+- `skills/shadcn/SKILL.md` — master skill definition
+- `skills/shadcn/rules/styling.md` — Tailwind rules
+- `skills/shadcn/rules/forms.md` — form composition
+- `skills/shadcn/rules/composition.md` — component structure
+- `skills/shadcn/rules/icons.md` — icon usage
+- `skills/shadcn/rules/base-vs-radix.md` — Base UI vs Radix API differences
+- `skills/shadcn/rules/chat.md` — chat primitives
+- `skills/shadcn/cli.md` — full CLI reference
+- `skills/shadcn/mcp.md` — MCP tools reference
+
+If the skill files are not present, tell the user to install the skill:
+
+    npx skills add shadcn/ui
+
+or see https://ui.shadcn.com/docs/skills.
+
+## 2. Detect the project
+
+If `components.json` is missing at the project root, run `npx shadcn@latest init` before continuing. Get current project context with:
+
+    npx shadcn@latest info --json
+
+## 3. Enforce the composition rules
+
+- Semantic colors only (`bg-primary`, `text-muted-foreground`) — never raw values like `bg-blue-500`.
+- Use `flex` + `gap-*` for layout — never `space-x-*` / `space-y-*`.
+- Forms use `FieldGroup` + `Field` — never raw `div` with `space-y-*` or `grid gap-*`.
+- Icons in `Button` use `data-icon`; no sizing classes on icons inside components.
+- `Dialog`, `Sheet`, `Drawer` always need a `Title` (use `className="sr-only"` if visually hidden).
+- Use full `Card` composition (`CardHeader` / `CardTitle` / `CardDescription` / `CardContent` / `CardFooter`).
+- Use `asChild` (Radix) or `render` (Base UI) for custom triggers — check the `base` field from `shadcn info`.
+- For chat UI use `MessageScroller`, `Message`, `Bubble` — not hand-rolled markup.
+
+Full Correct/Incorrect examples live in `skills/shadcn/rules/`.
+
+## 4. Prefer the CLI or MCP over hand-rolled work
+
+**CLI** (substitute the runner that matches the project's `packageManager`):
+
+- `npx shadcn@latest search <query>` — search registries before writing custom UI
+- `npx shadcn@latest view <item>` — inspect a component before adding
+- `npx shadcn@latest add <item>` — add a component
+- `npx shadcn@latest docs <component>` — component docs URL
+
+**MCP tools** (if the shadcn MCP server is configured):
+
+- `shadcn:get_project_registries`
+- `shadcn:search_items_in_registries`
+- `shadcn:view_items_in_registries`
+- `shadcn:get_add_command_for_items`
+- `shadcn:get_audit_checklist`
+
+If arguments were provided, proceed with that task using the rules above. Otherwise ask the user what they want to build.

--- a/skills/shadcn/agents/continue/.continue/prompts/shadcn-ui.prompt
+++ b/skills/shadcn/agents/continue/.continue/prompts/shadcn-ui.prompt
@@ -1,0 +1,62 @@
+---
+name: shadcn
+description: Load the shadcn/ui skill — composition rules, CLI, and MCP tools — and follow them for the rest of the session.
+---
+
+You are working in a shadcn/ui project. Load the shadcn/ui skill context and enforce its patterns for the rest of the session.
+
+## 1. Load the skill
+
+Read these files if they exist in the current project:
+
+- `skills/shadcn/SKILL.md` — master skill definition
+- `skills/shadcn/rules/styling.md` — Tailwind rules
+- `skills/shadcn/rules/forms.md` — form composition
+- `skills/shadcn/rules/composition.md` — component structure
+- `skills/shadcn/rules/icons.md` — icon usage
+- `skills/shadcn/rules/base-vs-radix.md` — Base UI vs Radix API differences
+- `skills/shadcn/rules/chat.md` — chat primitives
+- `skills/shadcn/cli.md` — full CLI reference
+- `skills/shadcn/mcp.md` — MCP tools reference
+
+If the skill files are not present, tell the user to install the skill:
+
+    npx skills add shadcn/ui
+
+or see https://ui.shadcn.com/docs/skills.
+
+## 2. Detect the project
+
+If `components.json` is missing at the project root, run `npx shadcn@latest init` before continuing. Get current project context with:
+
+    npx shadcn@latest info --json
+
+## 3. Enforce the composition rules
+
+- Semantic colors only (`bg-primary`, `text-muted-foreground`) — never raw values like `bg-blue-500`.
+- Use `flex` + `gap-*` for layout — never `space-x-*` / `space-y-*`.
+- Forms use `FieldGroup` + `Field` — never raw `div` with `space-y-*` or `grid gap-*`.
+- Icons in `Button` use `data-icon`; no sizing classes on icons inside components.
+- `Dialog`, `Sheet`, `Drawer` always need a `Title` (use `className="sr-only"` if visually hidden).
+- Use full `Card` composition (`CardHeader` / `CardTitle` / `CardDescription` / `CardContent` / `CardFooter`).
+- Use `asChild` (Radix) or `render` (Base UI) for custom triggers — check the `base` field from `shadcn info`.
+- For chat UI use `MessageScroller`, `Message`, `Bubble` — not hand-rolled markup.
+
+Full Correct/Incorrect examples live in `skills/shadcn/rules/`.
+
+## 4. Prefer the CLI or MCP over hand-rolled work
+
+**CLI** (substitute the runner that matches the project's `packageManager`):
+
+- `npx shadcn@latest search <query>` — search registries before writing custom UI
+- `npx shadcn@latest view <item>` — inspect a component before adding
+- `npx shadcn@latest add <item>` — add a component
+- `npx shadcn@latest docs <component>` — component docs URL
+
+**MCP tools** (if the shadcn MCP server is configured):
+
+- `shadcn:get_project_registries`
+- `shadcn:search_items_in_registries`
+- `shadcn:view_items_in_registries`
+- `shadcn:get_add_command_for_items`
+- `shadcn:get_audit_checklist`

--- a/skills/shadcn/agents/copilot/.github/prompts/shadcn-ui.prompt.md
+++ b/skills/shadcn/agents/copilot/.github/prompts/shadcn-ui.prompt.md
@@ -1,0 +1,63 @@
+---
+mode: agent
+description: Load the shadcn/ui skill — composition rules, CLI, and MCP tools — and follow them for the rest of the session.
+tools: ['codebase']
+---
+
+You are working in a shadcn/ui project. Load the shadcn/ui skill context and enforce its patterns for the rest of the session.
+
+## 1. Load the skill
+
+Read these files if they exist in the current project:
+
+- `skills/shadcn/SKILL.md` — master skill definition
+- `skills/shadcn/rules/styling.md` — Tailwind rules
+- `skills/shadcn/rules/forms.md` — form composition
+- `skills/shadcn/rules/composition.md` — component structure
+- `skills/shadcn/rules/icons.md` — icon usage
+- `skills/shadcn/rules/base-vs-radix.md` — Base UI vs Radix API differences
+- `skills/shadcn/rules/chat.md` — chat primitives
+- `skills/shadcn/cli.md` — full CLI reference
+- `skills/shadcn/mcp.md` — MCP tools reference
+
+If the skill files are not present, tell the user to install the skill:
+
+    npx skills add shadcn/ui
+
+or see https://ui.shadcn.com/docs/skills.
+
+## 2. Detect the project
+
+If `components.json` is missing at the project root, run `npx shadcn@latest init` before continuing. Get current project context with:
+
+    npx shadcn@latest info --json
+
+## 3. Enforce the composition rules
+
+- Semantic colors only (`bg-primary`, `text-muted-foreground`) — never raw values like `bg-blue-500`.
+- Use `flex` + `gap-*` for layout — never `space-x-*` / `space-y-*`.
+- Forms use `FieldGroup` + `Field` — never raw `div` with `space-y-*` or `grid gap-*`.
+- Icons in `Button` use `data-icon`; no sizing classes on icons inside components.
+- `Dialog`, `Sheet`, `Drawer` always need a `Title` (use `className="sr-only"` if visually hidden).
+- Use full `Card` composition (`CardHeader` / `CardTitle` / `CardDescription` / `CardContent` / `CardFooter`).
+- Use `asChild` (Radix) or `render` (Base UI) for custom triggers — check the `base` field from `shadcn info`.
+- For chat UI use `MessageScroller`, `Message`, `Bubble` — not hand-rolled markup.
+
+Full Correct/Incorrect examples live in `skills/shadcn/rules/`.
+
+## 4. Prefer the CLI or MCP over hand-rolled work
+
+**CLI** (substitute the runner that matches the project's `packageManager`):
+
+- `npx shadcn@latest search <query>` — search registries before writing custom UI
+- `npx shadcn@latest view <item>` — inspect a component before adding
+- `npx shadcn@latest add <item>` — add a component
+- `npx shadcn@latest docs <component>` — component docs URL
+
+**MCP tools** (if the shadcn MCP server is configured):
+
+- `shadcn:get_project_registries`
+- `shadcn:search_items_in_registries`
+- `shadcn:view_items_in_registries`
+- `shadcn:get_add_command_for_items`
+- `shadcn:get_audit_checklist`

--- a/skills/shadcn/agents/cursor/.cursor/commands/shadcn-ui.md
+++ b/skills/shadcn/agents/cursor/.cursor/commands/shadcn-ui.md
@@ -1,0 +1,57 @@
+You are working in a shadcn/ui project. Load the shadcn/ui skill context and enforce its patterns for the rest of the session.
+
+## 1. Load the skill
+
+Read these files if they exist in the current project:
+
+- `skills/shadcn/SKILL.md` — master skill definition
+- `skills/shadcn/rules/styling.md` — Tailwind rules
+- `skills/shadcn/rules/forms.md` — form composition
+- `skills/shadcn/rules/composition.md` — component structure
+- `skills/shadcn/rules/icons.md` — icon usage
+- `skills/shadcn/rules/base-vs-radix.md` — Base UI vs Radix API differences
+- `skills/shadcn/rules/chat.md` — chat primitives
+- `skills/shadcn/cli.md` — full CLI reference
+- `skills/shadcn/mcp.md` — MCP tools reference
+
+If the skill files are not present, tell the user to install the skill:
+
+    npx skills add shadcn/ui
+
+or see https://ui.shadcn.com/docs/skills.
+
+## 2. Detect the project
+
+If `components.json` is missing at the project root, run `npx shadcn@latest init` before continuing. Get current project context with:
+
+    npx shadcn@latest info --json
+
+## 3. Enforce the composition rules
+
+- Semantic colors only (`bg-primary`, `text-muted-foreground`) — never raw values like `bg-blue-500`.
+- Use `flex` + `gap-*` for layout — never `space-x-*` / `space-y-*`.
+- Forms use `FieldGroup` + `Field` — never raw `div` with `space-y-*` or `grid gap-*`.
+- Icons in `Button` use `data-icon`; no sizing classes on icons inside components.
+- `Dialog`, `Sheet`, `Drawer` always need a `Title` (use `className="sr-only"` if visually hidden).
+- Use full `Card` composition (`CardHeader` / `CardTitle` / `CardDescription` / `CardContent` / `CardFooter`).
+- Use `asChild` (Radix) or `render` (Base UI) for custom triggers — check the `base` field from `shadcn info`.
+- For chat UI use `MessageScroller`, `Message`, `Bubble` — not hand-rolled markup.
+
+Full Correct/Incorrect examples live in `skills/shadcn/rules/`.
+
+## 4. Prefer the CLI or MCP over hand-rolled work
+
+**CLI** (substitute the runner that matches the project's `packageManager`):
+
+- `npx shadcn@latest search <query>` — search registries before writing custom UI
+- `npx shadcn@latest view <item>` — inspect a component before adding
+- `npx shadcn@latest add <item>` — add a component
+- `npx shadcn@latest docs <component>` — component docs URL
+
+**MCP tools** (if the shadcn MCP server is configured):
+
+- `shadcn:get_project_registries`
+- `shadcn:search_items_in_registries`
+- `shadcn:view_items_in_registries`
+- `shadcn:get_add_command_for_items`
+- `shadcn:get_audit_checklist`

--- a/skills/shadcn/agents/gemini/.gemini/commands/shadcn-ui.toml
+++ b/skills/shadcn/agents/gemini/.gemini/commands/shadcn-ui.toml
@@ -1,0 +1,63 @@
+description = "Load the shadcn/ui skill — composition rules, CLI, and MCP tools — and follow them for the rest of the session."
+
+prompt = """
+You are working in a shadcn/ui project. Load the shadcn/ui skill context and enforce its patterns for the rest of the session.
+
+## 1. Load the skill
+
+Read these files if they exist in the current project:
+
+- `skills/shadcn/SKILL.md` — master skill definition
+- `skills/shadcn/rules/styling.md` — Tailwind rules
+- `skills/shadcn/rules/forms.md` — form composition
+- `skills/shadcn/rules/composition.md` — component structure
+- `skills/shadcn/rules/icons.md` — icon usage
+- `skills/shadcn/rules/base-vs-radix.md` — Base UI vs Radix API differences
+- `skills/shadcn/rules/chat.md` — chat primitives
+- `skills/shadcn/cli.md` — full CLI reference
+- `skills/shadcn/mcp.md` — MCP tools reference
+
+If the skill files are not present, tell the user to install the skill:
+
+    npx skills add shadcn/ui
+
+or see https://ui.shadcn.com/docs/skills.
+
+## 2. Detect the project
+
+If `components.json` is missing at the project root, run `npx shadcn@latest init` before continuing. Get current project context with:
+
+    npx shadcn@latest info --json
+
+## 3. Enforce the composition rules
+
+- Semantic colors only (`bg-primary`, `text-muted-foreground`) — never raw values like `bg-blue-500`.
+- Use `flex` + `gap-*` for layout — never `space-x-*` / `space-y-*`.
+- Forms use `FieldGroup` + `Field` — never raw `div` with `space-y-*` or `grid gap-*`.
+- Icons in `Button` use `data-icon`; no sizing classes on icons inside components.
+- `Dialog`, `Sheet`, `Drawer` always need a `Title` (use `className="sr-only"` if visually hidden).
+- Use full `Card` composition (`CardHeader` / `CardTitle` / `CardDescription` / `CardContent` / `CardFooter`).
+- Use `asChild` (Radix) or `render` (Base UI) for custom triggers — check the `base` field from `shadcn info`.
+- For chat UI use `MessageScroller`, `Message`, `Bubble` — not hand-rolled markup.
+
+Full Correct/Incorrect examples live in `skills/shadcn/rules/`.
+
+## 4. Prefer the CLI or MCP over hand-rolled work
+
+**CLI** (substitute the runner that matches the project's `packageManager`):
+
+- `npx shadcn@latest search <query>` — search registries before writing custom UI
+- `npx shadcn@latest view <item>` — inspect a component before adding
+- `npx shadcn@latest add <item>` — add a component
+- `npx shadcn@latest docs <component>` — component docs URL
+
+**MCP tools** (if the shadcn MCP server is configured):
+
+- `shadcn:get_project_registries`
+- `shadcn:search_items_in_registries`
+- `shadcn:view_items_in_registries`
+- `shadcn:get_add_command_for_items`
+- `shadcn:get_audit_checklist`
+
+If arguments were provided ({{args}}), proceed with that task using the rules above. Otherwise ask the user what they want to build.
+"""

--- a/skills/shadcn/agents/opencode/.opencode/command/shadcn-ui.md
+++ b/skills/shadcn/agents/opencode/.opencode/command/shadcn-ui.md
@@ -1,0 +1,63 @@
+---
+description: Load the shadcn/ui skill — composition rules, CLI, and MCP tools — and follow them for the rest of the session.
+---
+
+You are working in a shadcn/ui project. Load the shadcn/ui skill context and enforce its patterns for the rest of the session.
+
+## 1. Load the skill
+
+Read these files if they exist in the current project:
+
+- `skills/shadcn/SKILL.md` — master skill definition
+- `skills/shadcn/rules/styling.md` — Tailwind rules
+- `skills/shadcn/rules/forms.md` — form composition
+- `skills/shadcn/rules/composition.md` — component structure
+- `skills/shadcn/rules/icons.md` — icon usage
+- `skills/shadcn/rules/base-vs-radix.md` — Base UI vs Radix API differences
+- `skills/shadcn/rules/chat.md` — chat primitives
+- `skills/shadcn/cli.md` — full CLI reference
+- `skills/shadcn/mcp.md` — MCP tools reference
+
+If the skill files are not present, tell the user to install the skill:
+
+    npx skills add shadcn/ui
+
+or see https://ui.shadcn.com/docs/skills.
+
+## 2. Detect the project
+
+If `components.json` is missing at the project root, run `npx shadcn@latest init` before continuing. Get current project context with:
+
+    npx shadcn@latest info --json
+
+## 3. Enforce the composition rules
+
+- Semantic colors only (`bg-primary`, `text-muted-foreground`) — never raw values like `bg-blue-500`.
+- Use `flex` + `gap-*` for layout — never `space-x-*` / `space-y-*`.
+- Forms use `FieldGroup` + `Field` — never raw `div` with `space-y-*` or `grid gap-*`.
+- Icons in `Button` use `data-icon`; no sizing classes on icons inside components.
+- `Dialog`, `Sheet`, `Drawer` always need a `Title` (use `className="sr-only"` if visually hidden).
+- Use full `Card` composition (`CardHeader` / `CardTitle` / `CardDescription` / `CardContent` / `CardFooter`).
+- Use `asChild` (Radix) or `render` (Base UI) for custom triggers — check the `base` field from `shadcn info`.
+- For chat UI use `MessageScroller`, `Message`, `Bubble` — not hand-rolled markup.
+
+Full Correct/Incorrect examples live in `skills/shadcn/rules/`.
+
+## 4. Prefer the CLI or MCP over hand-rolled work
+
+**CLI** (substitute the runner that matches the project's `packageManager`):
+
+- `npx shadcn@latest search <query>` — search registries before writing custom UI
+- `npx shadcn@latest view <item>` — inspect a component before adding
+- `npx shadcn@latest add <item>` — add a component
+- `npx shadcn@latest docs <component>` — component docs URL
+
+**MCP tools** (if the shadcn MCP server is configured):
+
+- `shadcn:get_project_registries`
+- `shadcn:search_items_in_registries`
+- `shadcn:view_items_in_registries`
+- `shadcn:get_add_command_for_items`
+- `shadcn:get_audit_checklist`
+
+If arguments were provided ($ARGUMENTS), proceed with that task using the rules above. Otherwise ask the user what they want to build.

--- a/skills/shadcn/agents/windsurf/.windsurf/workflows/shadcn-ui.md
+++ b/skills/shadcn/agents/windsurf/.windsurf/workflows/shadcn-ui.md
@@ -1,0 +1,62 @@
+---
+description: Load the shadcn/ui skill — composition rules, CLI, and MCP tools — and follow them for the rest of the session.
+auto_execute_steps: false
+---
+
+You are working in a shadcn/ui project. Load the shadcn/ui skill context and enforce its patterns for the rest of the session.
+
+## 1. Load the skill
+
+Read these files if they exist in the current project:
+
+- `skills/shadcn/SKILL.md` — master skill definition
+- `skills/shadcn/rules/styling.md` — Tailwind rules
+- `skills/shadcn/rules/forms.md` — form composition
+- `skills/shadcn/rules/composition.md` — component structure
+- `skills/shadcn/rules/icons.md` — icon usage
+- `skills/shadcn/rules/base-vs-radix.md` — Base UI vs Radix API differences
+- `skills/shadcn/rules/chat.md` — chat primitives
+- `skills/shadcn/cli.md` — full CLI reference
+- `skills/shadcn/mcp.md` — MCP tools reference
+
+If the skill files are not present, tell the user to install the skill:
+
+    npx skills add shadcn/ui
+
+or see https://ui.shadcn.com/docs/skills.
+
+## 2. Detect the project
+
+If `components.json` is missing at the project root, run `npx shadcn@latest init` before continuing. Get current project context with:
+
+    npx shadcn@latest info --json
+
+## 3. Enforce the composition rules
+
+- Semantic colors only (`bg-primary`, `text-muted-foreground`) — never raw values like `bg-blue-500`.
+- Use `flex` + `gap-*` for layout — never `space-x-*` / `space-y-*`.
+- Forms use `FieldGroup` + `Field` — never raw `div` with `space-y-*` or `grid gap-*`.
+- Icons in `Button` use `data-icon`; no sizing classes on icons inside components.
+- `Dialog`, `Sheet`, `Drawer` always need a `Title` (use `className="sr-only"` if visually hidden).
+- Use full `Card` composition (`CardHeader` / `CardTitle` / `CardDescription` / `CardContent` / `CardFooter`).
+- Use `asChild` (Radix) or `render` (Base UI) for custom triggers — check the `base` field from `shadcn info`.
+- For chat UI use `MessageScroller`, `Message`, `Bubble` — not hand-rolled markup.
+
+Full Correct/Incorrect examples live in `skills/shadcn/rules/`.
+
+## 4. Prefer the CLI or MCP over hand-rolled work
+
+**CLI** (substitute the runner that matches the project's `packageManager`):
+
+- `npx shadcn@latest search <query>` — search registries before writing custom UI
+- `npx shadcn@latest view <item>` — inspect a component before adding
+- `npx shadcn@latest add <item>` — add a component
+- `npx shadcn@latest docs <component>` — component docs URL
+
+**MCP tools** (if the shadcn MCP server is configured):
+
+- `shadcn:get_project_registries`
+- `shadcn:search_items_in_registries`
+- `shadcn:view_items_in_registries`
+- `shadcn:get_add_command_for_items`
+- `shadcn:get_audit_checklist`

--- a/skills/shadcn/agents/zed/prompts/shadcn-ui.md
+++ b/skills/shadcn/agents/zed/prompts/shadcn-ui.md
@@ -1,0 +1,67 @@
+# shadcn/ui skill (Zed Prompt Library)
+
+Zed does not support project-local slash commands without a Rust/WASM
+extension. Import this file into Zed's Prompt Library (Assistant panel →
+Prompt Library → New Prompt → paste this content), then invoke with:
+
+    /prompt shadcn
+
+---
+
+You are working in a shadcn/ui project. Load the shadcn/ui skill context and enforce its patterns for the rest of the session.
+
+## 1. Load the skill
+
+Read these files if they exist in the current project:
+
+- `skills/shadcn/SKILL.md` — master skill definition
+- `skills/shadcn/rules/styling.md` — Tailwind rules
+- `skills/shadcn/rules/forms.md` — form composition
+- `skills/shadcn/rules/composition.md` — component structure
+- `skills/shadcn/rules/icons.md` — icon usage
+- `skills/shadcn/rules/base-vs-radix.md` — Base UI vs Radix API differences
+- `skills/shadcn/rules/chat.md` — chat primitives
+- `skills/shadcn/cli.md` — full CLI reference
+- `skills/shadcn/mcp.md` — MCP tools reference
+
+If the skill files are not present, tell the user to install the skill:
+
+    npx skills add shadcn/ui
+
+or see https://ui.shadcn.com/docs/skills.
+
+## 2. Detect the project
+
+If `components.json` is missing at the project root, run `npx shadcn@latest init` before continuing. Get current project context with:
+
+    npx shadcn@latest info --json
+
+## 3. Enforce the composition rules
+
+- Semantic colors only (`bg-primary`, `text-muted-foreground`) — never raw values like `bg-blue-500`.
+- Use `flex` + `gap-*` for layout — never `space-x-*` / `space-y-*`.
+- Forms use `FieldGroup` + `Field` — never raw `div` with `space-y-*` or `grid gap-*`.
+- Icons in `Button` use `data-icon`; no sizing classes on icons inside components.
+- `Dialog`, `Sheet`, `Drawer` always need a `Title` (use `className="sr-only"` if visually hidden).
+- Use full `Card` composition (`CardHeader` / `CardTitle` / `CardDescription` / `CardContent` / `CardFooter`).
+- Use `asChild` (Radix) or `render` (Base UI) for custom triggers — check the `base` field from `shadcn info`.
+- For chat UI use `MessageScroller`, `Message`, `Bubble` — not hand-rolled markup.
+
+Full Correct/Incorrect examples live in `skills/shadcn/rules/`.
+
+## 4. Prefer the CLI or MCP over hand-rolled work
+
+**CLI** (substitute the runner that matches the project's `packageManager`):
+
+- `npx shadcn@latest search <query>` — search registries before writing custom UI
+- `npx shadcn@latest view <item>` — inspect a component before adding
+- `npx shadcn@latest add <item>` — add a component
+- `npx shadcn@latest docs <component>` — component docs URL
+
+**MCP tools** (if the shadcn MCP server is configured):
+
+- `shadcn:get_project_registries`
+- `shadcn:search_items_in_registries`
+- `shadcn:view_items_in_registries`
+- `shadcn:get_add_command_for_items`
+- `shadcn:get_audit_checklist`


### PR DESCRIPTION
## Summary

Adds per-agent entry-point files for the shadcn/ui skill under `skills/shadcn/agents/`, so users of every major coding agent can invoke `/shadcn-ui` to prime the model with the skill's composition rules, CLI reference, and MCP tools.

- **File-based slash commands** (drop-in): Claude Code, Cursor, Windsurf, Cline, Continue.dev, GitHub Copilot (VS Code), Gemini CLI, OpenCode.
- **Best-effort equivalents** (documented as such): Codex CLI (user-scoped `~/.codex/prompts/`), Aider (`CONVENTIONS.md` via `--read`), Zed (Prompt Library import via UI).

Each subdirectory under `skills/shadcn/agents/<agent>/` mirrors the exact path the file must land in a user's project (e.g. `skills/shadcn/agents/claude/.claude/commands/shadcn-ui.md` copies to `.claude/commands/shadcn-ui.md`), so installation is a single `cp -R`. A new `skills/shadcn/agents/README.md` documents the full install matrix.

## Why `shadcn-ui`, not `shadcn`?

The existing shadcn skill (`skills/shadcn/SKILL.md`) is deliberately marked `user-invocable: false`. If the slash command were named `shadcn`, Claude Code's skill router would intercept `/shadcn` first and reject the invocation for anyone who's already installed the skill. `shadcn-ui` matches the package name and avoids the collision on every agent.

## Content strategy

Command bodies delegate to `skills/shadcn/SKILL.md`, `skills/shadcn/rules/*.md`, `skills/shadcn/cli.md`, and `skills/shadcn/mcp.md` rather than duplicating content. When the skill is updated, all 11 commands are updated implicitly — no per-agent maintenance burden.

## Test plan

- [x] All 12 new files present at expected paths
- [x] Gemini TOML parses (`python3 -c 'import tomllib; ...'`)
- [x] YAML frontmatter present and structurally valid on the six files that require it
- [x] Existing skill files (`SKILL.md`, `openai.yml`, `rules/`, `cli.md`, `mcp.md`) are unchanged (verified via \`git diff\`)
- [x] Verified \`/shadcn-ui\` end-to-end in Claude Code — both project-local (`.claude/commands/shadcn-ui.md`) and global (`~/.claude/commands/shadcn-ui.md`)
- [ ] Cursor / Copilot / Windsurf / other agents — not smoke-tested by author; formats follow each vendor's current docs. Reviewers on those agents welcome to try.

## Non-goals in this PR

- No CLI change. A future `shadcn commands init --client <agent>` (mirroring `shadcn mcp init`) that writes the files into a user's project is a natural next step, explicitly out of scope here.
- No changes to registry schema, MCP config, existing skill files, or the `openai.yml` interface file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)