### PR TITLE
fix(react): keep the message-scroller at the end when it is narrowed

### DIFF
--- a/.changeset/message-scroller-resize-keeps-the-end.md
+++ b/.changeset/message-scroller-resize-keeps-the-end.md
@@ -1,0 +1,5 @@
+---
+"@shadcn/react": patch
+---
+
+Keep MessageScroller at the end when the viewport is narrowed. A transcript resting at the bottom lost that position whenever something took width away from it: the rows rewrap taller, all of the added height lands above the reader, and the end walks away by however much the text grew. Nothing brought it back, because `handleResize` only re-pinned while following output, and a transcript with nothing arriving into it is not following. A width change now re-pins a reader who was already at the end. Content growing inside a viewport that kept its width is untouched, so appended messages still stay below the fold for a reader who is not following, as does a viewport that only changed height. A reader scrolled anywhere else is left where they were.

--- a/packages/react/src/message-scroller/message-scroller.browser.test.tsx
+++ b/packages/react/src/message-scroller/message-scroller.browser.test.tsx
@@ -43,6 +43,9 @@ type TestItem = {
   height?: number
   id: string
   scrollAnchor?: boolean
+  // Rows carrying text take their height from how the text wraps, so a change
+  // of viewport width reflows them the way real message content does.
+  text?: string
 }
 
 let root: Root | null = null
