### PR TITLE
fix(registry): fix message-scroller scrollbar strobing during autoscroll on classic scrollbar platforms (#11576)

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/message-scroller.tsx
+++ b/apps/v4/registry/new-york-v4/ui/message-scroller.tsx
@@ -42,7 +42,7 @@ function MessageScrollerViewport({
     <MessageScrollerPrimitive.Viewport
       data-slot="message-scroller-viewport"
       className={cn(
-        "size-full min-h-0 min-w-0 scroll-fade-b scrollbar-thin scrollbar-gutter-stable overflow-y-auto overscroll-contain contain-content data-autoscrolling:scrollbar-none",
+        "size-full min-h-0 min-w-0 scroll-fade-b scrollbar-thin scrollbar-gutter-stable overflow-y-auto overscroll-contain contain-content data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Closes #11576.

In `apps/v4/registry/new-york-v4/ui/message-scroller.tsx`, `MessageScrollerViewport` applied `data-autoscrolling:scrollbar-none`.

During programmatic streaming scrolls, the `data-autoscrolling` attribute toggles at chunk cadence (clearing after ~180ms timeout). When network/LLM chunk intervals exceed this threshold, the attribute flips on and off repeatedly, causing `scrollbar-width` to alternate between `thin` and `none`. On platforms with classic scrollbars (Windows, Linux, macOS with "Show scroll bars: Always"), this causes the scrollbar to strobe visibly and reflow content on each flip.

This change aligns `new-york-v4/ui/message-scroller.tsx` with the `bases/radix`, `bases/base`, and `bases/aria` implementations which use `data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent` instead of `scrollbar-none`.

## Changes

- Replace `data-autoscrolling:scrollbar-none` with `data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent` in `apps/v4/registry/new-york-v4/ui/message-scroller.tsx`.