### PR TITLE
fix(registry): merge registries from package.json and components.json

### DIFF
--- a/.changeset/spicy-buttons-brake.md
+++ b/.changeset/spicy-buttons-brake.md
@@ -1,0 +1,5 @@
+---
+"shadcn": minor
+---
+
+merge registries from package.json and components.json, and support adding registries to package.json when components.json is not present

--- a/packages/shadcn/src/commands/registry/add.test.ts
+++ b/packages/shadcn/src/commands/registry/add.test.ts
@@ -1,6 +1,9 @@
+import { tmpdir } from "os"
+import path from "path"
+import fs from "fs-extra"
 import { describe, expect, it } from "vitest"
 
-import { parseRegistryArg } from "./add"
+import { addRegistriesToConfig, parseRegistryArg } from "./add"
 
 describe("parseRegistryArg", () => {
   it("should parse namespace without URL", () => {
@@ -54,5 +57,158 @@ describe("parseRegistryArg", () => {
     expect(() =>
       parseRegistryArg("mycompany=https://example.com/r/{name}.json")
     ).toThrow("must start with @")
+  })
+})
+
+describe("addRegistriesToConfig", () => {
+  it("should write registries to components.json when it exists", async () => {
+    const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
+    const componentsJsonFile = path.join(tempDir, "components.json")
+
+    await fs.writeJson(componentsJsonFile, { style: "new-york" })
+
+    try {
+      await addRegistriesToConfig(
+        ["@acme=https://acme.com/r/{name}.json"],
+        tempDir,
+        { silent: true }
+      )
+
+      const config = await fs.readJson(componentsJsonFile)
+      expect(config).toEqual({
+        style: "new-york",
+        registries: {
+          "@acme": "https://acme.com/r/{name}.json",
+        },
+      })
+    } finally {
+      await fs.rm(tempDir, { recursive: true })
+    }
+  })
+
+  it("should prefer components.json over package.json when both exist", async () => {
+    const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
+    const componentsJsonFile = path.join(tempDir, "components.json")
+    const packageJsonFile = path.join(tempDir, "package.json")
+
+    await fs.writeJson(componentsJsonFile, { style: "new-york" })
+    await fs.writeJson(packageJsonFile, { name: "test-package" })
+
+    try {
+      await addRegistriesToConfig(
+        ["@acme=https://acme.com/r/{name}.json"],
+        tempDir,
+        { silent: true }
+      )
+
+      const componentsJson = await fs.readJson(componentsJsonFile)
+      const packageJson = await fs.readJson(packageJsonFile)
+      expect(componentsJson.registries).toEqual({
+        "@acme": "https://acme.com/r/{name}.json",
+      })
+      expect(packageJson.registries).toBeUndefined()
+    } finally {
+      await fs.rm(tempDir, { recursive: true })
+    }
+  })
+
+  it("should write registries to package.json when components.json does not exist", async () => {
+    const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
+    const packageJsonFile = path.join(tempDir, "package.json")
+
+    await fs.writeJson(packageJsonFile, {
+      name: "test-package",
+      version: "1.0.0",
+    })
+
+    try {
+      await addRegistriesToConfig(
+        ["@acme=https://acme.com/r/{name}.json"],
+        tempDir,
+        { silent: true }
+      )
+
+      const packageJson = await fs.readJson(packageJsonFile)
+      expect(packageJson).toEqual({
+        name: "test-package",
+        version: "1.0.0",
+        registries: {
+          "@acme": "https://acme.com/r/{name}.json",
+        },
+      })
+    } finally {
+      await fs.rm(tempDir, { recursive: true })
+    }
+  })
+
+  it("should preserve existing registries when adding to package.json", async () => {
+    const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
+    const packageJsonFile = path.join(tempDir, "package.json")
+
+    await fs.writeJson(packageJsonFile, {
+      name: "test-package",
+      registries: {
+        "@existing": "https://existing.com/r/{name}.json",
+      },
+    })
+
+    try {
+      await addRegistriesToConfig(
+        ["@acme=https://acme.com/r/{name}.json"],
+        tempDir,
+        { silent: true }
+      )
+
+      const packageJson = await fs.readJson(packageJsonFile)
+      expect(packageJson.registries).toEqual({
+        "@existing": "https://existing.com/r/{name}.json",
+        "@acme": "https://acme.com/r/{name}.json",
+      })
+    } finally {
+      await fs.rm(tempDir, { recursive: true })
+    }
+  })
+
+  it("should skip registries already configured in package.json", async () => {
+    const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
+    const packageJsonFile = path.join(tempDir, "package.json")
+
+    await fs.writeJson(packageJsonFile, {
+      name: "test-package",
+      registries: {
+        "@acme": "https://existing.com/r/{name}.json",
+      },
+    })
+
+    try {
+      await addRegistriesToConfig(
+        ["@acme=https://new.com/r/{name}.json"],
+        tempDir,
+        { silent: true }
+      )
+
+      const packageJson = await fs.readJson(packageJsonFile)
+      expect(packageJson.registries).toEqual({
+        "@acme": "https://existing.com/r/{name}.json",
+      })
+    } finally {
+      await fs.rm(tempDir, { recursive: true })
+    }
+  })
+
+  it("should throw when neither components.json nor package.json exists", async () => {
+    const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
+
+    try {
+      await expect(
+        addRegistriesToConfig(
+          ["@acme=https://acme.com/r/{name}.json"],
+          tempDir,
+          { silent: true }
+        )
+      ).rejects.toThrow(/No .*components\.json.* or .*package\.json.* found/)
+    } finally {
+      await fs.rm(tempDir, { recursive: true })
+    }
   })
 })

--- a/packages/shadcn/src/commands/registry/add.ts
+++ b/packages/shadcn/src/commands/registry/add.ts
@@ -70,19 +70,26 @@ function pluralize(count: number, singular: string, plural: string) {
   return `${count} ${count === 1 ? singular : plural}`
 }
 
-async function addRegistriesToConfig(
+export async function addRegistriesToConfig(
   registryArgs: string[],
   cwd: string,
   options: { silent?: boolean }
 ) {
-  const configPath = path.resolve(cwd, "components.json")
-  if (!fs.existsSync(configPath)) {
+  // Write to components.json when it exists, otherwise fall back to
+  // package.json. This mirrors how registries are resolved.
+  const configPath = ["components.json", "package.json"]
+    .map((file) => path.resolve(cwd, file))
+    .find((file) => fs.existsSync(file))
+
+  if (!configPath) {
     throw new Error(
-      `No ${highlighter.info("components.json")} found. Run ${highlighter.info(
-        "shadcn init"
-      )} first.`
+      `No ${highlighter.info("components.json")} or ${highlighter.info(
+        "package.json"
+      )} found. Run ${highlighter.info("shadcn init")} first.`
     )
   }
+
+  const configFileName = path.basename(configPath)
 
   const parsed = registryArgs.map(parseRegistryArg)
   const needsLookup = parsed.filter((p) => !p.url)
@@ -179,7 +186,7 @@ async function addRegistriesToConfig(
     },
   }
 
-  const writeSpinner = spinner("Updating components.json.", {
+  const writeSpinner = spinner(`Updating ${configFileName}.`, {
     silent: options.silent,
   }).start()
   await fs.writeJson(configPath, updatedConfig, { spaces: 2 })

--- a/packages/shadcn/src/registry/api.test.ts
+++ b/packages/shadcn/src/registry/api.test.ts
@@ -1539,7 +1539,7 @@ describe("getRegistriesConfig", () => {
     }
   })
 
-  it("should prefer components.json over package.json", async () => {
+  it("should merge registries from components.json and package.json", async () => {
     const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
     const componentsJsonFile = path.join(tempDir, "components.json")
     const packageJsonFile = path.join(tempDir, "package.json")
@@ -1567,8 +1567,8 @@ describe("getRegistriesConfig", () => {
       expect(result.registries).toEqual({
         ...BUILTIN_REGISTRIES,
         "@components": "https://components.com/{name}.json",
+        "@package": "https://package.com/{name}.json",
       })
-      expect(result.registries["@package"]).toBeUndefined()
     } finally {
       await fs.unlink(componentsJsonFile)
       await fs.unlink(packageJsonFile)
@@ -1576,7 +1576,46 @@ describe("getRegistriesConfig", () => {
     }
   })
 
-  it("should not fall back to package.json when components.json has no registries", async () => {
+  it("should prefer components.json over package.json for conflicting registries", async () => {
+    const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
+    const componentsJsonFile = path.join(tempDir, "components.json")
+    const packageJsonFile = path.join(tempDir, "package.json")
+
+    await fs.writeFile(
+      componentsJsonFile,
+      JSON.stringify({
+        registries: {
+          "@acme": "https://components.com/{name}.json",
+        },
+      })
+    )
+    await fs.writeFile(
+      packageJsonFile,
+      JSON.stringify({
+        registries: {
+          "@acme": "https://package.com/{name}.json",
+          "@package": "https://package.com/{name}.json",
+        },
+      })
+    )
+
+    try {
+      const result = await getRegistriesConfig(tempDir)
+
+      expect(result.registries["@acme"]).toBe(
+        "https://components.com/{name}.json"
+      )
+      expect(result.registries["@package"]).toBe(
+        "https://package.com/{name}.json"
+      )
+    } finally {
+      await fs.unlink(componentsJsonFile)
+      await fs.unlink(packageJsonFile)
+      await fs.rmdir(tempDir)
+    }
+  })
+
+  it("should merge package.json registries when components.json has no registries", async () => {
     const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
     const componentsJsonFile = path.join(tempDir, "components.json")
     const packageJsonFile = path.join(tempDir, "package.json")
@@ -1599,7 +1638,51 @@ describe("getRegistriesConfig", () => {
     try {
       const result = await getRegistriesConfig(tempDir)
 
-      expect(result.registries).toEqual(BUILTIN_REGISTRIES)
+      expect(result.registries).toEqual({
+        ...BUILTIN_REGISTRIES,
+        "@package": "https://package.com/{name}.json",
+      })
+    } finally {
+      await fs.unlink(componentsJsonFile)
+      await fs.unlink(packageJsonFile)
+      await fs.rmdir(tempDir)
+    }
+  })
+
+  it("should throw ConfigParseError for invalid package.json registries even when components.json exists", async () => {
+    const tempDir = await fs.mkdtemp(path.join(tmpdir(), "shadcn-test-"))
+    const componentsJsonFile = path.join(tempDir, "components.json")
+    const packageJsonFile = path.join(tempDir, "package.json")
+
+    await fs.writeFile(
+      componentsJsonFile,
+      JSON.stringify({
+        registries: {
+          "@components": "https://components.com/{name}.json",
+        },
+      })
+    )
+    await fs.writeFile(
+      packageJsonFile,
+      JSON.stringify({
+        registries: {
+          "@invalid": {
+            headers: {
+              Authorization: "Bearer token",
+            },
+          },
+        },
+      })
+    )
+
+    try {
+      await getRegistriesConfig(tempDir)
+      expect.fail("Should have thrown ConfigParseError")
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConfigParseError)
+      if (error instanceof ConfigParseError) {
+        expect(error.configFile).toBe("package.json")
+      }
     } finally {
       await fs.unlink(componentsJsonFile)
       await fs.unlink(packageJsonFile)

--- a/packages/shadcn/src/registry/api.ts
+++ b/packages/shadcn/src/registry/api.ts
@@ -220,6 +220,21 @@ export async function getRegistriesConfig(
     packageRegistriesExplorer.clearCaches()
   }
 
+  const packageJsonPath = path.resolve(cwd, "package.json")
+  let packageJsonRegistries: z.infer<typeof registryConfigSchema> = {}
+  if (existsSync(packageJsonPath)) {
+    const configResult = await packageRegistriesExplorer.load(packageJsonPath)
+    packageJsonRegistries = parseRegistriesConfig(
+      cwd,
+      {
+        registries: configResult?.config,
+      },
+      "package.json"
+    ).registries
+  }
+
+  // Registries are merged from package.json and components.json, with
+  // components.json taking precedence per key.
   const componentsJsonPath = path.resolve(cwd, "components.json")
   if (existsSync(componentsJsonPath)) {
     const configResult = await explorer.load(componentsJsonPath)
@@ -232,25 +247,14 @@ export async function getRegistriesConfig(
     return {
       registries: {
         ...BUILTIN_REGISTRIES,
+        ...packageJsonRegistries,
         ...config.registries,
       },
     }
   }
 
-  const packageJsonPath = path.resolve(cwd, "package.json")
-  if (existsSync(packageJsonPath)) {
-    const configResult = await packageRegistriesExplorer.load(packageJsonPath)
-    return parseRegistriesConfig(
-      cwd,
-      {
-        registries: configResult?.config,
-      },
-      "package.json"
-    )
-  }
-
   return {
-    registries: {},
+    registries: packageJsonRegistries,
   }
 }
 


### PR DESCRIPTION
Follow-up to #11304.

## Bugs fixed

1. `registry add` errored with "No components.json found" in projects that only have a `package.json`, even though registries can now be resolved from `package.json`. It now writes to `components.json` when present, otherwise `package.json` — mirroring how registries are resolved.

2. `getRegistriesConfig` treated `components.json` and `package.json` as either/or: if `components.json` existed, registries declared in `package.json` were ignored entirely. Registries are now merged from both files with precedence `BUILTIN → package.json → components.json` (most specific wins per key).

The package.json-only and no-config cases are unchanged from #11304: consumers without a `components.json` still get exactly what they declared, with no built-in registries injected.

## Follow-up

The `getConfig` path used by `shadcn add` still resolves registries from `components.json` only, so `shadcn add @pkg/item` won't see a registry declared only in `package.json`. That fix routes through `ensureRegistriesInConfig` and needs write-back leak protection in `init` — coming in a separate PR.