### PR TITLE
fix(skill): pin CLI version and remove load-time package execution

### DIFF
--- a/packages/shadcn/src/skill-cli-pin.test.ts
+++ b/packages/shadcn/src/skill-cli-pin.test.ts
@@ -1,0 +1,70 @@
+import { promises as fs } from "fs"
+import path from "path"
+import { fileURLToPath } from "url"
+import { describe, expect, it } from "vitest"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const packageRoot = path.resolve(__dirname, "..")
+const repoRoot = path.resolve(packageRoot, "../..")
+const skillRoot = path.join(repoRoot, "skills/shadcn")
+const skillMdPath = path.join(skillRoot, "SKILL.md")
+
+const BINARY_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".ico",
+])
+
+async function listSkillTextFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  const files: string[] = []
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...(await listSkillTextFiles(fullPath)))
+      continue
+    }
+    if (BINARY_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
+      continue
+    }
+    files.push(fullPath)
+  }
+
+  return files
+}
+
+describe("skills/shadcn CLI pin", () => {
+  it("pins the skill CLI to the published package version without load-time execution", async () => {
+    const packageJson = JSON.parse(
+      await fs.readFile(path.join(packageRoot, "package.json"), "utf8")
+    ) as { version: string }
+    const pinnedSpecifier = `shadcn@${packageJson.version}`
+    const skillMd = await fs.readFile(skillMdPath, "utf8")
+    const skillFiles = await listSkillTextFiles(skillRoot)
+
+    expect(skillMd).toContain(pinnedSpecifier)
+    expect(skillMd).not.toMatch(/^allowed-tools:/m)
+    expect(skillMd).not.toMatch(/!`[^`]+`/)
+
+    for (const file of skillFiles) {
+      const content = await fs.readFile(file, "utf8")
+      const relative = path.relative(repoRoot, file)
+
+      expect(content, `${relative} must not use shadcn@latest`).not.toContain(
+        "shadcn@latest"
+      )
+      expect(
+        content,
+        `${relative} must not use load-time ! interpolation`
+      ).not.toMatch(/!`[^`]+`/)
+      expect(
+        content,
+        `${relative} must not pre-approve shadcn CLI via allowed-tools`
+      ).not.toMatch(/allowed-tools:.*Bash\([^)]*shadcn@/s)
+    }
+  })
+})

--- a/skills/shadcn/SKILL.md
+++ b/skills/shadcn/SKILL.md
@@ -2,26 +2,31 @@
 name: shadcn
 description: Manages shadcn components and projects — adding, searching, fixing, debugging, styling, and composing UI, including chat interfaces. Provides project context, component docs, and usage examples. Applies when working with shadcn/ui, component registries, presets, --preset codes, or any project with a components.json file. Also triggers for "shadcn init", "create an app with --preset", or "switch to --preset".
 user-invocable: false
-allowed-tools: Bash(npx shadcn@latest *), Bash(pnpm dlx shadcn@latest *), Bash(bunx --bun shadcn@latest *)
 ---
 
 # shadcn/ui
 
 A framework for building ui, components and design systems. Components are added as source code to the user's project via the CLI.
 
-> **IMPORTANT:** Run all CLI commands using the project's package runner: `npx shadcn@latest`, `pnpm dlx shadcn@latest`, or `bunx --bun shadcn@latest` — based on the project's `packageManager`. Examples below use `npx shadcn@latest` but substitute the correct runner for the project.
+> **IMPORTANT:** Pin the CLI to this exact reviewed version: `shadcn@4.18.0`. Do **not** substitute `@latest` or any other tag. Bump the pin in the same PR that versions `packages/shadcn`.
+
+> **IMPORTANT:** Run all CLI commands using the project's package runner: `npx shadcn@4.18.0`, `pnpm dlx shadcn@4.18.0`, or `bunx --bun shadcn@4.18.0` — based on the project's `packageManager`. Examples below use `npx shadcn@4.18.0` but substitute the correct runner for the project.
 
 ## Current Project Context
 
