### PR TITLE
fix(dialog): bump DialogContent z-index above DialogOverlay to prevent overlay coverage (Fixes #11380)

### DIFF
--- a/apps/v4/registry/bases/base/ui/dialog.tsx
+++ b/apps/v4/registry/bases/base/ui/dialog.tsx
@@ -50,7 +50,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "cn-dialog-content fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+          "cn-dialog-content fixed top-1/2 left-1/2 z-[60] w-full -translate-x-1/2 -translate-y-1/2 outline-none",
           className
         )}
         {...props}

--- a/apps/v4/registry/bases/radix/ui/dialog.tsx
+++ b/apps/v4/registry/bases/radix/ui/dialog.tsx
@@ -58,7 +58,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "cn-dialog-content fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+          "cn-dialog-content fixed top-1/2 left-1/2 z-[60] w-full -translate-x-1/2 -translate-y-1/2 outline-none",
           className
         )}
         {...props}

--- a/apps/v4/registry/new-york-v4/ui/dialog.tsx
+++ b/apps/v4/registry/new-york-v4/ui/dialog.tsx
@@ -61,7 +61,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          "fixed top-[50%] left-[50%] z-[60] grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
           className
         )}
         {...props}


### PR DESCRIPTION
## Description

Fixes #11380

`DialogContent` and `DialogOverlay` both use `z-50`, which can cause the overlay to occasionally cover the dialog content during rendering or animation. This PR bumps the `DialogContent` z-index to `z-[60]` to ensure it's always stacked above the overlay.

### Changes

- `apps/v4/registry/bases/radix/ui/dialog.tsx`: DialogContent `z-50` → `z-[60]`
- `apps/v4/registry/bases/base/ui/dialog.tsx`: DialogContent `z-50` → `z-[60]`
- `apps/v4/registry/new-york-v4/ui/dialog.tsx`: DialogContent `z-50` → `z-[60]`

### Root cause

Both `DialogOverlay` and `DialogContent` share the same `z-50` Tailwind class. In a stacking context, elements with the same `z-index` are stacked by DOM order. While `DialogContent` is rendered after `DialogOverlay` in the portal, CSS properties such as `backdrop-filter`, `filter`, and animation transforms can create new stacking contexts that cause the overlay to appear on top of the content.

### Related

- Issue: #11380