### PR TITLE
fix(sidebar): add asChild and custom element support to SidebarContent (#11533)

### DIFF
--- a/PR_DESCRIPTION_DRAFT.md
+++ b/PR_DESCRIPTION_DRAFT.md
@@ -1,0 +1,17 @@
+## 📌 Summary
+Fixes #11533
+
+Adds `asChild` / `render` / `elementType` support to `SidebarContent`, enabling developers to render `SidebarContent` as a `<nav>` landmark for screen reader navigation and accessibility compliance without breaking layout or styling.
+
+---
+
+## 🔍 Root Cause Analysis
+Previously, `SidebarContent` rendered a hardcoded `<div>` and did not accept `asChild` (unlike sibling components like `SidebarGroupLabel`, `SidebarGroupAction`, and `SidebarMenuButton`). Because `SidebarContent` manages flex and scroll container behavior (`min-h-0 flex-1 overflow-auto`), wrapping it in an external `<nav>` breaks layout behavior, while omitting `<nav>` prevents screen readers from discovering the main navigation landmark.
+
+---
+
+## 🛠️ Changes
+- **`apps/v4/registry/new-york-v4/ui/sidebar.tsx`**: Added `asChild` prop support using `Slot.Root` from `@radix-ui/react-slot`.
+- **`apps/v4/registry/bases/radix/ui/sidebar.tsx`**: Added `asChild` prop support using `Slot.Root`.
+- **`apps/v4/registry/bases/base/ui/sidebar.tsx`**: Added `render` prop support via `useRender`.
+- **`apps/v4/registry/bases/aria/ui/sidebar.tsx`**: Added `elementType` prop support.

--- a/apps/v4/registry/bases/aria/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/aria/ui/sidebar.tsx
@@ -376,9 +376,13 @@ function SidebarSeparator({
   )
 }
 
-function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarContent({
+  className,
+  elementType: Element = "div",
+  ...props
+}: React.HTMLAttributes<HTMLElement> & { elementType?: React.ElementType }) {
   return (
-    <div
+    <Element
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(

--- a/apps/v4/registry/bases/base/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/base/ui/sidebar.tsx
@@ -372,18 +372,28 @@ function SidebarSeparator({
   )
 }
 
-function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="sidebar-content"
-      data-sidebar="content"
-      className={cn(
-        "cn-sidebar-content flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden",
-        className
-      )}
-      {...props}
-    />
-  )
+function SidebarContent({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"div"> & React.ComponentProps<"div">) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(
+          "cn-sidebar-content flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "sidebar-content",
+      sidebar: "content",
+    },
+  })
 }
 
 function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {

--- a/apps/v4/registry/bases/radix/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/radix/ui/sidebar.tsx
@@ -371,9 +371,15 @@ function SidebarSeparator({
   )
 }
 
-function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarContent({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "div"
+
   return (
-    <div
+    <Comp
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(

--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -368,9 +368,15 @@ function SidebarSeparator({
   )
 }
 
-function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarContent({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "div"
+
   return (
-    <div
+    <Comp
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(


### PR DESCRIPTION
## 📌 Summary
Fixes #11533

Adds `asChild` / `render` / `elementType` support to `SidebarContent`, enabling developers to render `SidebarContent` as a `<nav>` landmark for screen reader navigation and accessibility compliance without breaking layout or styling.

---

## 🔍 Root Cause Analysis
Previously, `SidebarContent` rendered a hardcoded `<div>` and did not accept `asChild` (unlike sibling components like `SidebarGroupLabel`, `SidebarGroupAction`, and `SidebarMenuButton`). Because `SidebarContent` manages flex and scroll container behavior (`min-h-0 flex-1 overflow-auto`), wrapping it in an external `<nav>` breaks layout behavior, while omitting `<nav>` prevents screen readers from discovering the main navigation landmark.

---

## 🛠️ Changes
- **`apps/v4/registry/new-york-v4/ui/sidebar.tsx`**: Added `asChild` prop support using `Slot.Root` from `@radix-ui/react-slot`.
- **`apps/v4/registry/bases/radix/ui/sidebar.tsx`**: Added `asChild` prop support using `Slot.Root`.
- **`apps/v4/registry/bases/base/ui/sidebar.tsx`**: Added `render` prop support via `useRender`.
- **`apps/v4/registry/bases/aria/ui/sidebar.tsx`**: Added `elementType` prop support.
