### PR TITLE
fix(cli): handle cross-platform path separators in getWorkspaceConfig…

### DIFF
--- a/packages/shadcn/src/utils/get-config.test.ts
+++ b/packages/shadcn/src/utils/get-config.test.ts
@@ -553,7 +553,7 @@ describe("getWorkspaceConfig", () => {
 
       await expect(getWorkspaceConfig(config)).rejects.toThrowError(
         new RegExp(
-          "Could not load the workspace config.*packages/ui.*components.json.*path aliases or package imports",
+          "Could not load the workspace config.*packages[/\\\\]ui.*components.json.*path aliases or package imports",
           "s"
         )
       )


### PR DESCRIPTION
## Summary

Fixes Windows path separator mismatch in `packages/shadcn/src/utils/get-config.test.ts` where `getWorkspaceConfig` unit tests failed on Windows environments due to hardcoded forward slashes `/` in path assertion regular expressions.

Closes #10799

---

## Problem

In `packages/shadcn/src/utils/get-config.test.ts` (line 554), the `getWorkspaceConfig` error test uses a regular expression with a hardcoded forward slash `/`:

```ts
await expect(getWorkspaceConfig(config)).rejects.toThrowError(
  new RegExp(
    "Could not load the workspace config.*packages/ui.*components.json.*path aliases or package imports",
    "s"
  )
)
