### PR TITLE
docs: replace __dirname with import.meta.dirname in Vite guide (Fixes #11383)

### DIFF
--- a/apps/v4/content/docs/installation/vite.mdx
+++ b/apps/v4/content/docs/installation/vite.mdx
@@ -273,7 +273,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
 })

--- a/templates/vite-app/vite.config.ts
+++ b/templates/vite-app/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
 })

--- a/templates/vite-monorepo/apps/web/vite.config.ts
+++ b/templates/vite-monorepo/apps/web/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
 })


### PR DESCRIPTION
## Description

Fixes #11383

Vite 8 warns when `__dirname` is used in `vite.config.ts` because it is unsupported by the upcoming default `configLoader: 'native'`. This PR replaces `__dirname` with `import.meta.dirname` in the Vite installation guide and the Vite templates.

## Changes

- `apps/v4/content/docs/installation/vite.mdx`: Replace `__dirname` with `import.meta.dirname`
- `templates/vite-app/vite.config.ts`: Replace `__dirname` with `import.meta.dirname`
- `templates/vite-monorepo/apps/web/vite.config.ts`: Replace `__dirname` with `import.meta.dirname`

## Verification

Confirmed that `import.meta.dirname` is available in Node.js 21+ and Vite 6+.