### PR TITLE
fix(spinner): render sr-only live region for assistive tech (#11531)

### DIFF
--- a/apps/v4/registry/bases/radix/ui/spinner.tsx
+++ b/apps/v4/registry/bases/radix/ui/spinner.tsx
@@ -1,8 +1,12 @@
 import { cn } from "@/registry/bases/radix/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
-  return (
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string | null }) {
+  const icon = (
     <IconPlaceholder
       lucide="Loader2Icon"
       tabler="IconLoader"
@@ -10,11 +14,23 @@ function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
       phosphor="SpinnerIcon"
       remixicon="RiLoaderLine"
       data-slot="spinner"
-      role="status"
-      aria-label="Loading"
+      aria-hidden="true"
       className={cn("size-4 animate-spin", className)}
       {...props}
     />
+  )
+
+  if (label == null || label === "") {
+    return icon
+  }
+
+  return (
+    <>
+      {icon}
+      <span role="status" className="sr-only">
+        {label}
+      </span>
+    </>
   )
 }
 

--- a/apps/v4/registry/new-york-v4/ui/spinner.tsx
+++ b/apps/v4/registry/new-york-v4/ui/spinner.tsx
@@ -2,14 +2,30 @@ import { Loader2Icon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
-  return (
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string | null }) {
+  const icon = (
     <Loader2Icon
-      role="status"
-      aria-label="Loading"
+      aria-hidden="true"
       className={cn("size-4 animate-spin", className)}
       {...props}
     />
+  )
+
+  if (label == null || label === "") {
+    return icon
+  }
+
+  return (
+    <>
+      {icon}
+      <span role="status" className="sr-only">
+        {label}
+      </span>
+    </>
   )
 }
 


### PR DESCRIPTION
# Title
fix(spinner): render sr-only live region for assistive technology announcements (#11531)

## Description
- Updates `Spinner` in `new-york-v4` and `radix` registries to render a sibling `<span role="status" className="sr-only">{label}</span>` element.
- Sets `aria-hidden="true"` on the spinning svg icon to avoid empty live regions or mangling button accessible names.
- Adds optional `label` prop (defaults to `"Loading"`) for localisability.

Closes #11531
