### PR TITLE
fix(transform-tw-prefix): preserve quotes in transformed class literals

### DIFF
--- a/packages/shadcn/src/utils/transformers/__snapshots__/transform-tw-prefix.test.ts.snap
+++ b/packages/shadcn/src/utils/transformers/__snapshots__/transform-tw-prefix.test.ts.snap
@@ -27,7 +27,7 @@ export function Foo() {
 exports[`transform tailwind prefix 4`] = `
 "import * as React from "react"
 export function Foo() {
-	return <div className={cn("tw:bg-white hover:tw:bg-stone-100 dark:tw:bg-stone-950 dark:hover:tw:bg-stone-800", true && "tw:text-stone-50 sm:focus:tw:text-stone-900 dark:tw:text-stone-900 dark:sm:focus:tw:text-stone-50")}>foo</div>
+	return <div className={cn('tw:bg-white hover:tw:bg-stone-100 dark:tw:bg-stone-950 dark:hover:tw:bg-stone-800', true && 'tw:text-stone-50 sm:focus:tw:text-stone-900 dark:tw:text-stone-900 dark:sm:focus:tw:text-stone-50')}>foo</div>
 }
     "
 `;

--- a/packages/shadcn/src/utils/transformers/transform-tw-prefix.test.ts
+++ b/packages/shadcn/src/utils/transformers/transform-tw-prefix.test.ts
@@ -1,4 +1,5 @@
 import type { Config } from "@/src/utils/get-config"
+import ts from "typescript"
 import { describe, expect, it } from "vitest"
 
 import { transform } from "."
@@ -182,4 +183,100 @@ export function Foo() {
       "v4"
     )
   ).toMatchSnapshot()
