### PR TITLE
fix(shadcn): scope css vars transform to class name literals

### DIFF
--- a/.changeset/scoped-css-vars-transform.md
+++ b/.changeset/scoped-css-vars-transform.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Only remap colors in class name literals when `tailwind.cssVariables` is `false`. The transform walked every string literal in a file, so unrelated strings were rewritten on install (`parts.join(" ")` became `parts.join("")`).

--- a/packages/shadcn/src/utils/transformers/transform-css-vars.test.ts
+++ b/packages/shadcn/src/utils/transformers/transform-css-vars.test.ts
@@ -176,3 +176,78 @@ export function Foo() {
     })
   ).toMatchSnapshot()
 })
+
+describe("transform css vars leaves non-class string literals alone", () => {
+  const config = {
+    tsx: true,
+    tailwind: {
+      baseColor: "stone",
+      cssVariables: false,
+    },
+    aliases: {
+      components: "@/components",
+      utils: "@/lib/utils",
+    },
+  } as Config
+
+  it.each([
+    {
+      name: "a whitespace separator passed to join",
+      raw: `export function Foo(parts: string[]) {
+  return parts.join(" ")
+}`,
+      expected: `parts.join(" ")`,
+    },
+    {
+      name: "repeated words in a message",
+      raw: `export function Foo() {
+  return "very very good"
+}`,
+      expected: `"very very good"`,
+    },
+    {
+      name: "surrounding whitespace in a template separator",
+      raw: `export function Foo() {
+  const separator = " - "
+  return separator
+}`,
+      expected: `" - "`,
+    },
+    {
+      name: "the word border inside prose",
+      raw: `export function Foo() {
+  return "click the border of the element"
+}`,
+      expected: `"click the border of the element"`,
+    },
+  ])("preserves $name", async ({ raw, expected }) => {
+    const output = await transform({
+      filename: "test.ts",
+      raw,
+      config,
+      baseColor: stone,
+    })
+
+    expect(output).toContain(expected)
+  })
+
+  it("still maps colors in className and cn()", async () => {
+    const output = await transform({
+      filename: "test.tsx",
+      raw: `export function Foo() {
+  return (
+    <div className="bg-background">
+      <span className={cn("text-primary-foreground", true && "bg-muted")} />
+    </div>
+  )
+}`,
+      config,
+      baseColor: stone,
+    })
+
+    expect(output).toContain("bg-white")
+    expect(output).toContain("dark:bg-stone-950")
+    expect(output).toContain("text-stone-900")
+    expect(output).toContain("bg-stone-100")
+  })
+})

--- a/packages/shadcn/src/utils/transformers/transform-css-vars.ts
+++ b/packages/shadcn/src/utils/transformers/transform-css-vars.ts
@@ -1,7 +1,44 @@
 import { registryBaseColorSchema } from "@/src/schema"
 import { Transformer } from "@/src/utils/transformers"
-import { ScriptKind, SyntaxKind } from "ts-morph"
+import { Node, ScriptKind, SyntaxKind } from "ts-morph"
 import { z } from "zod"
+
+// JSX attributes whose value is a list of class names.
+const CLASS_ATTRIBUTES = ["className", "class"]
+
+// Helpers whose arguments are lists of class names.
+const CLASS_UTILITIES = [
+  "cn",
+  "clsx",
+  "classNames",
+  "cva",
+  "tv",
+  "twMerge",
+  "twJoin",
+]
+
+// Color mapping rewrites a class list: it splits on whitespace, dedupes and
+// trims. Applied to a string that is not a class list, that is silent data
+// loss (`join(" ")` -> `join("")`), so only rewrite literals we can attribute
+// to a class name. The nearest enclosing call or JSX attribute decides, which
+// keeps `cn(foo("..."))` out while keeping `cn("...", cond && "...")` in.
+function isClassNameLiteral(node: Node) {
+  for (const ancestor of node.getAncestors()) {
+    if (Node.isCallExpression(ancestor)) {
+      const expression = ancestor.getExpression()
+      const name = Node.isPropertyAccessExpression(expression)
+        ? expression.getName()
+        : expression.getText()
+      return CLASS_UTILITIES.includes(name)
+    }
+
+    if (Node.isJsxAttribute(ancestor)) {
+      return CLASS_ATTRIBUTES.includes(ancestor.getNameNode().getText())
+    }
+  }
+
+  return false
+}
 
 export const transformCssVars: Transformer = async ({
   sourceFile,
@@ -13,24 +50,11 @@ export const transformCssVars: Transformer = async ({
     return sourceFile
   }
 
-  // Find jsx attributes with the name className.
-  // const openingElements = sourceFile.getDescendantsOfKind(SyntaxKind.JsxElement)
-  // console.log(openingElements)
-  // const jsxAttributes = sourceFile
-  //   .getDescendantsOfKind(SyntaxKind.JsxAttribute)
-  //   .filter((node) => node.getName() === "className")
-
-  // for (const jsxAttribute of jsxAttributes) {
-  //   const value = jsxAttribute.getInitializer()?.getText()
-  //   if (value) {
-  //     const valueWithColorMapping = applyColorMapping(
-  //       value.replace(/"/g, ""),
-  //       baseColor.inlineColors
-  //     )
-  //     jsxAttribute.setInitializer(`"${valueWithColorMapping}"`)
-  //   }
-  // }
   sourceFile.getDescendantsOfKind(SyntaxKind.StringLiteral).forEach((node) => {
+    if (!isClassNameLiteral(node)) {
+      return
+    }
+
     const raw = node.getLiteralText()
     const mapped = applyColorMapping(raw, baseColor.inlineColors).trim()
     if (mapped !== raw) {


### PR DESCRIPTION
Fixes #9972

## Problem

When a project sets `tailwind.cssVariables` to `false`, `shadcn add` rewrites string literals that have nothing to do with class names.

```ts
// before install
const value = parts.join(" ")

// after install
const value = parts.join("")
```

Ordinary text gets mangled the same way. `"click the border of the element"` comes back as `"click the border border-stone-200 of element dark:border-stone-800"`, with the duplicate `the` dropped.

Nothing errors, so the change is easy to miss.

## Cause

`transformCssVars` walks every `StringLiteral` in the file and passes it to `applyColorMapping`. That function assumes a class list, so it splits on whitespace, dedupes through a `Set` and trims. All three steps destroy strings that are not class lists.

The commented out block above the walk shows the original intent was `className` attributes only. It also calls `JsxAttribute.getName()`, which no longer exists in ts-morph 26, so I removed it rather than leave a snippet that cannot compile.

## Fix

A literal is only remapped when it can be attributed to a class name. The nearest enclosing call expression or JSX attribute decides:

* the value of a `className` or `class` attribute
* an argument of `cn`, `clsx`, `classNames`, `cva`, `tv`, `twMerge`, `twJoin`

So `cn("a", cond && "b")` and `cva` variant objects stay in scope, while `parts.join(" ")` and `cn(foo("x"))` are left alone.

## Verification

* Five regression tests, covering the reported case plus the whitespace, dedupe and prose variants.
* The four existing snapshots are unchanged, so the color mapping itself behaves the same as before.
* I scanned `registry/new-york-v4/ui` and `registry/bases/*/ui` with the same predicate: 345 of 345 class strings containing a color token are still in scope, so no component loses its mapping.
* `pnpm --filter=shadcn typecheck` passes.

One note on test runs: `src/utils/updaters/update-files.test.ts` fails for me with and without this change (41 failures either way, including cases like `resolveModuleByProbablePath`), so those look pre-existing and Windows specific rather than related to this patch.
