### PR TITLE
docs(field): wrap the FieldError example value in an array

### DIFF
--- a/apps/v4/content/docs/components/aria/field.mdx
+++ b/apps/v4/content/docs/components/aria/field.mdx
@@ -396,7 +396,7 @@ Accessible error container that accepts children or an `errors` array (e.g., fro
 | `className` | `string`                                   |         |
 
 ```tsx
-<FieldError errors={errors.username} />
+<FieldError errors={[errors.username]} />
 ```
 
 When the `errors` array contains multiple messages, the component renders a list automatically.

--- a/apps/v4/content/docs/components/base/field.mdx
+++ b/apps/v4/content/docs/components/base/field.mdx
@@ -397,7 +397,7 @@ Accessible error container that accepts children or an `errors` array (e.g., fro
 | `className` | `string`                                   |         |
 
 ```tsx
-<FieldError errors={errors.username} />
+<FieldError errors={[errors.username]} />
 ```
 
 When the `errors` array contains multiple messages, the component renders a list automatically.

--- a/apps/v4/content/docs/components/radix/field.mdx
+++ b/apps/v4/content/docs/components/radix/field.mdx
@@ -397,7 +397,7 @@ Accessible error container that accepts children or an `errors` array (e.g., fro
 | `className` | `string`                                   |         |
 
 ```tsx
-<FieldError errors={errors.username} />
+<FieldError errors={[errors.username]} />
 ```
 
 When the `errors` array contains multiple messages, the component renders a list automatically.


### PR DESCRIPTION
Fixes #11430.

The `FieldError` API snippet on the three Field docs pages passes a value the component cannot read, so the error message silently never renders:

```tsx
<FieldError errors={errors.username} />
```

react-hook-form's `errors.username` for a scalar field is a single `FieldError` object (`{ type, message, ref }`), not an array. `FieldError` guards with:

```tsx
if (!errors?.length) {
  return null
}
```

A plain object has no `.length`, so the guard reads it as "no error" and returns `null` regardless of what the validator reported. Following the example verbatim gives a field that validates correctly and never shows the message, with nothing in the console.

It is also invisible in the happy path: while the field is valid, `errors.username` is `undefined` and returning `null` is correct — so the example looks right up until the first validation failure.

The prop is already typed `Array<{ message?: string } | undefined>` in the table directly above the snippet, and the [react-hook-form guide](https://ui.shadcn.com/docs/forms/react-hook-form) passes `[fieldState.error]` in all of its examples. This just aligns the API snippet with both.

## Changes

One line in each of the three per-base copies of the page:

- `apps/v4/content/docs/components/base/field.mdx`
- `apps/v4/content/docs/components/radix/field.mdx`
- `apps/v4/content/docs/components/aria/field.mdx`

Docs only — no registry or component code touched.

## Verification

I checked every other `FieldError` usage in the repo, and these three are the only ones passing a non-array. Everything else already wraps correctly: the react-hook-form guide uses `[fieldState.error]`, the TanStack pages pass `field.state.meta.errors`, the Formisch pages map to `{ message }` objects, the field-array example passes `[form.formState.errors.emails.root]`, and the `children` usages return before the `.length` guard. All 66 usages under the example directories are correct, so the blast radius is the API-reference snippet itself — which is the one people copy.
