### PR TITLE
fix(cli): migrate radix outputs Slot.Root instead of SlotPrimitive.Slot

### DIFF
--- a/packages/shadcn/src/migrations/migrate-radix.test.ts
+++ b/packages/shadcn/src/migrations/migrate-radix.test.ts
@@ -532,11 +532,11 @@ export const Accordion = AccordionPrimitive.Root
 export const AlertDialog = AlertDialogPrimitive.Root
 export const Button = Slot`
 
-    const expected = `import { Accordion as AccordionPrimitive, AlertDialog as AlertDialogPrimitive, AspectRatio as AspectRatioPrimitive, Avatar as AvatarPrimitive, Slot as SlotPrimitive, Checkbox as CheckboxPrimitive, Collapsible as CollapsiblePrimitive, ContextMenu as ContextMenuPrimitive, Dialog as DialogPrimitive, DropdownMenu as DropdownMenuPrimitive, HoverCard as HoverCardPrimitive, Label as LabelPrimitive, Menubar as MenubarPrimitive, NavigationMenu as NavigationMenuPrimitive, Popover as PopoverPrimitive, Progress as ProgressPrimitive, RadioGroup as RadioGroupPrimitive, ScrollArea as ScrollAreaPrimitive, Select as SelectPrimitive, Separator as SeparatorPrimitive, Slider as SliderPrimitive, Switch as SwitchPrimitive, Tabs as TabsPrimitive, Toggle as TogglePrimitive, ToggleGroup as ToggleGroupPrimitive, Tooltip as TooltipPrimitive } from "radix-ui"
+    const expected = `import { Accordion as AccordionPrimitive, AlertDialog as AlertDialogPrimitive, AspectRatio as AspectRatioPrimitive, Avatar as AvatarPrimitive, Slot, Checkbox as CheckboxPrimitive, Collapsible as CollapsiblePrimitive, ContextMenu as ContextMenuPrimitive, Dialog as DialogPrimitive, DropdownMenu as DropdownMenuPrimitive, HoverCard as HoverCardPrimitive, Label as LabelPrimitive, Menubar as MenubarPrimitive, NavigationMenu as NavigationMenuPrimitive, Popover as PopoverPrimitive, Progress as ProgressPrimitive, RadioGroup as RadioGroupPrimitive, ScrollArea as ScrollAreaPrimitive, Select as SelectPrimitive, Separator as SeparatorPrimitive, Slider as SliderPrimitive, Switch as SwitchPrimitive, Tabs as TabsPrimitive, Toggle as TogglePrimitive, ToggleGroup as ToggleGroupPrimitive, Tooltip as TooltipPrimitive } from "radix-ui"
 
 export const Accordion = AccordionPrimitive.Root
 export const AlertDialog = AlertDialogPrimitive.Root
-export const Button = SlotPrimitive.Slot`
+export const Button = Slot.Root`
 
     const result = await migrateRadixFile(input)
     expect(result.content.trim()).toBe(expected.trim())
@@ -597,10 +597,10 @@ import { Slot } from "@radix-ui/react-slot"
 export const FormLabel = LabelPrimitive.Root
 export const FormControl = Slot`
 
-    const expected = `import { Label as LabelPrimitive, Slot as SlotPrimitive } from "radix-ui"
+    const expected = `import { Label as LabelPrimitive, Slot } from "radix-ui"
 
 export const FormLabel = LabelPrimitive.Root
-export const FormControl = SlotPrimitive.Slot`
+export const FormControl = Slot.Root`
 
     const result = await migrateRadixFile(input)
     expect(result.content.trim()).toBe(expected.trim())
@@ -666,7 +666,8 @@ export const FormControl = SlotPrimitive.Slot`
     // Should be a single unified import from radix-ui
     expect(result.content).toContain('from "radix-ui"')
     expect(result.content.startsWith("import {")).toBe(true)
-    expect(result.content).toContain("Slot as SlotPrimitive") // Slot should be aliased as SlotPrimitive
+    expect(result.content).toMatch(/[{,]\s*Slot\s*[,}]/) // Slot kept unaliased to match registry Slot.Root usage
+    expect(result.content).not.toContain("Slot as SlotPrimitive")
     expect(result.content).toContain("Accordion as AccordionPrimitive") // Namespace should be aliased
 
     // Should have transformed all imports into a single statement
@@ -685,11 +686,11 @@ const Button = ({ asChild, children }) => {
   return <Comp>{children}</Comp>
 }`
 
