### PR TITLE
feat(registry): add @ns-ui to the registry directory

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1002,6 +1002,13 @@
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36'><path fill='var(--foreground)' d='M13.5 6.745L0 20.25v9h9l13.5-13.505v-9zm9 9v13.5H36c0-7.456-6.044-13.5-13.5-13.5z'/></svg>"
   },
   {
+    "name": "@ns-ui",
+    "homepage": "https://design.helpmarq.com",
+    "url": "https://design.helpmarq.com/r/{name}.json",
+    "description": "228 animated React components for Tailwind v4 and React 19, with a CLI and an MCP server.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='8' fill='var(--background)'/><circle cx='16' cy='16' r='5' fill='none' stroke='var(--foreground)' stroke-width='2'/></svg>"
+  },
+  {
     "name": "@nteract",
     "homepage": "https://nteract-elements.vercel.app/",
     "url": "https://nteract-elements.vercel.app/r/{name}.json",

--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1005,7 +1005,7 @@
     "name": "@ns-ui",
     "homepage": "https://design.helpmarq.com",
     "url": "https://design.helpmarq.com/r/{name}.json",
-    "description": "228 animated React components for Tailwind v4 and React 19, with a CLI and an MCP server.",
+    "description": "389 animated React components for Tailwind v4 and React 19, with a CLI and an MCP server.",
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='8' fill='var(--background)'/><circle cx='16' cy='16' r='5' fill='none' stroke='var(--foreground)' stroke-width='2'/></svg>"
   },
   {


### PR DESCRIPTION
Adds `@ns-ui` to `apps/v4/registry/directory.json`.

**ns-ui** is a public, MIT-licensed registry of 228 React components for Tailwind v4 and React 19, installable with `npx shadcn add`.

- Homepage: https://design.helpmarq.com
- Registry: https://design.helpmarq.com/registry.json
- Item URL: `https://design.helpmarq.com/r/{name}.json` (live, returns a valid `registry-item.json`)
- Source: https://github.com/nikolas-sapa/ns-ui (public, MIT)

It also ships a CLI (`@nikolas.sapa/ns-ui`) and a first-party MCP server (`@nikolas.sapa/ns-ui-mcp`) for browsing the catalog from an agent.

Requirements checked against the docs:

- [x] Open source and publicly accessible
- [x] Valid `registry.json` conforming to `https://ui.shadcn.com/schema/registry.json`
- [x] Flat registry, no nested items
- [x] No `content` property in any `files` entry
- [x] `validate:registries` passes locally