+})
+
+describe("transformTwPrefixes preserves quotes in class values", () => {
+  async function run(raw: string) {
+    return await transform({
+      filename: "test.tsx",
+      raw: `import * as React from "react"\n${raw}\n`,
+      config: {
+        tailwind: {
+          baseColor: "stone",
+          cssVariables: false,
+          prefix: "tw:",
+        },
+        aliases: {
+          components: "@/components",
+          utils: "@/lib/utils",
+        },
+      } as Config,
+      baseColor: stone,
+    })
+  }
+
+  it("preserves quotes in a className attribute", async () => {
+    const result = await run(
+      `export function Foo() {
+  return <div className="[&_svg:not([class*='size-'])]:size-4" />
+}`
+    )
+
+    expect(result).toContain("[&_svg:not([class*='size-'])]:tw:size-4")
+  })
+
+  it("preserves quotes in cn() arguments", async () => {
+    const result = await run(
+      `export function Foo({ x }) {
+  return <div className={cn("[&_svg:not([class*='size-'])]:size-4", x && "after:content-['']", x ? "data-[a='b']:p-1" : "data-[a='c']:p-2")} />
+}`
+    )
+
+    expect(result).toContain("[&_svg:not([class*='size-'])]:tw:size-4")
+    expect(result).toContain("after:tw:content-['']")
+    expect(result).toContain("data-[a='b']:tw:p-1")
+    expect(result).toContain("data-[a='c']:tw:p-2")
+  })
+
+  it("preserves quotes in cva base and variants", async () => {
+    const result = await run(
+      `const foo = cva("[&_svg:not([class*='size-'])]:size-4", {
+  variants: { size: { sm: "data-[state='open']:block" } },
+})`
+    )
+
+    expect(result).toContain("[&_svg:not([class*='size-'])]:tw:size-4")
+    expect(result).toContain("data-[state='open']:tw:block")
+  })
+
+  it("preserves quotes in a classNames object", async () => {
+    const result = await run(
+      `export function Foo({ x }) {
+  return <div classNames={{ day: "after:content-['']", month: cn("data-[a='b']:p-1", x ? "data-[a='c']:p-2" : "data-[a='d']:p-3") }} />
+}`
+    )
+
+    expect(result).toContain("after:tw:content-['']")
+    expect(result).toContain("data-[a='b']:tw:p-1")
+    expect(result).toContain("data-[a='c']:tw:p-2")
+    expect(result).toContain("data-[a='d']:tw:p-3")
+  })
+
+  it("escapes quotes that match the enclosing delimiter", async () => {
+    const result = await run(
+      String.raw`export function Foo() {
+  return <div className={cn('[&_svg:not([class*=\'size-\'])]:size-4')} />
+}`
+    )
+
+    const sourceFile = ts.createSourceFile(
+      "test.tsx",
+      result,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX
+    )
+    const stringLiterals: string[] = []
+
+    function visit(node: ts.Node) {
+      if (ts.isStringLiteral(node)) {
+        stringLiterals.push(node.text)
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(sourceFile)
+
+    expect((sourceFile as any).parseDiagnostics).toHaveLength(0)
+    expect(stringLiterals).toContain("[&_svg:not([class*='size-'])]:tw:size-4")
+  })
 })

--- a/packages/shadcn/src/utils/transformers/transform-tw-prefix.ts
+++ b/packages/shadcn/src/utils/transformers/transform-tw-prefix.ts
@@ -22,17 +22,17 @@ export const transformTwPrefixes: Transformer = async ({
     .filter((node) => node.getExpression().getText() === "cva")
     .forEach((node) => {
       // cva(base, ...)
-      if (node.getArguments()[0]?.isKind(SyntaxKind.StringLiteral)) {
-        const defaultClassNames = node.getArguments()[0]
-        if (defaultClassNames) {
-          defaultClassNames.replaceWithText(
-            `"${applyPrefix(
-              defaultClassNames.getText()?.replace(/"|'/g, ""),
-              config.tailwind.prefix,
-              tailwindVersion
-            )}"`
+      const defaultClassNames = node
+        .getArguments()[0]
+        ?.asKind(SyntaxKind.StringLiteral)
+      if (defaultClassNames) {
+        defaultClassNames.setLiteralValue(
+          applyPrefix(
+            defaultClassNames.getLiteralText(),
+            config.tailwind.prefix,
+            tailwindVersion
           )
-        }
+        )
       }
 
       // cva(..., { variants: { ... } })
@@ -50,12 +50,12 @@ export const transformTwPrefixes: Transformer = async ({
                   SyntaxKind.StringLiteral
                 )
                 if (classNames) {
-                  classNames?.replaceWithText(
-                    `"${applyPrefix(
-                      classNames.getText()?.replace(/"|'/g, ""),
+                  classNames.setLiteralValue(
+                    applyPrefix(
+                      classNames.getLiteralText(),
                       config.tailwind.prefix,
                       tailwindVersion
-                    )}"`
+                    )
                   )
                 }
               })
@@ -67,17 +67,15 @@ export const transformTwPrefixes: Transformer = async ({
   sourceFile.getDescendantsOfKind(SyntaxKind.JsxAttribute).forEach((node) => {
     if (node.getNameNode().getText() === "className") {
       // className="..."
-      if (node.getInitializer()?.isKind(SyntaxKind.StringLiteral)) {
-        const value = node.getInitializer()
-        if (value) {
-          value.replaceWithText(
-            `"${applyPrefix(
-              value.getText()?.replace(/"|'/g, ""),
-              config.tailwind.prefix,
-              tailwindVersion
-            )}"`
+      const value = node.getInitializer()?.asKind(SyntaxKind.StringLiteral)
+      if (value) {
+        value.setLiteralValue(
+          applyPrefix(
+            value.getLiteralText(),
+            config.tailwind.prefix,
+            tailwindVersion
           )
-        }
+        )
       }
 
       // className={...}
@@ -97,23 +95,23 @@ export const transformTwPrefixes: Transformer = async ({
               node
                 .getChildrenOfKind(SyntaxKind.StringLiteral)
                 .forEach((node) => {
-                  node.replaceWithText(
-                    `"${applyPrefix(
-                      node.getText()?.replace(/"|'/g, ""),
+                  node.setLiteralValue(
+                    applyPrefix(
+                      node.getLiteralText(),
                       config.tailwind.prefix,
                       tailwindVersion
-                    )}"`
+                    )
                   )
                 })
             }
 
             if (node.isKind(SyntaxKind.StringLiteral)) {
-              node.replaceWithText(
-                `"${applyPrefix(
-                  node.getText()?.replace(/"|'/g, ""),
+              node.setLiteralValue(
+                applyPrefix(
+                  node.getLiteralText(),
                   config.tailwind.prefix,
                   tailwindVersion
-                )}"`
+                )
               )
             }
           })
@@ -138,41 +136,41 @@ export const transformTwPrefixes: Transformer = async ({
                     arg
                       .getChildrenOfKind(SyntaxKind.StringLiteral)
                       .forEach((node) => {
-                        node.replaceWithText(
-                          `"${applyPrefix(
-                            node.getText()?.replace(/"|'/g, ""),
+                        node.setLiteralValue(
+                          applyPrefix(
+                            node.getLiteralText(),
                             config.tailwind.prefix,
                             tailwindVersion
-                          )}"`
+                          )
                         )
                       })
                   }
 
                   if (arg.isKind(SyntaxKind.StringLiteral)) {
-                    arg.replaceWithText(
-                      `"${applyPrefix(
-                        arg.getText()?.replace(/"|'/g, ""),
+                    arg.setLiteralValue(
+                      applyPrefix(
+                        arg.getLiteralText(),
                         config.tailwind.prefix,
                         tailwindVersion
-                      )}"`
+                      )
                     )
                   }
                 })
               }
             }
 
-            if (node.getInitializer()?.isKind(SyntaxKind.StringLiteral)) {
-              if (node.getNameNode().getText() !== "variant") {
-                const classNames = node.getInitializer()
-                if (classNames) {
-                  classNames.replaceWithText(
-                    `"${applyPrefix(
-                      classNames.getText()?.replace(/"|'/g, ""),
-                      config.tailwind.prefix,
-                      tailwindVersion
-                    )}"`
+            if (node.getNameNode().getText() !== "variant") {
+              const classNames = node.getInitializerIfKind(
+                SyntaxKind.StringLiteral
+              )
+              if (classNames) {
+                classNames.setLiteralValue(
+                  applyPrefix(
+                    classNames.getLiteralText(),
+                    config.tailwind.prefix,
+                    tailwindVersion
                   )
-                }
+                )
               }
             }
           })


### PR DESCRIPTION
This is the same defect as #10495, in the sibling transformer.

## The bug

`transformTwPrefixes` rebuilds each class literal as quoted source text by hand:

```js
node.replaceWithText(
  `"${applyPrefix(node.getText()?.replace(/"|'/g, ""), prefix, version)}"`
)
```

`getText()` returns the raw source *including* the delimiters, so the `.replace(/"|'/g, "")` that strips them also strips **every quote inside the class value**. Tailwind arbitrary values use quotes routinely, so they are silently destroyed:

| source | today |
|---|---|
| `[&_.recharts-dot[stroke='#fff']]:stroke-transparent` | `[&_.recharts-dot[stroke=#fff]]:tw:stroke-transparent` |
| `after:content-['']` | `after:tw:content-[]` |
| `[&_svg:not([class*='size-'])]:size-4` | `[&_svg:not([class*=size-])]:tw:size-4` |

All eight literal-rewriting sites in the file were affected, covering `cva` base and variants, `className="..."`, `className={cn(...)}` including conditional and logical arguments, and `classNames={{ ... }}`.

## Why it matters

Not every stripped quote changes behaviour, so I checked which ones actually do by compiling the before/after classes with Tailwind v4.3.3 and validating the generated selectors.

**`[stroke='#fff']` → `[stroke=#fff]` — rule is dropped by the browser.** Tailwind still emits the rule, but `#fff` is not a valid unquoted attribute value, so the selector fails to parse. Confirmed independently by two parsers:

```
jsdom querySelector   [stroke=#ccc]     SyntaxError
                      [stroke='#ccc']   ok
lightningcss          [stroke=#ccc]     Invalid value in attribute selector: IDHash("ccc")
                      [stroke='#ccc']   ok
```

**`content-['']` → `content-[]` — no rule is emitted at all.** Tailwind generates `.after\:content-\[\'\'\]::after { … }` for the correct form and nothing whatsoever for the degraded one, so the pseudo-element never renders.

**`[class*='size-']` → `[class*=size-]` — harmless.** `size-` is a valid CSS identifier, both forms parse and match identically. I mention it because it is by far the most common instance and it is *not* a bug; only the two cases above break.

## The change

Each site now uses ts-morph's literal APIs — `getLiteralText()` to read the cooked value and `setLiteralValue()` to write it back — so the parser owns delimiting and escaping instead of a template string. This is exactly the fix #10495 applied to `transform-rtl.ts`.

Three sites re-fetched the node after an `isKind` check, which discarded the narrowing; they now narrow with `asKind` / `getInitializerIfKind`, already the idiom used elsewhere in this file.

## Verification

I ran the transformer over every `.tsx` under `apps/*/registry` — **1,435 files** — on `main` and on this branch, and diffed:

| | |
|---|---|
| byte-identical | **1,404** |
| files differing | **31** |
| changed tokens | **76** |
| of which a restored quote | **76** |
| any other kind of difference | **0** |
| files throwing, either build | **0** |

Splitting those 76 by the analysis above:

| | tokens | files |
|---|---|---|
| broken today, fixed here | **22** | 5 — `chart.tsx` ×4, `toast.tsx` |
| cosmetic | 54 | 27 |

So on the repo's own components the entire observable effect of this change is quotes that stop being deleted, and 22 of those instances are currently producing CSS the browser discards.

## Behaviour change worth flagging

`setLiteralValue` keeps the literal's existing delimiter, where the old template always emitted double quotes. One existing snapshot covered an input written with single quotes and recorded the rewrite to double, so it is updated:

```diff
-return <div className={cn("tw:bg-white …", true && "tw:text-stone-50 …")}>foo</div>
+return <div className={cn('tw:bg-white …', true && 'tw:text-stone-50 …')}>foo</div>
```

Class values are unchanged; only the delimiter differs. Leaving the author's quote style alone seemed right for a transformer whose job is prefixing, but say the word and I will force the delimiter instead.

Relatedly, escape sequences in ordinary JS string literals are now emitted in cooked form — `"w-[calc(100%\_-\_1rem)]"` becomes `"w-[calc(100%_-_1rem)]"`. The runtime value is identical, since `\_` is not a JS escape and already evaluated to `_`. JSX attribute literals, where backslashes are genuinely *not* escapes, are correctly left alone and round-trip unchanged. Neither form occurs anywhere in the registry, which is why the diff above shows no instances of either.

## Tests

Five cases added to `transform-tw-prefix.test.ts`, one per code path plus an escaping case that reparses the output and asserts `parseDiagnostics` is empty, following the test added in #10495.

**With the fix reverted but the tests kept, all five fail.**

## Checks

- `pnpm --filter=shadcn test` — **1,681 passed**, up from 1,676
- `pnpm --filter=shadcn typecheck` — unchanged from `main`
- `pnpm --filter=shadcn build` — clean
- prettier — clean

One test *file* (`../tests/src/utils/registry.ts`) cannot resolve `fs-extra` in my checkout, and the identical typecheck error appears on unmodified `main`, so it is pre-existing and unrelated to this change.