-```json
-!`npx shadcn@latest info --json`
+Do **not** run package code at skill load time. After the user explicitly approves package execution, run the pinned **read-only** command:
+
+```bash
+npx shadcn@4.18.0 info --json
 ```
 
-The JSON above contains the project config and installed components. Use `npx shadcn@latest docs <component>` to get documentation and example URLs for any component.
+Use the JSON output for project config and installed components. If the response is a `monorepo_root` error, re-run with `-c <target>` (prompt the user when there are multiple targets).
+
+Mutating commands (`init`, `add`, `apply`, `--overwrite`, `--force`) require a **separate** approval from the read-only `info` call. Use `npx shadcn@4.18.0 docs <component>` to get documentation and example URLs for any component.
 
 ## Principles
 
-1. **Use existing components first.** Use `npx shadcn@latest search` to check registries before writing custom UI. Check community registries too.
+1. **Use existing components first.** Use `npx shadcn@4.18.0 search` to check registries before writing custom UI. Check community registries too.
 2. **Compose, don't reinvent.** Settings page = Tabs + Card + form controls. Dashboard = Sidebar + Card + Chart + Table.
 3. **Use built-in variants before custom styles.** `variant="outline"`, `size="sm"`, etc.
 4. **Use semantic colors.** `bg-primary`, `text-muted-foreground` — never raw values like `bg-blue-500`.
@@ -52,7 +57,7 @@ These rules are **always enforced**. Each links to a file with Incorrect/Correct
 ### Component Structure → [composition.md](./rules/composition.md)
 
 - **Items always inside their Group.** `SelectItem` → `SelectGroup`. `DropdownMenuItem` → `DropdownMenuGroup`. `CommandItem` → `CommandGroup`.
-- **Use `asChild` (radix) or `render` (base) for custom triggers.** Check `base` field from `npx shadcn@latest info`. → [base-vs-radix.md](./rules/base-vs-radix.md)
+- **Use `asChild` (radix) or `render` (base) for custom triggers.** Check `base` field from `npx shadcn@4.18.0 info`. → [base-vs-radix.md](./rules/base-vs-radix.md)
 - **Dialog, Sheet, and Drawer always need a Title.** `DialogTitle`, `SheetTitle`, `DrawerTitle` required for accessibility. Use `className="sr-only"` if visually hidden.
 - **Use full Card composition.** `CardHeader`/`CardTitle`/`CardDescription`/`CardContent`/`CardFooter`. Don't dump everything in `CardContent`.
 - **Button has no `isPending`/`isLoading`.** Compose with `Spinner` + `data-icon` + `disabled`.
@@ -85,8 +90,8 @@ These rules are **always enforced**. Each links to a file with Incorrect/Correct
 
 ### CLI
 
-- **Never decode preset codes or build preset URLs manually.** Use `npx shadcn@latest preset decode <code>`, `preset url <code>`, or `preset open <code>`. For project-aware preset detection, use `npx shadcn@latest preset resolve`.
-- **Apply preset codes directly with the CLI.** Use `npx shadcn@latest apply <code>` for existing projects, or `npx shadcn@latest init --preset <code>` when initializing.
+- **Never decode preset codes or build preset URLs manually.** Use `npx shadcn@4.18.0 preset decode <code>`, `preset url <code>`, or `preset open <code>`. For project-aware preset detection, use `npx shadcn@4.18.0 preset resolve`.
+- **Apply preset codes directly with the CLI.** Use `npx shadcn@4.18.0 apply <code>` for existing projects, or `npx shadcn@4.18.0 init --preset <code>` when initializing.
 
 ## Key Patterns
 
@@ -160,45 +165,45 @@ The injected project context contains these key fields:
 - **`resolvedPaths`** → exact file-system destinations for components, utils, hooks, etc.
 - **`framework`** → routing and file conventions (e.g. Next.js App Router vs Vite SPA).
 - **`packageManager`** → use this for any non-shadcn dependency installs (e.g. `pnpm add date-fns` vs `npm install date-fns`).
-- **`preset`** → resolved preset code and values for the current project. Use `npx shadcn@latest preset resolve --json` when you only need preset information.
+- **`preset`** → resolved preset code and values for the current project. Use `npx shadcn@4.18.0 preset resolve --json` when you only need preset information.
 
 See [cli.md — `info` command](./cli.md) for the full field reference.
 
 ## Component Docs, Examples, and Usage
 
-Run `npx shadcn@latest docs <component>` to get the URLs for a component's documentation, examples, and API reference. Fetch these URLs to get the actual content.
+Run `npx shadcn@4.18.0 docs <component>` to get the URLs for a component's documentation, examples, and API reference. Fetch these URLs to get the actual content.
 
 ```bash
