### PR TITLE
fix(scroll-area): remove unused React import in base registry component

### DIFF
--- a/apps/v4/registry/bases/base/ui/scroll-area.tsx
+++ b/apps/v4/registry/bases/base/ui/scroll-area.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import * as React from "react"
 import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area"
 
 import { cn } from "@/registry/bases/base/lib/utils"


### PR DESCRIPTION
Fixes #11274. Removes the unused `import * as React` from the base `scroll-area.tsx` which broke tsc with `noUnusedLocals: true`.