-    const expected = `import { Slot as SlotPrimitive } from "radix-ui"
+    const expected = `import { Slot } from "radix-ui"
 
 const Button = ({ asChild, children }) => {
-  const Comp = asChild ? SlotPrimitive.Slot : "button"
-  const Element = asChild ? SlotPrimitive.Slot : "div"
+  const Comp = asChild ? Slot.Root : "button"
+  const Element = asChild ? Slot.Root : "div"
   return <Comp>{children}</Comp>
 }`
 
@@ -708,12 +709,12 @@ const Button = ({ asChild }) => {
   return null
 }`
 
-    const expected = `import { Slot as SlotPrimitive } from "radix-ui"
+    const expected = `import { Slot } from "radix-ui"
 
 const Button = ({ asChild }) => {
-  const Comp1 = asChild ? SlotPrimitive.Slot : "button"
-  const Comp2 = asChild?SlotPrimitive.Slot:"button"
-  const Comp3 = asChild  ?  SlotPrimitive.Slot  :  "button"
+  const Comp1 = asChild ? Slot.Root : "button"
+  const Comp2 = asChild?Slot.Root:"button"
+  const Comp3 = asChild  ?  Slot.Root  :  "button"
   return null
 }`
 
@@ -754,13 +755,13 @@ const Button = ({ asChild }) => {
   return <Slot />
 }`
 
-    const expected = `import { Slot as SlotPrimitive } from "radix-ui"
+    const expected = `import { Slot } from "radix-ui"
 
 const Button = ({ asChild }) => {
   const SlotName = "Slot"
   const someSlot = slot
-  const Comp = asChild ? SlotPrimitive.Slot : "button"
-  return <SlotPrimitive.Slot />
+  const Comp = asChild ? Slot.Root : "button"
+  return <Slot.Root />
 }`
 
     const result = await migrateRadixFile(input)
@@ -781,15 +782,15 @@ const Button = ({ asChild, ...props }: ButtonProps) => {
   return <Comp {...props} />
 }`
 
-    const expected = `import { Slot as SlotPrimitive } from "radix-ui"
+    const expected = `import { Slot } from "radix-ui"
 import React from "react"
 
