### PR TITLE
fix: restore Next.js init prompts for new projects

### DIFF
--- a/packages/shadcn/src/templates/next.test.ts
+++ b/packages/shadcn/src/templates/next.test.ts
@@ -1,0 +1,61 @@
+import { execa } from "execa"
+import { describe, expect, it, vi } from "vitest"
+
+import { next } from "./next"
+
+vi.mock("execa", () => ({
+  execa: vi.fn().mockResolvedValue({}),
+}))
+
+describe("next scaffold", () => {
+  it("uses create-next-app with npm and preserves interactive prompts", async () => {
+    await next.scaffold?.({
+      projectPath: "/tmp/my-app",
+      packageManager: "npm",
+      cwd: "/tmp",
+    })
+
+    expect(execa).toHaveBeenCalledWith(
+      "npx",
+      ["create-next-app@latest", "my-app", "--use-npm"],
+      {
+        cwd: "/tmp",
+        stdio: "inherit",
+      }
+    )
+  })
+
+  it("uses pnpm dlx for pnpm projects", async () => {
+    await next.scaffold?.({
+      projectPath: "/tmp/my-app",
+      packageManager: "pnpm",
+      cwd: "/tmp",
+    })
+
+    expect(execa).toHaveBeenCalledWith(
+      "pnpm",
+      ["dlx", "create-next-app@latest", "my-app", "--use-pnpm"],
+      {
+        cwd: "/tmp",
+        stdio: "inherit",
+      }
+    )
+  })
+
+  it("uses bunx for bun projects", async () => {
+    await next.scaffold?.({
+      projectPath: "/tmp/my-app",
+      packageManager: "bun",
+      cwd: "/tmp",
+    })
+
+    expect(execa).toHaveBeenCalledWith(
+      "bunx",
+      ["create-next-app@latest", "my-app", "--use-bun"],
+      {
+        cwd: "/tmp",
+        stdio: "inherit",
+      }
+    )
+  })
+})

--- a/packages/shadcn/src/templates/next.ts
+++ b/packages/shadcn/src/templates/next.ts
@@ -3,6 +3,7 @@ import { iconLibraries, type IconLibraryName } from "@/src/icons/libraries"
 import { configWithDefaults } from "@/src/registry/config"
 import { resolveRegistryTree } from "@/src/registry/resolver"
 import { rawConfigSchema } from "@/src/schema"
+import type { TemplateOptions } from "@/src/templates"
 import { addComponents } from "@/src/utils/add-components"
 import { resolveConfigPaths } from "@/src/utils/get-config"
 import { ensureRegistriesInConfig } from "@/src/utils/registries"
@@ -11,6 +12,7 @@ import { updateDependencies } from "@/src/utils/updaters/update-dependencies"
 import { updateFonts } from "@/src/utils/updaters/update-fonts"
 import dedent from "dedent"
 import deepmerge from "deepmerge"
+import { execa } from "execa"
 import fs from "fs-extra"
 
 import { createTemplate } from "./create-template"
@@ -21,6 +23,9 @@ export const next = createTemplate({
   defaultProjectName: "next-app",
   templateDir: "next-app",
   frameworks: ["next-app", "next-pages"],
+  scaffold: async (options) => {
+    await scaffoldNextApp(options)
+  },
   create: async () => {
     // Empty for now.
   },
@@ -158,3 +163,59 @@ export default function Page() {
     ],
   },
 })
+
+async function scaffoldNextApp({
+  projectPath,
+  packageManager,
+  cwd,
+}: TemplateOptions) {
+  const projectName = path.basename(projectPath)
+  const createCommand = getCreateNextAppCommand(packageManager)
+
+  await execa(createCommand.command, createCommand.args(projectName), {
+    cwd,
+    stdio: "inherit",
+  })
+}
+
+function getCreateNextAppCommand(packageManager: string) {
+  switch (packageManager) {
+    case "pnpm":
+      return {
+        command: "pnpm",
+        args: (projectName: string) => [
+          "dlx",
+          "create-next-app@latest",
+          projectName,
+          "--use-pnpm",
+        ],
+      }
+    case "bun":
+      return {
+        command: "bunx",
+        args: (projectName: string) => [
+          "create-next-app@latest",
+          projectName,
+          "--use-bun",
+        ],
+      }
+    default:
+      return {
+        command: "npx",
+        args: (projectName: string) => [
+          "create-next-app@latest",
+          projectName,
+          getPackageManagerFlag(packageManager),
+        ].filter(Boolean) as string[],
+      }
+  }
+}
+
+function getPackageManagerFlag(packageManager: string) {
+  switch (packageManager) {
+    case "yarn":
+      return "--use-yarn"
+    default:
+      return "--use-npm"
+  }
+}

--- a/packages/shadcn/src/utils/create-project.test.ts
+++ b/packages/shadcn/src/utils/create-project.test.ts
@@ -6,6 +6,7 @@ import {
 import { spinner } from "@/src/utils/spinner"
 import { execa } from "execa"
 import fs from "fs-extra"
+import path from "path"
 import prompts from "prompts"
 import {
   afterEach,
@@ -111,7 +112,7 @@ describe("createProject", () => {
     })
 
     expect(result).toEqual({
-      projectPath: "/test/my-app",
+      projectPath: path.join("/test", "my-app"),
       projectName: "my-app",
       template: "next",
     })
@@ -130,7 +131,7 @@ describe("createProject", () => {
     })
 
     expect(result).toEqual({
-      projectPath: "/test/my-monorepo",
+      projectPath: path.join("/test", "my-monorepo"),
       projectName: "my-monorepo",
       template: "next",
     })
@@ -148,8 +149,10 @@ describe("createProject", () => {
 
   it("should throw error if project path already exists", async () => {
     // Mock fs.existsSync to return true only for the specific package.json path
-    vi.mocked(fs.existsSync).mockImplementation((path: any) => {
-      return path.toString().includes("existing-app/package.json")
+    vi.mocked(fs.existsSync).mockImplementation((inputPath: any) => {
+      return inputPath
+        .toString()
+        .includes(path.join("existing-app", "package.json"))
     })
     vi.mocked(prompts).mockResolvedValue({ type: "next", name: "existing-app" })
 


### PR DESCRIPTION
## Summary

- Fixes #11355.
- restore the single-app Next.js scaffold flow to use `create-next-app`
- preserve the native Next.js setup prompts instead of generating the project immediately from the internal template
- add focused tests for the Next scaffold command and make `createProject` assertions platform-safe

## Problem

`shadcn init` for a new Next.js project was skipping the standard Next.js initialization prompts and creating the app immediately with default settings. This happened because the `next` template scaffold path cloned the internal template directly instead of delegating project creation to `create-next-app`.

## Solution

- override the `next` template scaffold implementation for single-app projects
- invoke `create-next-app@latest` with the detected package manager (`npm`, `yarn`, `pnpm`, or `bun`)
- keep monorepo handling unchanged so the existing monorepo template flow still works
- add scaffold command coverage and normalize existing path assertions so tests pass on Windows and POSIX

## Testing

- `pnpm --filter shadcn exec vitest run src/templates/next.test.ts src/utils/create-project.test.ts src/commands/init.test.ts`
- `pnpm --filter shadcn typecheck`

## Notes

- the PR body file was intentionally left uncommitted at the repository root
