### PR TITLE
fix(base-ui): fix PaginationLink data-slot hydration mismatch (#11489)

### DIFF
--- a/apps/v4/registry/bases/base/ui/pagination.tsx
+++ b/apps/v4/registry/bases/base/ui/pagination.tsx
@@ -53,11 +53,11 @@ function PaginationLink({
       size={size}
       className={cn("cn-pagination-link", className)}
       nativeButton={false}
+      data-slot="pagination-link"
+      data-active={isActive}
       render={
         <a
           aria-current={isActive ? "page" : undefined}
-          data-slot="pagination-link"
-          data-active={isActive}
           {...props}
         />
       }


### PR DESCRIPTION
# Title
fix(base-ui): prevent PaginationLink data-slot hydration mismatch (#11489)

## Description
- Passes `data-slot="pagination-link"` directly to `<Button>` in `PaginationLink` (Base UI base variant).
- Prevents server-to-client hydration attribute mismatch where SSR emitted `data-slot="button"` while client hydration rendered `data-slot="pagination-link"`.

Closes #11489
