### PR TITLE
fix(combobox): add tabIndex={-1} to base popup (#11554)

### DIFF
--- a/apps/v4/registry/bases/base/ui/combobox.tsx
+++ b/apps/v4/registry/bases/base/ui/combobox.tsx
@@ -123,6 +123,7 @@ function ComboboxContent({
       >
         <ComboboxPrimitive.Popup
           data-slot="combobox-content"
+          tabIndex={-1}
           data-chips={!!anchor}
           className={cn(
             "cn-combobox-content cn-combobox-content-logical cn-menu-target cn-menu-translucent group/combobox-content relative max-h-(--available-height) w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) data-[chips=true]:min-w-(--anchor-width)",


### PR DESCRIPTION
# Title
fix(combobox): add tabIndex={-1} to base popup to preserve input DOM focus (#11554)

## Description
- Adds `tabIndex={-1}` to `ComboboxPrimitive.Popup` in Base UI combobox registry.
- Conforms with WAI-ARIA APG combobox pattern by preventing DOM focus from leaving the input element while the popup is open.

Closes #11554
