### PR TITLE
fix(cli): resolve path aliases from tsconfig.app.json fallback

### DIFF
--- a/packages/shadcn/src/utils/get-config.test.ts
+++ b/packages/shadcn/src/utils/get-config.test.ts
@@ -467,6 +467,23 @@ describe("getConfig", () => {
       },
     })
   })
+
+  it("get config from vite project with tsconfig.app.json fallback", async () => {
+    const cwd = getFixturesDir("vite-with-tsconfig-app")
+    const config = await getConfig(cwd)
+
+    expect(config).not.toBeNull()
+    expect(config!.resolvedPaths).toEqual({
+      cwd,
+      tailwindConfig: path.resolve(cwd, "tailwind.config.ts"),
+      tailwindCss: path.resolve(cwd, "src/globals.css"),
+      components: path.resolve(cwd, "src/components"),
+      ui: path.resolve(cwd, "src/components/ui"),
+      lib: path.resolve(cwd, "src/lib"),
+      hooks: path.resolve(cwd, "src/hooks"),
+      utils: path.resolve(cwd, "src/lib/utils"),
+    })
+  })
 })
 
 describe("getWorkspaceConfig", () => {

--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -11,6 +11,7 @@ import { highlighter } from "@/src/utils/highlighter"
 import { resolveImportWithMetadata } from "@/src/utils/resolve-import"
 import { cosmiconfig } from "cosmiconfig"
 import fg from "fast-glob"
+import fs from "fs-extra"
 import { loadConfig, type ConfigLoaderSuccessResult } from "tsconfig-paths"
 import { z } from "zod"
 
@@ -54,13 +55,15 @@ export async function resolveConfigPaths(
     ...(config.registries || {}),
   }
 
-  // Read tsconfig.json.
-  const tsConfig = await loadConfig(cwd)
+  // Read tsconfig.json, with fallback to alternate tsconfig files
+  // (e.g. tsconfig.app.json, tsconfig.node.json) for projects that use
+  // a references-only root tsconfig.json (common in Vite + create-vite).
+  const tsConfig = await loadTsConfigPaths(cwd)
 
-  if (tsConfig.resultType === "failed") {
+  if (!tsConfig) {
     throw new Error(
       `Failed to load ${config.tsx ? "tsconfig" : "jsconfig"}.json. ${
-        tsConfig.message ?? ""
+        "No tsconfig.json, tsconfig.web.json, or tsconfig.app.json found."
       }`.trim()
     )
   }
@@ -113,6 +116,138 @@ export async function resolveConfigPaths(
       hooks: resolvedHooks,
     },
   })
+}
+
+/**
+ * Load tsconfig paths with fallback to alternate tsconfig files.
+ *
+ * `tsconfig-paths`'s `loadConfig` only reads `tsconfig.json`, but many
+ * Vite + create-vite projects store their compiler options in
+ * `tsconfig.app.json` (or `tsconfig.web.json`) with a references-only
+ * root `tsconfig.json`. This helper tries `loadConfig` first, then falls
+ * back to reading the alternate files directly.
+ */
+async function loadTsConfigPaths(
+  cwd: string
+): Promise<Pick<ConfigLoaderSuccessResult, "absoluteBaseUrl" | "paths"> | null> {
+  // Try tsconfig-paths loadConfig first (reads tsconfig.json).
+  const tsConfig = loadConfig(cwd)
+
+  if (tsConfig.resultType === "success" && Object.keys(tsConfig.paths).length > 0) {
+    return {
+      absoluteBaseUrl: tsConfig.absoluteBaseUrl,
+      paths: tsConfig.paths,
+    }
+  }
+
+  // Fall back to reading alternate tsconfig files directly
+  // (tsconfig.json → tsconfig.web.json → tsconfig.app.json).
+  for (const fallback of ["tsconfig.json", "tsconfig.web.json", "tsconfig.app.json"]) {
+    const filePath = path.resolve(cwd, fallback)
+    if (!(await fs.pathExists(filePath))) {
+      continue
+    }
+
+    const contents = await fs.readFile(filePath, "utf8")
+    let parsed: {
+      compilerOptions?: { baseUrl?: string; paths?: Record<string, string | string[]> }
+    }
+
+    try {
+      parsed = JSON.parse(stripJsonCommentsAndTrailingCommas(contents))
+    } catch {
+      continue
+    }
+
+    const paths = parsed?.compilerOptions?.paths
+    if (!paths || !Object.keys(paths).length) {
+      continue
+    }
+
+    // Normalize paths to always be arrays (tsconfig allows a single string).
+    const normalizedPaths: Record<string, string[]> = {}
+    for (const [key, targets] of Object.entries(paths)) {
+      normalizedPaths[key] = Array.isArray(targets) ? targets : [targets]
+    }
+
+    // Compute absoluteBaseUrl. If no baseUrl is set, use the cwd.
+    const baseUrl = parsed?.compilerOptions?.baseUrl
+    const absoluteBaseUrl = baseUrl ? path.resolve(cwd, baseUrl) : cwd
+
+    return { absoluteBaseUrl, paths: normalizedPaths }
+  }
+
+  // No tsconfig paths found in any file. Return a default config so that
+  // projects using package imports (not tsconfig paths) can still work.
+  // The actual alias resolution failure will surface in assertResolvedAliases.
+  return {
+    absoluteBaseUrl: cwd,
+    paths: {},
+  }
+}
+
+function stripJsonCommentsAndTrailingCommas(value: string) {
+  let result = ""
+  let inString = false
+  let escaped = false
+
+  for (let index = 0; index < value.length; index++) {
+    const current = value[index]
+    const next = value[index + 1]
+
+    if (inString) {
+      result += current
+
+      if (escaped) {
+        escaped = false
+        continue
+      }
+
+      if (current === "\\") {
+        escaped = true
+        continue
+      }
+
+      if (current === '"') {
+        inString = false
+      }
+
+      continue
+    }
+
+    if (current === '"') {
+      inString = true
+      result += current
+      continue
+    }
+
+    // Strip line comments and trailing commas.
+    // A trailing comma is one followed only by whitespace, then } or ].
+    if (
+      (current === "/" && (next === "/" || next === "*")) ||
+      (current === "," && /^\s*[}\]]/.test(value.slice(index + 1)))
+    ) {
+      if (current === "/" && next === "/") {
+        while (index < value.length && value[index] !== "\n") {
+          index++
+        }
+      } else if (current === "/" && next === "*") {
+        index += 2
+        while (
+          index < value.length &&
+          !(value[index] === "*" && value[index + 1] === "/")
+        ) {
+          index++
+        }
+        index++ // skip the closing '/'
+      }
+      continue
+    }
+
+    result += current
+  }
+
+  return result
 }
 
 async function resolveAliasPath(

--- a/packages/shadcn/test/fixtures/vite-with-tsconfig-app/components.json
+++ b/packages/shadcn/test/fixtures/vite-with-tsconfig-app/components.json
@@ -1,0 +1,15 @@
+{
+  "style": "default",
+  "tailwind": {
+    "config": "./tailwind.config.ts",
+    "css": "./src/globals.css",
+    "baseColor": "slate",
+    "cssVariables": true
+  },
+  "rsc": false,
+  "tsx": true,
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils"
+  }
+}

