### PR TITLE
fix(docs): move placeholder to SelectValue attribute in field-select (#11486)

### DIFF
--- a/apps/v4/examples/base/field-select.tsx
+++ b/apps/v4/examples/base/field-select.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/styles/base-nova/ui/select"
 
 const items = [
-  { label: "Choose department", value: null },
   { label: "Engineering", value: "engineering" },
   { label: "Design", value: "design" },
   { label: "Marketing", value: "marketing" },
@@ -30,7 +29,7 @@ export default function FieldSelect() {
       <FieldLabel>Department</FieldLabel>
       <Select items={items}>
         <SelectTrigger>
-          <SelectValue />
+          <SelectValue placeholder="Choose department" />
         </SelectTrigger>
         <SelectContent>
           <SelectGroup>


### PR DESCRIPTION
# Title
fix(docs): move placeholder from items list to SelectValue placeholder attribute (#11486)

## Description
- Removes null dummy option `{ label: "Choose department", value: null }` from `items` in base `field-select` example.
- Sets `placeholder="Choose department"` on `SelectValue` to match radix example and prevent placeholder from appearing as selectable list item.

Closes #11486
