### PR TITLE
feat(sonner): add icon examples to create preview

### DIFF
--- a/apps/v4/registry/bases/aria/examples/sonner-example.tsx
+++ b/apps/v4/registry/bases/aria/examples/sonner-example.tsx
@@ -13,6 +13,7 @@ export default function SonnerExample() {
     <ExampleWrapper>
       <SonnerBasic />
       <SonnerWithDescription />
+      <SonnerWithIcons />
     </ExampleWrapper>
   )
 }
@@ -45,6 +46,47 @@ function SonnerWithDescription() {
       >
         Show Toast
       </Button>
+    </Example>
+  )
+}
+
+function SonnerWithIcons() {
+  return (
+    <Example title="With Icons" className="items-center justify-center">
+      <div className="flex flex-wrap justify-center gap-2">
+        <Button
+          onPress={() => toast.success("Event has been created")}
+          variant="outline"
+          className="w-fit"
+        >
+          Success
+        </Button>
+        <Button
+          onPress={() =>
+            toast.info("Be at the area 10 minutes before the event time")
+          }
+          variant="outline"
+          className="w-fit"
+        >
+          Info
+        </Button>
+        <Button
+          onPress={() =>
+            toast.warning("Event start time cannot be earlier than 8am")
+          }
+          variant="outline"
+          className="w-fit"
+        >
+          Warning
+        </Button>
+        <Button
+          onPress={() => toast.error("Event has not been created")}
+          variant="outline"
+          className="w-fit"
+        >
+          Error
+        </Button>
+      </div>
     </Example>
   )
 }

--- a/apps/v4/registry/bases/base/examples/sonner-example.tsx
+++ b/apps/v4/registry/bases/base/examples/sonner-example.tsx
@@ -13,6 +13,7 @@ export default function SonnerExample() {
     <ExampleWrapper>
       <SonnerBasic />
       <SonnerWithDescription />
+      <SonnerWithIcons />
     </ExampleWrapper>
   )
 }
@@ -45,6 +46,47 @@ function SonnerWithDescription() {
       >
         Show Toast
       </Button>
+    </Example>
+  )
+}
+
+function SonnerWithIcons() {
+  return (
+    <Example title="With Icons" className="items-center justify-center">
+      <div className="flex flex-wrap justify-center gap-2">
+        <Button
+          onClick={() => toast.success("Event has been created")}
+          variant="outline"
+          className="w-fit"
+        >
+          Success
+        </Button>
+        <Button
+          onClick={() =>
+            toast.info("Be at the area 10 minutes before the event time")
+          }
+          variant="outline"
+          className="w-fit"
+        >
+          Info
+        </Button>
+        <Button
+          onClick={() =>
+            toast.warning("Event start time cannot be earlier than 8am")
+          }
+          variant="outline"
+          className="w-fit"
+        >
+          Warning
+        </Button>
+        <Button
+          onClick={() => toast.error("Event has not been created")}
+          variant="outline"
+          className="w-fit"
+        >
+          Error
+        </Button>
+      </div>
     </Example>
   )
 }

--- a/apps/v4/registry/bases/radix/examples/sonner-example.tsx
+++ b/apps/v4/registry/bases/radix/examples/sonner-example.tsx
@@ -13,6 +13,7 @@ export default function SonnerExample() {
     <ExampleWrapper>
       <SonnerBasic />
       <SonnerWithDescription />
+      <SonnerWithIcons />
     </ExampleWrapper>
   )
 }
@@ -45,6 +46,47 @@ function SonnerWithDescription() {
       >
         Show Toast
       </Button>
+    </Example>
+  )
+}
+
+function SonnerWithIcons() {
+  return (
+    <Example title="With Icons" className="items-center justify-center">
+      <div className="flex flex-wrap justify-center gap-2">
+        <Button
+          onClick={() => toast.success("Event has been created")}
+          variant="outline"
+          className="w-fit"
+        >
+          Success
+        </Button>
+        <Button
+          onClick={() =>
+            toast.info("Be at the area 10 minutes before the event time")
+          }
+          variant="outline"
+          className="w-fit"
+        >
+          Info
+        </Button>
+        <Button
+          onClick={() =>
+            toast.warning("Event start time cannot be earlier than 8am")
+          }
+          variant="outline"
+          className="w-fit"
+        >
+          Warning
+        </Button>
+        <Button
+          onClick={() => toast.error("Event has not been created")}
+          variant="outline"
+          className="w-fit"
+        >
+          Error
+        </Button>
+      </div>
     </Example>
   )
 }


### PR DESCRIPTION
## Summary

Adds a new **With Icons** section to the Sonner create preview examples across all supported bases (Base UI, Radix, and Aria).

This allows users to preview icon toasts (success, info, warning, error) for Vega and other styles directly from the Create page.

Closes #10652.

## Changes

- Added `SonnerWithIcons` example
- Added Success, Info, Warning and Error buttons
- Reused the same toast wording used in existing Sonner documentation
- Preserved existing Base/Radix (`onClick`) and Aria (`onPress`) conventions

## Testing

- ✅ pnpm install
- ✅ registry:build
- ✅ typecheck
- ✅ eslint
- ✅ Verified `/create?item=sonner-example`
- ✅ Verified Vega preview