### PR TITLE
feat(registry): add @motion-lexicon to the registry directory

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -954,6 +954,13 @@
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' fill='none' stroke='var(--foreground)' stroke-width='2' stroke-linecap='round'><path d='M4 22c4-10 8 10 12 0s8-10 12 0'/></svg>"
   },
   {
+    "name": "@motion-lexicon",
+    "homepage": "https://motion-lexicon.pages.dev",
+    "url": "https://motion-lexicon.pages.dev/r/{name}.json",
+    "description": "Copy-ready React page blocks and motion components with bilingual previews, reduced-motion paths, and shadcn Registry delivery.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' fill='none'><rect width='32' height='32' rx='8' fill='var(--foreground)'/><path d='M8 23V9M8 23h16' stroke='var(--background)' stroke-width='1.5' stroke-linecap='round'/><path d='M8.5 22.5C10 14 14 10 23.5 9.5' stroke='#4568ff' stroke-width='2.5' stroke-linecap='round'/></svg>"
+  },
+  {
     "name": "@motion-primitives",
     "homepage": "https://www.motion-primitives.com",
     "url": "https://motion-primitives.com/c/{name}.json",


### PR DESCRIPTION
## Summary

- **Name:** `@motion-lexicon`
- **Homepage:** https://motion-lexicon.pages.dev
- **Registry:** `https://motion-lexicon.pages.dev/r/{name}.json`
- **Source:** https://github.com/Ryan-yang125/motion-lexicon (MIT)
- **Items:** 104 (5 page blocks, 59 components, and 40 motion primitives)

Motion Lexicon is a bilingual visual vocabulary for browsing motion, previewing behavior, tuning parameters, and copying production-ready React source. Registry items include reduced-motion behavior and portable implementation guidance. Version 5.0 introduces a complete zero-chroma visual rebuild across the site, all five page blocks, and the 31 components added after the initial collection, including the 11-part Agent product interface collection and Agent Workspace block.

## Checklist

- [x] Entry inserted in alphabetical order between `@motion-menu` and `@motion-primitives`
- [x] Registry URL includes the `{name}` placeholder and is publicly accessible
- [x] Root catalog and all 104 item endpoints are live
- [x] `pnpm --filter=v4 validate:registries` passes in this repository
- [x] `shadcn build registry.json` accepts all 104 source items
- [x] The production Agent Workspace URL installs in a fresh shadcn Vite app
- [x] The fresh app passes its production build after installation
- [x] Namespace search and view were verified with `@motion-lexicon`
- [x] Logo adapts to light and dark directory themes