### PR TITLE
Handle a 3-state dark mode toggle with a simple 2-state control

### DIFF
--- a/apps/v4/content/docs/dark-mode/tanstack-start.mdx
+++ b/apps/v4/content/docs/dark-mode/tanstack-start.mdx
@@ -149,7 +149,7 @@ function RootComponent() {
 Place a mode toggle on your site to toggle between light and dark mode.
 
 ```tsx title="components/mode-toggle.tsx" showLineNumbers
-import { Moon, Sun } from "lucide-react"
+import { SunMoon } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useTheme } from "@/components/theme-provider"
 
@@ -177,8 +177,7 @@ export function ModeToggle() {
       size="icon"
       variant="outline"
     >
-      <Sun className="h-6 w-6 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
-      <Moon className="absolute h-6 w-6 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+      <SunMoon className="h-6 w-6" />
       <span className="sr-only">Toggle theme</span>
     </Button>
   )

--- a/apps/v4/content/docs/dark-mode/tanstack-start.mdx
+++ b/apps/v4/content/docs/dark-mode/tanstack-start.mdx
@@ -150,40 +150,37 @@ Place a mode toggle on your site to toggle between light and dark mode.
 
 ```tsx title="components/mode-toggle.tsx" showLineNumbers
 import { Moon, Sun } from "lucide-react"
-
 import { Button } from "@/components/ui/button"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import { useTheme } from "@/components/theme-provider"
 
 export function ModeToggle() {
   const { setTheme } = useTheme()
+  const { theme, setTheme } = useTheme()
+
+  const handleSetTheme = () => {
+    // Handle three theme states (light/dark/system) with two ui states
+    const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
+      .matches
+      ? "dark"
+      : "light"
+
+    if (theme === "system" || theme === systemTheme) {
+      setTheme(systemTheme === "dark" ? "light" : "dark")
+    } else {
+      setTheme("system")
+    }
+  }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon">
-          <Sun className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
-          <Moon className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
-          <span className="sr-only">Toggle theme</span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => setTheme("light")}>
-          Light
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme("dark")}>
-          Dark
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme("system")}>
-          System
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <Button
+      onClick={() => handleSetTheme()}
+      size="icon"
+      variant="outline"
+    >
+      <Sun className="h-6 w-6 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+      <Moon className="absolute h-6 w-6 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
   )
 }
 ```

--- a/apps/v4/content/docs/dark-mode/tanstack-start.mdx
+++ b/apps/v4/content/docs/dark-mode/tanstack-start.mdx
@@ -58,12 +58,12 @@ export function ThemeProvider({
   defaultTheme = "system",
   storageKey = "theme",
 }: ThemeProviderProps) {
-  const [theme, setThemeState] = useState<Theme>(defaultTheme)
+  const [theme, setTheme] = useState<Theme>(defaultTheme)
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
     const stored = localStorage.getItem(storageKey)
-    setThemeState(
+    setTheme(
       stored === "light" || stored === "dark" || stored === "system"
         ? stored
         : defaultTheme
@@ -85,13 +85,13 @@ export function ThemeProvider({
     return () => media.removeEventListener("change", onChange)
   }, [theme, mounted])
 
-  const setTheme = (next: Theme) => {
+  const setThemeHandler = (next: Theme) => {
     localStorage.setItem(storageKey, next)
-    setThemeState(next)
+    setTheme(next)
   }
 
   return (
-    <ThemeProviderContext value={{ theme, setTheme }}>
+    <ThemeProviderContext value={{ theme, setTheme: SetThemeHandler }}>
       <ScriptOnce>{getThemeScript(storageKey, defaultTheme)}</ScriptOnce>
       {children}
     </ThemeProviderContext>


### PR DESCRIPTION
Many thanks to @ramonclaudio for his working tri-state toggle which I've been using. From a recent article (https://lea.verou.me/blog/2026/dark-mode-toggles/) I decided to rework the UI to make it a simpler two-state toggle that still processes all 3-states in the background. Did I miss anything?