### PR TITLE
fix(spinner): move live region to wrapper for proper a11y announcement

### DIFF
--- a/apps/v4/registry/bases/aria/ui/spinner.tsx
+++ b/apps/v4/registry/bases/aria/ui/spinner.tsx
@@ -1,20 +1,25 @@
 import { cn } from "@/registry/bases/aria/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string }) {
   return (
-    <IconPlaceholder
-      lucide="Loader2Icon"
-      tabler="IconLoader"
-      hugeicons="Loading03Icon"
-      phosphor="SpinnerIcon"
-      remixicon="RiLoaderLine"
-      data-slot="spinner"
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
+    <span role="status" aria-label={label}>
+      <IconPlaceholder
+        lucide="Loader2Icon"
+        tabler="IconLoader"
+        hugeicons="Loading03Icon"
+        phosphor="SpinnerIcon"
+        remixicon="RiLoaderLine"
+        data-slot="spinner"
+        aria-hidden="true"
+        className={cn("size-4 animate-spin", className)}
+        {...props}
+      />
+    </span>
   )
 }
 

--- a/apps/v4/registry/bases/base/ui/spinner.tsx
+++ b/apps/v4/registry/bases/base/ui/spinner.tsx
@@ -1,20 +1,25 @@
 import { cn } from "@/registry/bases/base/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string }) {
   return (
-    <IconPlaceholder
-      lucide="Loader2Icon"
-      tabler="IconLoader"
-      hugeicons="Loading03Icon"
-      phosphor="SpinnerIcon"
-      remixicon="RiLoaderLine"
-      data-slot="spinner"
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
+    <span role="status" aria-label={label}>
+      <IconPlaceholder
+        lucide="Loader2Icon"
+        tabler="IconLoader"
+        hugeicons="Loading03Icon"
+        phosphor="SpinnerIcon"
+        remixicon="RiLoaderLine"
+        data-slot="spinner"
+        aria-hidden="true"
+        className={cn("size-4 animate-spin", className)}
+        {...props}
+      />
+    </span>
   )
 }
 

--- a/apps/v4/registry/bases/radix/ui/spinner.tsx
+++ b/apps/v4/registry/bases/radix/ui/spinner.tsx
@@ -1,20 +1,25 @@
 import { cn } from "@/registry/bases/radix/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string }) {
   return (
-    <IconPlaceholder
-      lucide="Loader2Icon"
-      tabler="IconLoader"
-      hugeicons="Loading03Icon"
-      phosphor="SpinnerIcon"
-      remixicon="RiLoaderLine"
-      data-slot="spinner"
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
+    <span role="status" aria-label={label}>
+      <IconPlaceholder
+        lucide="Loader2Icon"
+        tabler="IconLoader"
+        hugeicons="Loading03Icon"
+        phosphor="SpinnerIcon"
+        remixicon="RiLoaderLine"
+        data-slot="spinner"
+        aria-hidden="true"
+        className={cn("size-4 animate-spin", className)}
+        {...props}
+      />
+    </span>
   )
 }
 

--- a/apps/v4/registry/new-york-v4/ui/spinner.tsx
+++ b/apps/v4/registry/new-york-v4/ui/spinner.tsx
@@ -2,14 +2,20 @@ import { Loader2Icon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string }) {
   return (
-    <Loader2Icon
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
+    <span role="status" aria-label={label}>
+      <Loader2Icon
+        aria-hidden="true"
+        data-slot="spinner"
+        className={cn("size-4 animate-spin", className)}
+        {...props}
+      />
+    </span>
   )
 }
 


### PR DESCRIPTION
## Summary

Moves `role="status"` from the SVG element to a wrapper `<span>`, so screen readers can actually announce the loading state.

## Problem

`Spinner` put `role="status"` directly on the `<svg>` icon. Since `role="status"` is a live region that announces changes to its **contents**, and an `<svg>` has no text content, the live region was permanently empty — screen readers said nothing when the spinner appeared.

Additionally, `aria-label` on an icon inside a button was folded into the button accessible name, causing buttons to announce "Loading Save" instead of "Save".

## Fix

- Wrap the icon in `<span role="status" aria-label="{label}">`
- Set `aria-hidden="true"` on the icon itself
- Add configurable `label` prop (default: `"Loading"`)
- Applied to all 4 spinner variants: `new-york-v4`, `radix`, `base`, `aria`

## Testing

- [ ] Screen reader announces "Loading" when spinner appears
- [ ] Button with spinner announces "Save" not "Loading Save"
- [ ] `label` prop overrides default text

Closes #11531