### PR TITLE
fix(www): make directory mobile View button navigate to registry home…

### DIFF
--- a/apps/v4/components/directory-list.tsx
+++ b/apps/v4/components/directory-list.tsx
@@ -258,7 +258,17 @@ function DirectoryListContent() {
                 <DirectoryAddButton registry={registry} />
               </ItemActions>
               <ItemFooter className="justify-start pl-16 sm:hidden">
-                <Button size="sm" variant="outline">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  render={
+                    <a
+                      href={getHomepageUrl(registry.homepage)}
+                      target="_blank"
+                      rel="noopener noreferrer external"
+                    />
+                  }
+                >
                   View <IconArrowUpRight />
                 </Button>
                 <DirectoryAddButton registry={registry} />


### PR DESCRIPTION
…page

The mobile-only View button rendered as a plain Button with no href or click handler, so tapping it did nothing. Renders it as an anchor via Base UI's render prop, matching the desktop title link's target/rel and reusing the existing getHomepageUrl helper.

Fixes #10899