### PR TITLE
fix(ui): contain command dialog labels

### DIFF
--- a/apps/v4/registry/bases/base/ui/command.tsx
+++ b/apps/v4/registry/bases/base/ui/command.tsx
@@ -49,10 +49,6 @@ function CommandDialog({
 }) {
   return (
     <Dialog {...props}>
-      <DialogHeader className="sr-only">
-        <DialogTitle>{title}</DialogTitle>
-        <DialogDescription>{description}</DialogDescription>
-      </DialogHeader>
       <DialogContent
         className={cn(
           "cn-command-dialog top-1/3 translate-y-0 overflow-hidden p-0",
@@ -60,6 +56,10 @@ function CommandDialog({
         )}
         showCloseButton={showCloseButton}
       >
+        <DialogHeader className="sr-only">
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
         {children}
       </DialogContent>
     </Dialog>

--- a/apps/v4/registry/bases/radix/ui/command.tsx
+++ b/apps/v4/registry/bases/radix/ui/command.tsx
@@ -48,10 +48,6 @@ function CommandDialog({
 }) {
   return (
     <Dialog {...props}>
-      <DialogHeader className="sr-only">
-        <DialogTitle>{title}</DialogTitle>
-        <DialogDescription>{description}</DialogDescription>
-      </DialogHeader>
       <DialogContent
         className={cn(
           "cn-command-dialog top-1/3 translate-y-0 overflow-hidden p-0",
@@ -59,6 +55,10 @@ function CommandDialog({
         )}
         showCloseButton={showCloseButton}
       >
+        <DialogHeader className="sr-only">
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
         {children}
       </DialogContent>
     </Dialog>

--- a/apps/v4/registry/new-york-v4/ui/command.tsx
+++ b/apps/v4/registry/new-york-v4/ui/command.tsx
@@ -44,14 +44,14 @@ function CommandDialog({
 }) {
   return (
     <Dialog {...props}>
-      <DialogHeader className="sr-only">
-        <DialogTitle>{title}</DialogTitle>
-        <DialogDescription>{description}</DialogDescription>
-      </DialogHeader>
       <DialogContent
         className={cn("overflow-hidden p-0", className)}
         showCloseButton={showCloseButton}
       >
+        <DialogHeader className="sr-only">
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
         <Command className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>


### PR DESCRIPTION
## Summary

- move the hidden command dialog title and description inside `DialogContent`
- keep labels unmounted while the dialog is closed
- preserve the accessible name and description while open

Fixes #8568.

## Testing

- `mise exec bun@latest -- pnpm registry:build`
- `mise exec bun@latest -- pnpm check`
- `NEXT_PUBLIC_APP_URL=http://localhost:4000 NEXT_PUBLIC_V0_URL=https://v0.dev mise exec bun@latest -- pnpm test` (216 passed, 1 skipped)
- verified Base UI and Radix examples in-browser: labels are absent when closed, present and associated when open, and focus returns on close