### PR TITLE
fix: pin TanStack Table registry dependency to v8

### DIFF
--- a/apps/v4/content/docs/components/aria/data-table.mdx
+++ b/apps/v4/content/docs/components/aria/data-table.mdx
@@ -55,7 +55,7 @@ npx shadcn@latest add table
 2. Add `tanstack/react-table` dependency:
 
 ```bash
-npm install @tanstack/react-table
+npm install @tanstack/react-table@^8.21.3
 ```
 
 ## Prerequisites

--- a/apps/v4/content/docs/components/base/data-table.mdx
+++ b/apps/v4/content/docs/components/base/data-table.mdx
@@ -55,7 +55,7 @@ npx shadcn@latest add table
 2. Add `tanstack/react-table` dependency:
 
 ```bash
-npm install @tanstack/react-table
+npm install @tanstack/react-table@^8.21.3
 ```
 
 ## Prerequisites

--- a/apps/v4/content/docs/components/radix/data-table.mdx
+++ b/apps/v4/content/docs/components/radix/data-table.mdx
@@ -55,7 +55,7 @@ npx shadcn@latest add table
 2. Add `tanstack/react-table` dependency:
 
 ```bash
-npm install @tanstack/react-table
+npm install @tanstack/react-table@^8.21.3
 ```
 
 ## Prerequisites

--- a/apps/v4/public/r/styles/default/dashboard-01.json
+++ b/apps/v4/public/r/styles/default/dashboard-01.json
@@ -9,7 +9,7 @@
     "@dnd-kit/modifiers",
     "@dnd-kit/sortable",
     "@dnd-kit/utilities",
-    "@tanstack/react-table",
+    "@tanstack/react-table@^8.21.3",
     "zod"
   ],
   "registryDependencies": [

--- a/apps/v4/public/r/styles/default/registry.json
+++ b/apps/v4/public/r/styles/default/registry.json
@@ -912,7 +912,7 @@
         "@dnd-kit/modifiers",
         "@dnd-kit/sortable",
         "@dnd-kit/utilities",
-        "@tanstack/react-table",
+        "@tanstack/react-table@^8.21.3",
         "zod"
       ],
       "registryDependencies": [

--- a/apps/v4/public/r/styles/new-york/dashboard-01.json
+++ b/apps/v4/public/r/styles/new-york/dashboard-01.json
@@ -9,7 +9,7 @@
     "@dnd-kit/modifiers",
     "@dnd-kit/sortable",
     "@dnd-kit/utilities",
-    "@tanstack/react-table",
+    "@tanstack/react-table@^8.21.3",
     "zod"
   ],
   "registryDependencies": [

--- a/apps/v4/public/r/styles/new-york/registry.json
+++ b/apps/v4/public/r/styles/new-york/registry.json
@@ -912,7 +912,7 @@
         "@dnd-kit/modifiers",
         "@dnd-kit/sortable",
         "@dnd-kit/utilities",
-        "@tanstack/react-table",
+        "@tanstack/react-table@^8.21.3",
         "zod"
       ],
       "registryDependencies": [

--- a/apps/v4/registry.json
+++ b/apps/v4/registry.json
@@ -682,7 +682,7 @@
         "@dnd-kit/modifiers",
         "@dnd-kit/sortable",
         "@dnd-kit/utilities",
-        "@tanstack/react-table",
+        "@tanstack/react-table@^8.21.3",
         "zod",
         "@tabler/icons-react"
       ],

--- a/apps/v4/registry/bases/aria/blocks/_registry.ts
+++ b/apps/v4/registry/bases/aria/blocks/_registry.ts
@@ -297,7 +297,7 @@ export const blocks: Registry["items"] = [
       "@dnd-kit/modifiers",
       "@dnd-kit/sortable",
       "@dnd-kit/utilities",
-      "@tanstack/react-table",
+      "@tanstack/react-table@^8.21.3",
       "zod",
     ],
     registryDependencies: [

--- a/apps/v4/registry/bases/base/blocks/_registry.ts
+++ b/apps/v4/registry/bases/base/blocks/_registry.ts
@@ -297,7 +297,7 @@ export const blocks: Registry["items"] = [
       "@dnd-kit/modifiers",
       "@dnd-kit/sortable",
       "@dnd-kit/utilities",
-      "@tanstack/react-table",
+      "@tanstack/react-table@^8.21.3",
       "zod",
     ],
     registryDependencies: [

--- a/apps/v4/registry/bases/radix/blocks/_registry.ts
+++ b/apps/v4/registry/bases/radix/blocks/_registry.ts
@@ -296,7 +296,7 @@ export const blocks: Registry["items"] = [
       "@dnd-kit/modifiers",
       "@dnd-kit/sortable",
       "@dnd-kit/utilities",
-      "@tanstack/react-table",
+      "@tanstack/react-table@^8.21.3",
       "zod",
     ],
     registryDependencies: [

--- a/apps/v4/registry/new-york-v4/blocks/_registry.ts
+++ b/apps/v4/registry/new-york-v4/blocks/_registry.ts
@@ -11,7 +11,7 @@ export const blocks: Registry["items"] = [
       "@dnd-kit/sortable",
       "@dnd-kit/utilities",
       "@tabler/icons-react",
-      "@tanstack/react-table",
+      "@tanstack/react-table@^8.21.3",
       "zod",
     ],
     registryDependencies: [


### PR DESCRIPTION
## Summary

- Pin shadcn registry-installed `@tanstack/react-table` dependencies to `^8.21.3`
- Update Data Table docs install snippets to install the same v8 range
- Keep existing Table/Data Table examples on the v8 API while TanStack Table v9 compatibility is tracked separately

Related to #11389

## Context

`@tanstack/react-table@latest` now resolves to v9. The current Data Table examples and dashboard block still use the v8 API (`useReactTable`, `getCoreRowModel`, etc.), so unversioned registry dependencies can install v9 and break copied examples.

## Verification

- `git diff --check`
- Confirmed no import specifier was changed to `@tanstack/react-table@^8.21.3`
- Confirmed no bare `"@tanstack/react-table"` remains in JSON registry dependency arrays under `apps/v4`
