### PR TITLE
fix: make BubbleReactions reserve space in flow instead of overlapping (Fixes #11474)

### DIFF
--- a/apps/v4/registry/bases/aria/ui/bubble.tsx
+++ b/apps/v4/registry/bases/aria/ui/bubble.tsx
@@ -90,7 +90,7 @@ function BubbleContent({
 }
 
 const bubbleReactionsVariants = cva(
-  "cn-bubble-reactions absolute z-10 flex w-fit items-center justify-center",
+  "cn-bubble-reactions flex w-fit items-center justify-center",
   {
     variants: {
       side: {

--- a/apps/v4/registry/bases/base/ui/bubble.tsx
+++ b/apps/v4/registry/bases/base/ui/bubble.tsx
@@ -79,7 +79,7 @@ function BubbleContent({
 }
 
 const bubbleReactionsVariants = cva(
-  "cn-bubble-reactions absolute z-10 flex w-fit items-center justify-center",
+  "cn-bubble-reactions flex w-fit items-center justify-center",
   {
     variants: {
       side: {

--- a/apps/v4/registry/bases/radix/ui/bubble.tsx
+++ b/apps/v4/registry/bases/radix/ui/bubble.tsx
@@ -76,7 +76,7 @@ function BubbleContent({
 }
 
 const bubbleReactionsVariants = cva(
-  "cn-bubble-reactions absolute z-10 flex w-fit items-center justify-center",
+  "cn-bubble-reactions flex w-fit items-center justify-center",
   {
     variants: {
       side: {

--- a/apps/v4/registry/new-york-v4/ui/bubble.tsx
+++ b/apps/v4/registry/new-york-v4/ui/bubble.tsx
@@ -83,16 +83,16 @@ function BubbleContent({
 }
 
 const bubbleReactionsVariants = cva(
-  "absolute z-10 flex w-fit shrink-0 items-center justify-center gap-1 rounded-full bg-muted px-1.5 py-0.5 text-sm ring-3 ring-card has-[button]:p-0",
+  "flex w-fit shrink-0 items-center justify-center gap-1 rounded-full bg-muted px-1.5 py-0.5 text-sm ring-3 ring-card has-[button]:p-0",
   {
     variants: {
       side: {
-        top: "top-0 -translate-y-3/4",
-        bottom: "bottom-0 translate-y-3/4",
+        top: "order-first",
+        bottom: "order-last",
       },
       align: {
-        start: "left-3",
-        end: "right-3",
+        start: "self-start",
+        end: "self-end",
       },
     },
     defaultVariants: {

--- a/apps/v4/registry/styles/style-luma.css
+++ b/apps/v4/registry/styles/style-luma.css
@@ -1493,19 +1493,19 @@
   }
 
   .cn-bubble-reactions-side-top {
-    @apply top-0 -translate-y-3/4;
+    @apply order-first;
   }
 
   .cn-bubble-reactions-side-bottom {
-    @apply bottom-0 translate-y-3/4;
+    @apply order-last;
   }
 
   .cn-bubble-reactions-align-start {
-    @apply left-3;
+    @apply self-start;
   }
 
   .cn-bubble-reactions-align-end {
-    @apply right-3;
+    @apply self-end;
   }
 
   .cn-bubble-group {

--- a/apps/v4/registry/styles/style-lyra.css
+++ b/apps/v4/registry/styles/style-lyra.css
@@ -1472,19 +1472,19 @@
   }
 
   .cn-bubble-reactions-side-top {
-    @apply top-0 -translate-y-3/4;
+    @apply order-first;
   }
 
   .cn-bubble-reactions-side-bottom {
-    @apply bottom-0 translate-y-3/4;
+    @apply order-last;
   }
 
   .cn-bubble-reactions-align-start {
-    @apply left-3;
+    @apply self-start;
   }
 
   .cn-bubble-reactions-align-end {
-    @apply right-3;
+    @apply self-end;
   }
 
   .cn-bubble-group {

--- a/apps/v4/registry/styles/style-maia.css
+++ b/apps/v4/registry/styles/style-maia.css
@@ -1494,19 +1494,19 @@
   }
 
   .cn-bubble-reactions-side-top {
-    @apply top-0 -translate-y-3/4;
+    @apply order-first;
   }
 
   .cn-bubble-reactions-side-bottom {
-    @apply bottom-0 translate-y-3/4;
+    @apply order-last;
   }
 
   .cn-bubble-reactions-align-start {
-    @apply left-3;
+    @apply self-start;
   }
 
   .cn-bubble-reactions-align-end {
-    @apply right-3;
+    @apply self-end;
   }
 
   .cn-bubble-group {

--- a/apps/v4/registry/styles/style-mira.css
+++ b/apps/v4/registry/styles/style-mira.css
@@ -1499,19 +1499,19 @@
   }
 
   .cn-bubble-reactions-side-top {
-    @apply top-0 -translate-y-3/4;
+    @apply order-first;
   }
 
   .cn-bubble-reactions-side-bottom {
-    @apply bottom-0 translate-y-3/4;
+    @apply order-last;
   }
 
   .cn-bubble-reactions-align-start {
-    @apply left-3;
+    @apply self-start;
   }
 
   .cn-bubble-reactions-align-end {
-    @apply right-3;
+    @apply self-end;
   }
 
   .cn-bubble-group {

--- a/apps/v4/registry/styles/style-nova.css
+++ b/apps/v4/registry/styles/style-nova.css
@@ -1497,19 +1497,19 @@
   }
 
   .cn-bubble-reactions-side-top {
-    @apply top-0 -translate-y-3/4;
+    @apply order-first;
   }
 
   .cn-bubble-reactions-side-bottom {
-    @apply bottom-0 translate-y-3/4;
+    @apply order-last;
   }
 
   .cn-bubble-reactions-align-start {
-    @apply left-3;
+    @apply self-start;
   }
 
   .cn-bubble-reactions-align-end {
-    @apply right-3;
+    @apply self-end;
   }
 
   .cn-bubble-group {

--- a/apps/v4/registry/styles/style-rhea.css
+++ b/apps/v4/registry/styles/style-rhea.css
@@ -1493,19 +1493,19 @@
   }
 
   .cn-bubble-reactions-side-top {
-    @apply top-0 -translate-y-3/4;
+    @apply order-first;
   }
 
   .cn-bubble-reactions-side-bottom {
-    @apply bottom-0 translate-y-3/4;
+    @apply order-last;
   }
 
   .cn-bubble-reactions-align-start {
-    @apply left-3;
+    @apply self-start;
   }
 
   .cn-bubble-reactions-align-end {
-    @apply right-3;
+    @apply self-end;
   }
 
   .cn-bubble-group {

--- a/apps/v4/registry/styles/style-sera.css
+++ b/apps/v4/registry/styles/style-sera.css
@@ -1484,19 +1484,19 @@
   }
 
   .cn-bubble-reactions-side-top {
-    @apply top-0 -translate-y-3/4;
+    @apply order-first;
   }
 
   .cn-bubble-reactions-side-bottom {
-    @apply bottom-0 translate-y-3/4;
+    @apply order-last;
   }
 
   .cn-bubble-reactions-align-start {
-    @apply left-3;
+    @apply self-start;
   }
 
   .cn-bubble-reactions-align-end {
-    @apply right-3;
+    @apply self-end;
   }
 
   .cn-bubble-group {

--- a/apps/v4/registry/styles/style-vega.css
+++ b/apps/v4/registry/styles/style-vega.css
@@ -1493,19 +1493,19 @@
   }
 
   .cn-bubble-reactions-side-top {
-    @apply top-0 -translate-y-3/4;
+    @apply order-first;
   }
 
   .cn-bubble-reactions-side-bottom {
-    @apply bottom-0 translate-y-3/4;
+    @apply order-last;
   }
 
   .cn-bubble-reactions-align-start {
-    @apply left-3;
+    @apply self-start;
   }
 
   .cn-bubble-reactions-align-end {
-    @apply right-3;
+    @apply self-end;
   }
 
   .cn-bubble-group {


### PR DESCRIPTION
Fixes #11474

## Description

`BubbleReactions` used `absolute z-10` positioning, removing it from the document flow. This caused the reaction pill to overlap any content rendered after the bubble — BubbleGroup siblings, MessageFooter, or any other content inside MessageContent.

## Changes

- Removed `absolute z-10` from BubbleReactions base styles — it now stays in normal flow
- `side="top"`: uses `order-first` to appear above content
- `side="bottom"`: uses `order-last` to appear below content
- `align="start"`: uses `self-start` for left alignment
- `align="end"`: uses `self-end` for right alignment
- Updated all 4 component variants (base, radix, aria, new-york-v4)
- Updated all 8 style CSS files

## Before

Reactions overlapped the next bubble in BubbleGroup and covered MessageFooter text.

## After

Reactions push content down, reserving space in the layout.