### PR TITLE
feat(docs): sync table of contents scrolling

### DIFF
--- a/apps/v4/components/docs-toc.tsx
+++ b/apps/v4/components/docs-toc.tsx
@@ -66,6 +66,29 @@ export function DocsTableOfContents({
     [toc]
   )
   const activeHeading = useActiveItem(itemIds)
+  const tocRef = React.useRef<HTMLDivElement>(null)
+  const activeItemRef = React.useRef<HTMLAnchorElement>(null)
+
+  React.useEffect(() => {
+    const container = tocRef.current?.parentElement
+    const activeItem = activeItemRef.current
+
+    if (!container || !activeItem) {
+      return
+    }
+
+    const containerRect = container.getBoundingClientRect()
+    const activeItemRect = activeItem.getBoundingClientRect()
+
+    container.scrollTo({
+      behavior: "smooth",
+      top:
+        container.scrollTop +
+        activeItemRect.top -
+        containerRect.top -
+        (container.clientHeight - activeItemRect.height) / 2,
+    })
+  }, [activeHeading])
 
   if (!toc?.length) {
     return null
@@ -106,13 +129,17 @@ export function DocsTableOfContents({
   }
 
   return (
-    <div className={cn("flex flex-col gap-2 p-4 pt-0 text-sm", className)}>
+    <div
+      ref={tocRef}
+      className={cn("flex flex-col gap-2 p-4 pt-0 text-sm", className)}
+    >
       <p className="h-6 bg-background text-xs font-medium text-muted-foreground">
         On This Page
       </p>
       {toc.map((item) => (
         <a
           key={item.url}
+          ref={item.url === `#${activeHeading}` ? activeItemRef : undefined}
           href={item.url}
           className="text-[0.8rem] text-muted-foreground no-underline transition-colors hover:text-foreground data-[active=true]:font-medium data-[active=true]:text-foreground data-[depth=3]:pl-4 data-[depth=4]:pl-6"
           data-active={item.url === `#${activeHeading}`}


### PR DESCRIPTION
 ## Summary

  The “On This Page” navigation highlights the active heading as users scroll, but on
  pages with many headings, the active item can move outside the visible TOC area.

  This change keeps the active item centered by smoothly scrolling only the TOC
  container. The document scroll position remains unaffected, and the existing
  dropdown behavior is unchanged.

  ## Demo

  ### Before

https://github.com/user-attachments/assets/e11e99a4-992d-492c-a0da-0d097fa7069f

  ### After

https://github.com/user-attachments/assets/7cb9cbb5-a7c9-4141-86cf-ec1b71f0deac

  ## Testing

  - Tested scrolling upward and downward on pages with long tables of contents
  - Passed Prettier, ESLint, and TypeScript checks