### PR TITLE
fix(base-ui): avoid PaginationLink data-slot hydration mismatch

### DIFF
--- a/apps/v4/registry/bases/base/ui/pagination.tsx
+++ b/apps/v4/registry/bases/base/ui/pagination.tsx
@@ -38,13 +38,13 @@ function PaginationItem({ ...props }: React.ComponentProps<"li">) {
 
 type PaginationLinkProps = {
   isActive?: boolean
-} & Pick<React.ComponentProps<typeof Button>, "size"> &
-  React.ComponentProps<"a">
+} & Omit<React.ComponentProps<typeof Button>, "variant">
 
 function PaginationLink({
   className,
   isActive,
   size = "icon",
+  render,
   ...props
 }: PaginationLinkProps) {
   return (
@@ -53,14 +53,11 @@ function PaginationLink({
       size={size}
       className={cn("cn-pagination-link", className)}
       nativeButton={false}
-      render={
-        <a
-          aria-current={isActive ? "page" : undefined}
-          data-slot="pagination-link"
-          data-active={isActive}
-          {...props}
-        />
-      }
+      render={render ?? <a />}
+      {...props}
+      aria-current={isActive ? "page" : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
     />
   )
 }


### PR DESCRIPTION
## Summary
- Stop nesting a hardcoded `<a data-slot="pagination-link">` inside Base UI `Button` (which also sets `data-slot="button"`), which caused SSR/client attribute mismatch.
- Default `render` to `<a />` and forward a custom `render` (e.g. Next.js `Link`) so it replaces the element instead of ending up as a prop on `<a>`.
- Aligns Base UI `PaginationLink` with the Aria base pattern (slot attrs on the button/link component).

Closes #11489

## Test plan
- [ ] Add Base UI pagination, SSR a page with `PaginationLink` / Previous / Next
- [ ] Confirm no hydration warning for `data-slot`
- [ ] Confirm `href="#"` links still work
- [ ] Confirm `render={<Link href="..." />}` works without nested `<a render={...}>`