-type ButtonProps = React.ComponentProps<typeof SlotPrimitive.Slot> & {
+type ButtonProps = React.ComponentProps<typeof Slot.Root> & {
   variant?: string
 }
 
 const Button = ({ asChild, ...props }: ButtonProps) => {
-  const Comp = asChild ? SlotPrimitive.Slot : "button"
+  const Comp = asChild ? Slot.Root : "button"
   return <Comp {...props} />
 }`
 
@@ -811,15 +812,15 @@ const Button = ({ asChild, ...props }: ButtonProps) => {
   return <Comp {...props} />
 }`
 
-    const expected = `import { Slot as SlotPrimitive } from "radix-ui"
+    const expected = `import { Slot } from "radix-ui"
 import { ComponentProps } from "react"
 
-type ButtonProps = ComponentProps<typeof SlotPrimitive.Slot> & {
+type ButtonProps = ComponentProps<typeof Slot.Root> & {
   variant?: string
 }
 
 const Button = ({ asChild, ...props }: ButtonProps) => {
-  const Comp = asChild ? SlotPrimitive.Slot : "button"
+  const Comp = asChild ? Slot.Root : "button"
   return <Comp {...props} />
 }`
 

--- a/packages/shadcn/src/migrations/migrate-radix.ts
+++ b/packages/shadcn/src/migrations/migrate-radix.ts
@@ -19,8 +19,7 @@ function toPascalCase(str: string): string {
 function processNamedImports(
   namedImports: string,
   isTypeOnly: boolean,
-  imports: Array<{ name: string; alias?: string; isType?: boolean }>,
-  packageName: string
+  imports: Array<{ name: string; alias?: string; isType?: boolean }>
 ) {
   // Clean up multi-line imports.
   // Remove comments and whitespace.
@@ -44,56 +43,27 @@ function processNamedImports(
       const importName = inlineTypeMatch[1]
       const importAlias = inlineTypeMatch[2]
 
-      if (packageName === "slot" && importName === "Slot" && !importAlias) {
-        imports.push({
-          name: "Slot",
-          alias: "SlotPrimitive",
-          isType: true,
-        })
-      } else {
-        imports.push({
-          name: importName,
-          alias: importAlias,
-          isType: true,
-        })
-      }
+      imports.push({
+        name: importName,
+        alias: importAlias,
+        isType: true,
+      })
     } else if (aliasMatch) {
       // Regular import with alias: "Root as DialogRoot"
       const importName = aliasMatch[1]
       const importAlias = aliasMatch[2]
 
-      if (
-        packageName === "slot" &&
-        importName === "Slot" &&
-        importAlias === "Slot"
-      ) {
-        imports.push({
-          name: "Slot",
-          alias: "SlotPrimitive",
-          isType: isTypeOnly,
-        })
-      } else {
-        imports.push({
-          name: importName,
-          alias: importAlias,
-          isType: isTypeOnly,
-        })
-      }
+      imports.push({
+        name: importName,
+        alias: importAlias,
+        isType: isTypeOnly,
+      })
     } else {
       // Simple import: "Root"
-      // Special handling for Slot: always alias it as SlotPrimitive
-      if (packageName === "slot" && importItem === "Slot") {
-        imports.push({
-          name: "Slot",
-          alias: "SlotPrimitive",
-          isType: isTypeOnly,
-        })
-      } else {
-        imports.push({
-          name: importItem,
-          isType: isTypeOnly,
-        })
-      }
+      imports.push({
+        name: importItem,
+        isType: isTypeOnly,
+      })
     }
   }
 }
@@ -329,7 +299,7 @@ export async function migrateRadixFile(
       // or import type { DialogProps } from "@radix-ui/react-dialog"
       // or import { type DialogProps, Root } from "@radix-ui/react-dialog"
 
-      processNamedImports(namedImports, isTypeOnly, imports, packageName)
+      processNamedImports(namedImports, isTypeOnly, imports)
     }
   }
 
@@ -376,11 +346,11 @@ export async function migrateRadixFile(
   result = result.replace(/\n\s*\n\s*\n/g, "\n\n")
 
   // Handle special case for Slot usage transformation
-  // Now that we import { Slot as SlotPrimitive }, we need to:
-  // 1. Transform: const Comp = asChild ? Slot : [ANYTHING] -> const Comp = asChild ? SlotPrimitive.Slot : [ANYTHING]
-  // 2. Transform: React.ComponentProps<typeof Slot> -> React.ComponentProps<typeof SlotPrimitive.Slot>
+  // Keep `import { Slot } from "radix-ui"` (matching registry) and rewrite usages to Slot.Root:
+  // 1. Transform: const Comp = asChild ? Slot : [ANYTHING] -> const Comp = asChild ? Slot.Root : [ANYTHING]
+  // 2. Transform: React.ComponentProps<typeof Slot> -> React.ComponentProps<typeof Slot.Root>
   const hasSlotImport = uniqueImports.some(
-    (imp) => imp.name === "Slot" && imp.alias === "SlotPrimitive"
+    (imp) => imp.name === "Slot" && (!imp.alias || imp.alias === "Slot")
   )
 
   if (hasSlotImport) {
@@ -436,10 +406,10 @@ export async function migrateRadixFile(
         }
       )
 
-      // Finally, replace all placeholders with SlotPrimitive.Slot
+      // Finally, replace all placeholders with Slot.Root
       transformedLine = transformedLine.replace(
         /__SLOT_PLACEHOLDER__/g,
-        "SlotPrimitive.Slot"
+        "Slot.Root"
       )
 
       return transformedLine


### PR DESCRIPTION
## Summary
- `shadcn migrate radix` no longer aliases `Slot` as `SlotPrimitive`.
- Slot usages (`asChild` ternaries, JSX, `ComponentProps<typeof Slot>`) are rewritten to `Slot.Root`, matching v4 registry components.
- Unit tests updated for the new output.

Closes #11564

## Test plan
- [x] `pnpm exec vitest run src/migrations/migrate-radix.test.ts` (38 passed)
- [ ] Run `npx shadcn migrate radix` on a file that imports `@radix-ui/react-slot` and confirm output uses `import { Slot } from "radix-ui"` and `Slot.Root`