### PR TITLE
fix(tailwind): match bare data-selected attribute in data-selected variant

### DIFF
--- a/packages/shadcn/src/tailwind.css
+++ b/packages/shadcn/src/tailwind.css
@@ -54,7 +54,8 @@
 }
 
 @custom-variant data-selected {
-  &:where([data-selected="true"]) {
+  &:where([data-selected="true"]),
+  &:where([data-selected]:not([data-selected="false"])) {
     @slot;
   }
 }


### PR DESCRIPTION
Closes #11101

## Problem

The `@custom-variant data-selected` in `packages/shadcn/src/tailwind.css` only matches `[data-selected="true"]`. Base UI writes the attribute bare (`data-selected=""`), so every `data-selected:*` utility in the registry styles (command item, select item, switch, tabs, calendar) compiles into the stylesheet but never applies.

It is the only presence-style variant without a presence branch - `data-open`, `data-closed`, `data-checked`, `data-unchecked`, `data-disabled`, and `data-active` all include `[data-x]:not([data-x="false"])`. This makes the bug hard to debug: because the variant is registered, Tailwind v4 does not fall back to the bare `[data-selected]` behavior that unregistered `data-*:` shorthands get.

## Fix

Give `data-selected` the same shape as its siblings:

```css
@custom-variant data-selected {
  &:where([data-selected="true"]),
  &:where([data-selected]:not([data-selected="false"])) {
    @slot;
  }
}
```

- `[data-selected=""]` (Base UI) now matches
- `[data-selected="true"]` (cmdk) still matches - backwards compatible
- `[data-selected="false"]` and absent still do not match
- `not-data-selected:*` negation still inverts correctly