### PR TITLE
fix: replace indeterminate prop with checked="indeterminate" in DataTable row selection doc

### DIFF
--- a/apps/v4/content/docs/components/base/data-table.mdx
+++ b/apps/v4/content/docs/components/base/data-table.mdx
@@ -764,9 +764,12 @@ export const columns = columnHelper.columns([
     id: "select",
     header: ({ table }) => (
       <Checkbox
-        checked={table.getIsAllPageRowsSelected()}
-        indeterminate={
-          table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected()
+        checked={
+          table.getIsAllPageRowsSelected()
+            ? true
+            : table.getIsSomePageRowsSelected()
+              ? "indeterminate"
+              : false
         }
         onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
         aria-label="Select all"


### PR DESCRIPTION
## Summary

Fixes the TypeScript error in the DataTable row selection documentation example where the `indeterminate` prop is not supported by the Base UI Checkbox component.

## Changes

- Replaced the `indeterminate` prop with `checked="indeterminate"` string value pattern
- The Base UI Checkbox's `checked` prop accepts `boolean | "indeterminate"`, so using `checked` with the `"indeterminate"` string achieves the same visual indeterminate state

## Related Issue

Closes #11450
