### PR TITLE
fix(sidebar): add asChild and polymorphism support to SidebarContent

### DIFF
--- a/apps/v4/registry/bases/aria/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/aria/ui/sidebar.tsx
@@ -376,9 +376,13 @@ function SidebarSeparator({
   )
 }
 
-function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarContent({
+  className,
+  elementType: Element = "div",
+  ...props
+}: React.HTMLAttributes<HTMLElement> & { elementType?: React.ElementType }) {
   return (
-    <div
+    <Element
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(

--- a/apps/v4/registry/bases/base/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/base/ui/sidebar.tsx
@@ -372,18 +372,26 @@ function SidebarSeparator({
   )
 }
 
-function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="sidebar-content"
-      data-sidebar="content"
-      className={cn(
-        "cn-sidebar-content flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden",
-        className
-      )}
-      {...props}
-    />
-  )
+function SidebarContent({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"div"> & React.ComponentProps<"div">) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(
+          "cn-sidebar-content flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+          className
+        ),
+        "data-slot": "sidebar-content",
+        "data-sidebar": "content",
+      },
+      props
+    ),
+    render,
+  })
 }
 
 function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {

--- a/apps/v4/registry/bases/radix/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/radix/ui/sidebar.tsx
@@ -371,9 +371,17 @@ function SidebarSeparator({
   )
 }
 
-function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarContent({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "div"
+
   return (
-    <div
+    <Comp
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(

--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -368,9 +368,17 @@ function SidebarSeparator({
   )
 }
 
-function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarContent({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "div"
+
   return (
-    <div
+    <Comp
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(


### PR DESCRIPTION
### Problem
`SidebarContent` rendered a hardcoded `<div>` and did not accept `asChild` / polymorphism. Consequently, applications could not render `SidebarContent` as a semantic `<nav>` landmark without introducing extra wrapping elements that disrupt flex and scroll behavior (`min-h-0 flex-1 overflow-auto`).

### Root cause
`SidebarContent` lacked `asChild` / `render` / `elementType` polymorphic props, unlike sibling sidebar components such as `SidebarGroupLabel` and `SidebarMenuButton`.

### Solution
Added polymorphic component support to `SidebarContent` across registry variants:
- `new-york-v4` and `radix`: Added `asChild = false` support using `Slot.Root`.
- `base`: Added `render` support via `@base-ui/react/use-render`.
- `aria`: Added `elementType = "div"` support.

### Proof

#### Test Run
```
PS C:\Users\erijo\Downloads\claude> node --test test_reproduce_issue_11533.mjs
▶ shadcn-ui Issue #11533: SidebarContent asChild landmark support
  ✔ reproduces bug: SidebarContent without asChild cannot render as <nav> landmark (4.4398ms)
  ✔ verified fix: SidebarContent with asChild renders semantic <nav> landmark (1.0789ms)
✔ shadcn-ui Issue #11533: SidebarContent asChild landmark support (13.3651ms)
ℹ tests 2
ℹ suites 1
ℹ pass 2
ℹ fail 0
```

### Reference
Fixes #11533
