### PR TITLE
fix(dropdown-menu): prevent radix content truncation (#11526)

### DIFF
--- a/apps/v4/registry/bases/radix/ui/dropdown-menu.tsx
+++ b/apps/v4/registry/bases/radix/ui/dropdown-menu.tsx
@@ -44,7 +44,7 @@ function DropdownMenuContent({
         sideOffset={sideOffset}
         align={align}
         className={cn(
-          "cn-dropdown-menu-content cn-menu-target cn-menu-translucent z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto data-[state=closed]:overflow-hidden",
+          "cn-dropdown-menu-content cn-menu-target cn-menu-translucent z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto data-[state=closed]:overflow-hidden",
           className
         )}
         {...props}


### PR DESCRIPTION
# Title
fix(dropdown-menu): prevent radix content truncation with small triggers (#11526)

## Description
- Changes `w-(--radix-dropdown-menu-trigger-width)` to `min-w-[8rem]` in Radix `DropdownMenuContent`.
- Matches the new-york-v4 specification and prevents dropdown menus with small or icon-only trigger buttons from collapsing and truncating menu item text.

Closes #11526