-npx shadcn@latest docs button dialog select
+npx shadcn@4.18.0 docs button dialog select
 ```
 
-**When creating, fixing, debugging, or using a component, always run `npx shadcn@latest docs` and fetch the URLs first.** This ensures you're working with the correct API and usage patterns rather than guessing.
+**When creating, fixing, debugging, or using a component, always run `npx shadcn@4.18.0 docs` and fetch the URLs first.** This ensures you're working with the correct API and usage patterns rather than guessing.
 
 ## Workflow
 
-1. **Get project context** — already injected above. Run `npx shadcn@latest info` again if you need to refresh.
+1. **Get project context** — after package-execution approval, run `npx shadcn@4.18.0 info --json`. Re-run if you need to refresh. Mutating commands need a separate approval.
 2. **Check installed components first** — before running `add`, always check the `components` list from project context or list the `resolvedPaths.ui` directory. Don't import components that haven't been added, and don't re-add ones already installed.
-3. **Find components** — `npx shadcn@latest search`.
-4. **Get docs and examples** — run `npx shadcn@latest docs <component>` to get URLs, then fetch them. Use `npx shadcn@latest view` to browse registry items you haven't installed. To preview changes to installed components, use `npx shadcn@latest add --diff`.
-5. **Install or update** — `npx shadcn@latest add`. When updating existing components, use `--dry-run` and `--diff` to preview changes first (see [Updating Components](#updating-components) below).
-6. **Fix imports in third-party components** — After adding components from community registries (e.g. `@bundui`, `@magicui`), check the added non-UI files for hardcoded import paths like `@/components/ui/...`. These won't match the project's actual aliases. Use `npx shadcn@latest info` to get the correct `ui` alias (e.g. `@workspace/ui/components`) and rewrite the imports accordingly. The CLI rewrites imports for its own UI files, but third-party registry components may use default paths that don't match the project.
+3. **Find components** — `npx shadcn@4.18.0 search`.
+4. **Get docs and examples** — run `npx shadcn@4.18.0 docs <component>` to get URLs, then fetch them. Use `npx shadcn@4.18.0 view` to browse registry items you haven't installed. To preview changes to installed components, use `npx shadcn@4.18.0 add --diff`.
+5. **Install or update** — `npx shadcn@4.18.0 add`. When updating existing components, use `--dry-run` and `--diff` to preview changes first (see [Updating Components](#updating-components) below).
+6. **Fix imports in third-party components** — After adding components from community registries (e.g. `@bundui`, `@magicui`), check the added non-UI files for hardcoded import paths like `@/components/ui/...`. These won't match the project's actual aliases. Use `npx shadcn@4.18.0 info` to get the correct `ui` alias (e.g. `@workspace/ui/components`) and rewrite the imports accordingly. The CLI rewrites imports for its own UI files, but third-party registry components may use default paths that don't match the project.
 7. **Review added components** — After adding a component or block from any registry, **always read the added files and verify they are correct**. Check for missing sub-components (e.g. `SelectItem` without `SelectGroup`), missing imports, incorrect composition, or violations of the [Critical Rules](#critical-rules). Also replace any icon imports with the project's `iconLibrary` from the project context (e.g. if the registry item uses `lucide-react` but the project uses `hugeicons`, swap the imports and icon names accordingly). Fix all issues before moving on.
 8. **Registry must be explicit** — When the user asks to add a block or component, **do not guess the registry**. If no registry is specified (e.g. user says "add a login block" without specifying `@shadcn`, `@tailark`, `owner/repo`, etc.), ask which registry to use. Never default to a registry on behalf of the user.
 9. **Switching presets** — Ask the user first: **overwrite**, **partial**, **merge**, or **skip**?
-   - **Inspect current preset**: `npx shadcn@latest preset resolve`. Use `--json` when you need structured values.
-   - **Inspect incoming preset**: `npx shadcn@latest preset decode <code>`. Use `preset url <code>` or `preset open <code>` to share or open the preset builder.
-   - **Overwrite**: `npx shadcn@latest apply <code>`. Overwrites detected components, fonts, and CSS variables.
-   - **Partial**: `npx shadcn@latest apply <code> --only theme,font`. Updates only the selected preset parts without reinstalling UI components. Supported values are `theme` and `font`; comma-separated combinations are allowed. `icon` is intentionally not supported, because icon changes may require full component reinstall and transforms.
-   - **Merge**: `npx shadcn@latest init --preset <code> --force --no-reinstall`, then run `npx shadcn@latest info` to list installed components, then for each installed component use `--dry-run` and `--diff` to [smart merge](#updating-components) it individually.
-   - **Skip**: `npx shadcn@latest init --preset <code> --force --no-reinstall`. Only updates config and CSS, leaves components as-is.
+   - **Inspect current preset**: `npx shadcn@4.18.0 preset resolve`. Use `--json` when you need structured values.
+   - **Inspect incoming preset**: `npx shadcn@4.18.0 preset decode <code>`. Use `preset url <code>` or `preset open <code>` to share or open the preset builder.
+   - **Overwrite**: `npx shadcn@4.18.0 apply <code>`. Overwrites detected components, fonts, and CSS variables.
+   - **Partial**: `npx shadcn@4.18.0 apply <code> --only theme,font`. Updates only the selected preset parts without reinstalling UI components. Supported values are `theme` and `font`; comma-separated combinations are allowed. `icon` is intentionally not supported, because icon changes may require full component reinstall and transforms.
+   - **Merge**: `npx shadcn@4.18.0 init --preset <code> --force --no-reinstall`, then run `npx shadcn@4.18.0 info` to list installed components, then for each installed component use `--dry-run` and `--diff` to [smart merge](#updating-components) it individually.
+   - **Skip**: `npx shadcn@4.18.0 init --preset <code> --force --no-reinstall`. Only updates config and CSS, leaves components as-is.
    - **Important**: Always run preset commands inside the user's project directory. `apply` only works in an existing project with a `components.json` file. The CLI automatically preserves the current base (`base` vs `radix`) from `components.json`. If you must use a scratch/temp directory (e.g. for `--dry-run` comparisons), pass `--base <current-base>` explicitly — preset codes do not encode the base.
 
 ## Updating Components
 
 When the user asks to update a component from upstream while keeping their local changes, use `--dry-run` and `--diff` to intelligently merge. **NEVER fetch raw files from GitHub manually — always use the CLI.**
 
-1. Run `npx shadcn@latest add <component> --dry-run` to see all files that would be affected.
-2. For each file, run `npx shadcn@latest add <component> --diff <file>` to see what changed upstream vs local.
+1. Run `npx shadcn@4.18.0 add <component> --dry-run` to see all files that would be affected.
+2. For each file, run `npx shadcn@4.18.0 add <component> --diff <file>` to see what changed upstream vs local.
 3. Decide per file based on the diff:
    - No local changes → safe to overwrite.
    - Has local changes → read the local file, analyze the diff, and apply upstream updates while preserving local modifications.
@@ -209,55 +214,55 @@ When the user asks to update a component from upstream while keeping their local
 
 ```bash
 # Create a new project.
