### PR TITLE
fix(shadcn): restore Tailwind v4 accordion animations

### DIFF
--- a/apps/v4/content/docs/(root)/cli.mdx
+++ b/apps/v4/content/docs/(root)/cli.mdx
@@ -576,6 +576,9 @@ npx shadcn@latest eject
 @import "tw-animate-css";
 /* ejected from shadcn@4.8.3 */
 @theme inline {
+  --animate-accordion-down: accordion-down 0.2s ease-out;
+  --animate-accordion-up: accordion-up 0.2s ease-out;
+
   @keyframes accordion-down {
     from {
       height: 0;

--- a/apps/v4/content/docs/changelog/2026-05-shadcn-eject.mdx
+++ b/apps/v4/content/docs/changelog/2026-05-shadcn-eject.mdx
@@ -31,6 +31,9 @@ npx shadcn@latest eject
 @import "tw-animate-css";
 /* ejected from shadcn@4.8.3 */
 @theme inline {
+  --animate-accordion-down: accordion-down 0.2s ease-out;
+  --animate-accordion-up: accordion-up 0.2s ease-out;
+
   @keyframes accordion-down {
     from {
       height: 0;

--- a/packages/shadcn/src/commands/eject.test.ts
+++ b/packages/shadcn/src/commands/eject.test.ts
@@ -148,6 +148,12 @@ describe("runEject", () => {
     expect(output).toContain('@import "tw-animate-css";')
     expect(output).toContain("/* ejected from shadcn@4.8.3 */")
     expect(output).toContain(shadcnCss.trim())
+    expect(shadcnCss).toContain(
+      "--animate-accordion-down: accordion-down 0.2s ease-out;"
+    )
+    expect(shadcnCss).toContain(
+      "--animate-accordion-up: accordion-up 0.2s ease-out;"
+    )
     expect(output).toContain("@layer base")
     expect(output).toContain("@apply bg-background text-foreground;")
     expect(execa).toHaveBeenCalledWith("pnpm", ["remove", "shadcn"], {

--- a/packages/shadcn/src/tailwind.css
+++ b/packages/shadcn/src/tailwind.css
@@ -1,4 +1,7 @@
 @theme inline {
+  --animate-accordion-down: accordion-down 0.2s ease-out;
+  --animate-accordion-up: accordion-up 0.2s ease-out;
+
   @keyframes accordion-down {
     from {
       height: 0;


### PR DESCRIPTION
Fixes #6925

## Summary

Tailwind v4 only generates the `animate-accordion-*` utilities when the corresponding `--animate-*` theme variables are defined. The shared shadcn CSS included the accordion keyframes but omitted those variables, so accordion open and close animations were missing.

This adds the two animation theme variables, covers them in the eject regression test, and updates the documented ejected CSS snippets.

## Testing

- `pnpm --filter=shadcn test` (84 files, 1,745 tests)
- `pnpm --filter=shadcn build`
- `pnpm --filter=shadcn exec tsc --noEmit`
- `pnpm --filter=v4 lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter=v4 typecheck`
- `pnpm --filter=v4 validate:registries`
- `pnpm format:check`
- `pnpm test` (registry build and app startup passed; 8 unrelated CLI tests exceeded the default Vitest timeout in the concurrent run)
