### PR TITLE
fix(shadcn): suppress EACCES when resolving monorepo targets

### DIFF
--- a/.changeset/fix-monorepo-glob-eacces.md
+++ b/.changeset/fix-monorepo-glob-eacces.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Skip unreadable directories when resolving monorepo targets.

--- a/packages/shadcn/src/utils/get-monorepo-info.test.ts
+++ b/packages/shadcn/src/utils/get-monorepo-info.test.ts
@@ -129,6 +129,30 @@ describe("getMonorepoTargets", () => {
     expect(targets).toEqual([{ name: "apps/web", hasConfig: false }])
   })
 
+  it("should skip unreadable workspace directories", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "pnpm-workspace.yaml"),
+      "packages:\n  - apps/**\n"
+    )
+    await fs.writeJson(path.join(tmpDir, "package.json"), { name: "root" })
+
+    const webDir = path.join(tmpDir, "apps", "web")
+    await fs.ensureDir(webDir)
+    await fs.writeJson(path.join(webDir, "package.json"), { name: "web" })
+    await fs.writeFile(path.join(webDir, "vite.config.ts"), "export default {}")
+
+    const unreadableDir = path.join(tmpDir, "apps", "unreadable")
+    await fs.ensureDir(unreadableDir)
+    await fs.chmod(unreadableDir, 0o000)
+
+    try {
+      const targets = await getMonorepoTargets(tmpDir)
+      expect(targets).toEqual([{ name: "apps/web", hasConfig: false }])
+    } finally {
+      await fs.chmod(unreadableDir, 0o755)
+    }
+  })
+
   it("should set hasConfig when components.json exists", async () => {
     await fs.writeFile(
       path.join(tmpDir, "pnpm-workspace.yaml"),

--- a/packages/shadcn/src/utils/get-monorepo-info.ts
+++ b/packages/shadcn/src/utils/get-monorepo-info.ts
@@ -61,6 +61,7 @@ export async function getMonorepoTargets(cwd: string) {
     cwd,
     onlyDirectories: true,
     ignore: ["**/node_modules/**"],
+    suppressErrors: true,
   })
 
   const targets: { name: string; hasConfig: boolean }[] = []


### PR DESCRIPTION
Suppress errors while resolving monorepo workspace targets and add a regression test for unreadable directories as the final follow-up to #9248 and #11500.