### PR TITLE
fix: skip I18nProvider for LTR aria previews to prevent MenuTrigger context conflict (Fixes #11213)

### DIFF
--- a/apps/v4/components/component-preview-tabs.tsx
+++ b/apps/v4/components/component-preview-tabs.tsx
@@ -266,14 +266,20 @@ function DirectionProviderWrapper({
   }
 
   if (base === "aria") {
+    // Only use I18nProvider when the locale is non-default (RTL).
+    // When the locale is "en" (LTR), the I18nProvider is redundant and
+    // can interfere with MenuTrigger's OverlayTriggerContext when
+    // multiple previews are on the same page.
+    const locale = explicitDir === "ltr"
+      ? "en"
+      : (translation.locale ?? translation.language)
+
+    if (locale === "en") {
+      return <>{children}</>
+    }
+
     return (
-      <I18nProvider
-        locale={
-          explicitDir === "ltr"
-            ? "en"
-            : (translation.locale ?? translation.language)
-        }
-      >
+      <I18nProvider locale={locale}>
         {children}
       </I18nProvider>
     )


### PR DESCRIPTION
## Description

When multiple dropdown menu previews are rendered on the same docs page (e.g., Basic, Submenu, Shortcuts, Icons, etc.), the `I18nProvider` with `locale="en"` from React Aria creates a nested React tree that interferes with the `MenuTrigger`'s `OverlayTriggerContext`.

This causes the LTR dropdown trigger to open the RTL dropdown menu instead of its own menu.

## Root Cause

The `DirectionProviderWrapper` in `component-preview-tabs.tsx` wraps every aria-base component preview in a React Aria `I18nProvider`. For LTR examples, the locale is `"en"` (the default), which is redundant but still creates an extra React context layer. When multiple `MenuTrigger` components are rendered on the same page, this extra context layer causes the `Popover` portal to find the wrong `OverlayTriggerContext`.

## Fix

Skip the `I18nProvider` wrapper when the locale is `"en"` (the default). The `I18nProvider` is still used for RTL locales where it is needed to set the text direction.

Fixes #11213