### PR TITLE
fix(sidebar): apply aria-expanded styling to base-ui menu button trigger

### DIFF
--- a/apps/v4/registry/bases/base/blocks/sidebar-01/components/version-switcher.tsx
+++ b/apps/v4/registry/bases/base/blocks/sidebar-01/components/version-switcher.tsx
@@ -31,7 +31,7 @@ export function VersionSwitcher({
             render={
               <SidebarMenuButton
                 size="lg"
-                className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+                className="aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
               />
             }
           >

--- a/apps/v4/registry/bases/base/blocks/sidebar-02/components/version-switcher.tsx
+++ b/apps/v4/registry/bases/base/blocks/sidebar-02/components/version-switcher.tsx
@@ -31,7 +31,7 @@ export function VersionSwitcher({
             render={
               <SidebarMenuButton
                 size="lg"
-                className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+                className="aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
               />
             }
           >

--- a/apps/v4/registry/bases/base/blocks/sidebar-07/components/team-switcher.tsx
+++ b/apps/v4/registry/bases/base/blocks/sidebar-07/components/team-switcher.tsx
@@ -42,7 +42,7 @@ export function TeamSwitcher({
             render={
               <SidebarMenuButton
                 size="lg"
-                className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+                className="aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
               />
             }
           >

--- a/apps/v4/registry/bases/base/blocks/sidebar-09/components/nav-user.tsx
+++ b/apps/v4/registry/bases/base/blocks/sidebar-09/components/nav-user.tsx
@@ -40,7 +40,7 @@ export function NavUser({
             render={
               <SidebarMenuButton
                 size="lg"
-                className="md:h-8 md:p-0 data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+                className="md:h-8 md:p-0 aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
               />
             }
           >

--- a/apps/v4/registry/bases/base/examples/sidebar-example.tsx
+++ b/apps/v4/registry/bases/base/examples/sidebar-example.tsx
@@ -179,7 +179,7 @@ export default function SidebarExample() {
                   render={
                     <SidebarMenuButton
                       size="lg"
-                      className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+                      className="aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
                     />
                   }
                 >

--- a/apps/v4/registry/bases/base/examples/sidebar-icon-example.tsx
+++ b/apps/v4/registry/bases/base/examples/sidebar-icon-example.tsx
@@ -245,7 +245,7 @@ export default function SidebarIconExample() {
                   render={
                     <SidebarMenuButton
                       size="lg"
-                      className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+                      className="aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
                     />
                   }
                 >
@@ -382,7 +382,7 @@ export default function SidebarIconExample() {
                   render={
                     <SidebarMenuButton
                       size="lg"
-                      className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+                      className="aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
                     />
                   }
                 >

--- a/apps/v4/registry/bases/base/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/base/ui/sidebar.tsx
@@ -485,7 +485,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "cn-sidebar-menu-button peer/menu-button group/menu-button flex w-full items-center overflow-hidden outline-hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
+  "cn-sidebar-menu-button cn-sidebar-menu-button-aria peer/menu-button group/menu-button flex w-full items-center overflow-hidden outline-hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
   {
     variants: {
       variant: {


### PR DESCRIPTION
Base UI trigger elements only set aria-expanded on open, never data-open (data-open is reserved for popup content), so sidebarMenuButtonVariants in the base preset never applied active styling on keyboard-triggered opens. Mirrors the aria preset, which already handles this correctly.

Fixes #11479