### PR TITLE
docs(dark-mode): pass scriptProps suppressHydrationWarning to next-themes provider for React 19 / Next.js 15+

### DIFF
--- a/apps/v4/content/docs/dark-mode/next.mdx
+++ b/apps/v4/content/docs/dark-mode/next.mdx
@@ -25,7 +25,14 @@ export function ThemeProvider({
   children,
   ...props
 }: React.ComponentProps<typeof NextThemesProvider>) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+  return (
+    <NextThemesProvider
+      {...props}
+      scriptProps={{ suppressHydrationWarning: true }}
+    >
+      {children}
+    </NextThemesProvider>
+  );
 }
 ```
 

--- a/apps/v4/content/docs/dark-mode/next.mdx
+++ b/apps/v4/content/docs/dark-mode/next.mdx
@@ -25,14 +25,7 @@ export function ThemeProvider({
   children,
   ...props
 }: React.ComponentProps<typeof NextThemesProvider>) {
-  return (
-    <NextThemesProvider
-      {...props}
-      scriptProps={{ suppressHydrationWarning: true }}
-    >
-      {children}
-    </NextThemesProvider>
-  );
+  return <NextThemesProvider {...props} scriptProps={{ suppressHydrationWarning: true }}>{children}</NextThemesProvider>
 }
 ```
 


### PR DESCRIPTION
### Description

With React 19 / Next.js 15+, React logs a runtime console error when client components render inline `<script>` tags without `suppressHydrationWarning` on the script tag itself:

> `Encountered a script tag while rendering React component. Scripts inside React components are never executed when rendering on the client...`

`next-themes` injects an inline `<script>` tag inside `ThemeProvider` to prevent theme flash (FOUC) before hydration. While `suppressHydrationWarning` on the `<html>` element handles attribute mismatches, React 19 raises this warning for the `<script>` tag rendered within the component tree.

Passing `scriptProps={{ suppressHydrationWarning: true }}` directly to `<NextThemesProvider>` ensures the internal `<script>` tag generated by `next-themes` includes `suppressHydrationWarning`, resolving the console error cleanly in React 19 / Next.js 15+.

### Proposed Changes

Updated the `ThemeProvider` code snippet in `docs/dark-mode/next.mdx`:

```tsx title="components/theme-provider.tsx" showLineNumbers
"use client"

import * as React from "react"
import { ThemeProvider as NextThemesProvider } from "next-themes"

export function ThemeProvider({
  children,
  ...props
}: React.ComponentProps<typeof NextThemesProvider>) {
  return (
    <NextThemesProvider
      {...props}
      scriptProps={{ suppressHydrationWarning: true }}
    >
      {children}
    </NextThemesProvider>
  )
}
