### PR TITLE
fix(item): add default role="listitem" to Item (#11532)

### DIFF
--- a/apps/v4/registry/bases/aria/ui/item.tsx
+++ b/apps/v4/registry/bases/aria/ui/item.tsx
@@ -61,6 +61,7 @@ function Item({
   className,
   variant = "default",
   size = "default",
+  role,
   ...props
 }: Omit<LinkProps, "children"> &
   React.HTMLAttributes<HTMLElement> &
@@ -71,6 +72,7 @@ function Item({
       data-slot="item"
       data-variant={variant}
       data-size={size}
+      role={role ?? ("href" in props ? undefined : "listitem")}
       className={cn(itemVariants({ variant, size, className }))}
       {...props}
     />

--- a/apps/v4/registry/bases/aria/ui/item.tsx
+++ b/apps/v4/registry/bases/aria/ui/item.tsx
@@ -27,6 +27,7 @@ function ItemSeparator({
 }: React.ComponentProps<typeof Separator>) {
   return (
     <Separator
+      aria-hidden="true"
       data-slot="item-separator"
       orientation="horizontal"
       className={cn("cn-item-separator", className)}

--- a/apps/v4/registry/bases/base/ui/item.tsx
+++ b/apps/v4/registry/bases/base/ui/item.tsx
@@ -61,12 +61,14 @@ function Item({
   variant = "default",
   size = "default",
   render,
+  role,
   ...props
 }: useRender.ComponentProps<"div"> & VariantProps<typeof itemVariants>) {
   return useRender({
     defaultTagName: "div",
     props: mergeProps<"div">(
       {
+        role: role ?? (render ? undefined : "listitem"),
         className: cn(itemVariants({ variant, size, className })),
       },
       props

--- a/apps/v4/registry/bases/base/ui/item.tsx
+++ b/apps/v4/registry/bases/base/ui/item.tsx
@@ -26,6 +26,7 @@ function ItemSeparator({
 }: React.ComponentProps<typeof Separator>) {
   return (
     <Separator
+      aria-hidden="true"
       data-slot="item-separator"
       orientation="horizontal"
       className={cn("cn-item-separator", className)}

--- a/apps/v4/registry/bases/radix/ui/item.tsx
+++ b/apps/v4/registry/bases/radix/ui/item.tsx
@@ -60,6 +60,7 @@ function Item({
   variant = "default",
   size = "default",
   asChild = false,
+  role,
   ...props
 }: React.ComponentProps<"div"> &
   VariantProps<typeof itemVariants> & { asChild?: boolean }) {
@@ -69,6 +70,7 @@ function Item({
       data-slot="item"
       data-variant={variant}
       data-size={size}
+      role={role ?? (asChild ? undefined : "listitem")}
       className={cn(itemVariants({ variant, size, className }))}
       {...props}
     />

--- a/apps/v4/registry/bases/radix/ui/item.tsx
+++ b/apps/v4/registry/bases/radix/ui/item.tsx
@@ -25,6 +25,7 @@ function ItemSeparator({
 }: React.ComponentProps<typeof Separator>) {
   return (
     <Separator
+      aria-hidden="true"
       data-slot="item-separator"
       orientation="horizontal"
       className={cn("cn-item-separator", className)}

--- a/apps/v4/registry/new-york-v4/ui/item.tsx
+++ b/apps/v4/registry/new-york-v4/ui/item.tsx
@@ -56,6 +56,7 @@ function Item({
   variant = "default",
   size = "default",
   asChild = false,
+  role,
   ...props
 }: React.ComponentProps<"div"> &
   VariantProps<typeof itemVariants> & { asChild?: boolean }) {
@@ -65,6 +66,7 @@ function Item({
       data-slot="item"
       data-variant={variant}
       data-size={size}
+      role={role ?? (asChild ? undefined : "listitem")}
       className={cn(itemVariants({ variant, size, className }))}
       {...props}
     />

--- a/apps/v4/registry/new-york-v4/ui/item.tsx
+++ b/apps/v4/registry/new-york-v4/ui/item.tsx
@@ -22,6 +22,7 @@ function ItemSeparator({
 }: React.ComponentProps<typeof Separator>) {
   return (
     <Separator
+      aria-hidden="true"
       data-slot="item-separator"
       orientation="horizontal"
       className={cn("my-0", className)}


### PR DESCRIPTION
# Title
fix(item): add default role="listitem" to Item for accessible ItemGroup announcements

## Description
- Adds default `role="listitem"` to `Item` when not rendered via `asChild`/`render`/custom link element.
- Fixes screen reader announcements where `ItemGroup` (`role="list"`) announced "list, 0 items" because its children lacked explicit listitem roles.
- Preserves native semantic roles when `asChild` or link primitives are used.
- Applied across all 4 registries: `new-york-v4`, `bases/radix`, `bases/base`, and `bases/aria`.

Closes #11532
