### PR TITLE
fix(data-table): use checked indeterminate value in base row selection docs (Fixes #11450)

### DIFF
--- a/apps/v4/content/docs/components/base/data-table.mdx
+++ b/apps/v4/content/docs/components/base/data-table.mdx
@@ -762,9 +762,9 @@ export const columns = columnHelper.columns([
     id: "select",
     header: ({ table }) => (
       <Checkbox
-        checked={table.getIsAllPageRowsSelected()}
-        indeterminate={
-          table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected()
+        checked={
+          table.getIsAllPageRowsSelected() ||
+          (table.getIsSomePageRowsSelected() && "indeterminate")
         }
         onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
         aria-label="Select all"

--- a/apps/v4/examples/base/data-table-demo.tsx
+++ b/apps/v4/examples/base/data-table-demo.tsx
@@ -106,9 +106,9 @@ export const columns = columnHelper.columns([
     id: "select",
     header: ({ table }) => (
       <Checkbox
-        checked={table.getIsAllPageRowsSelected()}
-        indeterminate={
-          table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected()
+        checked={
+          table.getIsAllPageRowsSelected() ||
+          (table.getIsSomePageRowsSelected() && "indeterminate")
         }
         onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
         aria-label="Select all"


### PR DESCRIPTION
## Description

Fixes #11450

The base data-table row selection docs and example use a standalone `indeterminate` prop on `<Checkbox>`, but Base UI's `Checkbox` does not have that prop — indeterminate state is expressed via `checked="indeterminate"` instead. This causes a TypeScript error for users following the docs:

```
Property 'indeterminate' does not exist on type 'IntrinsicAttributes & CheckboxProps & RefAttributes<HTMLButtonElement>'.ts(2322)
```

## Fix

Changed both places to use the `checked` prop with the `"indeterminate"` string value, matching how the Radix/New York variant already does it:

```tsx
<Checkbox
  checked={
    table.getIsAllPageRowsSelected() ||
    (table.getIsSomePageRowsSelected() && "indeterminate")
  }
  onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
  aria-label="Select all"
/>
```

## Changes

- `apps/v4/content/docs/components/base/data-table.mdx` — updated the row selection docs example
- `apps/v4/examples/base/data-table-demo.tsx` — updated the demo component