### PR TITLE
fix(v4): type Base UI Input from InputPrimitive.Props

### DIFF
--- a/apps/v4/registry/bases/base/ui/input-group.tsx
+++ b/apps/v4/registry/bases/base/ui/input-group.tsx
@@ -116,7 +116,7 @@ function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
 function InputGroupInput({
   className,
   ...props
-}: React.ComponentProps<"input">) {
+}: React.ComponentProps<typeof Input>) {
   return (
     <Input
       data-slot="input-group-control"

--- a/apps/v4/registry/bases/base/ui/input.tsx
+++ b/apps/v4/registry/bases/base/ui/input.tsx
@@ -1,9 +1,8 @@
-import * as React from "react"
 import { Input as InputPrimitive } from "@base-ui/react/input"
 
 import { cn } from "@/registry/bases/base/lib/utils"
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+function Input({ className, type, ...props }: InputPrimitive.Props) {
   return (
     <InputPrimitive
       type={type}


### PR DESCRIPTION
## Summary
- Base UI `Input` declared `React.ComponentProps<"input">` while rendering `InputPrimitive`, so the wrapper accepted props it could not forward (breaks Preact compat `tsc`, drops `render` / state-function `className`/`style` / `onValueChange`).
- Types `Input` as `InputPrimitive.Props` (same pattern as `Button` / `Separator`).
- Updates `InputGroupInput` to `React.ComponentProps<typeof Input>` so the mismatch does not move one file up.
- Radix/aria unchanged: Radix uses a DOM `<input>`; aria already types from its primitive.

Closes #11303

## Test plan
- [x] Audited `bases/base/ui` for Base UI wrappers using `ComponentProps<"tag">` while rendering a primitive — only `Input` (+ `InputGroupInput` propagation)
- [x] Focused `tsc` confirms `ComponentProps<typeof Input>` ↔ `InputPrimitive.Props` assignable both ways
- [ ] `npx shadcn@latest add input` in a Preact-compat project → `tsc --noEmit` no longer fails on the Input spread
- [ ] `InputGroup` still accepts normal input props; Base UI-only props (e.g. `onValueChange`) type-check on `Input`