### PR TITLE
fix(sidebar): exclude Shift and Alt modifiers from keyboard shortcut

### DIFF
--- a/apps/v4/registry/bases/aria/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/aria/ui/sidebar.tsx
@@ -101,7 +101,9 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey &&
+        !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/registry/bases/base/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/base/ui/sidebar.tsx
@@ -98,7 +98,9 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey &&
+        !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/registry/bases/radix/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/radix/ui/sidebar.tsx
@@ -97,7 +97,9 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey &&
+        !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()

--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -98,7 +98,9 @@ function SidebarProvider({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
         event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey &&
+        !event.altKey
       ) {
         event.preventDefault()
         toggleSidebar()


### PR DESCRIPTION
## Problem

`SidebarProvider` registers a global keyboard shortcut for toggling the sidebar with `Cmd`+`B` / `Ctrl`+`B`, but the current matching logic only checks:

```ts
event.key === "b" && (event.metaKey || event.ctrlKey)
```

It does not exclude additional modifier keys such as `Shift` or `Alt`. As a result, `Cmd`+`Shift`+`B`, which is a browser-level shortcut, can be intercepted by the sidebar shortcut handler, preventing the browser default behavior from working.

## Fix

Added `!event.shiftKey && !event.altKey` checks to ensure only plain `Cmd`+`B` / `Ctrl`+`B` toggles the sidebar.

Applied to all 4 sidebar variants: new-york-v4, bases/base, bases/radix, bases/aria.

Closes #11104