### PR TITLE
fix: Remove role link from BreadcrumbPage (last item)

### DIFF
--- a/apps/v4/registry/bases/base/ui/breadcrumb.tsx
+++ b/apps/v4/registry/bases/base/ui/breadcrumb.tsx
@@ -63,7 +63,6 @@ function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
       data-slot="breadcrumb-page"
-      role="link"
       aria-disabled="true"
       aria-current="page"
       className={cn("cn-breadcrumb-page", className)}


### PR DESCRIPTION
## Summary

Removes the unnecessary `role="link"` from the `<span>` used by the `BreadcrumbPage` component for the last item in the breadcrumbs list.

## Root Cause

The last breadcrumb item represents the current page and is not a navigational link. Applying `role="link"` to the `<span>` incorrectly exposes it as a link to assistive technologies.

## Changes

* Removed `role="link"` from the `<span>` used for the last breadcrumb item.

## Verification

* Verified the last breadcrumb item is no longer exposed as a link.
* Verified preceding breadcrumb items remain navigable links.
* Verified the visual appearance and behavior of the breadcrumbs remain unchanged.
