### PR TITLE
fix(scroll-fade): remove broken @supports not fallback for Firefox

### DIFF
--- a/packages/shadcn/src/tailwind.css
+++ b/packages/shadcn/src/tailwind.css
@@ -189,10 +189,6 @@
     animation-fill-mode: both;
   }
 
-  @supports not (animation-timeline: scroll()) {
-    --scroll-fade-t: var(--_scroll-fade-size-t);
-    --scroll-fade-b: var(--_scroll-fade-size-b);
-  }
 }
 
 @utility scroll-fade-y {
@@ -229,10 +225,6 @@
     animation-fill-mode: both;
   }
 
-  @supports not (animation-timeline: scroll()) {
-    --scroll-fade-t: var(--_scroll-fade-size-t);
-    --scroll-fade-b: var(--_scroll-fade-size-b);
-  }
 }
 
 @utility scroll-fade-x {
@@ -278,10 +270,6 @@
     animation-fill-mode: both;
   }
 
-  @supports not (animation-timeline: scroll()) {
-    --scroll-fade-s: var(--_scroll-fade-size-s);
-    --scroll-fade-e: var(--_scroll-fade-size-e);
-  }
 }
 
 @utility scroll-fade-t {
@@ -309,9 +297,6 @@
     animation-fill-mode: both;
   }
 
-  @supports not (animation-timeline: scroll()) {
-    --scroll-fade-t: var(--_scroll-fade-size-t);
-  }
 }
 
 @utility scroll-fade-b {
@@ -342,9 +327,6 @@
     animation-fill-mode: both;
   }
 
-  @supports not (animation-timeline: scroll()) {
-    --scroll-fade-b: var(--_scroll-fade-size-b);
-  }
 }
 
 @utility scroll-fade-l {
@@ -372,9 +354,6 @@
     animation-fill-mode: both;
   }
 
-  @supports not (animation-timeline: scroll()) {
-    --scroll-fade-s: var(--_scroll-fade-size-s);
-  }
 }
 
 @utility scroll-fade-r {
@@ -405,9 +384,6 @@
     animation-fill-mode: both;
   }
 
-  @supports not (animation-timeline: scroll()) {
-    --scroll-fade-e: var(--_scroll-fade-size-e);
-  }
 }
 
 @utility scroll-fade-s {
@@ -443,9 +419,6 @@
     animation-fill-mode: both;
   }
 
-  @supports not (animation-timeline: scroll()) {
-    --scroll-fade-s: var(--_scroll-fade-size-s);
-  }
 }
 
 @utility scroll-fade-e {
@@ -484,9 +457,6 @@
     animation-fill-mode: both;
   }
 
-  @supports not (animation-timeline: scroll()) {
-    --scroll-fade-e: var(--_scroll-fade-size-e);
-  }
 }
 
 @utility scroll-fade-* {


### PR DESCRIPTION
## Description

Fixes #11291 — scroll-fade always fades in Firefox, including containers with no overflow.

### Root cause

Firefox hasn't shipped scroll-driven animations (`animation-timeline: scroll()`). The `@supports not` fallback unconditionally applied a permanent fade mask to every `scroll-fade` element, regardless of whether it actually scrolls.

### Fix

Removed the `@supports not (animation-timeline: scroll())` fallback blocks from all 9 `scroll-fade` utilities in `packages/shadcn/src/tailwind.css`. Firefox now renders crisp content without any fade mask, which is strictly better than the broken permanent fade.

### Before (Firefox)

Every `scroll-fade` element shows a permanent fade on both edges, even when content doesn't overflow. The docs sidebar, "On This Page" nav, and tables are all faded.

### After (Firefox)

No fade is applied. Content renders crisply. Chrome and Safari users are unaffected — they continue to get the correct scroll-driven animation.
