### PR TITLE
fix(Select): ignore empty value in onValueChange for controlled usage

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/select.tsx
+++ b/apps/v4/registry/new-york-v4/ui/select.tsx
@@ -7,9 +7,19 @@ import { Select as SelectPrimitive } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 function Select({
+  onValueChange,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />
+  return (
+    <SelectPrimitive.Root
+      data-slot="select"
+      {...props}
+      onValueChange={(value) => {
+        if (!value) return;
+        onValueChange?.(value);
+      }}
+    />
+  )
 }
 
 function SelectGroup({


### PR DESCRIPTION
## Description

When Select is used as a controlled component (e.g. with React Hook Form),
`onValueChange` can be called with an empty string when the controlled
`value` changes programmatically, causing the form value to be reset to `''`.

This guard prevents empty values from being propagated through `onValueChange`,
keeping the Select from reverting to its placeholder state unexpectedly.

## Related issue

Closes #11453

## Changes

- `apps/v4/registry/new-york-v4/ui/select.tsx`: wrap `onValueChange` to skip empty strings