### PR TITLE
fix(Select): prevent trigger border from leaking behind popup in dark mode

### DIFF
--- a/apps/v4/registry/bases/radix/ui/select.tsx
+++ b/apps/v4/registry/bases/radix/ui/select.tsx
@@ -77,7 +77,7 @@ function SelectContent({
         data-slot="select-content"
         data-align-trigger={position === "item-aligned"}
         className={cn(
-          "cn-select-content cn-menu-target cn-menu-translucent relative z-50 max-h-(--radix-select-content-available-height) origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto data-[align-trigger=true]:animate-none",
+          "cn-select-content cn-menu-target cn-menu-translucent relative z-50 max-h-(--radix-select-content-available-height) origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto data-[align-trigger=true]:animate-none data-[align-trigger=true]:-translate-x-px",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className
@@ -141,7 +141,7 @@ function SelectItem({
           />
         </SelectPrimitive.ItemIndicator>
       </span>
-      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemText className="pl-px">{children}</SelectPrimitive.ItemText>
     </SelectPrimitive.Item>
   )
 }


### PR DESCRIPTION
## Summary

When the Select popup opens and overlaps the trigger in dark mode, the trigger's left border remains slightly visible behind the popup. This is especially noticeable in dark mode where the border contrast is higher.

## Changes

1. **SelectContent**: Added `data-[align-trigger=true]:-translate-x-px` to shift the popup left by 1px, fully covering the trigger border.
2. **SelectItemText**: Added `pl-px` to compensate for the horizontal shift, keeping the selected item text visually aligned with the trigger text.

## Related issue

Closes #11008