### PR TITLE
fix(docs): replace radix asChild with render prop in base docs

### DIFF
--- a/apps/v4/content/docs/components/base/button-group.mdx
+++ b/apps/v4/content/docs/components/base/button-group.mdx
@@ -215,7 +215,7 @@ Use this component to display text within a button group.
 
 | Prop      | Type      | Default |
 | --------- | --------- | ------- |
-| `asChild` | `boolean` | `false` |
+| `render` | `React.ReactElement` | -       |
 
 ```tsx
 <ButtonGroup>
@@ -224,7 +224,7 @@ Use this component to display text within a button group.
 </ButtonGroup>
 ```
 
-Use the `asChild` prop to render a custom component as the text, for example a label.
+Use the `render` prop to render a custom component as the text, for example a label.
 
 ```tsx showLineNumbers
 import { ButtonGroupText } from "@/components/ui/button-group"
@@ -233,8 +233,8 @@ import { Label } from "@/components/ui/label"
 export function ButtonGroupTextDemo() {
   return (
     <ButtonGroup>
-      <ButtonGroupText asChild>
-        <Label htmlFor="name">Text</Label>
+      <ButtonGroupText render={<Label htmlFor="name" />}>
+        Text
       </ButtonGroupText>
       <Input placeholder="Type something here..." id="name" />
     </ButtonGroup>

--- a/apps/v4/content/docs/components/base/data-table.mdx
+++ b/apps/v4/content/docs/components/base/data-table.mdx
@@ -399,11 +399,9 @@ export const columns = columnHelper.columns([
 
       return (
         <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" className="h-8 w-8 p-0">
-              <span className="sr-only">Open menu</span>
-              <MoreHorizontal className="h-4 w-4" />
-            </Button>
+          <DropdownMenuTrigger render={<Button variant="ghost" className="h-8 w-8 p-0" />}>
+            <span className="sr-only">Open menu</span>
+            <MoreHorizontal className="h-4 w-4" />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuLabel>Actions</DropdownMenuLabel>
@@ -703,10 +701,8 @@ export function DataTable<TData extends RowData>({
           className="max-w-sm"
         />
         <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" className="ml-auto">
-              Columns
-            </Button>
+          <DropdownMenuTrigger render={<Button variant="outline" className="ml-auto" />}>
+            Columns
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             {table

--- a/apps/v4/content/docs/components/base/field.mdx
+++ b/apps/v4/content/docs/components/base/field.mdx
@@ -342,7 +342,7 @@ Label styled for both direct inputs and nested `Field` children.
 | Prop        | Type      | Default |
 | ----------- | --------- | ------- |
 | `className` | `string`  |         |
-| `asChild`   | `boolean` | `false` |
+| `render`    | `React.ReactElement` | -       |
 
 ```tsx
 <FieldLabel htmlFor="email">Email</FieldLabel>

--- a/apps/v4/content/docs/components/base/sidebar.mdx
+++ b/apps/v4/content/docs/components/base/sidebar.mdx
@@ -274,13 +274,11 @@ Use the `SidebarHeader` component to add a sticky header to the sidebar.
     <SidebarMenu>
       <SidebarMenuItem>
         <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <SidebarMenuButton>
-              Select Workspace
-              <ChevronDown className="ml-auto" />
-            </SidebarMenuButton>
+          <DropdownMenuTrigger render={<SidebarMenuButton />}>
+            Select Workspace
+            <ChevronDown className="ml-auto" />
           </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-[--radix-popper-anchor-width]">
+          <DropdownMenuContent className="w-(--anchor-width)">
             <DropdownMenuItem>
               <span>Acme Inc</span>
             </DropdownMenuItem>