-npx shadcn@latest init --name my-app --preset base-nova
-npx shadcn@latest init --name my-app --preset a2r6bw --template vite
+npx shadcn@4.18.0 init --name my-app --preset base-nova
+npx shadcn@4.18.0 init --name my-app --preset a2r6bw --template vite
 
 # Create a monorepo project.
-npx shadcn@latest init --name my-app --preset base-nova --monorepo
-npx shadcn@latest init --name my-app --preset base-nova --template next --monorepo
+npx shadcn@4.18.0 init --name my-app --preset base-nova --monorepo
+npx shadcn@4.18.0 init --name my-app --preset base-nova --template next --monorepo
 
 # Initialize existing project.
-npx shadcn@latest init --preset base-nova
-npx shadcn@latest init --defaults  # shortcut: --template=next --preset=nova (base style implied)
+npx shadcn@4.18.0 init --preset base-nova
+npx shadcn@4.18.0 init --defaults  # shortcut: --template=next --preset=nova (base style implied)
 
 # Apply a preset to an existing project.
-npx shadcn@latest apply a2r6bw
-npx shadcn@latest apply a2r6bw --only theme
-npx shadcn@latest apply a2r6bw --only font
-npx shadcn@latest apply a2r6bw --only theme,font
+npx shadcn@4.18.0 apply a2r6bw
+npx shadcn@4.18.0 apply a2r6bw --only theme
+npx shadcn@4.18.0 apply a2r6bw --only font
+npx shadcn@4.18.0 apply a2r6bw --only theme,font
 
 # Inspect preset codes and project preset state.
-npx shadcn@latest preset decode a2r6bw
-npx shadcn@latest preset url a2r6bw
-npx shadcn@latest preset open a2r6bw
-npx shadcn@latest preset resolve
-npx shadcn@latest preset resolve --json
+npx shadcn@4.18.0 preset decode a2r6bw
+npx shadcn@4.18.0 preset url a2r6bw
+npx shadcn@4.18.0 preset open a2r6bw
+npx shadcn@4.18.0 preset resolve
+npx shadcn@4.18.0 preset resolve --json
 
 # Add components.
-npx shadcn@latest add button card dialog
-npx shadcn@latest add @magicui/shimmer-button
-npx shadcn@latest add owner/repo/item
-npx shadcn@latest add --all
+npx shadcn@4.18.0 add button card dialog
+npx shadcn@4.18.0 add @magicui/shimmer-button
+npx shadcn@4.18.0 add owner/repo/item
+npx shadcn@4.18.0 add --all
 
 # Preview changes before adding/updating.
-npx shadcn@latest add button --dry-run
-npx shadcn@latest add button --diff button.tsx
-npx shadcn@latest add @acme/form --view button.tsx
-npx shadcn@latest add owner/repo/item --dry-run
+npx shadcn@4.18.0 add button --dry-run
+npx shadcn@4.18.0 add button --diff button.tsx
+npx shadcn@4.18.0 add @acme/form --view button.tsx
+npx shadcn@4.18.0 add owner/repo/item --dry-run
 
 # Search registries.
-npx shadcn@latest search @shadcn -q "sidebar"
-npx shadcn@latest search @tailark -q "stats"
-npx shadcn@latest search owner/repo -q "login"
-npx shadcn@latest search                          # all configured registries
-npx shadcn@latest search @shadcn -q "menu" -t ui  # filter by item type
+npx shadcn@4.18.0 search @shadcn -q "sidebar"
+npx shadcn@4.18.0 search @tailark -q "stats"
+npx shadcn@4.18.0 search owner/repo -q "login"
+npx shadcn@4.18.0 search                          # all configured registries
+npx shadcn@4.18.0 search @shadcn -q "menu" -t ui  # filter by item type
 
 # Get component docs and example URLs.
-npx shadcn@latest docs button dialog select
+npx shadcn@4.18.0 docs button dialog select
 
 # View registry item details (for items not yet installed).
