### PR TITLE
feat(shadcn): allow project detection overrides

### DIFF
--- a/.changeset/tidy-pandas-detect.md
+++ b/.changeset/tidy-pandas-detect.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Allow `components.json` to override automatic framework and source-directory detection.

--- a/apps/v4/content/docs/(root)/components-json.mdx
+++ b/apps/v4/content/docs/(root)/components-json.mdx
@@ -138,6 +138,32 @@ Setting this option to `false` allows components to be added as JavaScript with 
 }
 ```
 
+## project
+
+Optional overrides for project structure that the CLI normally detects
+automatically. Most projects should omit this field.
+
+Use `project.framework` when a project contains files from multiple frameworks
+or when framework detection selects the wrong integration. Set it to `manual`
+to disable framework-specific behavior.
+
+Use `project.srcDirectory` when the project has a `src` directory that does not
+contain the frontend source. This controls whether framework-relative registry
+targets are placed under `src`.
+
+For example, a PHP or WordPress project can contain `composer.json` and a
+backend `src` directory while its React application is built by Vite from
+`resources`:
+
+```json title="components.json"
+{
+  "project": {
+    "framework": "vite",
+    "srcDirectory": false
+  }
+}
+```
+
 ## aliases
 
 The CLI uses these values to place generated components in the correct location and rewrite imports.

--- a/apps/v4/public/schema.json
+++ b/apps/v4/public/schema.json
@@ -60,6 +60,34 @@
     "tsx": {
       "type": "boolean"
     },
+    "project": {
+      "type": "object",
+      "description": "Overrides for project structure that the CLI normally detects automatically.",
+      "properties": {
+        "framework": {
+          "type": "string",
+          "description": "The framework to use instead of automatic detection. Use manual to disable framework-specific behavior.",
+          "enum": [
+            "next-app",
+            "next-pages",
+            "remix",
+            "react-router",
+            "vite",
+            "astro",
+            "laravel",
+            "tanstack-start",
+            "gatsby",
+            "expo",
+            "manual"
+          ]
+        },
+        "srcDirectory": {
+          "type": "boolean",
+          "description": "Whether framework-relative registry targets should be placed under src."
+        }
+      },
+      "additionalProperties": false
+    },
     "iconLibrary": {
       "type": "string"
     },

--- a/packages/shadcn/src/registry/schema.test.ts
+++ b/packages/shadcn/src/registry/schema.test.ts
@@ -1,10 +1,28 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  projectConfigSchema,
   registryChunkSchema,
   registryConfigSchema,
   registrySchema,
 } from "./schema"
+
+describe("projectConfigSchema", () => {
+  it("accepts framework and source directory overrides", () => {
+    expect(
+      projectConfigSchema.safeParse({
+        framework: "vite",
+        srcDirectory: false,
+      }).success
+    ).toBe(true)
+  })
+
+  it("rejects unsupported frameworks", () => {
+    expect(
+      projectConfigSchema.safeParse({ framework: "wordpress" }).success
+    ).toBe(false)
+  })
+})
 
 describe("registryConfigSchema", () => {
   it("should accept valid registry names starting with @", () => {

--- a/packages/shadcn/src/registry/schema.ts
+++ b/packages/shadcn/src/registry/schema.ts
@@ -25,6 +25,27 @@ export const registryConfigSchema = z.record(
   registryConfigItemSchema
 )
 
+export const projectConfigSchema = z
+  .object({
+    framework: z
+      .enum([
+        "next-app",
+        "next-pages",
+        "remix",
+        "react-router",
+        "vite",
+        "astro",
+        "laravel",
+        "tanstack-start",
+        "gatsby",
+        "expo",
+        "manual",
+      ])
+      .optional(),
+    srcDirectory: z.boolean().optional(),
+  })
+  .strict()
+
 export const rawConfigSchema = z
   .object({
     $schema: z.string().optional(),
@@ -50,6 +71,7 @@ export const rawConfigSchema = z
       .default("default")
       .optional(),
     menuAccent: z.enum(["subtle", "bold"]).default("subtle").optional(),
+    project: projectConfigSchema.optional(),
     aliases: z.object({
       components: z.string(),
       utils: z.string(),

--- a/packages/shadcn/src/utils/get-project-info.test.ts
+++ b/packages/shadcn/src/utils/get-project-info.test.ts
@@ -217,6 +217,70 @@ describe("get project info", async () => {
   })
 })
 
+describe("project config overrides", () => {
+  let cwd: string
+
+  beforeEach(async () => {
+    cwd = await fs.mkdtemp(path.join(tmpdir(), "shadcn-project-overrides-"))
+    await fs.mkdir(path.join(cwd, "src"))
+    await fs.writeFile(path.join(cwd, "composer.json"), "{}")
+    await fs.writeFile(path.join(cwd, "vite.config.ts"), "")
+  })
+
+  afterEach(async () => {
+    await fs.rm(cwd, { recursive: true, force: true })
+  })
+
+  it("overrides framework and source directory detection", async () => {
+    await writeComponentsConfig(cwd, {
+      framework: "vite",
+      srcDirectory: false,
+    })
+
+    const projectInfo = await getProjectInfo(cwd)
+
+    expect(projectInfo?.framework).toBe(FRAMEWORKS.vite)
+    expect(projectInfo?.isSrcDir).toBe(false)
+  })
+
+  it("allows framework-specific detection to be disabled", async () => {
+    await writeComponentsConfig(cwd, {
+      framework: "manual",
+    })
+
+    const projectInfo = await getProjectInfo(cwd)
+
+    expect(projectInfo?.framework).toBe(FRAMEWORKS.manual)
+    expect(projectInfo?.isSrcDir).toBe(true)
+  })
+})
+
+async function writeComponentsConfig(
+  cwd: string,
+  project: { framework?: "vite" | "manual"; srcDirectory?: boolean }
+) {
+  await fs.writeFile(
+    path.join(cwd, "components.json"),
+    JSON.stringify({
+      $schema: "https://ui.shadcn.com/schema.json",
+      style: "new-york",
+      rsc: false,
+      tsx: true,
+      tailwind: {
+        config: "",
+        css: "resources/styles.css",
+        baseColor: "zinc",
+        cssVariables: true,
+      },
+      aliases: {
+        components: "@/components",
+        utils: "@/lib/utils",
+      },
+      project,
+    })
+  )
+}
+
 describe("getFrameworkVersion", () => {
   describe("Next.js version detection", () => {
     it.each([

--- a/packages/shadcn/src/utils/get-project-info.ts
+++ b/packages/shadcn/src/utils/get-project-info.ts
@@ -2,7 +2,7 @@ import { promises as fsPromises } from "fs"
 import path from "path"
 import { getShadcnRegistryIndex } from "@/src/registry/api"
 import { SHADCN_URL } from "@/src/registry/constants"
-import { rawConfigSchema } from "@/src/schema"
+import { projectConfigSchema, rawConfigSchema } from "@/src/schema"
 import { Framework, FRAMEWORKS } from "@/src/utils/frameworks"
 import { Config, getConfig, resolveConfigPaths } from "@/src/utils/get-config"
 import { getPackageInfo } from "@/src/utils/get-package-info"
@@ -56,6 +56,7 @@ export async function getProjectInfo(
     tailwindVersion,
     aliasPrefixInfo,
     packageJson,
+    projectConfig,
   ] = await Promise.all([
     fg.glob(
       "**/{next,vite,astro,app}.config.*|gatsby-config.*|composer.json|react-router.config.*",
@@ -73,6 +74,7 @@ export async function getProjectInfo(
     getTailwindVersion(cwd),
     getProjectAliasInfo(cwd),
     getPackageInfo(cwd, false),
+    getProjectConfigOverrides(cwd),
   ])
 
   const isUsingAppDir = await fs.pathExists(
@@ -91,6 +93,16 @@ export async function getProjectInfo(
     aliasPrefix: aliasPrefixInfo.prefix,
   }
 
+  if (projectConfig?.framework !== undefined) {
+    type.framework = FRAMEWORKS[projectConfig.framework]
+    type.isRSC = projectConfig.framework === "next-app"
+    type.frameworkVersion = await getFrameworkVersion(
+      type.framework,
+      packageJson
+    )
+    return applySourceDirectoryOverride(type, projectConfig)
+  }
+
   // Next.js.
   if (configFiles.find((file) => file.startsWith("next.config."))?.length) {
     type.framework = isUsingAppDir
@@ -101,25 +113,25 @@ export async function getProjectInfo(
       type.framework,
       packageJson
     )
-    return type
+    return applySourceDirectoryOverride(type, projectConfig)
   }
 
   // Astro.
   if (configFiles.find((file) => file.startsWith("astro.config."))?.length) {
     type.framework = FRAMEWORKS["astro"]
-    return type
+    return applySourceDirectoryOverride(type, projectConfig)
   }
 
   // Gatsby.
   if (configFiles.find((file) => file.startsWith("gatsby-config."))?.length) {
     type.framework = FRAMEWORKS["gatsby"]
-    return type
+    return applySourceDirectoryOverride(type, projectConfig)
   }
 
   // Laravel.
   if (configFiles.find((file) => file.startsWith("composer.json"))?.length) {
     type.framework = FRAMEWORKS["laravel"]
-    return type
+    return applySourceDirectoryOverride(type, projectConfig)
   }
 
   // Remix.
@@ -129,7 +141,7 @@ export async function getProjectInfo(
     )
   ) {
     type.framework = FRAMEWORKS["remix"]
-    return type
+    return applySourceDirectoryOverride(type, projectConfig)
   }
 
   // TanStack Start.
@@ -140,7 +152,7 @@ export async function getProjectInfo(
     ].find((dep) => dep.startsWith("@tanstack/react-start"))
   ) {
     type.framework = FRAMEWORKS["tanstack-start"]
-    return type
+    return applySourceDirectoryOverride(type, projectConfig)
   }
 
   // React Router.
@@ -148,7 +160,7 @@ export async function getProjectInfo(
     configFiles.find((file) => file.startsWith("react-router.config."))?.length
   ) {
     type.framework = FRAMEWORKS["react-router"]
-    return type
+    return applySourceDirectoryOverride(type, projectConfig)
   }
 
   // Vite.
@@ -156,7 +168,7 @@ export async function getProjectInfo(
   // We'll assume that it got caught by the Remix check above.
   if (configFiles.find((file) => file.startsWith("vite.config."))?.length) {
     type.framework = FRAMEWORKS["vite"]
-    return type
+    return applySourceDirectoryOverride(type, projectConfig)
   }
 
   // Vinxi-based (such as @tanstack/start and @solidjs/solid-start)
@@ -169,17 +181,44 @@ export async function getProjectInfo(
     )
     if (appConfigContents.includes("defineConfig")) {
       type.framework = FRAMEWORKS["vite"]
-      return type
+      return applySourceDirectoryOverride(type, projectConfig)
     }
   }
 
   // Expo.
   if (packageJson?.dependencies?.expo) {
     type.framework = FRAMEWORKS["expo"]
-    return type
+    return applySourceDirectoryOverride(type, projectConfig)
   }
 
-  return type
+  return applySourceDirectoryOverride(type, projectConfig)
+}
+
+async function getProjectConfigOverrides(cwd: string) {
+  const configPath = path.resolve(cwd, "components.json")
+
+  if (!(await fs.pathExists(configPath))) {
+    return null
+  }
+
+  try {
+    const config = await fs.readJson(configPath)
+    const result = projectConfigSchema.safeParse(config.project)
+    return result.success ? result.data : null
+  } catch {
+    return null
+  }
+}
+
+function applySourceDirectoryOverride(
+  projectInfo: ProjectInfo,
+  projectConfig: z.infer<typeof projectConfigSchema> | null
+) {
+  if (projectConfig?.srcDirectory !== undefined) {
+    projectInfo.isSrcDir = projectConfig.srcDirectory
+  }
+
+  return projectInfo
 }
 
 export async function getFrameworkVersion(


### PR DESCRIPTION
## Summary

- add optional `project.framework` and `project.srcDirectory` overrides to `components.json`
- short-circuit framework inference when an explicit framework is configured, with `manual` available to disable framework-specific behavior
- apply the configured source-directory value to registry target resolution
- document the mixed PHP/WordPress + Vite use case and expose both fields in the public JSON schema
- add runtime schema and project-detection regression tests

## Motivation

Automatic detection is ambiguous in brownfield repositories. A WordPress plugin can legitimately contain `composer.json`, a backend PHP `src/` directory, a Vite config, and React source rooted at `resources/`. Today this is reported as Laravel with `srcDirectory: true`, and framework-relative registry targets can be routed into the backend source tree.

The new configuration is opt-in, so existing projects keep the current detection behavior:

```json
{
  "project": {
    "framework": "vite",
    "srcDirectory": false
  }
}
```

Closes #11529.

## Testing

- `pnpm --filter shadcn test` — 84 files, 1764 tests passed
- `pnpm --filter shadcn typecheck`
- `pnpm --filter shadcn build`
- Prettier check for all changed files