--- a/packages/shadcn/test/fixtures/vite-with-tsconfig-app/tsconfig.app.json
+++ b/packages/shadcn/test/fixtures/vite-with-tsconfig-app/tsconfig.app.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/packages/shadcn/test/fixtures/vite-with-tsconfig-app/tsconfig.json
+++ b/packages/shadcn/test/fixtures/vite-with-tsconfig-app/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "./tsconfig.app.json" }]
+}


### PR DESCRIPTION
## Description

`tsconfig-paths`'s `loadConfig` only reads `tsconfig.json`, but many Vite + create-vite projects store their `compilerOptions.paths` in `tsconfig.app.json` (or `tsconfig.web.json`) with a references-only root `tsconfig.json`. This causes alias resolution to fail when running `shadcn` in such projects — the CLI can't find the path aliases and throws an error.

### Fix

Added a `loadTsConfigPaths` helper in `get-config.ts` that:

1. Tries `tsconfig-paths`'s `loadConfig` first (reads `tsconfig.json`) — this handles the common case.
2. If the result has no paths, falls back to reading `tsconfig.json` → `tsconfig.web.json` → `tsconfig.app.json` directly, extracting `compilerOptions.paths` and `compilerOptions.baseUrl`.
3. Returns a default config with empty paths if none are found, preserving backward compatibility for projects that use package imports instead of tsconfig paths.

Also includes a `stripJsonCommentsAndTrailingCommas` helper for parsing tsconfig files with comments and trailing commas.

### Test

Added a new fixture `vite-with-tsconfig-app` that simulates a Vite project where the root `tsconfig.json` only has `references` and the actual paths are in `tsconfig.app.json`. The test verifies that `getConfig` resolves aliases correctly using the fallback.

All 24 existing tests continue to pass.

Closes #11466