### PR TITLE
fix(registry): add min-w-0 to SidebarInset to prevent horizontal overflow

### DIFF
--- a/apps/v4/registry/bases/aria/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/aria/ui/sidebar.tsx
@@ -318,7 +318,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "cn-sidebar-inset relative flex w-full flex-1 flex-col",
+        "cn-sidebar-inset relative flex w-full min-w-0 flex-1 flex-col",
         className
       )}
       {...props}

--- a/apps/v4/registry/bases/base/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/base/ui/sidebar.tsx
@@ -314,7 +314,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "cn-sidebar-inset relative flex w-full flex-1 flex-col",
+        "cn-sidebar-inset relative flex w-full min-w-0 flex-1 flex-col",
         className
       )}
       {...props}

--- a/apps/v4/registry/bases/radix/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/radix/ui/sidebar.tsx
@@ -313,7 +313,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "cn-sidebar-inset relative flex w-full flex-1 flex-col",
+        "cn-sidebar-inset relative flex w-full min-w-0 flex-1 flex-col",
         className
       )}
       {...props}

--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -309,7 +309,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "relative flex w-full flex-1 flex-col bg-background",
+        "relative flex w-full min-w-0 flex-1 flex-col bg-background",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className
       )}


### PR DESCRIPTION
## Fixes #11370

### Problem

`SidebarInset` renders with `relative flex w-full flex-1 flex-col` but is missing `min-w-0`. Because it is a **horizontal flex child** of `SidebarProvider` (which is `flex w-full` with no `flex-col`, i.e. `flex-direction: row`), it inherits the flexbox default of `min-width: auto`. This prevents the content column from shrinking below its content's intrinsic width, so any wide child (tables, `<pre>` blocks, long unbreakable strings) forces the entire page to overflow horizontally — by exactly the width of the sidebar.

The visible symptom reported in the issue is the page header's right-side controls sliding off-screen.

### Fix

Add `min-w-0` to the `SidebarInset` base classes. This lets the column shrink into its `flex-1` allotment. It is a **no-op for pages that do not overflow**, and it is consistent with the `min-w-0` already used on sibling sidebar wrappers (`SidebarHeader`, `SidebarContent`, menu wrappers) in the same file.

### Changes

Applied to all registry source files (the `styles/*` permutations are generated from these):

- `apps/v4/registry/bases/aria/ui/sidebar.tsx`
- `apps/v4/registry/bases/base/ui/sidebar.tsx`
- `apps/v4/registry/bases/radix/ui/sidebar.tsx`
- `apps/v4/registry/new-york-v4/ui/sidebar.tsx`

### Reproduction (from the issue)

| Configuration | Content column | Page scrollWidth | Viewport | Overflows? |
|---|---|---|---|---|
| With `min-w-0` | 1272px | 1496 | 1496 | No |
| Stock (no `min-w-0`) | 1496px | 1720 | 1496 | Yes, by 224px |

The 224px overflow matches the sidebar width exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)