### PR TITLE
fix(vite): use import.meta.dirname instead of __dirname in Vite config

### DIFF
--- a/apps/v4/content/docs/installation/vite.mdx
+++ b/apps/v4/content/docs/installation/vite.mdx
@@ -273,7 +273,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
 })

--- a/templates/vite-app/vite.config.ts
+++ b/templates/vite-app/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
 })

--- a/templates/vite-monorepo/apps/web/vite.config.ts
+++ b/templates/vite-monorepo/apps/web/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
 })


### PR DESCRIPTION
## Description

The Vite installation docs and the Vite scaffolding templates configure the `@`
alias with `path.resolve(__dirname, "./src")`. With recent Vite (v8), this emits
a warning because `__dirname` is unsupported by the upcoming default
`configLoader: 'native'`:

(!) Your Vite config uses features that are unsupported by configLoader: 'native',
which is planned to become the default in a future major version of Vite:
- __dirname (vite.config.ts:11:25). Use import.meta.dirname instead

`import.meta.dirname` is the ESM-native equivalent (Node 20.11+) and is what Vite
itself migrated to. Since Vite 8 already requires Node 20.19+, every project that
hits this warning supports the replacement — no compatibility regression.

Closes #11383

## Changes

- `templates/vite-app/vite.config.ts` — output of `shadcn init -t vite`
- `templates/vite-monorepo/apps/web/vite.config.ts` — monorepo template output
- `apps/v4/content/docs/installation/vite.mdx` — the documented snippet

All three now use `path.resolve(import.meta.dirname, "./src")`.

## Notes

- CommonJS usages elsewhere (`.cjs` / `.eslintrc.js` files, the Gatsby
  `gatsby-node.js` snippet in `gatsby.mdx`) are intentionally left unchanged —
  `__dirname` is correct in CommonJS.
- Internal test fixtures under `packages/tests` and `packages/shadcn/test` were
  left as-is to keep this change scoped to the reported issue.