### PR TITLE
fix: separate variant exports to dedicated files

### DIFF
--- a/apps/v4/registry/bases/base/ui/badge-variants.ts
+++ b/apps/v4/registry/bases/base/ui/badge-variants.ts
@@ -1,0 +1,24 @@
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/registry/bases/base/lib/utils"
+
+export const badgeVariants = cva(
+  "cn-badge group/badge inline-flex w-fit shrink-0 items-center justify-center overflow-hidden whitespace-nowrap focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none",
+  {
+    variants: {
+      variant: {
+        default: "cn-badge-variant-default",
+        secondary: "cn-badge-variant-secondary",
+        destructive: "cn-badge-variant-destructive",
+        outline: "cn-badge-variant-outline",
+        ghost: "cn-badge-variant-ghost",
+        link: "cn-badge-variant-link",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export type BadgeVariants = VariantProps<typeof badgeVariants>

--- a/apps/v4/registry/bases/base/ui/badge.tsx
+++ b/apps/v4/registry/bases/base/ui/badge.tsx
@@ -1,34 +1,15 @@
 import { mergeProps } from "@base-ui/react/merge-props"
 import { useRender } from "@base-ui/react/use-render"
-import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/registry/bases/base/lib/utils"
-
-const badgeVariants = cva(
-  "cn-badge group/badge inline-flex w-fit shrink-0 items-center justify-center overflow-hidden whitespace-nowrap focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none",
-  {
-    variants: {
-      variant: {
-        default: "cn-badge-variant-default",
-        secondary: "cn-badge-variant-secondary",
-        destructive: "cn-badge-variant-destructive",
-        outline: "cn-badge-variant-outline",
-        ghost: "cn-badge-variant-ghost",
-        link: "cn-badge-variant-link",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-    },
-  }
-)
+import { badgeVariants, type BadgeVariants } from "@/registry/bases/base/ui/badge-variants"
 
 function Badge({
   className,
   variant = "default",
   render,
   ...props
-}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+}: useRender.ComponentProps<"span"> & BadgeVariants) {
   return useRender({
     defaultTagName: "span",
     props: mergeProps<"span">(

--- a/apps/v4/registry/bases/base/ui/button-variants.ts
+++ b/apps/v4/registry/bases/base/ui/button-variants.ts
@@ -1,0 +1,35 @@
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/registry/bases/base/lib/utils"
+
+export const buttonVariants = cva(
+  "cn-button group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "cn-button-variant-default",
+        outline: "cn-button-variant-outline",
+        secondary: "cn-button-variant-secondary",
+        ghost: "cn-button-variant-ghost",
+        destructive: "cn-button-variant-destructive",
+        link: "cn-button-variant-link",
+      },
+      size: {
+        default: "cn-button-size-default",
+        xs: "cn-button-size-xs",
+        sm: "cn-button-size-sm",
+        lg: "cn-button-size-lg",
+        icon: "cn-button-size-icon",
+        "icon-xs": "cn-button-size-icon-xs",
+        "icon-sm": "cn-button-size-icon-sm",
+        "icon-lg": "cn-button-size-icon-lg",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export type ButtonVariants = VariantProps<typeof buttonVariants>

--- a/apps/v4/registry/bases/base/ui/button.tsx
+++ b/apps/v4/registry/bases/base/ui/button.tsx
@@ -1,44 +1,14 @@
 import { Button as ButtonPrimitive } from "@base-ui/react/button"
-import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/registry/bases/base/lib/utils"
-
-const buttonVariants = cva(
-  "cn-button group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-  {
-    variants: {
-      variant: {
-        default: "cn-button-variant-default",
-        outline: "cn-button-variant-outline",
-        secondary: "cn-button-variant-secondary",
-        ghost: "cn-button-variant-ghost",
-        destructive: "cn-button-variant-destructive",
-        link: "cn-button-variant-link",
-      },
-      size: {
-        default: "cn-button-size-default",
-        xs: "cn-button-size-xs",
-        sm: "cn-button-size-sm",
-        lg: "cn-button-size-lg",
-        icon: "cn-button-size-icon",
-        "icon-xs": "cn-button-size-icon-xs",
-        "icon-sm": "cn-button-size-icon-sm",
-        "icon-lg": "cn-button-size-icon-lg",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+import { buttonVariants, type ButtonVariants } from "@/registry/bases/base/ui/button-variants"
 
 function Button({
   className,
   variant = "default",
   size = "default",
   ...props
-}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+}: ButtonPrimitive.Props & ButtonVariants) {
   return (
     <ButtonPrimitive
       data-slot="button"

--- a/apps/v4/registry/bases/radix/ui/badge-variants.ts
+++ b/apps/v4/registry/bases/radix/ui/badge-variants.ts
@@ -1,0 +1,24 @@
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/registry/bases/radix/lib/utils"
+
+export const badgeVariants = cva(
+  "cn-badge group/badge inline-flex w-fit shrink-0 items-center justify-center overflow-hidden whitespace-nowrap focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none",
+  {
+    variants: {
+      variant: {
+        default: "cn-badge-variant-default",
+        secondary: "cn-badge-variant-secondary",
+        destructive: "cn-badge-variant-destructive",
+        outline: "cn-badge-variant-outline",
+        ghost: "cn-badge-variant-ghost",
+        link: "cn-badge-variant-link",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export type BadgeVariants = VariantProps<typeof badgeVariants>

--- a/apps/v4/registry/bases/radix/ui/badge.tsx
+++ b/apps/v4/registry/bases/radix/ui/badge.tsx
@@ -1,35 +1,15 @@
 import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
 
 import { cn } from "@/registry/bases/radix/lib/utils"
-
-const badgeVariants = cva(
-  "cn-badge group/badge inline-flex w-fit shrink-0 items-center justify-center overflow-hidden whitespace-nowrap focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none",
-  {
-    variants: {
-      variant: {
-        default: "cn-badge-variant-default",
-        secondary: "cn-badge-variant-secondary",
-        destructive: "cn-badge-variant-destructive",
-        outline: "cn-badge-variant-outline",
-        ghost: "cn-badge-variant-ghost",
-        link: "cn-badge-variant-link",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-    },
-  }
-)
+import { badgeVariants, type BadgeVariants } from "@/registry/bases/radix/ui/badge-variants"
 
 function Badge({
   className,
   variant = "default",
   asChild = false,
   ...props
-}: React.ComponentProps<"span"> &
-  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+}: React.ComponentProps<"span"> & BadgeVariants & { asChild?: boolean }) {
   const Comp = asChild ? Slot.Root : "span"
 
   return (

--- a/apps/v4/registry/bases/radix/ui/button-variants.ts
+++ b/apps/v4/registry/bases/radix/ui/button-variants.ts
@@ -1,0 +1,35 @@
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/registry/bases/radix/lib/utils"
+
+export const buttonVariants = cva(
+  "cn-button group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "cn-button-variant-default",
+        outline: "cn-button-variant-outline",
+        secondary: "cn-button-variant-secondary",
+        ghost: "cn-button-variant-ghost",
+        destructive: "cn-button-variant-destructive",
+        link: "cn-button-variant-link",
+      },
+      size: {
+        default: "cn-button-size-default",
+        xs: "cn-button-size-xs",
+        sm: "cn-button-size-sm",
+        lg: "cn-button-size-lg",
+        icon: "cn-button-size-icon",
+        "icon-xs": "cn-button-size-icon-xs",
+        "icon-sm": "cn-button-size-icon-sm",
+        "icon-lg": "cn-button-size-icon-lg",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export type ButtonVariants = VariantProps<typeof buttonVariants>

--- a/apps/v4/registry/bases/radix/ui/button.tsx
+++ b/apps/v4/registry/bases/radix/ui/button.tsx
@@ -1,38 +1,8 @@
 import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
 
 import { cn } from "@/registry/bases/radix/lib/utils"
-
-const buttonVariants = cva(
-  "cn-button group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-  {
-    variants: {
-      variant: {
-        default: "cn-button-variant-default",
-        outline: "cn-button-variant-outline",
-        secondary: "cn-button-variant-secondary",
-        ghost: "cn-button-variant-ghost",
-        destructive: "cn-button-variant-destructive",
-        link: "cn-button-variant-link",
-      },
-      size: {
-        default: "cn-button-size-default",
-        xs: "cn-button-size-xs",
-        sm: "cn-button-size-sm",
-        lg: "cn-button-size-lg",
-        icon: "cn-button-size-icon",
-        "icon-xs": "cn-button-size-icon-xs",
-        "icon-sm": "cn-button-size-icon-sm",
-        "icon-lg": "cn-button-size-icon-lg",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+import { buttonVariants, type ButtonVariants } from "@/registry/bases/radix/ui/button-variants"
 
 function Button({
   className,
@@ -41,7 +11,7 @@ function Button({
   asChild = false,
   ...props
 }: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
+  ButtonVariants & {
     asChild?: boolean
   }) {
   const Comp = asChild ? Slot.Root : "button"


### PR DESCRIPTION
Components (Button, Badge) export both the component and a buttonVariants/badgeVariants function from the same file. This triggers the react-refresh/only-export-components ESLint rule and breaks Fast Refresh in Vite/Next.js projects.

Move variants to separate files so component files export only the component, which satisfies the ESLint rule and keeps Fast Refresh working.

Refs #7736