### PR TITLE
fix(registry): add accessible text content to spinner live region

### DIFF
--- a/apps/v4/content/docs/components/aria/spinner.mdx
+++ b/apps/v4/content/docs/components/aria/spinner.mdx
@@ -64,14 +64,25 @@ import { LoaderIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string }) {
   return (
-    <LoaderIcon
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
+    <>
+      <LoaderIcon
+        aria-hidden="true"
+        data-slot="spinner"
+        className={cn("size-4 animate-spin", className)}
+        {...props}
+      />
+      {label ? (
+        <span role="status" className="sr-only">
+          {label}
+        </span>
+      ) : null}
+    </>
   )
 }
 

--- a/apps/v4/content/docs/components/base/spinner.mdx
+++ b/apps/v4/content/docs/components/base/spinner.mdx
@@ -64,14 +64,25 @@ import { LoaderIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string }) {
   return (
-    <LoaderIcon
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
+    <>
+      <LoaderIcon
+        aria-hidden="true"
+        data-slot="spinner"
+        className={cn("size-4 animate-spin", className)}
+        {...props}
+      />
+      {label ? (
+        <span role="status" className="sr-only">
+          {label}
+        </span>
+      ) : null}
+    </>
   )
 }
 

--- a/apps/v4/content/docs/components/radix/spinner.mdx
+++ b/apps/v4/content/docs/components/radix/spinner.mdx
@@ -64,14 +64,25 @@ import { LoaderIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string }) {
   return (
-    <LoaderIcon
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
+    <>
+      <LoaderIcon
+        aria-hidden="true"
+        data-slot="spinner"
+        className={cn("size-4 animate-spin", className)}
+        {...props}
+      />
+      {label ? (
+        <span role="status" className="sr-only">
+          {label}
+        </span>
+      ) : null}
+    </>
   )
 }
 

--- a/apps/v4/examples/aria/spinner-custom.tsx
+++ b/apps/v4/examples/aria/spinner-custom.tsx
@@ -2,14 +2,25 @@ import { LoaderIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string }) {
   return (
-    <LoaderIcon
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
+    <>
+      <LoaderIcon
+        aria-hidden="true"
+        data-slot="spinner"
+        className={cn("size-4 animate-spin", className)}
+        {...props}
+      />
+      {label ? (
+        <span role="status" className="sr-only">
+          {label}
+        </span>
+      ) : null}
+    </>
   )
 }
 

--- a/apps/v4/examples/base/spinner-custom.tsx
+++ b/apps/v4/examples/base/spinner-custom.tsx
@@ -2,14 +2,25 @@ import { LoaderIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string }) {
   return (
-    <LoaderIcon
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
+    <>
+      <LoaderIcon
+        aria-hidden="true"
+        data-slot="spinner"
+        className={cn("size-4 animate-spin", className)}
+        {...props}
+      />
+      {label ? (
+        <span role="status" className="sr-only">
+          {label}
+        </span>
+      ) : null}
+    </>
   )
 }
 

--- a/apps/v4/examples/radix/spinner-custom.tsx
+++ b/apps/v4/examples/radix/spinner-custom.tsx
@@ -2,14 +2,25 @@ import { LoaderIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string }) {
   return (
-    <LoaderIcon
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
+    <>
+      <LoaderIcon
+        aria-hidden="true"
+        data-slot="spinner"
+        className={cn("size-4 animate-spin", className)}
+        {...props}
+      />
+      {label ? (
+        <span role="status" className="sr-only">
+          {label}
+        </span>
+      ) : null}
+    </>
   )
 }
 

