### PR TITLE
fix(sidebar): add min-w-0 to SidebarInset to prevent overflow

### DIFF
--- a/apps/v4/registry/bases/aria/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/aria/ui/sidebar.tsx
@@ -318,7 +318,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "cn-sidebar-inset relative flex w-full flex-1 flex-col",
+        "cn-sidebar-inset relative flex w-full min-w-0 flex-1 flex-col",
         className
       )}
       {...props}

--- a/apps/v4/registry/bases/base/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/base/ui/sidebar.tsx
@@ -314,7 +314,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "cn-sidebar-inset relative flex w-full flex-1 flex-col",
+        "cn-sidebar-inset relative flex w-full min-w-0 flex-1 flex-col",
         className
       )}
       {...props}

--- a/apps/v4/registry/bases/radix/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/radix/ui/sidebar.tsx
@@ -313,7 +313,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "cn-sidebar-inset relative flex w-full flex-1 flex-col",
+        "cn-sidebar-inset relative flex w-full min-w-0 flex-1 flex-col",
         className
       )}
       {...props}

--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -309,7 +309,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "relative flex w-full flex-1 flex-col bg-background",
+        "relative flex w-full min-w-0 flex-1 flex-col bg-background",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className
       )}


### PR DESCRIPTION
Fixes #11370. This adds `min-w-0` to the `SidebarInset` components in the aria, radix, base, and new-york-v4 templates to prevent horizontally-overflowing content (like tables or wide code blocks) from pushing the page wider than the viewport.