### PR TITLE
fix(ci): use GitHub token for stale workflow

### DIFF
--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -6,6 +6,11 @@ on:
     # This runs every day 20 minutes before midnight: https://crontab.guru/#40_23_*_*_*
     - cron: "40 23 * * *"
 
+permissions:
+  actions: write
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -15,7 +20,7 @@ jobs:
         id: issue-stale
         name: "Mark stale issues, close stale issues"
         with:
-          repo-token: ${{ secrets.STALE_TOKEN }}
+          repo-token: ${{ github.token }}
           ascending: true
           days-before-issue-close: 7
           days-before-issue-stale: 365
@@ -31,7 +36,7 @@ jobs:
         id: pr-state
         name: "Mark stale PRs, close stale PRs"
         with:
-          repo-token: ${{ secrets.STALE_TOKEN }}
+          repo-token: ${{ github.token }}
           ascending: true
           days-before-issue-close: -1
           days-before-issue-stale: -1

--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -20,7 +20,7 @@ jobs:
         id: issue-stale
         name: "Mark stale issues, close stale issues"
         with:
-          repo-token: ${{ github.token }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           ascending: true
           days-before-issue-close: 7
           days-before-issue-stale: 365
@@ -36,7 +36,7 @@ jobs:
         id: pr-state
         name: "Mark stale PRs, close stale PRs"
         with:
-          repo-token: ${{ github.token }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           ascending: true
           days-before-issue-close: -1
           days-before-issue-stale: -1


### PR DESCRIPTION
Use the built-in GitHub App installation token for the stale workflow and grant the permissions required to update issues, pull requests, and cache-backed action state.

Fixes the authentication failure in https://github.com/shadcn-ui/ui/actions/runs/32198541873/job/95907349702.