### PR TITLE
docs(components): fix broken Base UI API reference link for hover-card

### DIFF
--- a/apps/v4/content/docs/components/base/hover-card.mdx
+++ b/apps/v4/content/docs/components/base/hover-card.mdx
@@ -4,8 +4,8 @@ description: For sighted users to preview content available behind a link.
 base: base
 component: true
 links:
-  doc: https://base-ui.com/react/components/hover-card
-  api: https://base-ui.com/react/components/hover-card#api-reference
+  doc: https://base-ui.com/react/components/preview-card
+  api: https://base-ui.com/react/components/preview-card#api-reference
 ---
 
 <ComponentPreview
@@ -141,4 +141,4 @@ To enable RTL support in shadcn/ui, see the [RTL configuration guide](/docs/rtl)
 
 ## API Reference
 
-See the [Base UI](https://base-ui.com/react/components/hover-card#api-reference) documentation for more information.
+See the [Base UI](https://base-ui.com/react/components/preview-card#api-reference) documentation for more information.


### PR DESCRIPTION
## What does this PR do?

Fixes a broken external link in the Hover Card component docs.

The API reference currently points to:
```
https://base-ui.com/react/components/hover-card#api-reference
```
This returns a **404** because Base UI renamed their component from `hover-card` to `preview-card`.

## Changes

- Updated the Base UI API reference link in `apps/v4/content/docs/components/base/hover-card.mdx` to point to the correct URL:
```
https://base-ui.com/react/components/preview-card#api-reference
```

## Type of change

`docs` — fixes a broken external link, no component logic affected.