### PR TITLE
fix(shadcn): normalize path separators when resolving aliases on windows

### DIFF
--- a/.changeset/windows-path-separators-get-config.md
+++ b/.changeset/windows-path-separators-get-config.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Normalize path separators when resolving aliases on Windows. `tsconfig-paths` returns the matched portion of an alias with posix separators, so resolved paths were a mix of both (`C:\app\src/components`). This broke three comparisons in `get-config`: the guard that rejects an unresolvable `#` alias never fired, `findPackageRoot` never matched a workspace package against `fast-glob`'s posix output, and `findCommonRoot` split on the wrong segments. Together these made `init` and `add` silently write components into the wrong workspace, or create a directory named after the alias itself.

--- a/packages/shadcn/src/utils/get-config.test.ts
+++ b/packages/shadcn/src/utils/get-config.test.ts
@@ -7,6 +7,8 @@ import { describe, expect, it } from "vitest"
 
 import {
   createConfig,
+  findCommonRoot,
+  findPackageRoot,
   getBase,
   getConfig,
   getRawConfig,
@@ -527,7 +529,7 @@ describe("getWorkspaceConfig", () => {
 
       await expect(getWorkspaceConfig(config)).rejects.toThrowError(
         new RegExp(
-          "Could not resolve the following aliases.*packages/ui.*components, ui, lib, hooks, utils",
+          "Could not resolve the following aliases.*packages[\\\\/]ui.*components, ui, lib, hooks, utils",
           "s"
         )
       )
@@ -553,13 +555,70 @@ describe("getWorkspaceConfig", () => {
 
       await expect(getWorkspaceConfig(config)).rejects.toThrowError(
         new RegExp(
-          "Could not load the workspace config.*packages/ui.*components.json.*path aliases or package imports",
+          "Could not load the workspace config.*packages[\\\\/]ui.*components.json.*path aliases or package imports",
           "s"
         )
       )
     } finally {
       await fs.remove(tempDir)
     }
+  })
+})
+
+describe("findCommonRoot", () => {
+  it("finds the common root of two paths", () => {
+    const root = path.resolve("/tmp/monorepo")
+
+    expect(
+      findCommonRoot(
+        path.join(root, "apps", "web"),
+        path.join(root, "packages", "ui", "src", "components")
+      )
+    ).toBe(root)
+  })
+
+  it("finds the common root when the resolved path uses posix separators", () => {
+    // tsconfig-paths returns the matched portion with posix separators, so on
+    // Windows the resolved path is a mix of both.
+    const root = path.resolve("/tmp/monorepo")
+    const cwd = path.join(root, "apps", "web")
+
+    expect(findCommonRoot(cwd, `${cwd}/src/components`)).toBe(cwd)
+  })
+})
+
+describe("findPackageRoot", () => {
+  const fixtureRoot = getFixturesDir("frameworks/vite-monorepo-imports")
+
+  it("finds the workspace package that owns a resolved path", async () => {
+    expect(
+      await findPackageRoot(
+        path.join(fixtureRoot, "apps", "web"),
+        path.join(fixtureRoot, "packages", "ui", "src", "components")
+      )
+    ).toBe(path.join(fixtureRoot, "packages", "ui"))
+  })
+
+  it("finds the workspace package when the resolved path uses posix separators", async () => {
+    // fast-glob always reports posix paths, so the relative path built with
+    // `path` has to be normalized before the two are compared.
+    const uiRoot = path.join(fixtureRoot, "packages", "ui")
+
+    expect(
+      await findPackageRoot(
+        path.join(fixtureRoot, "apps", "web"),
+        `${uiRoot}/src/components`
+      )
+    ).toBe(uiRoot)
+  })
+
+  it("returns null when no workspace package owns the resolved path", async () => {
+    expect(
+      await findPackageRoot(
+        path.join(fixtureRoot, "apps", "web"),
+        path.join(fixtureRoot, "does-not-exist", "src")
+      )
+    ).toBe(null)
   })
 })
 

