### PR TITLE
fix(cli): resolve compiler paths from tsconfig.app.json and tsconfig.web.json (#11466)

### DIFF
--- a/packages/shadcn/src/utils/get-config.ts
+++ b/packages/shadcn/src/utils/get-config.ts
@@ -54,8 +54,29 @@ export async function resolveConfigPaths(
     ...(config.registries || {}),
   }
 
-  // Read tsconfig.json.
-  const tsConfig = await loadConfig(cwd)
+  // Read tsconfig.json with fallback to tsconfig.app.json / tsconfig.web.json for Vite projects.
+  let tsConfig = await loadConfig(cwd)
+
+  if (
+    tsConfig.resultType === "failed" ||
+    !Object.keys(tsConfig.paths || {}).length
+  ) {
+    for (const fallback of ["tsconfig.app.json", "tsconfig.web.json"]) {
+      const fallbackPath = path.resolve(cwd, fallback)
+      try {
+        const fallbackConfig = await loadConfig(fallbackPath)
+        if (
+          fallbackConfig.resultType === "success" &&
+          Object.keys(fallbackConfig.paths || {}).length
+        ) {
+          tsConfig = fallbackConfig
+          break
+        }
+      } catch {
+        // Continue checking other fallbacks
+      }
+    }
+  }
 
   if (tsConfig.resultType === "failed") {
     throw new Error(


### PR DESCRIPTION
## Summary
Resolves #11466 by adding fallback resolution to 	sconfig.app.json and 	sconfig.web.json in esolveConfigPaths when the root 	sconfig.json does not declare compilerOptions.paths (standard Vite project structure with project references).

### Changes
- In esolveConfigPaths, if loadConfig(cwd) fails or returns empty paths, try loading 	sconfig.app.json or 	sconfig.web.json.

Closes #11466