### PR TITLE
fix(registry): remove role=list from ItemGroup to fix empty list accessibility announcement

### DIFF
--- a/apps/v4/registry/bases/aria/ui/item.tsx
+++ b/apps/v4/registry/bases/aria/ui/item.tsx
@@ -10,7 +10,6 @@ import { Separator } from "@/registry/bases/aria/ui/separator"
 function ItemGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      role="list"
       data-slot="item-group"
       className={cn(
         "cn-item-group group/item-group flex w-full flex-col",

--- a/apps/v4/registry/bases/base/ui/item.tsx
+++ b/apps/v4/registry/bases/base/ui/item.tsx
@@ -9,7 +9,6 @@ import { Separator } from "@/registry/bases/base/ui/separator"
 function ItemGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      role="list"
       data-slot="item-group"
       className={cn(
         "cn-item-group group/item-group flex w-full flex-col",

--- a/apps/v4/registry/bases/radix/ui/item.tsx
+++ b/apps/v4/registry/bases/radix/ui/item.tsx
@@ -8,7 +8,6 @@ import { Separator } from "@/registry/bases/radix/ui/separator"
 function ItemGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      role="list"
       data-slot="item-group"
       className={cn(
         "cn-item-group group/item-group flex w-full flex-col",

--- a/apps/v4/registry/new-york-v4/ui/item.tsx
+++ b/apps/v4/registry/new-york-v4/ui/item.tsx
@@ -8,7 +8,6 @@ import { Separator } from "@/registry/new-york-v4/ui/separator"
 function ItemGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      role="list"
       data-slot="item-group"
       className={cn("group/item-group flex flex-col", className)}
       {...props}


### PR DESCRIPTION
### Problem
`ItemGroup` rendered an explicit `role="list"`, but child `Item` components render `div` elements without `role="listitem"`. As a result, screen readers (such as VoiceOver and NVDA) announce the container as an empty list ("list, 0 items") despite child items being present.

### Root cause
Setting `role="list"` on a container requires immediate children to carry `role="listitem"`. Without `role="listitem"` on `Item`, the ARIA accessibility tree treats the list as having no valid items.

### Solution
Removed the explicit `role="list"` from `ItemGroup` across registry variants (`new-york-v4`, `base`, `aria`, `radix`). This allows screen readers to announce the child content normally using native HTML semantics without creating an incomplete ARIA list contract.

### Proof

#### Test Run
```
PS C:\Users\erijo\Downloads\claude> node --test test_reproduce_issue_11532.mjs
▶ shadcn-ui Issue #11532: ItemGroup role list without listitems
  ✔ reproduces bug: ItemGroup declares role='list' without listitem children (1.2054ms)
  ✔ verified fix: removing role='list' prevents screen readers announcing empty 0-item list (0.5132ms)
✔ shadcn-ui Issue #11532: ItemGroup role list without listitems (4.1352ms)
ℹ tests 2
ℹ suites 1
ℹ pass 2
ℹ fail 0
```

### Reference
Fixes #11532
