### PR TITLE
docs: prevent FOUC in Vite dark mode guide

### DIFF
--- a/apps/v4/content/docs/dark-mode/vite.mdx
+++ b/apps/v4/content/docs/dark-mode/vite.mdx
@@ -142,3 +142,30 @@ export function ModeToggle() {
   )
 }
 ```
+
+## Prevent FOUC
+
+Add this script to the `<head>` of your `index.html`. It applies the saved
+theme before React loads, preventing a flash of unstyled content (FOUC).
+
+```html title="index.html"
+<script>
+  function applyTheme() {
+    const root = document.documentElement
+    const theme = localStorage.getItem("vite-ui-theme") || "dark"
+
+    root.classList.remove("light", "dark")
+
+    const resolvedTheme =
+      theme === "system"
+        ? window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light"
+        : theme
+
+    root.classList.add(resolvedTheme)
+  }
+
+  applyTheme()
+</script>
+```


### PR DESCRIPTION
## Summary

Adds a new **Prevent FOUC** section to the Vite dark mode guide.

The section documents an inline script for `index.html` that reads the saved `vite-
ui-theme` preference and applies the appropriate `light` or `dark` class before
React loads. It also respects the user’s system color-scheme preference when the
saved theme is set to `system`.

This prevents the page from briefly rendering with the wrong color theme on initial
load, while leaving the existing theme provider and mode-toggle instructions
unchanged.
