### PR TITLE
docs: replace __dirname with import.meta.dirname in Vite guide

### DIFF
--- a/apps/v4/content/docs/installation/vite.mdx
+++ b/apps/v4/content/docs/installation/vite.mdx
@@ -273,7 +273,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
 })

--- a/packages/shadcn/test/fixtures/vite-with-tailwind/vite.config.ts
+++ b/packages/shadcn/test/fixtures/vite-with-tailwind/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
 })


### PR DESCRIPTION
Fixes #11383. Vite 6 / configLoader native warns against using `__dirname`. This updates the Vite guide and test fixtures to use `import.meta.dirname`.