### PR TITLE
fix(slider): pass an array default in the base slider example

### DIFF
--- a/apps/v4/registry/bases/base/examples/slider-example.tsx
+++ b/apps/v4/registry/bases/base/examples/slider-example.tsx
@@ -25,7 +25,7 @@ export default function SliderExample() {
 function SliderBasic() {
   return (
     <Example title="Basic">
-      <Slider defaultValue={50} max={100} step={1} />
+      <Slider defaultValue={[50]} max={100} step={1} />
     </Example>
   )
 }


### PR DESCRIPTION
`apps/v4/registry/bases/base/examples/slider-example.tsx` renders two thumbs for what is meant to be a single-value slider.

The base `Slider` wrapper derives its thumb count from the default:

```tsx
// apps/v4/registry/bases/base/ui/slider.tsx
const _values = Array.isArray(value)
  ? value
  : Array.isArray(defaultValue)
    ? defaultValue
    : [min, max]
```

and then renders one thumb per entry:

```tsx
{Array.from({ length: _values.length }, (_, index) => (
```

The example passes a scalar `defaultValue={50}`, which matches neither `Array.isArray` branch, so `_values` falls back to `[min, max]` — `[0, 100]`, length 2. The slider renders a second thumb with no backing value.

Base UI's own prop type accepts `number | readonly number[]`, so TypeScript does not catch it.

## Changes

One line. The radix sibling at `apps/v4/registry/bases/radix/examples/slider-example.tsx:28` already passes `[50]`, so this brings the base example in line with it.

## Deliberately not changed

`apps/v4/registry/bases/aria/examples/slider-example.tsx:30` also passes a scalar `defaultValue={50}` and looks like the same bug, but it is **correct** and should be left alone — the aria wrapper maps over React Aria's `state.values` (`apps/v4/registry/bases/aria/ui/slider.tsx:46`), which normalises a scalar into a one-element array. Only the base wrapper derives length from the raw prop.

Found while auditing a separate docs issue (#11430); filed separately since it is a different component.
