### PR TITLE
fix(skill): keep skill loading when info exits 1 at monorepo root

### DIFF
--- a/skills/shadcn/SKILL.md
+++ b/skills/shadcn/SKILL.md
@@ -14,10 +14,10 @@ A framework for building ui, components and design systems. Components are added
 ## Current Project Context
 
 ```json
-!`npx shadcn@latest info --json`
+!`npx shadcn@latest info --json || true`
 ```
 
-The JSON above contains the project config and installed components. Use `npx shadcn@latest docs <component>` to get documentation and example URLs for any component.
+The JSON above contains the project config and installed components. If it contains `"error": "monorepo_root"`, re-run `npx shadcn@latest info --json -c <workspace>` with one of the listed `targets` and use that output as the project context. Use `npx shadcn@latest docs <component>` to get documentation and example URLs for any component.
 
 ## Principles
 


### PR DESCRIPTION
In a monorepo, the shadcn skill fails to load entirely. Line 17 of `skills/shadcn/SKILL.md` runs a shell probe at load time:

```
!`npx shadcn@latest info --json`
```

`info` at a monorepo root exits 1 by design and prints `{"error": "monorepo_root", ...}` asking for `-c`. Claude Code treats a non-zero exit from an inline command as fatal for the whole skill, so it returns an error and zero content. None of the rules or workflow make it into context. The bad part is that this is silent: to the agent, a skill that returns nothing looks like a skill with nothing to say, so it just builds UI without any of this file's rules. Every monorepo hits this on every session, including ones created by the CLI's own `init --monorepo` template.

The fix is two lines:

- `|| true` on the probe, so a failed `info` no longer kills the load. The error JSON gets injected instead, which turns out to be useful context since it lists the workspace `targets`.
- a sentence under the context block telling the agent to re-run `info --json -c <workspace>` with one of the listed targets when it sees `"error": "monorepo_root"`.

Single-package projects are unaffected. `info` succeeds there and `|| true` never fires.

I hit this on my own pnpm + turborepo monorepo (Windows 11, shadcn 4.16.1) and verified the patch there. Before: invoking the skill errors with zero content. After: the skill loads with the `monorepo_root` JSON injected, and `info --json -c apps/web` / `-c packages/ui` both return full project config, matching the sentence this PR adds. Repro steps with the `--monorepo` template are in #11271.

Worth naming the tradeoff: `|| true` also soft-fails other probe errors (npx offline, registry down). In those cases the agent gets a loaded skill with a visible error, which beats a silently absent skill.

Fixes #11271. Same root cause as #10283. Narrower alternative to #10287, which drops the auto-injection entirely; this keeps the instant injection for the common single-package case.
