### PR TITLE
fix(docs): resolve Astro dark mode toggle flash

### DIFF
--- a/apps/v4/content/docs/dark-mode/astro.mdx
+++ b/apps/v4/content/docs/dark-mode/astro.mdx
@@ -51,22 +51,12 @@ import {
 } from "@/components/ui/dropdown-menu"
 
 export function ModeToggle() {
-  const [theme, setThemeState] = React.useState<
-    "theme-light" | "dark" | "system"
-  >("theme-light")
-
-  React.useEffect(() => {
-    const isDarkMode = document.documentElement.classList.contains("dark")
-    setThemeState(isDarkMode ? "dark" : "theme-light")
-  }, [])
-
-  React.useEffect(() => {
+  const changeTheme = (theme: "theme-light" | "dark" | "system") => {
     const isDark =
       theme === "dark" ||
-      (theme === "system" &&
-        window.matchMedia("(prefers-color-scheme: dark)").matches)
-    document.documentElement.classList[isDark ? "add" : "remove"]("dark")
-  }, [theme])
+      (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+    document.documentElement.classList.toggle("dark", isDark);
+  };
 
   return (
     <DropdownMenu>
@@ -78,18 +68,12 @@ export function ModeToggle() {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => setThemeState("theme-light")}>
-          Light
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setThemeState("dark")}>
-          Dark
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setThemeState("system")}>
-          System
-        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => changeTheme("theme-light")}>Light</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => changeTheme("dark")}>Dark</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => changeTheme("system")}>System</DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
-  )
+  );
 }
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Lands [@debabin](https://github.com/debabin)’s Astro dark mode docs fix from #2822 on current `main`.

Credit: original work by **@debabin** in #2822. This PR only rebases that change after the docs moved from `apps/www` to `apps/v4` (the fork PR could not be updated due to GitHub App `workflows` permission limits).

- Remove `useEffect`/`useState` theme sync from the ModeToggle example
- Toggle the `dark` class in an `onClick` handler via `classList.toggle`

Closes #2822
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a022c2-4077-7db6-9f4b-fe5086f97515?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a022c2-4077-7db6-9f4b-fe5086f97515&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

