### PR TITLE
fix(bubble): reserve space for BubbleReactions (#11474)

### DIFF
--- a/apps/v4/registry/bases/radix/ui/bubble.tsx
+++ b/apps/v4/registry/bases/radix/ui/bubble.tsx
@@ -15,7 +15,7 @@ function BubbleGroup({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 const bubbleVariants = cva(
-  "cn-bubble group/bubble relative flex w-fit min-w-0 flex-col",
+  "cn-bubble group/bubble relative flex w-fit max-w-[80%] min-w-0 flex-col gap-1 group-data-[align=end]/message:self-end data-[align=end]:self-end data-[variant=ghost]:max-w-full has-[[data-slot=bubble-reactions][data-side=bottom]]:mb-3.5 has-[[data-slot=bubble-reactions][data-side=top]]:mt-3.5",
   {
     variants: {
       variant: {

--- a/apps/v4/registry/new-york-v4/ui/bubble.tsx
+++ b/apps/v4/registry/new-york-v4/ui/bubble.tsx
@@ -15,7 +15,7 @@ function BubbleGroup({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 const bubbleVariants = cva(
-  "group/bubble relative flex w-fit max-w-[80%] min-w-0 flex-col gap-1 group-data-[align=end]/message:self-end data-[align=end]:self-end data-[variant=ghost]:max-w-full",
+  "group/bubble relative flex w-fit max-w-[80%] min-w-0 flex-col gap-1 group-data-[align=end]/message:self-end data-[align=end]:self-end data-[variant=ghost]:max-w-full has-[[data-slot=bubble-reactions][data-side=bottom]]:mb-3.5 has-[[data-slot=bubble-reactions][data-side=top]]:mt-3.5",
   {
     variants: {
       variant: {


### PR DESCRIPTION
# Title
fix(bubble): reserve space for BubbleReactions to avoid overlapping adjacent bubbles and message footers (#11474)

## Description
- Updates `bubbleVariants` to apply margin offset when `data-slot="bubble-reactions"` is present (`has-[[data-slot=bubble-reactions][data-side=bottom]]:mb-3.5`).
- Prevents out-of-flow reaction pills from covering subsequent messages in `BubbleGroup` or overlapping `MessageFooter` content.

Closes #11474
