### PR TITLE
fix(styles): skip :has() selectors in createStyleMap

### DIFF
--- a/packages/shadcn/src/styles/create-style-map.test.ts
+++ b/packages/shadcn/src/styles/create-style-map.test.ts
@@ -143,6 +143,27 @@ describe("parseStyle", () => {
     `)
   })
 
+  it("ignores :has() selectors — styles are conditional and cannot be inlined", () => {
+    const css = `
+      .style-vega {
+        .cn-card-content {
+          @apply px-6;
+        }
+        .cn-card-content:has(> [data-slot=questionnaire-choices]) {
+          @apply flex flex-col gap-3;
+        }
+      }
+    `
+
+    const result = createStyleMap(css)
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "cn-card-content": "px-6",
+      }
+    `)
+  })
+
   it("ignores non-cn- classes", () => {
     const css = `
       .button {

--- a/packages/shadcn/src/styles/create-style-map.ts
+++ b/packages/shadcn/src/styles/create-style-map.ts
@@ -37,6 +37,14 @@ export function createStyleMap(input: string) {
 
       selectorParser((selectorsRoot) => {
         selectorsRoot.each((sel) => {
+          let isConditional = false
+          sel.walk((node) => {
+            if (node.type === "pseudo" && node.value === ":has") {
+              isConditional = true
+            }
+          })
+          if (isConditional) return
+
           const targetClass = findSubjectClass(sel)
 
           if (!targetClass) {


### PR DESCRIPTION
## What

  Fixes #11584

  `createStyleMap` was incorrectly including classes from `:has()` selectors
  in the style map. This caused `transformStyleMap` to inline those classes
  unconditionally into every component instance.

  For example, `style-vega.css` has:

  ```css
  .cn-card-content {
    @apply px-(--card-spacing);
  }
  .cn-card-content:has(> [data-slot=questionnaire-choices]) {
    @apply flex flex-col gap-3;
  }

  The CLI was generating:
  
  className={cn("flex flex-col gap-3 px-(--card-spacing)", className)}

  instead of the correct:

  className={cn("px-(--card-spacing)", className)}
  
  Why

  :has() selectors are conditional — they apply only when the element
  contains specific children. They cannot be represented as a static Tailwind
  class name. The fix skips any selector containing a :has pseudo-class
  during style map construction so the styles remain in CSS where the
  condition is respected.

  Changes
  
  - packages/shadcn/src/styles/create-style-map.ts — skip :has() selectors
  - packages/shadcn/src/styles/create-style-map.test.ts — regression test

 