-npx shadcn@latest view @shadcn/button
-npx shadcn@latest view owner/repo/item
+npx shadcn@4.18.0 view @shadcn/button
+npx shadcn@4.18.0 view owner/repo/item
 ```
 
 **Named presets:** `nova`, `vega`, `maia`, `lyra`, `mira`, `luma`

--- a/skills/shadcn/cli.md
+++ b/skills/shadcn/cli.md
@@ -2,7 +2,9 @@
 
 Configuration is read from `components.json`.
 
-> **IMPORTANT:** Always run commands using the project's package runner: `npx shadcn@latest`, `pnpm dlx shadcn@latest`, or `bunx --bun shadcn@latest`. Check `packageManager` from project context to choose the right one. Examples below use `npx shadcn@latest` but substitute the correct runner for the project.
+> **IMPORTANT:** Pin the CLI to this exact reviewed version: `shadcn@4.18.0`. Do **not** substitute `@latest` or any other tag. Bump the pin in the same PR that versions `packages/shadcn`.
+
+> **IMPORTANT:** Always run commands using the project's package runner: `npx shadcn@4.18.0`, `pnpm dlx shadcn@4.18.0`, or `bunx --bun shadcn@4.18.0`. Check `packageManager` from project context to choose the right one. Examples below use `npx shadcn@4.18.0` but substitute the correct runner for the project.
 
 > **IMPORTANT:** Only use the flags documented below. Do not invent or guess flags — if a flag isn't listed here, it doesn't exist. The CLI auto-detects the package manager from the project's lockfile; there is no `--package-manager` flag.
 
@@ -20,7 +22,7 @@ Configuration is read from `components.json`.
 ### `init` — Initialize or create a project
 
 ```bash
-npx shadcn@latest init [components...] [options]
+npx shadcn@4.18.0 init [components...] [options]
 ```
 
 Initializes shadcn/ui in an existing project or creates a new project (when `--name` is provided). Optionally installs components in the same step.
@@ -40,12 +42,12 @@ Initializes shadcn/ui in an existing project or creates a new project (when `--n
 | `--monorepo`            |       | Scaffold a monorepo project                               | —       |
 | `--no-monorepo`         |       | Skip the monorepo prompt                                  | —       |
 
-`npx shadcn@latest create` is an alias for `npx shadcn@latest init`.
+`npx shadcn@4.18.0 create` is an alias for `npx shadcn@4.18.0 init`.
 
 ### `apply` — Apply a preset to an existing project
 
 ```bash
-npx shadcn@latest apply [preset] [options]
+npx shadcn@4.18.0 apply [preset] [options]
 ```
 
 Applies a preset to an existing project, overwriting preset-driven config, fonts, CSS variables, and detected UI components.
@@ -62,10 +64,10 @@ If no preset is provided, the CLI offers to open the custom preset builder on `u
 
 ### `add` — Add components
 
-> **IMPORTANT:** To compare local components against upstream or to preview changes, ALWAYS use `npx shadcn@latest add <component> --dry-run`, `--diff`, or `--view`. NEVER fetch raw files from GitHub or other sources manually. The CLI handles registry resolution, file paths, and CSS diffing automatically.
+> **IMPORTANT:** To compare local components against upstream or to preview changes, ALWAYS use `npx shadcn@4.18.0 add <component> --dry-run`, `--diff`, or `--view`. NEVER fetch raw files from GitHub or other sources manually. The CLI handles registry resolution, file paths, and CSS diffing automatically.
 
 ```bash
-npx shadcn@latest add [components...] [options]
+npx shadcn@4.18.0 add [components...] [options]
 ```
 
 Accepts component names, registry-prefixed names (`@magicui/shimmer-button`),
@@ -89,28 +91,28 @@ Use `--dry-run` to preview what `add` would do without writing any files. `--dif
 
 ```bash
 # Preview all changes.
-npx shadcn@latest add button --dry-run
+npx shadcn@4.18.0 add button --dry-run
 
 # Show diffs for all files (top 5).
-npx shadcn@latest add button --diff
+npx shadcn@4.18.0 add button --diff
 
 # Show the diff for a specific file.
-npx shadcn@latest add button --diff button.tsx
+npx shadcn@4.18.0 add button --diff button.tsx
 
 # Show contents for all files (top 5).
-npx shadcn@latest add button --view
+npx shadcn@4.18.0 add button --view
 
 # Show the full content of a specific file.
-npx shadcn@latest add button --view button.tsx
+npx shadcn@4.18.0 add button --view button.tsx
 
 # Works with URLs too.
-npx shadcn@latest add https://api.npoint.io/abc123 --dry-run
+npx shadcn@4.18.0 add https://api.npoint.io/abc123 --dry-run
 
 # Works with public GitHub registries too.
-npx shadcn@latest add owner/repo/item --dry-run
+npx shadcn@4.18.0 add owner/repo/item --dry-run
 
 # CSS diffs.
-npx shadcn@latest add button --diff globals.css
+npx shadcn@4.18.0 add button --diff globals.css
 ```
 
 **When to use dry-run:**