@@ -344,11 +342,9 @@ To make a `SidebarGroup` collapsible, wrap it in a `Collapsible`.
 ```tsx showLineNumbers
 <Collapsible defaultOpen className="group/collapsible">
   <SidebarGroup>
-    <SidebarGroupLabel asChild>
-      <CollapsibleTrigger>
-        Help
-        <ChevronDown className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-180" />
-      </CollapsibleTrigger>
+    <SidebarGroupLabel render={<CollapsibleTrigger />}>
+      Help
+      <ChevronDown className="ml-auto transition-transform group-data-open/collapsible:rotate-180" />
     </SidebarGroupLabel>
     <CollapsibleContent>
       <SidebarGroupContent />
@@ -380,11 +376,9 @@ The `SidebarMenu` component is used for building a menu within a `SidebarGroup`.
 <SidebarMenu>
   {projects.map((project) => (
     <SidebarMenuItem key={project.name}>
-      <SidebarMenuButton asChild>
-        <a href={project.url}>
-          <project.icon />
-          <span>{project.name}</span>
-        </a>
+      <SidebarMenuButton render={<a href={project.url} />}>
+        <project.icon />
+        <span>{project.name}</span>
       </SidebarMenuButton>
     </SidebarMenuItem>
   ))}
@@ -395,13 +389,13 @@ The `SidebarMenu` component is used for building a menu within a `SidebarGroup`.
 
 The `SidebarMenuButton` component is used to render a menu button within a `SidebarMenuItem`.
 
-By default, the `SidebarMenuButton` renders a button but you can use the `asChild` prop to render a different component such as a `Link` or an `a` tag.
+By default, the `SidebarMenuButton` renders a button but you can use the `render` prop to render a different component such as a `Link` or an `a` tag.
 
 Use the `isActive` prop to mark a menu item as active.
 
 ```tsx showLineNumbers
-<SidebarMenuButton asChild isActive>
-  <a href="#">Home</a>
+<SidebarMenuButton render={<a href="#" />} isActive>
+  Home
 </SidebarMenuButton>
 ```
 
@@ -411,11 +405,9 @@ The `SidebarMenuAction` component is used to render a menu action within a `Side
 
 ```tsx showLineNumbers
 <SidebarMenuItem>
-  <SidebarMenuButton asChild>
-    <a href="#">
-      <Home />
-      <span>Home</span>
-    </a>
+  <SidebarMenuButton render={<a href="#" />}>
+    <Home />
+    <span>Home</span>
   </SidebarMenuButton>
   <SidebarMenuAction>
     <Plus /> <span className="sr-only">Add Project</span>


### PR DESCRIPTION
## Summary

Several **base** docs pages still show the radix `asChild` composition in their code snippets, which doesn't exist in Base UI components (they use the `render` prop). This PR converts the remaining occurrences across the base docs:

- **`base/sidebar`** — `SidebarMenuButton` link examples (×3), `DropdownMenuTrigger` in the SidebarHeader example, `SidebarGroupLabel` in the collapsible group example, and the `SidebarMenuButton` prose. Also converts two radix-isms in the same snippets: `w-[--radix-popper-anchor-width]` → `w-(--anchor-width)` and `group-data-[state=open]/collapsible` → `group-data-open/collapsible`.
- **`base/data-table`** — `DropdownMenuTrigger asChild` in the row-actions and column-visibility examples (fixes #10934).
- **`base/button-group`** — `ButtonGroupText` prop table, prose, and example.
- **`base/field`** — `FieldLabel` prop table.

Deliberately untouched: the `base/drawer` migration guide (its `asChild` occurrences are intentional "before" diffs) and the live `<Button asChild>` MDX at the bottom of the sidebar pages (site code, not a snippet).

Each conversion was verified against the published `base-nova` registry payloads (`SidebarMenuButton`/`SidebarGroupLabel`/`ButtonGroupText` expose `render` via `useRender`; `DropdownMenuTrigger`/`FieldLabel` pass through to Base UI parts) and the Base UI docs (`--anchor-width`, `data-open`).

Related: #9049 (reports the sidebar page showing `asChild` even with Base UI selected), #10465.

Worth noting: the docs pages server-render these snippets, so non-JS consumers — curl, search engines, and LLM coding agents fetching the docs — receive the radix-style code on base pages. We traced real Base UI apps shipping `<SidebarMenuButton asChild>` (silently broken nested `<button><a>`) back to agents reading these pages.

## Test plan

- [ ] `asChild` no longer appears in base docs snippets (`rg asChild apps/v4/content/docs/components/base` returns only the drawer migration guide and the live MDX button)
- [ ] Snippets match the corresponding base registry examples' composition style
