### PR TITLE
fix(input-otp): add dir="ltr" to force LTR layout in RTL contexts

### DIFF
--- a/apps/v4/registry/bases/aria/ui/input-otp.tsx
+++ b/apps/v4/registry/bases/aria/ui/input-otp.tsx
@@ -15,6 +15,7 @@ function InputOTP({
 }) {
   return (
     <OTPInput
+      dir="ltr"
       data-slot="input-otp"
       containerClassName={cn(
         "cn-input-otp flex items-center has-disabled:opacity-50",

--- a/apps/v4/registry/bases/base/ui/input-otp.tsx
+++ b/apps/v4/registry/bases/base/ui/input-otp.tsx
@@ -15,6 +15,7 @@ function InputOTP({
 }) {
   return (
     <OTPInput
+      dir="ltr"
       data-slot="input-otp"
       containerClassName={cn(
         "cn-input-otp flex items-center has-disabled:opacity-50",

--- a/apps/v4/registry/bases/radix/ui/input-otp.tsx
+++ b/apps/v4/registry/bases/radix/ui/input-otp.tsx
@@ -15,6 +15,7 @@ function InputOTP({
 }) {
   return (
     <OTPInput
+      dir="ltr"
       data-slot="input-otp"
       containerClassName={cn(
         "cn-input-otp flex items-center has-disabled:opacity-50",

--- a/apps/v4/registry/new-york-v4/ui/input-otp.tsx
+++ b/apps/v4/registry/new-york-v4/ui/input-otp.tsx
@@ -15,6 +15,7 @@ function InputOTP({
 }) {
   return (
     <OTPInput
+      dir="ltr"
       data-slot="input-otp"
       containerClassName={cn(
         "flex items-center gap-2 has-disabled:opacity-50",


### PR DESCRIPTION
## Description

In RTL layout contexts, the `InputOTP` component renders slots and digits from right to left. Since numeric verification codes are always read left-to-right regardless of document locale, this breaks user experience.

This PR adds `dir="ltr"` to the `OTPInput` component to force LTR direction for the OTP input slots in all four variants (aria, base, radix, new-york-v4).

## Changes

- Added `dir="ltr"` to `OTPInput` in:
  - `apps/v4/registry/bases/aria/ui/input-otp.tsx`
  - `apps/v4/registry/bases/base/ui/input-otp.tsx`
  - `apps/v4/registry/bases/radix/ui/input-otp.tsx`
  - `apps/v4/registry/new-york-v4/ui/input-otp.tsx`

Fixes #11201