### PR TITLE
fix: move placeholder out of items array in base field-select example

### DIFF
--- a/apps/v4/examples/base/field-select.tsx
+++ b/apps/v4/examples/base/field-select.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/styles/base-nova/ui/select"
 
 const items = [
-  { label: "Choose department", value: null },
   { label: "Engineering", value: "engineering" },
   { label: "Design", value: "design" },
   { label: "Marketing", value: "marketing" },
@@ -28,7 +27,7 @@ export default function FieldSelect() {
   return (
     <Field className="w-full max-w-xs">
       <FieldLabel>Department</FieldLabel>
-      <Select items={items}>
+      <Select items={items} placeholder="Choose department">
         <SelectTrigger>
           <SelectValue />
         </SelectTrigger>


### PR DESCRIPTION
## Description

The base Field Select example included `{ label: "Choose department", value: null }` in the items array, which made it appear as a selectable dropdown option and prevented the `SelectValue` component from showing a placeholder.

## Fix

- Removed the `{ label: "Choose department", value: null }` entry from the items array
- Added `placeholder="Choose department"` to the `Select` component

This matches the existing pattern used in the [aria](https://github.com/shadcn-ui/ui/blob/main/apps/v4/examples/aria/field-select.tsx) and [radix](https://github.com/shadcn-ui/ui/blob/main/apps/v4/examples/radix/field-select.tsx) Field Select examples.

Closes #11486