### PR TITLE
fix(spinner): add screen reader live region text

### DIFF
--- a/apps/v4/registry/bases/aria/ui/spinner.tsx
+++ b/apps/v4/registry/bases/aria/ui/spinner.tsx
@@ -1,8 +1,12 @@
 import { cn } from "@/registry/bases/aria/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
-  return (
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string | null }) {
+  const icon = (
     <IconPlaceholder
       lucide="Loader2Icon"
       tabler="IconLoader"
@@ -10,11 +14,21 @@ function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
       phosphor="SpinnerIcon"
       remixicon="RiLoaderLine"
       data-slot="spinner"
-      role="status"
-      aria-label="Loading"
+      aria-hidden="true"
       className={cn("size-4 animate-spin", className)}
       {...props}
     />
+  )
+
+  if (label == null || label === "") return icon
+
+  return (
+    <>
+      {icon}
+      <span role="status" className="sr-only">
+        {label}
+      </span>
+    </>
   )
 }
 

--- a/apps/v4/registry/bases/base/ui/spinner.tsx
+++ b/apps/v4/registry/bases/base/ui/spinner.tsx
@@ -1,8 +1,12 @@
 import { cn } from "@/registry/bases/base/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
-  return (
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string | null }) {
+  const icon = (
     <IconPlaceholder
       lucide="Loader2Icon"
       tabler="IconLoader"
@@ -10,11 +14,21 @@ function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
       phosphor="SpinnerIcon"
       remixicon="RiLoaderLine"
       data-slot="spinner"
-      role="status"
-      aria-label="Loading"
+      aria-hidden="true"
       className={cn("size-4 animate-spin", className)}
       {...props}
     />
+  )
+
+  if (label == null || label === "") return icon
+
+  return (
+    <>
+      {icon}
+      <span role="status" className="sr-only">
+        {label}
+      </span>
+    </>
   )
 }
 

--- a/apps/v4/registry/bases/radix/ui/spinner.tsx
+++ b/apps/v4/registry/bases/radix/ui/spinner.tsx
@@ -1,8 +1,12 @@
 import { cn } from "@/registry/bases/radix/lib/utils"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
-  return (
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string | null }) {
+  const icon = (
     <IconPlaceholder
       lucide="Loader2Icon"
       tabler="IconLoader"
@@ -10,11 +14,21 @@ function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
       phosphor="SpinnerIcon"
       remixicon="RiLoaderLine"
       data-slot="spinner"
-      role="status"
-      aria-label="Loading"
+      aria-hidden="true"
       className={cn("size-4 animate-spin", className)}
       {...props}
     />
+  )
+
+  if (label == null || label === "") return icon
+
+  return (
+    <>
+      {icon}
+      <span role="status" className="sr-only">
+        {label}
+      </span>
+    </>
   )
 }
 

--- a/apps/v4/registry/new-york-v4/ui/spinner.tsx
+++ b/apps/v4/registry/new-york-v4/ui/spinner.tsx
@@ -2,14 +2,29 @@ import { Loader2Icon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
-  return (
+function Spinner({
+  className,
+  label = "Loading",
+  ...props
+}: React.ComponentProps<"svg"> & { label?: string | null }) {
+  const icon = (
     <Loader2Icon
-      role="status"
-      aria-label="Loading"
+      data-slot="spinner"
+      aria-hidden="true"
       className={cn("size-4 animate-spin", className)}
       {...props}
     />
+  )
+
+  if (label == null || label === "") return icon
+
+  return (
+    <>
+      {icon}
+      <span role="status" className="sr-only">
+        {label}
+      </span>
+    </>
   )
 }
 


### PR DESCRIPTION
Fixes #11531.

Added a `label` prop to Spinner and rendered it inside a visually hidden sibling with `role="status"`. The SVG itself gets `aria-hidden="true"`. This ensures screen readers actually announce when a spinner appears.