### PR TITLE
feat(registry): add cligentic

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -320,7 +320,7 @@
     "homepage": "https://cligentic.railly.dev",
     "url": "https://cligentic.railly.dev/r/{name}.json",
     "description": "Copy-paste TypeScript primitives for agent-first CLIs: trust ladders, killswitches, JSON mode, audit logs, and cross-platform utilities.",
-    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' fill='var(--foreground)'/><rect x='8' y='8' width='16' height='16' fill='#FF6B1A'/><rect x='12' y='12' width='8' height='8' fill='var(--foreground)'/></svg>"
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' fill='#000000'/><rect x='8' y='8' width='16' height='16' fill='#FF6B1A'/><rect x='12' y='12' width='8' height='8' fill='#000000'/></svg>"
   },
   {
     "name": "@cnippet",

--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -316,6 +316,13 @@
     "logo": "<svg role='img' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><title>Clerk</title><path d='m21.47 20.829-2.881-2.881a.572.572 0 0 0-.7-.084 6.854 6.854 0 0 1-7.081 0 .576.576 0 0 0-.7.084l-2.881 2.881a.576.576 0 0 0-.103.69.57.57 0 0 0 .166.186 12 12 0 0 0 14.113 0 .58.58 0 0 0 .239-.423.576.576 0 0 0-.172-.453Zm.002-17.668-2.88 2.88a.569.569 0 0 1-.701.084A6.857 6.857 0 0 0 8.724 8.08a6.862 6.862 0 0 0-1.222 3.692 6.86 6.86 0 0 0 .978 3.764.573.573 0 0 1-.083.699l-2.881 2.88a.567.567 0 0 1-.864-.063A11.993 11.993 0 0 1 6.771 2.7a11.99 11.99 0 0 1 14.637-.405.566.566 0 0 1 .232.418.57.57 0 0 1-.168.448Zm-7.118 12.261a3.427 3.427 0 1 0 0-6.854 3.427 3.427 0 0 0 0 6.854Z'/></svg>"
   },
   {
+    "name": "@cligentic",
+    "homepage": "https://cligentic.railly.dev",
+    "url": "https://cligentic.railly.dev/r/{name}.json",
+    "description": "Copy-paste TypeScript primitives for agent-first CLIs: trust ladders, killswitches, JSON mode, audit logs, and cross-platform utilities.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' fill='var(--foreground)'/><rect x='8' y='8' width='16' height='16' fill='#FF6B1A'/><rect x='12' y='12' width='8' height='8' fill='var(--foreground)'/></svg>"
+  },
+  {
     "name": "@cnippet",
     "homepage": "https://ui.cnippet.dev/",
     "url": "https://ui.cnippet.dev/r/{name}.json",


### PR DESCRIPTION
## Summary

Adds `@cligentic`, an open-source registry of copy-paste TypeScript primitives for agent-first CLIs. The registry distributes non-component code such as trust ladders, killswitches, JSON output helpers, audit logs, and cross-platform utilities.

- Homepage: https://cligentic.railly.dev
- Source: https://github.com/Railly/cligentic
- Registry: https://cligentic.railly.dev/r/registry.json
- License: MIT

## Verification

- `pnpm validate:registries`
- directory JSON passes Prettier
- production catalog returns 200 with 24 flat items
- all 24 item JSON URLs return 200
- catalog file entries do not embed `content`
