### PR TITLE
feat(registry): add @blockforge to the registry directory

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -238,6 +238,14 @@
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='var(--foreground)'><path stroke='none' d='M0 0h24v24H0z' fill='none'/><path d='M12 2c-.218 0 -.432 .002 -.642 .005l-.616 .017l-.299 .013l-.579 .034l-.553 .046c-4.785 .464 -6.732 2.411 -7.196 7.196l-.046 .553l-.034 .579c-.005 .098 -.01 .198 -.013 .299l-.017 .616l-.004 .318l-.001 .324c0 .218 .002 .432 .005 .642l.017 .616l.013 .299l.034 .579l.046 .553c.464 4.785 2.411 6.732 7.196 7.196l.553 .046l.579 .034c.098 .005 .198 .01 .299 .013l.616 .017l.642 .005l.642 -.005l.616 -.017l.299 -.013l.579 -.034l.553 -.046c4.785 -.464 6.732 -2.411 7.196 -7.196l.046 -.553l.034 -.579c.005 -.098 .01 -.198 .013 -.299l.017 -.616l.005 -.642l-.005 -.642l-.017 -.616l-.013 -.299l-.034 -.579l-.046 -.553c-.464 -4.785 -2.411 -6.732 -7.196 -7.196l-.553 -.046l-.579 -.034a28.058 28.058 0 0 0 -.299 -.013l-.616 -.017l-.318 -.004l-.324 -.001z'/></svg>"
   },
   {
+    "name": "@blockforge",
+    "homepage": "https://blockforge.terravidhal.me",
+    "url": "https://blockforge.terravidhal.me/r/{name}.json",
+    "description": "170+ production-grade shadcn/ui blocks, forged to ship. Full source in TypeScript + Tailwind CSS, plus a page builder and starter pages. Copy, paste, ship.",
+    "author": "terravidhal",
+    "logo": "<svg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' xmlns='http://www.w3.org/2000/svg'><path d='M10 22V7a1 1 0 0 0-1-1H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-5a1 1 0 0 0-1-1H2'/><rect x='14.5' y='2.5' width='7' height='7' rx='1' transform='rotate(-8 18 6)'/></svg>"
+  },
+  {
     "name": "@blockus",
     "homepage": "https://blockus.lndevui.com",
     "url": "https://blockus.lndevui.com/r/{name}.json",


### PR DESCRIPTION
Adds Blockforge to the registry directory.

**Blockforge** — 170+ production-grade shadcn/ui blocks, forged to ship. Full source in TypeScript + Tailwind CSS, plus a page builder and starter pages.

- **Name:** `@blockforge`
- **Homepage:** https://blockforge.terravidhal.me
- **Registry:** https://blockforge.terravidhal.me/r/{name}.json

The entry is inserted alphabetically (between `@blocks-so` and `@blockus`) and the logo uses `currentColor` so it adapts to light and dark themes.

### Checklist
- [x] Entry added to `apps/v4/registry/directory.json`
- [x] Kept alphabetical order
- [x] Registry URL follows the `{name}` pattern and is publicly reachable
- [x] Commit is signed
