### PR TITLE
fix(shadcn): respect tailwind prefix in shimmer reduced-motion override

### DIFF
--- a/packages/shadcn/src/tailwind.css
+++ b/packages/shadcn/src/tailwind.css
@@ -583,6 +583,12 @@
   &:where([dir="rtl"], [dir="rtl"] *) {
     animation-direction: reverse;
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    background-image: none;
+    -webkit-text-fill-color: currentColor;
+  }
 }
 
 @utility shimmer-once {
@@ -618,12 +624,4 @@
 
 @utility shimmer-angle-* {
   --shimmer-angle: calc(--value(integer) * 1deg);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .shimmer {
-    animation: none;
-    background-image: none;
-    -webkit-text-fill-color: currentColor;
-  }
 }


### PR DESCRIPTION
## Summary

Fixes #11363.

`shimmer` is defined via `@utility shimmer { ... }`, which Tailwind compiles and correctly rewrites when a project configures `prefix()` (e.g. `prefix(tw)` → `.tw\:shimmer`). But the `prefers-reduced-motion` override that disables the animation was written as a separate, hand-authored selector:

```css
@media (prefers-reduced-motion: reduce) {
  .shimmer {
    animation: none;
    background-image: none;
    -webkit-text-fill-color: currentColor;
  }
}
```

Since this isn't compiled through `@utility`, it's never rewritten by the prefixer. With a prefix configured, the element renders as `.tw\:shimmer` but this rule still only matches `.shimmer`, so it never applies — `prefers-reduced-motion: reduce` silently stops disabling the shimmer animation.

## Fix

Move the reduced-motion rule inside the existing `@utility shimmer { ... }` block, following the same pattern already used there for `@variant dark { ... }`, so it's compiled by Tailwind and inherits the prefix automatically. No other copies of this rule exist elsewhere in the repo (`grep -r "prefers-reduced-motion: reduce"` only matches this one file).

## Test plan

I have not built/run this against the actual Tailwind v4 compiler with a `prefix()` config — I only verified the change by reading the `@utility`/`@variant` compilation model and by symmetry with the existing `@variant dark` block in the same utility. Maintainers, please verify:

- [ ] `pnpm --filter=shadcn build` / `pnpm registry:build` succeed
- [ ] Compiled output with a `prefix()` configured shows the reduced-motion rule scoped to the prefixed class (e.g. `.tw\:shimmer`) instead of the old unprefixed `.shimmer`
- [ ] `pnpm test` passes