### PR TITLE
fix(registry): include titles in SDK search results

### DIFF
--- a/.changeset/tidy-registry-titles.md
+++ b/.changeset/tidy-registry-titles.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Include registry item titles in `searchRegistries` results and fuzzy matching.

--- a/apps/v4/content/docs/registry/api-reference.mdx
+++ b/apps/v4/content/docs/registry/api-reference.mdx
@@ -243,6 +243,7 @@ Returns matching items wrapped in pagination metadata:
   "items": [
     {
       "name": "button",
+      "title": "Button",
       "type": "registry:ui",
       "description": "A button component.",
       "registry": "@shadcn",

--- a/packages/shadcn/src/registry/schema.ts
+++ b/packages/shadcn/src/registry/schema.ts
@@ -293,6 +293,7 @@ export const registryResolvedItemsTreeSchema = registryItemCommonSchema
 
 export const searchResultItemSchema = z.object({
   name: z.string(),
+  title: z.string().optional(),
   type: z.string().optional(),
   description: z.string().optional(),
   registry: z.string(),

--- a/packages/shadcn/src/registry/search.test.ts
+++ b/packages/shadcn/src/registry/search.test.ts
@@ -31,6 +31,7 @@ describe("searchRegistries", () => {
           items: [
             {
               name: "button",
+              title: "Button",
               type: "registry:ui",
               description: "A button component",
             },
@@ -64,6 +65,7 @@ describe("searchRegistries", () => {
       items: [
         {
           name: "button",
+          title: "Button",
           type: "registry:ui",
           description: "A button component",
           registry: "@shadcn",
@@ -91,6 +93,47 @@ describe("searchRegistries", () => {
         hasMore: false,
       },
     })
+
+    mockGetRegistry.mockRestore()
+  })
+
+  it("includes titles in the SDK output and searches them", async () => {
+    vi.mock("./api", () => ({
+      getRegistry: vi.fn(),
+    }))
+
+    const mockGetRegistry = vi.mocked(getRegistry)
+
+    mockGetRegistry.mockResolvedValue({
+      name: "test/registry",
+      homepage: "https://test.com",
+      items: [
+        {
+          name: "account-menu",
+          title: "User Settings",
+          type: "registry:ui",
+          description: "An account menu",
+        },
+        {
+          name: "button",
+          type: "registry:ui",
+          description: "A button component",
+        },
+      ],
+    })
+
+    const results = await searchRegistries(["@test"], { query: "settings" })
+
+    expect(results.items).toEqual([
+      {
+        name: "account-menu",
+        title: "User Settings",
+        type: "registry:ui",
+        description: "An account menu",
+        registry: "@test",
+        addCommandArgument: "@test/account-menu",
+      },
+    ])
 
     mockGetRegistry.mockRestore()
   })

--- a/packages/shadcn/src/registry/search.ts
+++ b/packages/shadcn/src/registry/search.ts
@@ -160,6 +160,7 @@ async function searchRegistriesWithContext(
 
     const itemsWithRegistry = (outcome.value.items || []).map((item) => ({
       name: item.name,
+      title: item.title,
       type: item.type,
       description: item.description,
       registry,
@@ -207,7 +208,7 @@ async function searchRegistriesWithContext(
     localItems = searchItems(localItems, {
       query,
       limit: localItems.length,
-      keys: ["name", "description"],
+      keys: ["name", "title", "description"],
     }) as z.infer<typeof searchResultItemSchema>[]
   }
 
@@ -259,6 +260,7 @@ async function searchRegistriesWithContext(
 const searchableItemSchema = z
   .object({
     name: z.string(),
+    title: z.string().optional(),
     type: z.string().optional(),
     description: z.string().optional(),
     registry: z.string().optional(),
@@ -271,6 +273,7 @@ type SearchableItem = z.infer<typeof searchableItemSchema>
 function searchItems<
   T extends {
     name: string
+    title?: string
     type?: string
     description?: string
     addCommandArgument?: string


### PR DESCRIPTION
## Summary

- include each registry entry's optional `title` in `searchRegistries` results
- search titles alongside names and descriptions during fuzzy matching
- document the field and add regression coverage

## Testing

- `pnpm --filter shadcn exec vitest run src/registry/search.test.ts`
- `pnpm --filter shadcn typecheck`
- Prettier check for changed files