### PR TITLE
fix: Vite guide uses __dirname which triggers Vite native configLoader warning (#11383)

### DIFF
--- a/apps/v4/content/docs/installation/vite.mdx
+++ b/apps/v4/content/docs/installation/vite.mdx
@@ -273,7 +273,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
 })

--- a/packages/shadcn/test/fixtures/vite-with-tailwind/vite.config.ts
+++ b/packages/shadcn/test/fixtures/vite-with-tailwind/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
 })

--- a/packages/tests/fixtures/vite-app/vite.config.ts
+++ b/packages/tests/fixtures/vite-app/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "#custom": path.resolve(__dirname, "./src"),
+      "#custom": path.resolve(import.meta.dirname, "./src"),
     },
   },
 })

--- a/templates/vite-app/vite.config.ts
+++ b/templates/vite-app/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
 })

--- a/templates/vite-monorepo/apps/web/vite.config.ts
+++ b/templates/vite-monorepo/apps/web/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
 })


### PR DESCRIPTION
Fixes #11383

`__dirname` triggers Vite's native config loader warning, which points to
`import.meta.dirname` as the replacement. Updated the Vite guide, the
vite-app and vite-monorepo templates, and the two matching test fixtures to
use `path.resolve(import.meta.dirname, "./src")` for the alias.
