### PR TITLE
fix(spinner): render accessible text content inside status live region

### DIFF
--- a/apps/v4/registry/bases/aria/ui/spinner.tsx
+++ b/apps/v4/registry/bases/aria/ui/spinner.tsx
@@ -1,8 +1,12 @@
 import { cn } from "@/registry/bases/aria/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
-  return (
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string | null }) {
+  const icon = (
     <IconPlaceholder
       lucide="Loader2Icon"
       tabler="IconLoader"
@@ -10,11 +14,23 @@ function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
       phosphor="SpinnerIcon"
       remixicon="RiLoaderLine"
       data-slot="spinner"
-      role="status"
-      aria-label="Loading"
+      aria-hidden="true"
       className={cn("size-4 animate-spin", className)}
       {...props}
     />
+  )
+
+  if (label == null || label === "") {
+    return icon
+  }
+
+  return (
+    <>
+      {icon}
+      <span role="status" className="sr-only">
+        {label}
+      </span>
+    </>
   )
 }
 

--- a/apps/v4/registry/bases/base/ui/spinner.tsx
+++ b/apps/v4/registry/bases/base/ui/spinner.tsx
@@ -1,8 +1,12 @@
 import { cn } from "@/registry/bases/base/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
-  return (
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string | null }) {
+  const icon = (
     <IconPlaceholder
       lucide="Loader2Icon"
       tabler="IconLoader"
@@ -10,11 +14,23 @@ function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
       phosphor="SpinnerIcon"
       remixicon="RiLoaderLine"
       data-slot="spinner"
-      role="status"
-      aria-label="Loading"
+      aria-hidden="true"
       className={cn("size-4 animate-spin", className)}
       {...props}
     />
+  )
+
+  if (label == null || label === "") {
+    return icon
+  }
+
+  return (
+    <>
+      {icon}
+      <span role="status" className="sr-only">
+        {label}
+      </span>
+    </>
   )
 }
 

--- a/apps/v4/registry/bases/radix/ui/spinner.tsx
+++ b/apps/v4/registry/bases/radix/ui/spinner.tsx
@@ -1,8 +1,12 @@
 import { cn } from "@/registry/bases/radix/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
-  return (
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string | null }) {
+  const icon = (
     <IconPlaceholder
       lucide="Loader2Icon"
       tabler="IconLoader"
@@ -10,11 +14,23 @@ function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
       phosphor="SpinnerIcon"
       remixicon="RiLoaderLine"
       data-slot="spinner"
-      role="status"
-      aria-label="Loading"
+      aria-hidden="true"
       className={cn("size-4 animate-spin", className)}
       {...props}
     />
+  )
+
+  if (label == null || label === "") {
+    return icon
+  }
+
+  return (
+    <>
+      {icon}
+      <span role="status" className="sr-only">
+        {label}
+      </span>
+    </>
   )
 }
 

--- a/apps/v4/registry/new-york-v4/ui/spinner.tsx
+++ b/apps/v4/registry/new-york-v4/ui/spinner.tsx
@@ -2,14 +2,31 @@ import { Loader2Icon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
-  return (
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string | null }) {
+  const icon = (
     <Loader2Icon
-      role="status"
-      aria-label="Loading"
+      data-slot="spinner"
+      aria-hidden="true"
       className={cn("size-4 animate-spin", className)}
       {...props}
     />
+  )
+
+  if (label == null || label === "") {
+    return icon
+  }
+
+  return (
+    <>
+      {icon}
+      <span role="status" className="sr-only">
+        {label}
+      </span>
+    </>
   )
 }
 


### PR DESCRIPTION
### Problem
`Spinner` attached `role="status"` and `aria-label="Loading"` directly onto the SVG element. Because `role="status"` is an ARIA live region that announces changes to its text content, and SVG elements contain no text content, the live region was permanently empty and screen readers remained silent when the spinner appeared. Furthermore, `aria-label` on the SVG was folded into parent buttons' accessible names (e.g. announcing "Loading Save" instead of "Save").

### Root cause
Live regions require accessible text content in the DOM rather than attribute labels on non-text elements.

### Solution
1. Applied `aria-hidden="true"` to the spinner icon element.
2. Rendered an accessible sibling `<span role="status" className="sr-only">{label}</span>` containing the status text.
3. Added a customizable `label?: string | null` prop (defaulting to `"Loading"`), allowing custom/localized text or passing `label={null}` to suppress the live region when managed by a parent container.

### Proof

#### Test Run
```
PS C:\Users\erijo\Downloads\claude> node --test test_reproduce_issue_11531.mjs
▶ shadcn-ui Issue #11531: Spinner role='status' live region with text content
  ✔ reproduces bug: SVG element as role='status' has empty text content (8.9268ms)
  ✔ verified fix: live region renders accessible text in sr-only span while icon is aria-hidden (0.8891ms)
  ✔ verified fix: label={null} suppresses sibling live region when caller manages status (2.1671ms)
✔ shadcn-ui Issue #11531: Spinner role='status' live region with text content (21.3167ms)
ℹ tests 3
ℹ suites 1
ℹ pass 3
ℹ fail 0
```

### Reference
Fixes #11531