--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -115,6 +115,11 @@ export async function resolveConfigPaths(
   })
 }
 
+// Both separators are accepted so these keep working against normalized
+// Windows paths.
+const INDEX_FILE_REGEX = /[\\/]index\.[^\\/]+$/
+const FILE_EXTENSION_REGEX = /\.[^\\/]+$/
+
 async function resolveAliasPath(
   aliasKey: "components" | "utils" | "ui" | "lib" | "hooks",
   alias: string,
@@ -130,7 +135,13 @@ async function resolveAliasPath(
     return null
   }
 
-  if (alias.startsWith("#") && resolved.path === path.resolve(cwd, alias)) {
+  // Alias targets come back with posix separators for the matched portion, so
+  // on Windows they are a mix of both (e.g. `C:\app\src/components`). Normalize
+  // once here so every comparison below and every consumer of `resolvedPaths`
+  // sees a platform-native path.
+  const resolvedPath = path.normalize(resolved.path)
+
+  if (alias.startsWith("#") && resolvedPath === path.resolve(cwd, alias)) {
     return null
   }
 
@@ -146,20 +157,23 @@ async function resolveAliasPath(
     // to the directory root.
     if (
       !resolved.matchedAlias.includes("*") &&
-      /\/index\.[^/]+$/.test(resolved.path)
+      INDEX_FILE_REGEX.test(resolvedPath)
     ) {
-      return path.dirname(resolved.path)
+      return path.dirname(resolvedPath)
     }
 
     // Wildcard aliases with explicit extensions (e.g. `#components/*` →
     // `./src/components/*.tsx`) should strip the source extension so `ui`
     // resolves to `/src/components/ui` instead of `/src/components/ui.tsx`.
-    if (resolved.matchedAlias.includes("*") && /\.[^/]+$/.test(resolved.path)) {
-      return resolved.path.replace(/\.[^/]+$/, "")
+    if (
+      resolved.matchedAlias.includes("*") &&
+      FILE_EXTENSION_REGEX.test(resolvedPath)
+    ) {
+      return resolvedPath.replace(FILE_EXTENSION_REGEX, "")
     }
   }
 
-  return resolved.path
+  return resolvedPath
 }
 
 function assertResolvedAliases(
@@ -274,7 +288,9 @@ export async function getWorkspaceConfig(config: Config) {
 
 export async function findPackageRoot(cwd: string, resolvedPath: string) {
   const commonRoot = findCommonRoot(cwd, resolvedPath)
-  const relativePath = path.relative(commonRoot, resolvedPath)
+  // fast-glob reports posix-style paths on every platform, so the relative path
+  // has to use the same separator before the two can be compared.
+  const relativePath = toPosixPath(path.relative(commonRoot, resolvedPath))
 
   const packageRoots = await fg.glob("**/package.json", {
     cwd: commonRoot,
@@ -283,10 +299,21 @@ export async function findPackageRoot(cwd: string, resolvedPath: string) {
   })
 
   const matchingPackageRoot = packageRoots
-    .map((pkgPath) => path.dirname(pkgPath))
-    .find((pkgDir) => relativePath.startsWith(pkgDir))
+    .map((pkgPath) => path.posix.dirname(pkgPath))
+    .find((pkgDir) => isPathInsideDir(relativePath, pkgDir))
 
   return matchingPackageRoot ? path.join(commonRoot, matchingPackageRoot) : null
+}
+
+function toPosixPath(value: string) {
+  return value.split(path.sep).join(path.posix.sep)
+}
+
+// Match on segment boundaries so `apps/web` does not also claim `apps/web-docs`.
+function isPathInsideDir(relativePath: string, dir: string) {
+  return (
+    relativePath === dir || relativePath.startsWith(`${dir}${path.posix.sep}`)
+  )
 }
 
 function isAliasKey(
@@ -299,8 +326,11 @@ function isAliasKey(
 }
 
 export function findCommonRoot(cwd: string, resolvedPath: string) {
-  const parts1 = cwd.split(path.sep)
-  const parts2 = resolvedPath.split(path.sep)
+  // Alias targets resolved from tsconfig paths can carry mixed separators on
+  // Windows (e.g. `C:\app\src/components`), which would split into the wrong
+  // segments below.
+  const parts1 = path.normalize(cwd).split(path.sep)
+  const parts2 = path.normalize(resolvedPath).split(path.sep)
   const commonParts = []
 
   for (let i = 0; i < Math.min(parts1.length, parts2.length); i++) {


### PR DESCRIPTION
Fixes #11428

## Problem

On Windows the CLI does not find the workspace package an alias points to. Nothing errors. `getWorkspaceConfig` falls back to the app's own config, so files land in the app instead of the shared package, and a `#` alias that did not resolve is accepted and turned into a real directory named after the alias.

## Cause

`tsconfig-paths` returns the matched portion of an alias with posix separators, so on Windows a resolved path uses both:

```
cwd            C:\Users\me\my-app
resolved.path  C:\Users\me\my-app\src/components/ui
```

Three comparisons in `get-config.ts` are affected.

`findPackageRoot` compares a relative path built with `path.relative` against `fast-glob` output. fast-glob reports posix paths on every platform, so the two never match:

```
glob dirnames  [ '.', 'apps/web', 'packages/ui' ]
relativePath   packages\ui\src\components
result         no match, returns null
```

`getWorkspaceConfig` reads that null as "not a workspace" and assigns the app config to the alias, which is why the failure is silent.

The guard in `resolveAliasPath` that rejects a `#` alias which did not resolve compares `resolved.path` to `path.resolve(cwd, alias)`. Same mismatch, so it never fires:

```
resolved.path      ...\packages\ui/#components
path.resolve(...)  ...\packages\ui\#components
```

`findCommonRoot` splits both paths on `path.sep`, and a mixed path splits into the wrong segments. I could not get this one to produce the parent directory scan the issue describes, since `path.join` always writes a native separator after the last cwd segment, but the split is wrong either way so I normalized it too.

## Fix

Normalize once at the boundary. `resolveAliasPath` returns `path.normalize(resolved.path)`, so the comparisons below it and every consumer of `resolvedPaths` see a native path. `findPackageRoot` converts its relative path to posix before comparing against fast-glob output.

That meant the two hardcoded `/` regexes in `resolveAliasPath` had to accept both separators, otherwise the index file and extension stripping stops working on a normalized Windows path.

While changing the fast-glob comparison I also made it match on segment boundaries, since `startsWith('apps/web')` was also true for `apps/web-docs`.

## Verification

* Five tests for `findCommonRoot` and `findPackageRoot`. Neither had direct coverage before, they are mocked everywhere else. Three of the five fail without the change.
* `src/utils/get-config.test.ts` goes from 5 failures to 0 on Windows. The three `getWorkspaceConfig` tests were already failing on main.
* Full `packages/shadcn` run on Windows: 120 failures before, 113 after, none of them new. I diffed the failing file lists rather than comparing counts.
* `tsc --noEmit` passes.

On Linux the only behavior that changes is the segment boundary check, since `path.sep` is `/` there and the rest becomes identity. No fixture has sibling packages in a prefix relationship, so nothing in the suite exercises it.

There is overlap with #11391. The hardcoded `packages/ui` in those two test regexes is a real problem, but on Windows the tests fail for a different reason first: `getWorkspaceConfig` never throws at all, because `findPackageRoot` returned null and the alias fell back to the app config. The regex only becomes the failure once resolution works, so the same two line change is included here.

Same file, so worth flagging: #11044 and #9239 describe symptoms that match this (a physical alias directory on Windows, and components written to the wrong workspace). I have not reproduced either one, so I am not claiming they are fixed.