--- a/apps/v4/public/r/styles/default/spinner.json
+++ b/apps/v4/public/r/styles/default/spinner.json
@@ -9,7 +9,7 @@
   "files": [
     {
       "path": "ui/spinner.tsx",
-      "content": "import { Loader2Icon } from \"lucide-react\"\n\nimport { cn } from \"@/lib/utils\"\n\nfunction Spinner({ className, ...props }: React.ComponentProps<\"svg\">) {\n  return (\n    <Loader2Icon\n      role=\"status\"\n      aria-label=\"Loading\"\n      className={cn(\"size-4 animate-spin\", className)}\n      {...props}\n    />\n  )\n}\n\nexport { Spinner }\n",
+      "content": "import { Loader2Icon } from \"lucide-react\"\n\nimport { cn } from \"@/lib/utils\"\n\nfunction Spinner({\n  className,\n  label = \"Loading\",\n  ...props\n}: React.ComponentProps<\"svg\"> & { label?: string }) {\n  return (\n    <>\n      <Loader2Icon\n        aria-hidden=\"true\"\n        data-slot=\"spinner\"\n        className={cn(\"size-4 animate-spin\", className)}\n        {...props}\n      />\n      {label ? (\n        <span role=\"status\" className=\"sr-only\">\n          {label}\n        </span>\n      ) : null}\n    </>\n  )\n}\n\nexport { Spinner }\n",
       "type": "registry:ui",
       "target": ""
     }

--- a/apps/v4/public/r/styles/new-york/spinner.json
+++ b/apps/v4/public/r/styles/new-york/spinner.json
@@ -9,7 +9,7 @@
   "files": [
     {
       "path": "ui/spinner.tsx",
-      "content": "import { Loader2Icon } from \"lucide-react\"\n\nimport { cn } from \"@/lib/utils\"\n\nfunction Spinner({ className, ...props }: React.ComponentProps<\"svg\">) {\n  return (\n    <Loader2Icon\n      role=\"status\"\n      aria-label=\"Loading\"\n      className={cn(\"size-4 animate-spin\", className)}\n      {...props}\n    />\n  )\n}\n\nexport { Spinner }\n",
+      "content": "import { Loader2Icon } from \"lucide-react\"\n\nimport { cn } from \"@/lib/utils\"\n\nfunction Spinner({\n  className,\n  label = \"Loading\",\n  ...props\n}: React.ComponentProps<\"svg\"> & { label?: string }) {\n  return (\n    <>\n      <Loader2Icon\n        aria-hidden=\"true\"\n        data-slot=\"spinner\"\n        className={cn(\"size-4 animate-spin\", className)}\n        {...props}\n      />\n      {label ? (\n        <span role=\"status\" className=\"sr-only\">\n          {label}\n        </span>\n      ) : null}\n    </>\n  )\n}\n\nexport { Spinner }\n",
       "type": "registry:ui",
       "target": ""
     }

--- a/apps/v4/registry/bases/aria/ui/spinner.tsx
+++ b/apps/v4/registry/bases/aria/ui/spinner.tsx
@@ -1,20 +1,30 @@
 import { cn } from "@/registry/bases/aria/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string }) {
   return (
-    <IconPlaceholder
-      lucide="Loader2Icon"
-      tabler="IconLoader"
-      hugeicons="Loading03Icon"
-      phosphor="SpinnerIcon"
-      remixicon="RiLoaderLine"
-      data-slot="spinner"
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
+    <>
+      <IconPlaceholder
+        lucide="Loader2Icon"
+        tabler="IconLoader"
+        hugeicons="Loading03Icon"
+        phosphor="SpinnerIcon"
+        remixicon="RiLoaderLine"
+        aria-hidden="true"
+        data-slot="spinner"
+        className={cn("size-4 animate-spin", className)}
+        {...props}
+      />
+      {label ? (
+        <span role="status" className="sr-only">
+          {label}
+        </span>
+      ) : null}
+    </>
   )
 }
 

--- a/apps/v4/registry/bases/base/ui/spinner.tsx
+++ b/apps/v4/registry/bases/base/ui/spinner.tsx
@@ -1,20 +1,30 @@
 import { cn } from "@/registry/bases/base/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string }) {
   return (
-    <IconPlaceholder
-      lucide="Loader2Icon"
-      tabler="IconLoader"
-      hugeicons="Loading03Icon"
-      phosphor="SpinnerIcon"
-      remixicon="RiLoaderLine"
-      data-slot="spinner"
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
+    <>
+      <IconPlaceholder
+        lucide="Loader2Icon"
+        tabler="IconLoader"
+        hugeicons="Loading03Icon"
+        phosphor="SpinnerIcon"
+        remixicon="RiLoaderLine"
+        aria-hidden="true"
+        data-slot="spinner"
+        className={cn("size-4 animate-spin", className)}
+        {...props}
+      />
+      {label ? (
+        <span role="status" className="sr-only">
+          {label}
+        </span>
+      ) : null}
+    </>
   )
 }
 

--- a/apps/v4/registry/bases/radix/ui/spinner.tsx
+++ b/apps/v4/registry/bases/radix/ui/spinner.tsx
@@ -1,20 +1,30 @@
 import { cn } from "@/registry/bases/radix/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string }) {
   return (
-    <IconPlaceholder
-      lucide="Loader2Icon"
-      tabler="IconLoader"
-      hugeicons="Loading03Icon"
-      phosphor="SpinnerIcon"
-      remixicon="RiLoaderLine"
-      data-slot="spinner"
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
+    <>
+      <IconPlaceholder
+        lucide="Loader2Icon"
+        tabler="IconLoader"
+        hugeicons="Loading03Icon"
+        phosphor="SpinnerIcon"
+        remixicon="RiLoaderLine"
+        aria-hidden="true"
+        data-slot="spinner"
+        className={cn("size-4 animate-spin", className)}
+        {...props}
+      />
+      {label ? (
+        <span role="status" className="sr-only">
+          {label}
+        </span>
+      ) : null}
+    </>
   )
 }
 

--- a/apps/v4/registry/new-york-v4/examples/spinner-custom.tsx
+++ b/apps/v4/registry/new-york-v4/examples/spinner-custom.tsx
@@ -2,14 +2,25 @@ import { LoaderIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string }) {
   return (
-    <LoaderIcon
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
+    <>
+      <LoaderIcon
+        aria-hidden="true"
+        data-slot="spinner"
+        className={cn("size-4 animate-spin", className)}
+        {...props}
+      />
+      {label ? (
+        <span role="status" className="sr-only">
+          {label}
+        </span>
+      ) : null}
+    </>
   )
 }
 

--- a/apps/v4/registry/new-york-v4/ui/spinner.tsx
+++ b/apps/v4/registry/new-york-v4/ui/spinner.tsx
@@ -2,14 +2,25 @@ import { Loader2Icon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string }) {
   return (
-    <Loader2Icon
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
+    <>
+      <Loader2Icon
+        aria-hidden="true"
+        data-slot="spinner"
+        className={cn("size-4 animate-spin", className)}
+        {...props}
+      />
+      {label ? (
+        <span role="status" className="sr-only">
+          {label}
+        </span>
+      ) : null}
+    </>
   )
 }
 


### PR DESCRIPTION
Fixes #11531

### Changes
- Adds a sr-only live region span with configurable label (default: 'Loading')
- Sets `aria-hidden='true'` on the spinner icon to avoid corrupting button accessible names.