### PR TITLE
fix(registry): resolve package.json registries when adding components

### DIFF
--- a/.changeset/olive-pianos-happen.md
+++ b/.changeset/olive-pianos-happen.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+resolve registries declared in package.json when adding components. `shadcn add`, `search`, `view` and `init` now resolve registries from package.json in memory without persisting them to components.json

--- a/packages/shadcn/src/commands/init.test.ts
+++ b/packages/shadcn/src/commands/init.test.ts
@@ -192,7 +192,12 @@ describe("runInit", () => {
       createProjectConfig(projectCwd)
     )
     vi.mocked(ensureRegistriesInConfig).mockImplementation(
-      async (_components, config) => ({ config, newRegistries: [] })
+      async (_components, config) => ({
+        config,
+        newRegistries: [],
+        discoveredRegistries: {},
+        packageJsonRegistries: {},
+      })
     )
     vi.mocked(addComponents).mockResolvedValue(undefined)
   })

--- a/packages/shadcn/src/commands/init.ts
+++ b/packages/shadcn/src/commands/init.ts
@@ -712,17 +712,20 @@ export async function runInit(
 
   // Ensure registries are configured for the components we're about to add.
   const fullConfigForRegistry = await resolveConfigPaths(options.cwd, config)
-  const { config: configWithRegistries } = await ensureRegistriesInConfig(
-    components,
-    fullConfigForRegistry,
-    {
+  const { discoveredRegistries, packageJsonRegistries } =
+    await ensureRegistriesInConfig(components, fullConfigForRegistry, {
       silent: true,
-    }
-  )
+      writeFile: false,
+    })
 
-  // Update config with any new registries found.
-  if (configWithRegistries.registries) {
-    config.registries = configWithRegistries.registries
+  // Update config with registries discovered from the registries index.
+  // Registries declared in package.json are resolved in memory below and
+  // never persisted to components.json.
+  if (Object.keys(discoveredRegistries).length > 0) {
+    config.registries = {
+      ...config.registries,
+      ...discoveredRegistries,
+    }
   }
 
   const componentSpinner = spinner(`Writing components.json.`).start()
@@ -775,6 +778,16 @@ export async function runInit(
 
   // Propagate design settings to workspace components.json files.
   const fullConfig = await resolveConfigPaths(options.cwd, config)
+
+  // Include package.json-declared registries for installation. These are
+  // resolved in memory and stay out of the components.json we just wrote.
+  if (Object.keys(packageJsonRegistries).length > 0) {
+    fullConfig.registries = {
+      ...fullConfig.registries,
+      ...packageJsonRegistries,
+    }
+  }
+
   const workspaceConfig = await getWorkspaceConfig(fullConfig)
   if (workspaceConfig) {
     const designSettings: Record<string, unknown> = {}

--- a/packages/shadcn/src/commands/search.test.ts
+++ b/packages/shadcn/src/commands/search.test.ts
@@ -82,6 +82,8 @@ vi.mock("@/src/utils/registries", () => ({
   ensureRegistriesInConfig: vi.fn(() => ({
     config: baseConfig,
     newRegistries: [],
+    discoveredRegistries: {},
+    packageJsonRegistries: {},
   })),
 }))
 

--- a/packages/shadcn/src/registry/api.ts
+++ b/packages/shadcn/src/registry/api.ts
@@ -220,18 +220,7 @@ export async function getRegistriesConfig(
     packageRegistriesExplorer.clearCaches()
   }
 
-  const packageJsonPath = path.resolve(cwd, "package.json")
-  let packageJsonRegistries: z.infer<typeof registryConfigSchema> = {}
-  if (existsSync(packageJsonPath)) {
-    const configResult = await packageRegistriesExplorer.load(packageJsonPath)
-    packageJsonRegistries = parseRegistriesConfig(
-      cwd,
-      {
-        registries: configResult?.config,
-      },
-      "package.json"
-    ).registries
-  }
+  const packageJsonRegistries = await getPackageJsonRegistries(cwd)
 
   // Registries are merged from package.json and components.json, with
   // components.json taking precedence per key.
@@ -256,6 +245,24 @@ export async function getRegistriesConfig(
   return {
     registries: packageJsonRegistries,
   }
+}
+
+export async function getPackageJsonRegistries(
+  cwd: string
+): Promise<z.infer<typeof registryConfigSchema>> {
+  const packageJsonPath = path.resolve(cwd, "package.json")
+  if (!existsSync(packageJsonPath)) {
+    return {}
+  }
+
+  const configResult = await packageRegistriesExplorer.load(packageJsonPath)
+  return parseRegistriesConfig(
+    cwd,
+    {
+      registries: configResult?.config,
+    },
+    "package.json"
+  ).registries
 }
 
 function parseRegistriesConfig(

--- a/packages/shadcn/src/utils/registries.test.ts
+++ b/packages/shadcn/src/utils/registries.test.ts
@@ -1,18 +1,22 @@
+import {
+  getPackageJsonRegistries,
+  getRegistriesIndex,
+} from "@/src/registry/api"
+import { resolveRegistryNamespaces } from "@/src/registry/namespaces"
 import type { Config } from "@/src/utils/get-config"
 import fs from "fs-extra"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ensureRegistriesInConfig } from "./registries"
 
 // Mock dependencies.
 vi.mock("@/src/registry/namespaces", () => ({
-  resolveRegistryNamespaces: vi.fn().mockResolvedValue(["@foo"]),
+  resolveRegistryNamespaces: vi.fn(),
 }))
 
 vi.mock("@/src/registry/api", () => ({
-  getRegistriesIndex: vi.fn().mockResolvedValue({
-    "@foo": "https://foo.com/r/{name}.json",
-  }),
+  getRegistriesIndex: vi.fn(),
+  getPackageJsonRegistries: vi.fn(),
 }))
 
 vi.mock("@/src/utils/spinner", () => ({
@@ -27,9 +31,22 @@ vi.mock("@/src/utils/spinner", () => ({
 
 vi.mock("fs-extra", () => ({
   default: {
-    writeFile: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn(),
+    readJson: vi.fn(),
+    existsSync: vi.fn(),
   },
 }))
+
+beforeEach(() => {
+  vi.mocked(resolveRegistryNamespaces).mockResolvedValue(["@foo"])
+  vi.mocked(getRegistriesIndex).mockResolvedValue({
+    "@foo": "https://foo.com/r/{name}.json",
+  })
+  vi.mocked(getPackageJsonRegistries).mockResolvedValue({})
+  vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+  vi.mocked(fs.readJson).mockResolvedValue({})
+  vi.mocked(fs.existsSync).mockReturnValue(true)
+})
 
 afterEach(() => {
   vi.clearAllMocks()
@@ -65,6 +82,11 @@ const baseConfig: Config = {
     hooks: "",
     ui: "",
   },
+}
+
+function writtenConfig() {
+  const write = vi.mocked(fs.writeFile).mock.calls[0]
+  return JSON.parse(write[1] as string)
 }
 
 describe("ensureRegistriesInConfig", () => {
@@ -116,5 +138,131 @@ describe("ensureRegistriesInConfig", () => {
 
     // No new registries, so no write.
     expect(fs.writeFile).not.toHaveBeenCalled()
+  })
+
+  it("resolves registries from package.json without fetching the index", async () => {
+    vi.mocked(getPackageJsonRegistries).mockResolvedValue({
+      "@foo": "https://package.com/r/{name}.json",
+    })
+
+    const { config, newRegistries, discoveredRegistries } =
+      await ensureRegistriesInConfig(["@foo/bar"], baseConfig)
+
+    expect(newRegistries).toEqual(["@foo"])
+    expect(config.registries?.["@foo"]).toBe(
+      "https://package.com/r/{name}.json"
+    )
+    expect(discoveredRegistries).toEqual({})
+
+    // Fully resolved from package.json: no index fetch, no write.
+    expect(getRegistriesIndex).not.toHaveBeenCalled()
+    expect(fs.writeFile).not.toHaveBeenCalled()
+  })
+
+  it("resolves from package.json and falls back to the index", async () => {
+    vi.mocked(resolveRegistryNamespaces).mockResolvedValue(["@foo", "@pkg"])
+    vi.mocked(getPackageJsonRegistries).mockResolvedValue({
+      "@pkg": "https://package.com/r/{name}.json",
+    })
+
+    const { config, newRegistries } = await ensureRegistriesInConfig(
+      ["@foo/bar", "@pkg/baz"],
+      baseConfig
+    )
+
+    expect(newRegistries.sort()).toEqual(["@foo", "@pkg"])
+    expect(config.registries?.["@foo"]).toBe("https://foo.com/r/{name}.json")
+    expect(config.registries?.["@pkg"]).toBe(
+      "https://package.com/r/{name}.json"
+    )
+
+    // Only the index-discovered registry is written to components.json.
+    expect(fs.writeFile).toHaveBeenCalledTimes(1)
+    expect(writtenConfig().registries).toEqual({
+      "@foo": "https://foo.com/r/{name}.json",
+    })
+  })
+
+  it("does not persist in-memory registries from a previous run", async () => {
+    // Simulate a config that already picked up a package.json registry
+    // in memory from an earlier ensureRegistriesInConfig call.
+    const configWithInMemoryRegistry: Config = {
+      ...baseConfig,
+      registries: {
+        "@pkg": "https://package.com/r/{name}.json",
+      },
+    }
+    vi.mocked(resolveRegistryNamespaces).mockResolvedValue(["@bar"])
+    vi.mocked(getRegistriesIndex).mockResolvedValue({
+      "@bar": "https://bar.com/r/{name}.json",
+    })
+
+    const { config } = await ensureRegistriesInConfig(
+      ["@bar/baz"],
+      configWithInMemoryRegistry
+    )
+
+    expect(config.registries?.["@pkg"]).toBe(
+      "https://package.com/r/{name}.json"
+    )
+    expect(config.registries?.["@bar"]).toBe("https://bar.com/r/{name}.json")
+
+    // The write starts from the file on disk, so the in-memory registry
+    // never leaks into components.json.
+    expect(writtenConfig().registries).toEqual({
+      "@bar": "https://bar.com/r/{name}.json",
+    })
+  })
+
+  it("returns package.json registries when the index is unavailable", async () => {
+    vi.mocked(getPackageJsonRegistries).mockResolvedValue({
+      "@foo": "https://package.com/r/{name}.json",
+    })
+    vi.mocked(resolveRegistryNamespaces).mockResolvedValue(["@foo", "@bar"])
+    vi.mocked(getRegistriesIndex).mockResolvedValue(null)
+
+    const { config, newRegistries } = await ensureRegistriesInConfig(
+      ["@foo/bar", "@bar/baz"],
+      baseConfig
+    )
+
+    expect(newRegistries).toEqual(["@foo"])
+    expect(config.registries?.["@foo"]).toBe(
+      "https://package.com/r/{name}.json"
+    )
+    expect(fs.writeFile).not.toHaveBeenCalled()
+  })
+
+  it("skips the write when components.json does not exist", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+
+    const { config, newRegistries } = await ensureRegistriesInConfig(
+      ["@foo/bar"],
+      baseConfig
+    )
+
+    // Config is still updated in memory.
+    expect(newRegistries).toEqual(["@foo"])
+    expect(config.registries?.["@foo"]).toBe("https://foo.com/r/{name}.json")
+    expect(fs.writeFile).not.toHaveBeenCalled()
+  })
+
+  it("preserves unrelated fields in components.json when writing", async () => {
+    vi.mocked(fs.readJson).mockResolvedValue({
+      style: "new-york",
+      registries: {
+        "@keep": "https://keep.com/r/{name}.json",
+      },
+    })
+
+    await ensureRegistriesInConfig(["@foo/bar"], baseConfig)
+
+    expect(writtenConfig()).toEqual({
+      style: "new-york",
+      registries: {
+        "@keep": "https://keep.com/r/{name}.json",
+        "@foo": "https://foo.com/r/{name}.json",
+      },
+    })
   })
 })

--- a/packages/shadcn/src/utils/registries.ts
+++ b/packages/shadcn/src/utils/registries.ts
@@ -1,8 +1,10 @@
 import path from "path"
-import { getRegistriesIndex } from "@/src/registry/api"
+import {
+  getPackageJsonRegistries,
+  getRegistriesIndex,
+} from "@/src/registry/api"
 import { BUILTIN_REGISTRIES } from "@/src/registry/constants"
 import { resolveRegistryNamespaces } from "@/src/registry/namespaces"
-import { rawConfigSchema } from "@/src/registry/schema"
 import { Config } from "@/src/utils/get-config"
 import { spinner } from "@/src/utils/spinner"
 import fs from "fs-extra"
@@ -34,33 +36,55 @@ export async function ensureRegistriesInConfig(
     return {
       config,
       newRegistries: [],
+      discoveredRegistries: {},
+      packageJsonRegistries: {},
     }
   }
 
+  // Resolve missing registries from package.json first. These are merged
+  // into the config in memory and never written to components.json.
+  const declaredRegistries = await getPackageJsonRegistries(
+    config.resolvedPaths.cwd
+  )
+  const packageJsonRegistries: NonNullable<Config["registries"]> = {}
+  const unresolvedRegistries: string[] = []
+  for (const registry of missingRegistries) {
+    if (declaredRegistries[registry]) {
+      packageJsonRegistries[registry] = declaredRegistries[registry]
+    } else {
+      unresolvedRegistries.push(registry)
+    }
+  }
+
+  // Fall back to the registries index for anything not in package.json.
   // We'll fail silently if we can't fetch the registry index.
   // The error handling by caller will guide user to add the missing registries.
-  const registryIndex = await getRegistriesIndex({
-    useCache: process.env.NODE_ENV !== "development",
-  })
+  const discoveredRegistries: Record<string, string> = {}
+  if (unresolvedRegistries.length > 0) {
+    const registryIndex = await getRegistriesIndex({
+      useCache: process.env.NODE_ENV !== "development",
+    })
 
-  if (!registryIndex) {
-    return {
-      config,
-      newRegistries: [],
+    if (registryIndex) {
+      for (const registry of unresolvedRegistries) {
+        if (registryIndex[registry]) {
+          discoveredRegistries[registry] = registryIndex[registry]
+        }
+      }
     }
   }
 
-  const foundRegistries: Record<string, string> = {}
-  for (const registry of missingRegistries) {
-    if (registryIndex[registry]) {
-      foundRegistries[registry] = registryIndex[registry]
-    }
+  const foundRegistries = {
+    ...packageJsonRegistries,
+    ...discoveredRegistries,
   }
 
   if (Object.keys(foundRegistries).length === 0) {
     return {
       config,
       newRegistries: [],
+      discoveredRegistries: {},
+      packageJsonRegistries: {},
     }
   }
 
@@ -79,23 +103,36 @@ export async function ensureRegistriesInConfig(
     },
   }
 
-  if (options.writeFile) {
-    const { resolvedPaths, ...configWithoutResolvedPaths } =
-      newConfigWithRegistries
-    const configSpinner = spinner("Updating components.json.", {
-      silent: options.silent,
-    }).start()
-    const updatedConfig = rawConfigSchema.parse(configWithoutResolvedPaths)
-    await fs.writeFile(
-      path.resolve(config.resolvedPaths.cwd, "components.json"),
-      JSON.stringify(updatedConfig, null, 2) + "\n",
-      "utf-8"
-    )
-    configSpinner.succeed()
+  // Only registries discovered from the registries index are persisted.
+  // The written config is built from the file on disk so registries that
+  // only live in memory (e.g. from package.json) are never persisted.
+  if (options.writeFile && Object.keys(discoveredRegistries).length > 0) {
+    const configPath = path.resolve(config.resolvedPaths.cwd, "components.json")
+    if (fs.existsSync(configPath)) {
+      const configSpinner = spinner("Updating components.json.", {
+        silent: options.silent,
+      }).start()
+      const rawConfig = await fs.readJson(configPath)
+      const updatedConfig = {
+        ...rawConfig,
+        registries: {
+          ...rawConfig.registries,
+          ...discoveredRegistries,
+        },
+      }
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(updatedConfig, null, 2) + "\n",
+        "utf-8"
+      )
+      configSpinner.succeed()
+    }
   }
 
   return {
     config: newConfigWithRegistries,
     newRegistries: Object.keys(foundRegistries),
+    discoveredRegistries,
+    packageJsonRegistries,
   }
 }


### PR DESCRIPTION
Stacked on #11501 — GitHub will retarget this to `main` once that merges.

Closes the gap called out in #11501: `shadcn add @pkg/item` (and `search`, `view`, `init`) now resolve registries declared in `package.json`, not just `components.json`.

## How it works

`ensureRegistriesInConfig` — the shared recovery path for missing registry namespaces — now checks `package.json` registries **before** falling back to the public registries index. Registries resolved from `package.json` are merged into the config in memory and are never persisted to `components.json`.

Two write-back paths were reworked to guarantee that:

- `ensureRegistriesInConfig` now builds its `components.json` update from the **file on disk** instead of the in-memory config, so in-memory registries (from `package.json`, or a previous call in the same run) can't leak into it. As a bonus, the write is now a minimal `registries`-only update instead of re-serializing the whole config.
- `init` now persists only registries discovered from the registries index, and overlays `package.json`-declared registries onto the install-time config in memory.

The function returns `discoveredRegistries` (index-found, persistable) and `packageJsonRegistries` (memory-only) separately so callers can make that distinction.

## Verification

- New unit tests for package.json resolution, index fallback, leak prevention, index-unavailable, and missing-file cases.
- Smoke-tested end to end: a project with `@pkg` declared only in `package.json` → `shadcn add @pkg/agent` installs the item from a local registry server and `components.json` is byte-identical afterwards.