@@ -63,6 +66,7 @@ function Thread({
   showButton = false,
   showJumpButton = false,
   showVisibility = false,
+  viewportWidth,
 }: {
   autoScroll?: boolean
   defaultScrollPosition?: React.ComponentProps<
@@ -73,6 +77,7 @@ function Thread({
   showButton?: boolean
   showJumpButton?: boolean
   showVisibility?: boolean
+  viewportWidth?: number
 }) {
   return (
     <MessageScrollerProvider
@@ -83,7 +88,11 @@ function Thread({
       <MessageScroller>
         <MessageScrollerViewport
           aria-label="viewport"
-          style={{ height: VIEWPORT_HEIGHT, overflowY: "auto" }}
+          style={{
+            height: VIEWPORT_HEIGHT,
+            overflowY: "auto",
+            width: viewportWidth,
+          }}
         >
           <MessageScrollerContent
             style={{ display: "flex", flexDirection: "column" }}
@@ -93,12 +102,13 @@ function Thread({
                 key={item.id}
                 messageId={item.id}
                 scrollAnchor={item.scrollAnchor}
-                style={{
-                  height: item.height ?? ITEM_HEIGHT,
-                  flex: "none",
-                }}
+                style={
+                  item.text
+                    ? { flex: "none" }
+                    : { height: item.height ?? ITEM_HEIGHT, flex: "none" }
+                }
               >
-                {item.id}
+                {item.text ?? item.id}
               </MessageScrollerItem>
             ))}
           </MessageScrollerContent>
@@ -224,6 +234,15 @@ function createItems(count: number) {
   }))
 }
 
+// Rows of prose rather than fixed boxes, so their height is a function of the
+// width they are given and narrowing the viewport reflows the whole transcript.
+function createWrappingItems(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `m${index}`,
+    text: `Message ${index}. ${"The quick brown fox jumps over the lazy dog. ".repeat(4)}`,
+  }))
+}
+
 test("keeps the visible message in place when older messages are prepended", async () => {
   const initial = createItems(8)
 
@@ -327,6 +346,78 @@ test("does not keep the end pinned when appending after the default bottom open"
   await settle()
 
   expect(getScrollTop(viewport)).toBe(scrollTop)
+  expect(getDistanceToBottom(viewport)).toBeGreaterThan(0)
+})
+
+test("holds an idle transcript at the end when a narrower viewport rewraps it", async () => {
+  const items = createWrappingItems(8)
+
+  await renderThread({ items, viewportWidth: 480 })
+
+  const viewport = getViewport()
+  const heightBefore = viewport.scrollHeight
+
+  expect(getDistanceToBottom(viewport)).toBeLessThanOrEqual(1)
+
+  // A pane opening beside the transcript: every row rewraps taller, which is
+  // growth the reader did not ask for and cannot see, all of it above them.
+  flushSync(() => {
+    root!.render(<Thread items={items} viewportWidth={200} />)
+  })
+  await settle()
+
+  expect(viewport.scrollHeight).toBeGreaterThan(heightBefore)
+  expect(getDistanceToBottom(viewport)).toBeLessThanOrEqual(1)
+})
+
+test("holds the end when the narrowing lands in the frame the scroller mounted in", async () => {
+  const items = createWrappingItems(8)
+
+  container = document.createElement("div")
+  document.body.appendChild(container)
+  root = createRoot(container)
+  flushSync(() => {
+    root!.render(<Thread items={items} viewportWidth={480} />)
+  })
+
+  // Deliberately no settle: a layout applied one commit after mount (a resizable
+  // pane sizing itself, a container query resolving) reaches the observer before
+  // its coalescing frame runs, so mount and narrowing arrive as a single resize
+  // pass with no earlier one to have measured the old width.
+  flushSync(() => {
+    root!.render(<Thread items={items} viewportWidth={200} />)
+  })
+  await settle()
+
+  expect(getDistanceToBottom(getViewport())).toBeLessThanOrEqual(1)
+})
+
+test("leaves a reader parked mid-transcript where they are when the viewport resizes", async () => {
+  const items = createWrappingItems(8)
+
+  await renderThread({ items, viewportWidth: 480 })
+
+  const viewport = getViewport()
+
+  viewport.dispatchEvent(
+    new WheelEvent("wheel", { bubbles: true, deltaY: -ITEM_HEIGHT })
+  )
+  viewport.scrollTop = 0
+  viewport.dispatchEvent(new Event("scroll", { bubbles: true }))
+  await settle()
+
+  expect(getDistanceToBottom(viewport)).toBeGreaterThan(0)
+
+  flushSync(() => {
+    root!.render(<Thread items={items} viewportWidth={200} />)
+  })
+  await settle()
+
+  // Only a reader at the end is moved by a resize. Anywhere else the position
+  // is theirs to keep, so the reflow leaves them where they were reading rather
+  // than dropping them at the bottom of a transcript they were scrolled up in.
+  // scrollTop itself is not asserted: the rewrap moves content above them, and
+  // the browser's own anchoring is entitled to shift it to compensate.
   expect(getDistanceToBottom(viewport)).toBeGreaterThan(0)
 })
 

--- a/packages/react/src/message-scroller/use-message-scroller-commands.ts
+++ b/packages/react/src/message-scroller/use-message-scroller-commands.ts
@@ -26,6 +26,7 @@ function useMessageScrollerCommands({
 }) {
   const {
     streamingTurnRef,
+    atEndRef,
     autoScrollRef,
     autoscrollingRef,
     autoscrollingTimeoutRef,
@@ -42,6 +43,7 @@ function useMessageScrollerCommands({
     spacerHeightRef,
     spacerRef,
     viewportRef,
+    viewportWidthRef,
   } = refs
 
   const setAutoScrolling = React.useCallback(
@@ -135,6 +137,7 @@ function useMessageScrollerCommands({
       setTailSpacerHeight(0)
       streamingTurnRef.current = null
       modeRef.current = "free-scrolling"
+      atEndRef.current = false
       scrollToPosition(0, { behavior })
       scheduleVisibilitySync()
 
@@ -156,6 +159,11 @@ function useMessageScrollerCommands({
       modeRef.current = autoScrollRef.current
         ? "following-bottom"
         : "free-scrolling"
+      // Recorded here rather than left to the state commit this schedules: that
+      // commit lands a frame later, and a resize in between would read a stale
+      // answer for a scroller that is, by definition, at the end.
+      atEndRef.current = true
+      viewportWidthRef.current = viewport.clientWidth
       scrollToPosition(getMaxScrollTop(viewport), {
         autoscrolling: true,
         behavior,

--- a/packages/react/src/message-scroller/use-message-scroller-controller.ts
+++ b/packages/react/src/message-scroller/use-message-scroller-controller.ts
@@ -66,6 +66,7 @@ function useMessageScrollerController({
 
   const {
     streamingTurnRef,
+    atEndRef,
     autoScrollRef,
     autoscrollingRef,
     autoscrollingTimeoutRef,
@@ -90,6 +91,7 @@ function useMessageScrollerController({
     stateFrameRef,
     stateStore,
     viewportRef,
+    viewportWidthRef,
     visibilityFrameRef,
     visibilityObserverRef,
     visibilityStore,
@@ -177,6 +179,27 @@ function useMessageScrollerController({
     })
 
     reconcileFollowMode(nextState)
+
+    // Where the reader is, kept for the resize pass, which runs after the
+    // browser has already moved them. Raw geometry rather than the published
+    // state, since follow-output publishes end as false whether or not the
+    // reader is at it.
+    //
+    // Paired with the width it was read at, and only recorded while that width
+    // is still the one on screen. A commit can land between a rewrap and the
+    // resize pass that answers for it, and such a commit is measuring lines
+    // that have already moved: it would report the reader as away from the end
+    // for the very reflow the resize pass is about to undo. Skipping it leaves
+    // the last honest answer in place, and the pass re-arms the width.
+    const width = viewportRef.current?.clientWidth ?? null
+
+    if (
+      viewportWidthRef.current === null ||
+      viewportWidthRef.current === width
+    ) {
+      atEndRef.current = !nextState.end
+      viewportWidthRef.current = width
+    }
 
     // While follow-output is engaged the scroller is already closing any gap a
     // streamed chunk just opened, so publishing it as scrollable toward the
@@ -493,7 +516,30 @@ function useMessageScrollerController({
     scrollToEnd,
   ])
 
+  // Whether the viewport changed width since the last resize pass. Content
+  // growing and content being rewrapped arrive through the same observers, and
+  // they mean opposite things: one is the transcript getting longer, the other
+  // is the same transcript in a new shape. Only a width change can rewrap it.
+  // Measured on every pass, including the ones that return early, so the stored
+  // width never goes stale enough to report a rewrap that did not happen.
+  const didViewportRewrap = React.useCallback(() => {
+    const viewport = viewportRef.current
+
+    if (!viewport) {
+      return false
+    }
+
+    const previous = viewportWidthRef.current
+    const next = viewport.clientWidth
+
+    viewportWidthRef.current = next
+
+    return previous !== null && previous !== next
+  }, [])
+
   const handleResize = React.useCallback(() => {
+    const rewrapped = didViewportRewrap()
+
     if (modeRef.current === "following-bottom" && autoScrollRef.current) {
       scrollToEnd({ behavior: "auto" })
       return
@@ -522,9 +568,23 @@ function useMessageScrollerController({
       return
     }
 
+    // A reader resting at the end is still at the end once the content has been
+    // rewrapped. Narrowing the viewport makes every row taller, all of it above
+    // them, so the end walks away by however much the text grew and stays there:
+    // follow-bottom is the only path back and a transcript with nothing arriving
+    // into it is not following. Their position is not preserved by leaving
+    // scrollTop alone here, because the line it pointed at has moved. A reader
+    // anywhere else is left alone: their position is a place in the transcript,
+    // and the browser's own anchoring is what keeps it.
+    if (rewrapped && atEndRef.current && modeRef.current === "free-scrolling") {
+      scrollToEnd({ behavior: "auto" })
+      return
+    }
+
     scheduleStateCommit()
     scheduleVisibilitySync()
   }, [
+    didViewportRewrap,
     reanchorToAnchoredMessage,
     scheduleStateCommit,
     scheduleVisibilitySync,

--- a/packages/react/src/message-scroller/use-message-scroller-refs.ts
+++ b/packages/react/src/message-scroller/use-message-scroller-refs.ts
@@ -18,6 +18,7 @@ import type {
 // controller and the commands so writes are visible across them without prop
 // threading. stateStore and visibilityStore fan out via useSyncExternalStore.
 type MessageScrollerRefs = {
+  atEndRef: React.RefObject<boolean>
   autoScrollRef: React.RefObject<boolean>
   autoscrollingRef: React.RefObject<boolean>
   autoscrollingTimeoutRef: React.RefObject<number | null>
@@ -49,6 +50,7 @@ type MessageScrollerRefs = {
   stateFrameRef: React.RefObject<number | null>
   stateStore: MessageScrollerStore<MessageScrollerScrollable>
   viewportRef: React.RefObject<HTMLDivElement | null>
+  viewportWidthRef: React.RefObject<number | null>
   visibilityFrameRef: React.RefObject<number | null>
   visibilityObserverRef: React.RefObject<IntersectionObserver | null>
   visibilityStore: MessageScrollerVisibilityStore
@@ -69,6 +71,10 @@ function useMessageScrollerRefs({
   scrollMargin: number
   scrollPreviousItemPeek: number
 }): MessageScrollerRefs {
+  // Whether the last state commit found the reader at the end. Read on resize,
+  // which arrives after the browser has already moved scrollTop, so the answer
+  // has to have been recorded before the box changed.
+  const atEndRef = React.useRef(true)
   const autoScrollRef = React.useRef(autoScroll)
   const autoscrollingRef = React.useRef(false)
   const contentRef = React.useRef<HTMLDivElement | null>(null)
@@ -109,6 +115,10 @@ function useMessageScrollerRefs({
     React.useRef<MessageScrollerStore<MessageScrollerScrollable> | null>(null)
   const autoscrollingTimeoutRef = React.useRef<number | null>(null)
   const viewportRef = React.useRef<HTMLDivElement | null>(null)
+  // The viewport's width at the last resize pass, so the next one can tell the
+  // content being rewrapped from the content simply growing. Null until the
+  // first pass, which has nothing to compare against.
+  const viewportWidthRef = React.useRef<number | null>(null)
   const visibilityFrameRef = React.useRef<number | null>(null)
   const visibilityObserverRef = React.useRef<IntersectionObserver | null>(null)
   const visibilityStoreRef =
@@ -135,6 +145,7 @@ function useMessageScrollerRefs({
   scrollPreviousItemPeekRef.current = scrollPreviousItemPeek
 
   return {
+    atEndRef,
     autoScrollRef,
     autoscrollingRef,
     autoscrollingTimeoutRef,
@@ -160,6 +171,7 @@ function useMessageScrollerRefs({
     stateFrameRef,
     stateStore: stateStoreRef.current,
     viewportRef,
+    viewportWidthRef,
     visibilityFrameRef,
     visibilityObserverRef,
     visibilityStore: visibilityStoreRef.current,


### PR DESCRIPTION
## Problem

A transcript that is resting at the end loses that position whenever something takes width away from it.

```tsx
// autoScroll off: nothing is streaming into this transcript.
<MessageScroller.Provider defaultScrollPosition="end">
  <MessageScroller.Root>
    <MessageScroller.Viewport style={{ width }}>
      <MessageScroller.Content>{messages}</MessageScroller.Content>
    </MessageScroller.Viewport>
  </MessageScroller.Root>
</MessageScroller.Provider>

// width 480, opened at the end
viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight // 0

// width 200, same messages: every row rewraps taller
viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight // 576
```

The added height all lands above the reader, so the end walks away by however much the text grew and stays there. Anything that changes the width does it: a resizable pane, a drawer opening beside the transcript, a container query, a sidebar.

It presents as the scroll-to-latest button lighting up on its own with the last turn sitting above the fold, which reads as content still arriving. That sends the search to the content (an image decoding late, a font swapping, markdown highlighting resolving) rather than to the layout, and none of those turn out to be it.

## Cause

Re-pinning is reachable only while following output:

```ts
const handleResize = React.useCallback(() => {
  if (modeRef.current === "following-bottom" && autoScrollRef.current) {
    scrollToEnd({ behavior: "auto" })
    return
  }
```

With `autoScroll` off, `scrollToEnd` sets `modeRef` to `free-scrolling`, so a transcript opened at the end by `defaultScrollPosition="end"` never qualifies. Every later resize falls through to a state commit, which publishes the gap rather than closing it.

The existing suites cannot see this. jsdom has no layout engine, so narrowing a viewport there rewraps nothing and the bug and the fix produce the same numbers. The one resize test that exists, `does not follow viewport resize while resting at the end without autoScroll`, changes height only, where the content genuinely has not moved and staying put is correct.

There is a second half, which is why the diff is not a one-line condition. `commitScrollState` is coalesced onto a frame and can land between the rewrap and the resize pass that answers for it. Such a commit measures lines that have already moved and reports the reader as away from the end for the very reflow the pass is about to undo, so a naive `atEnd` flag reads false exactly when it matters.

## Fix

`handleResize` re-pins to the end when the viewport changed width and the reader was at the end, in `free-scrolling` mode only. "At the end" is recorded with the width it was read at, and a commit whose width no longer matches is skipped rather than allowed to overwrite it.

The broader version of this would re-pin on any resize, height included. It is not here because it contradicts the existing height-only assertion, and because a height change moves the fold without moving the content, which is a weaker case. Happy to add it behind the same branch if you would rather have both.

## Scope

Unchanged:

- `autoScroll` following, and its release on user scroll intent
- appends to an idle transcript resting at the end, which still stay below the fold
- a height-only resize, which still leaves an idle reader where they are
- `anchored-to-message` holds, which are handled before this branch
- a reader parked anywhere other than the end, who is left to the browser's own scroll anchoring

Not addressed, deliberately:

- content that grows late inside a viewport that kept its width (an image finishing decode, a font swap). It has the same end result, but it is not distinguishable from an append, and appends must keep staying below the fold.

## Tests

Three added to the browser suite, which is the only project that can observe this:

- `holds an idle transcript at the end when a narrower viewport rewraps it` — the reported defect. Asserts the content actually grew, so it cannot pass vacuously.
- `holds the end when the narrowing lands in the frame the scroller mounted in` — the coalesced case, where mount and narrowing reach the observer as a single resize pass. This is the one that fails against a version of the fix that looks correct.
- `leaves a reader parked mid-transcript where they are when the viewport resizes` — the guard on the risky half. It asserts they are still not at the end rather than asserting `scrollTop`, since the rewrap moves content above them and the browser's anchoring is entitled to compensate.

What they do not prove: nothing here covers a width change arriving while a turn is streaming, or one arriving under an ancestor CSS `zoom`.

Suites on this branch: 132 node tests across 4 files, 49 browser tests across 3 files, all passing, `tsc --noEmit` clean. No pre-existing failures. The first two tests were confirmed to fail against unpatched source by checking out `main`'s copies of the three changed files and re-running, not inferred.

---

Authored with Claude Opus 5
