### PR TITLE
docs(v4): remove deprecated tsconfig baseUrl setting from Vite and Astro guides

### DIFF
--- a/apps/v4/content/docs/installation/astro.mdx
+++ b/apps/v4/content/docs/installation/astro.mdx
@@ -203,11 +203,10 @@ If your project already has the `@/*` alias configured, skip this step.
 
 Add the following code to the `tsconfig.json` file to resolve paths:
 
-```ts title="tsconfig.json" {4-9} showLineNumbers
+```ts title="tsconfig.json" {4-8} showLineNumbers
 {
   "compilerOptions": {
     // ...
-    "baseUrl": ".",
     "paths": {
       "@/*": [
         "./src/*"

--- a/apps/v4/content/docs/installation/vite.mdx
+++ b/apps/v4/content/docs/installation/vite.mdx
@@ -213,9 +213,9 @@ Replace everything in `src/index.css` with the following:
 
 If your project already has the `@/*` alias configured, skip this step.
 
-Vite splits TypeScript configuration across multiple files. Add the `baseUrl` and `paths` properties to the `compilerOptions` section of `tsconfig.json` and `tsconfig.app.json`:
+Vite splits TypeScript configuration across multiple files. Add the `paths` property to the `compilerOptions` section of `tsconfig.json` and `tsconfig.app.json`:
 
-```ts title="tsconfig.json" {11-16} showLineNumbers
+```ts title="tsconfig.json" {11-15} showLineNumbers
 {
   "files": [],
   "references": [
@@ -227,7 +227,6 @@ Vite splits TypeScript configuration across multiple files. Add the `baseUrl` an
     }
   ],
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }
@@ -239,11 +238,10 @@ Vite splits TypeScript configuration across multiple files. Add the `baseUrl` an
 
 Add the same alias to `tsconfig.app.json` so your editor can resolve imports:
 
-```ts title="tsconfig.app.json" {4-9} showLineNumbers
+```ts title="tsconfig.app.json" {4-8} showLineNumbers
 {
   "compilerOptions": {
     // ...
-    "baseUrl": ".",
     "paths": {
       "@/*": [
         "./src/*"


### PR DESCRIPTION
### Summary
Fixes #11421

Removes deprecated `"baseUrl": "."` from the tsconfig code blocks in Vite (`apps/v4/content/docs/installation/vite.mdx`) and Astro (`apps/v4/content/docs/installation/astro.mdx`) documentation pages to support modern bundler resolution in TypeScript 5.0+ / 6.0+.