@@ -121,7 +123,7 @@ npx shadcn@latest add button --diff globals.css
 - When checking what CSS changes would be made to `globals.css` — use `--diff globals.css`.
 - When the user asks to review or audit third-party registry code before installing — use `--view` to inspect the source.
 
-> **`npx shadcn@latest add --dry-run` vs `npx shadcn@latest view`:** Prefer `npx shadcn@latest add --dry-run/--diff/--view` over `npx shadcn@latest view` when the user wants to preview changes to their project. `npx shadcn@latest view` only shows raw registry metadata. `npx shadcn@latest add --dry-run` shows exactly what would happen in the user's project: resolved file paths, diffs against existing files, and CSS updates. Use `npx shadcn@latest view` only when the user wants to browse registry info without a project context.
+> **`npx shadcn@4.18.0 add --dry-run` vs `npx shadcn@4.18.0 view`:** Prefer `npx shadcn@4.18.0 add --dry-run/--diff/--view` over `npx shadcn@4.18.0 view` when the user wants to preview changes to their project. `npx shadcn@4.18.0 view` only shows raw registry metadata. `npx shadcn@4.18.0 add --dry-run` shows exactly what would happen in the user's project: resolved file paths, diffs against existing files, and CSS updates. Use `npx shadcn@4.18.0 view` only when the user wants to browse registry info without a project context.
 
 #### Smart Merge from Upstream
 
