### PR TITLE
fix(docs): exclude accordion from typeset styles

### DIFF
--- a/apps/v4/content/docs/(root)/index.mdx
+++ b/apps/v4/content/docs/(root)/index.mdx
@@ -32,13 +32,13 @@ _In a typical library, if you need to change a button’s behavior, you have to 
     <AccordionTrigger>
       How do I pull upstream updates in an Open Code approach?
     </AccordionTrigger>
-    <AccordionContent>
+    <AccordionContent className="flex flex-col gap-4">
       <p>
         shadcn/ui follows a headless component architecture. This means the core
         of your app can receive fixes by updating your dependencies, for
         instance, @base-ui/react or input-otp.
       </p>
-      <p className="mt-4">
+      <p>
         The topmost layer, i.e., the one closest to your design system, is not
         coupled with the implementation of the library. It stays open for
         modification.

--- a/apps/v4/mdx-components.tsx
+++ b/apps/v4/mdx-components.tsx
@@ -330,7 +330,12 @@ export const mdxComponents = {
     <Button className={cn("not-typeset", className)} {...props} />
   ),
   Callout,
-  Accordion,
+  Accordion: ({
+    className,
+    ...props
+  }: React.ComponentProps<typeof Accordion>) => (
+    <Accordion className={cn("not-typeset", className)} {...props} />
+  ),
   AccordionContent,
   AccordionItem,
   AccordionTrigger,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Typeset was applying heading and paragraph styles to the upstream-updates accordion on `/docs/introduction`, which broke trigger alignment and content spacing.

- Mark docs `Accordion` with `not-typeset` (same escape hatch as Callout/Button)
- Use `flex flex-col gap-4` for the introduction accordion content instead of `mt-4`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a022db-ba2b-799a-89db-af450abb75a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a022db-ba2b-799a-89db-af450abb75a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

