### PR TITLE
fix(sidebar): use aria-expanded for base-vega open-state instead of data-open

### DIFF
--- a/apps/v4/registry/bases/base/blocks/sidebar-01/components/version-switcher.tsx
+++ b/apps/v4/registry/bases/base/blocks/sidebar-01/components/version-switcher.tsx
@@ -31,7 +31,7 @@ export function VersionSwitcher({
             render={
               <SidebarMenuButton
                 size="lg"
-                className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+                className="aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
               />
             }
           >

--- a/apps/v4/registry/bases/base/blocks/sidebar-02/components/version-switcher.tsx
+++ b/apps/v4/registry/bases/base/blocks/sidebar-02/components/version-switcher.tsx
@@ -31,7 +31,7 @@ export function VersionSwitcher({
             render={
               <SidebarMenuButton
                 size="lg"
-                className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+                className="aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
               />
             }
           >

--- a/apps/v4/registry/bases/base/blocks/sidebar-07/components/team-switcher.tsx
+++ b/apps/v4/registry/bases/base/blocks/sidebar-07/components/team-switcher.tsx
@@ -42,7 +42,7 @@ export function TeamSwitcher({
             render={
               <SidebarMenuButton
                 size="lg"
-                className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+                className="aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
               />
             }
           >

--- a/apps/v4/registry/bases/base/blocks/sidebar-09/components/nav-user.tsx
+++ b/apps/v4/registry/bases/base/blocks/sidebar-09/components/nav-user.tsx
@@ -40,7 +40,7 @@ export function NavUser({
             render={
               <SidebarMenuButton
                 size="lg"
-                className="md:h-8 md:p-0 data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+                className="md:h-8 md:p-0 aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
               />
             }
           >

--- a/apps/v4/registry/bases/base/examples/sidebar-example.tsx
+++ b/apps/v4/registry/bases/base/examples/sidebar-example.tsx
@@ -179,7 +179,7 @@ export default function SidebarExample() {
                   render={
                     <SidebarMenuButton
                       size="lg"
-                      className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+                      className="aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
                     />
                   }
                 >

--- a/apps/v4/registry/bases/base/examples/sidebar-icon-example.tsx
+++ b/apps/v4/registry/bases/base/examples/sidebar-icon-example.tsx
@@ -245,7 +245,7 @@ export default function SidebarIconExample() {
                   render={
                     <SidebarMenuButton
                       size="lg"
-                      className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+                      className="aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
                     />
                   }
                 >
@@ -382,7 +382,7 @@ export default function SidebarIconExample() {
                   render={
                     <SidebarMenuButton
                       size="lg"
-                      className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+                      className="aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
                     />
                   }
                 >

--- a/apps/v4/registry/styles/style-vega.css
+++ b/apps/v4/registry/styles/style-vega.css
@@ -1160,7 +1160,7 @@
   }
 
   .cn-sidebar-menu-button {
-    @apply ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground gap-2 rounded-md p-2 text-left text-sm transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! focus-visible:ring-2 data-active:font-medium;
+    @apply ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground aria-expanded:hover:bg-sidebar-accent aria-expanded:hover:text-sidebar-accent-foreground gap-2 rounded-md p-2 text-left text-sm transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! focus-visible:ring-2 data-active:font-medium;
   }
 
   .cn-sidebar-menu-button-aria {


### PR DESCRIPTION
## Summary

Fixes #11479 — `sidebarMenuButtonVariants` uses `data-open:hover:bg-sidebar-accent` but Base UI triggers never set `data-open`. This attribute is set on the popup content, not the trigger. The open-state accent never appears.

## Root cause

In Base UI:
- `Menu.Trigger` → `data-popup-open`
- `Collapsible.Trigger` / `Accordion.Trigger` → `data-panel-open`
- `Tooltip.Trigger` → `data-popup-open`
- **None** set `data-open` on the trigger

The `data-open` selector is the popup content attribute, so it never matches a `SidebarMenuButton` trigger.

## Fix

Replace `data-open` with `aria-expanded` in:
1. `style-vega.css` — `.cn-sidebar-menu-button` rule 
2. All base-vega blocks and examples that use `data-open:bg-sidebar-accent`

`aria-expanded` is set by `Menu.Trigger`, `Collapsible.Trigger`, and `Accordion.Trigger`, but not by `Tooltip.Trigger`. This correctly styles the open state without triggering on tooltip hover.

## Files changed

- `apps/v4/registry/styles/style-vega.css` — CSS rule: `data-open:hover:bg-sidebar-accent` → `aria-expanded:hover:bg-sidebar-accent`
- `apps/v4/registry/bases/base/blocks/sidebar-01/components/version-switcher.tsx`
- `apps/v4/registry/bases/base/blocks/sidebar-02/components/version-switcher.tsx`
- `apps/v4/registry/bases/base/blocks/sidebar-07/components/team-switcher.tsx`
- `apps/v4/registry/bases/base/blocks/sidebar-09/components/nav-user.tsx`
- `apps/v4/registry/bases/base/examples/sidebar-example.tsx`
- `apps/v4/registry/bases/base/examples/sidebar-icon-example.tsx`