### PR TITLE
fix(docs): add missing asChild to DrawerClose in radix drawer docs

### DIFF
--- a/apps/v4/content/docs/components/radix/drawer.mdx
+++ b/apps/v4/content/docs/components/radix/drawer.mdx
@@ -80,7 +80,7 @@ import {
     </DrawerHeader>
     <DrawerFooter>
       <Button>Submit</Button>
-      <DrawerClose>
+      <DrawerClose asChild>
         <Button variant="outline">Cancel</Button>
       </DrawerClose>
     </DrawerFooter>


### PR DESCRIPTION
Closes #6205

The radix drawer usage docs were missing the asChild prop on DrawerClose, which caused a nested buttons warning/error since DrawerClose renders a <button> by default and contained a <Button> component.

This change adds asChild to DrawerClose so the Button is rendered directly as the close trigger.