@@ -130,10 +132,10 @@ See [Updating Components in SKILL.md](./SKILL.md#updating-components) for the fu
 ### `search` — Search registries
 
 ```bash
-npx shadcn@latest search [registries...] [options]
+npx shadcn@4.18.0 search [registries...] [options]
 ```
 
-Fuzzy search across registries. Also aliased as `npx shadcn@latest list`.
+Fuzzy search across registries. Also aliased as `npx shadcn@4.18.0 list`.
 Supports namespaces (`@acme`), public GitHub registry sources (`owner/repo`),
 and registry catalog URLs. Without `-q`, lists all items. When no registries are
 passed, searches every registry configured in `components.json`.
@@ -150,22 +152,22 @@ passed, searches every registry configured in `components.json`.
 ### `view` — View item details
 
 ```bash
-npx shadcn@latest view <items...> [options]
+npx shadcn@4.18.0 view <items...> [options]
 ```
 
 Displays item info including file contents. Examples:
-`npx shadcn@latest view @shadcn/button`,
-`npx shadcn@latest view owner/repo/item`.
+`npx shadcn@4.18.0 view @shadcn/button`,
+`npx shadcn@4.18.0 view owner/repo/item`.
 
 ### `docs` — Get component documentation URLs
 
 ```bash
-npx shadcn@latest docs <components...> [options]
+npx shadcn@4.18.0 docs <components...> [options]
 ```
 
 Outputs resolved URLs for component documentation, examples, and API references. Accepts one or more component names. Fetch the URLs to get the actual content.
 
-Example output for `npx shadcn@latest docs input button`:
+Example output for `npx shadcn@4.18.0 docs input button`:
 
 ```
 base  radix
@@ -183,12 +185,12 @@ Some components include an `api` link to the underlying library (e.g. `cmdk` for
 
 ### `diff` — Check for updates
 
-Do not use this command. Use `npx shadcn@latest add --diff` instead.
+Do not use this command. Use `npx shadcn@4.18.0 add --diff` instead.
 
 ### `info` — Project information
 
 ```bash
-npx shadcn@latest info [options]
+npx shadcn@4.18.0 info [options]
 ```
 
 Displays project info and `components.json` configuration. Run this first to discover the project's framework, aliases, Tailwind version, and resolved paths.
@@ -233,12 +235,12 @@ Displays project info and `components.json` configuration. Run this first to dis
 
 **Links fields:**
 
-The `info` output includes a **Links** section with templated URLs for component docs, source, and examples. For resolved URLs, use `npx shadcn@latest docs <component>` instead.
+The `info` output includes a **Links** section with templated URLs for component docs, source, and examples. For resolved URLs, use `npx shadcn@4.18.0 docs <component>` instead.
 
 ### `build` — Build a custom registry
 
 ```bash
-npx shadcn@latest build [registry] [options]
+npx shadcn@4.18.0 build [registry] [options]
 ```
 
 Builds `registry.json` into individual JSON files for distribution. Default input: `./registry.json`, default output: `./public/r`.
@@ -276,15 +278,15 @@ Three ways to specify a preset via `--preset`:
 2. **Code:** `--preset a2r6bw` (version-prefixed base62 string, e.g. `a2r6bw` or `b0`)
 3. **URL:** `--preset "https://ui.shadcn.com/init?base=radix&style=nova&..."`
 
-> **IMPORTANT:** Never try to decode, fetch, or resolve preset codes manually. Preset codes are opaque — pass them directly to `npx shadcn@latest init --preset <code>` and let the CLI handle resolution.
-> Use `npx shadcn@latest apply --preset <code>` when overwriting an existing project's preset.
+> **IMPORTANT:** Never try to decode, fetch, or resolve preset codes manually. Preset codes are opaque — pass them directly to `npx shadcn@4.18.0 init --preset <code>` and let the CLI handle resolution.
+> Use `npx shadcn@4.18.0 apply --preset <code>` when overwriting an existing project's preset.
 
 ## Switching Presets
 
 Ask the user first: **overwrite**, **merge**, or **skip** existing components?
 
-- **Overwrite / Re-install** → `npx shadcn@latest apply --preset <code>`. Overwrites all detected component files with the new preset styles. Use when the user hasn't customized components.
-- **Merge** → `npx shadcn@latest init --preset <code> --force --no-reinstall`, then run `npx shadcn@latest info` to get the list of installed components and use the [smart merge workflow](./SKILL.md#updating-components) to update them one by one, preserving local changes. Use when the user has customized components.
-- **Skip** → `npx shadcn@latest init --preset <code> --force --no-reinstall`. Only updates config and CSS variables, leaves existing components as-is.
+- **Overwrite / Re-install** → `npx shadcn@4.18.0 apply --preset <code>`. Overwrites all detected component files with the new preset styles. Use when the user hasn't customized components.
+- **Merge** → `npx shadcn@4.18.0 init --preset <code> --force --no-reinstall`, then run `npx shadcn@4.18.0 info` to get the list of installed components and use the [smart merge workflow](./SKILL.md#updating-components) to update them one by one, preserving local changes. Use when the user has customized components.
+- **Skip** → `npx shadcn@4.18.0 init --preset <code> --force --no-reinstall`. Only updates config and CSS variables, leaves existing components as-is.
 
 Always run preset commands inside the user's project directory. `apply` only works in an existing project with a `components.json` file. The CLI automatically preserves the current base (`base` vs `radix`) from `components.json`. If you must use a scratch/temp directory (e.g. for `--dry-run` comparisons), pass `--base <current-base>` explicitly — preset codes do not encode the base.

--- a/skills/shadcn/customization.md
+++ b/skills/shadcn/customization.md
@@ -65,19 +65,19 @@ import { ThemeProvider } from "next-themes"
 
 ```bash
 # Apply a preset code from ui.shadcn.com.
-npx shadcn@latest apply --preset a2r6bw
+npx shadcn@4.18.0 apply --preset a2r6bw
 
 # Positional shorthand also works.
-npx shadcn@latest apply a2r6bw
+npx shadcn@4.18.0 apply a2r6bw
 
 # Switch to a named preset and overwrite existing components.
-npx shadcn@latest apply --preset nova
+npx shadcn@4.18.0 apply --preset nova
 
 # Preserve existing components instead.
-npx shadcn@latest init --preset nova --force --no-reinstall
+npx shadcn@4.18.0 init --preset nova --force --no-reinstall
 
 # Use a custom theme URL.
-npx shadcn@latest apply --preset "https://ui.shadcn.com/init?base=radix&style=nova&theme=blue&..."
+npx shadcn@4.18.0 apply --preset "https://ui.shadcn.com/init?base=radix&style=nova&theme=blue&..."
 ```
 
 Or edit CSS variables directly in `globals.css`.
@@ -86,7 +86,7 @@ Or edit CSS variables directly in `globals.css`.
 
 ## Adding Custom Colors
 
-Add variables to the file at `tailwindCssFile` from `npx shadcn@latest info` (typically `globals.css`). Never create a new CSS file for this.
+Add variables to the file at `tailwindCssFile` from `npx shadcn@4.18.0 info` (typically `globals.css`). Never create a new CSS file for this.
 
 ```css
 /* 1. Define in the global CSS file. */
@@ -108,7 +108,7 @@ Add variables to the file at `tailwindCssFile` from `npx shadcn@latest info` (ty
 }
 ```
 
-When `tailwindVersion` is `"v3"` (check via `npx shadcn@latest info`), register in `tailwind.config.js` instead:
+When `tailwindVersion` is `"v3"` (check via `npx shadcn@4.18.0 info`), register in `tailwind.config.js` instead:
 
 ```js
 // 2b. Register with Tailwind v3 (tailwind.config.js).
@@ -196,14 +196,14 @@ export function ConfirmDialog({ title, description, onConfirm, children }) {
 ## Checking for Updates
 
 ```bash
-npx shadcn@latest add button --diff
+npx shadcn@4.18.0 add button --diff
 ```
 
 To preview exactly what would change before updating, use `--dry-run` and `--diff`:
 
 ```bash
-npx shadcn@latest add button --dry-run        # see all affected files
-npx shadcn@latest add button --diff button.tsx # see the diff for a specific file
+npx shadcn@4.18.0 add button --dry-run        # see all affected files
+npx shadcn@4.18.0 add button --diff button.tsx # see the diff for a specific file
 ```
 
 See [Updating Components in SKILL.md](./SKILL.md#updating-components) for the full smart merge workflow.

--- a/skills/shadcn/mcp.md
+++ b/skills/shadcn/mcp.md
@@ -25,7 +25,7 @@ Editor config files:
 
 ## Tools
 
-> **Tip:** MCP tools handle registry operations (search, view, install). For project configuration (aliases, framework, Tailwind version), use `npx shadcn@latest info` — there is no MCP equivalent.
+> **Tip:** MCP tools handle registry operations (search, view, install). For project configuration (aliases, framework, Tailwind version), use `npx shadcn@4.18.0 info` — there is no MCP equivalent.
 
 ### `shadcn:get_project_registries`
 

--- a/skills/shadcn/registry.md
+++ b/skills/shadcn/registry.md
@@ -10,7 +10,7 @@ A registry has two forms:
 - **Source registry**: an authored `registry.json` in a project or repository.
   It may use `include` and file paths that point at source files.
 - **Built registry**: generated JSON files served to CLI consumers, usually
-  from `public/r`. Use `npx shadcn@latest build` to create this form.
+  from `public/r`. Use `npx shadcn@4.18.0 build` to create this form.
 
 The CLI installer consumes registry item payloads. A source registry is a way to
 author those payloads from real files.
@@ -241,28 +241,28 @@ commit SHA first.
 Use the CLI to build source registries:
 
 ```bash
-npx shadcn@latest build
-npx shadcn@latest build registry.json --output public/r
+npx shadcn@4.18.0 build
+npx shadcn@4.18.0 build registry.json --output public/r
 ```
 
 Use CLI commands to inspect the result:
 
 ```bash
-npx shadcn@latest list @acme
-npx shadcn@latest search @acme -q "login"
-npx shadcn@latest view @acme/login-form
-npx shadcn@latest add @acme/login-form --dry-run
-npx shadcn@latest registry validate ./registry.json
+npx shadcn@4.18.0 list @acme
+npx shadcn@4.18.0 search @acme -q "login"
+npx shadcn@4.18.0 view @acme/login-form
+npx shadcn@4.18.0 add @acme/login-form --dry-run
+npx shadcn@4.18.0 registry validate ./registry.json
 ```
 
 Use GitHub addresses directly for public GitHub registries:
 
 ```bash
-npx shadcn@latest list owner/repo
-npx shadcn@latest search owner/repo -q "login"
-npx shadcn@latest view owner/repo/item
-npx shadcn@latest add owner/repo/item --dry-run
-npx shadcn@latest registry validate owner/repo
+npx shadcn@4.18.0 list owner/repo
+npx shadcn@4.18.0 search owner/repo -q "login"
+npx shadcn@4.18.0 view owner/repo/item
+npx shadcn@4.18.0 add owner/repo/item --dry-run
+npx shadcn@4.18.0 registry validate owner/repo
 ```
 
 When working on registry implementation in the shadcn/ui codebase:

--- a/skills/shadcn/rules/base-vs-radix.md
+++ b/skills/shadcn/rules/base-vs-radix.md
@@ -1,6 +1,6 @@
 # Base vs Radix
 
-API differences between `base` and `radix`. Check the `base` field from `npx shadcn@latest info`.
+API differences between `base` and `radix`. Check the `base` field from `npx shadcn@4.18.0 info`.
 
 ## Contents
 

--- a/skills/shadcn/rules/chat.md
+++ b/skills/shadcn/rules/chat.md
@@ -3,7 +3,7 @@
 Components for conversation and chat UI. Compose these instead of hand-rolling
 bubbles, scroll containers, dividers, or attachment cards.
 
-Install: `npx shadcn@latest add message-scroller message bubble attachment marker`
+Install: `npx shadcn@4.18.0 add message-scroller message bubble attachment marker`
 
 The same component names and props ship for both `base` and `radix`; only
 composition differs (`render` vs `asChild`). See [base-vs-radix.md](./base-vs-radix.md).


### PR DESCRIPTION
## Summary

- Pins every official skill CLI invocation to the reviewed package version (`shadcn@4.18.0`) instead of `@latest`
- Removes load-time `!` interpolation of `info --json` and drops the `allowed-tools` Bash wildcard so package code is not executed or pre-approved at skill load
- Requires a separate approval for mutating commands (`init`, `add`, `apply`, `--overwrite`, `--force`) after the read-only `info` call
- Adds a vitest guard so release bumps cannot leave the skill pin out of sync with `packages/shadcn`

Closes #11269

Related: also stops the skill from failing to load in monorepos due to load-time `info` (see #10283); full `-c` UX for monorepos is still separate.

## Test plan

- [x] Grep `skills/shadcn` for `shadcn@latest`, `!`, and `allowed-tools` — none remain
- [x] Confirm examples use `shadcn@4.18.0` and still mention `npx` / `pnpm dlx` / `bunx --bun`
- [x] Run `pnpm --filter=shadcn exec vitest run src/skill-cli-pin.test.ts`
- [ ] Confirm skill load does no package execution; first CLI call is pinned `info --json`


Made with [Cursor](https://cursor.com)