### PR TITLE
fix(shadcn): skip app index update when app/page.tsx is missing

### DIFF
--- a/.changeset/fix-app-index-missing.md
+++ b/.changeset/fix-app-index-missing.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Skip the app index update when `app/page.tsx` is missing instead of throwing `ENOENT`.

--- a/packages/shadcn/src/utils/update-app-index.test.ts
+++ b/packages/shadcn/src/utils/update-app-index.test.ts
@@ -1,0 +1,90 @@
+import os from "os"
+import path from "path"
+import { getRegistryItems } from "@/src/registry/api"
+import { Config } from "@/src/utils/get-config"
+import fs from "fs-extra"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { updateAppIndex } from "./update-app-index"
+
+vi.mock("@/src/registry/api", () => ({
+  getRegistryItems: vi.fn(),
+}))
+
+const tempDirs: string[] = []
+
+async function createTempCwd() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "shadcn-app-index-"))
+  tempDirs.push(dir)
+
+  return dir
+}
+
+function createConfig(cwd: string) {
+  return { resolvedPaths: { cwd } } as Config
+}
+
+afterEach(async () => {
+  vi.clearAllMocks()
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.remove(dir)))
+})
+
+describe("updateAppIndex", () => {
+  it("should not throw when app/page.tsx does not exist", async () => {
+    const cwd = await createTempCwd()
+
+    await expect(
+      updateAppIndex("component", createConfig(cwd))
+    ).resolves.toBeUndefined()
+    expect(getRegistryItems).not.toHaveBeenCalled()
+  })
+
+  it("should not throw when app/page.tsx is a directory", async () => {
+    const cwd = await createTempCwd()
+    await fs.ensureDir(path.join(cwd, "app/page.tsx"))
+
+    await expect(
+      updateAppIndex("component", createConfig(cwd))
+    ).resolves.toBeUndefined()
+    expect(getRegistryItems).not.toHaveBeenCalled()
+  })
+
+  it("should overwrite app/page.tsx with the component import", async () => {
+    const cwd = await createTempCwd()
+    const indexPath = path.join(cwd, "app/page.tsx")
+    await fs.outputFile(indexPath, "export default function Page() {}\n")
+
+    vi.mocked(getRegistryItems).mockResolvedValue([
+      {
+        name: "component",
+        type: "registry:component",
+        meta: {
+          importSpecifier: "ComponentExample",
+          moduleSpecifier: "@/components/component-example",
+        },
+      },
+    ] as Awaited<ReturnType<typeof getRegistryItems>>)
+
+    await updateAppIndex("component", createConfig(cwd))
+
+    expect(await fs.readFile(indexPath, "utf8")).toBe(
+      'import { ComponentExample } from "@/components/component-example"\n\nexport default function Page() {\n  return <ComponentExample />\n}'
+    )
+  })
+
+  it("should leave app/page.tsx untouched when the item has no meta", async () => {
+    const cwd = await createTempCwd()
+    const indexPath = path.join(cwd, "app/page.tsx")
+    await fs.outputFile(indexPath, "export default function Page() {}\n")
+
+    vi.mocked(getRegistryItems).mockResolvedValue([
+      { name: "component", type: "registry:component" },
+    ] as Awaited<ReturnType<typeof getRegistryItems>>)
+
+    await updateAppIndex("component", createConfig(cwd))
+
+    expect(await fs.readFile(indexPath, "utf8")).toBe(
+      "export default function Page() {}\n"
+    )
+  })
+})

--- a/packages/shadcn/src/utils/update-app-index.ts
+++ b/packages/shadcn/src/utils/update-app-index.ts
@@ -6,7 +6,9 @@ import { Config } from "@/src/utils/get-config"
 export async function updateAppIndex(component: string, config: Config) {
   const indexPath = path.join(config.resolvedPaths.cwd, "app/page.tsx")
 
-  if (!(await fs.stat(indexPath)).isFile()) {
+  const stat = await fs.stat(indexPath).catch(() => null)
+
+  if (!stat?.isFile()) {
     return
   }
 


### PR DESCRIPTION
`updateAppIndex` guards on the index file existing:

```ts
if (!(await fs.stat(indexPath)).isFile()) {
  return
}
```

`fs.stat` rejects with `ENOENT` on a missing path rather than resolving, so this early return is unreachable — a missing `app/page.tsx` throws instead of being skipped. The error propagates to the `catch` in `add.ts` and surfaces through `handleError` as a raw `ENOENT`, after the component has already been written.

The rest of the codebase already uses the tolerant idiom for exactly this case — `migrate-radix.ts`, `migrate-rtl.ts` and `migrate-icons.ts` all do `await fs.stat(fullPath).catch(() => null)`. This is the only `fs.stat` call site in `packages/shadcn` that doesn't, so this change just brings it in line.

I wasn't able to reach the throw from the CLI today: `updateAppIndex` only runs after `createProject` scaffolds a fresh Next.js app from a v0 chat URL, and that template always writes `app/page.tsx`. So this is a latent bug rather than one users are currently hitting — happy to close it if you'd rather leave the guard as is.

`update-app-index.ts` had no test file, so this also adds one covering the missing-file and directory cases alongside the happy path.

## Testing

- The new `should not throw when app/page.tsx does not exist` test fails with `ENOENT` on `main` and passes with the fix.
- Full `packages/shadcn` suite: 1778 passed. Two pre-existing failures are unrelated to this change and environmental in my checkout (`github-cli.test.ts` asserts a stack trace doesn't contain `"private"`, and my clone lives under `/private/tmp`; `resolver.test.ts` fails to collect because I installed with `--filter`/`--ignore-scripts`).
