### PR TITLE
fix(Select): filter empty string from onValueChange in controlled mode (Fixes #11453)

### DIFF
--- a/.changeset/fix-select-onvaluechange.md
+++ b/.changeset/fix-select-onvaluechange.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+fix(Select): filter empty string from onValueChange in controlled mode

--- a/apps/v4/registry/bases/radix/ui/select.tsx
+++ b/apps/v4/registry/bases/radix/ui/select.tsx
@@ -7,9 +7,19 @@ import { cn } from "@/registry/bases/radix/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
 function Select({
+  onValueChange,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />
+  return (
+    <SelectPrimitive.Root
+      data-slot="select"
+      {...props}
+      onValueChange={(value) => {
+        if (value === "") return
+        onValueChange?.(value)
+      }}
+    />
+  )
 }
 
 function SelectGroup({

--- a/apps/v4/registry/new-york-v4/ui/select.tsx
+++ b/apps/v4/registry/new-york-v4/ui/select.tsx
@@ -7,9 +7,19 @@ import { Select as SelectPrimitive } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 function Select({
+  onValueChange,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />
+  return (
+    <SelectPrimitive.Root
+      data-slot="select"
+      {...props}
+      onValueChange={(value) => {
+        if (value === "") return
+        onValueChange?.(value)
+      }}
+    />
+  )
 }
 
 function SelectGroup({


### PR DESCRIPTION
## Description

Fixes #11453

When using the shadcn/ui Select component as a controlled component, `onValueChange` is called with an empty string (`""`) when the controlled `value` changes programmatically. This causes issues with React Hook Form integration and other controlled use cases.

**Root cause**: Radix's `onValueChange` fires with `""` during controlled value synchronization.

**Fix**: Filter empty string values in `onValueChange` at the shadcn/ui Select wrapper level.

## Changes

- `apps/v4/registry/new-york-v4/ui/select.tsx` — intercept `onValueChange` and skip empty strings
- `apps/v4/registry/bases/radix/ui/select.tsx` — intercept `onValueChange` and skip empty strings

## Testing

- [x] Empty string ("") is filtered out, only non-empty values propagate
- [x] Normal selection still works as expected
- [x] Controlled value updates no longer trigger phantom empty string calls