### PR TITLE
fix(hooks): prevent tearing in use-mobile with SSR-safe singleton

### DIFF
--- a/apps/v4/hooks/use-mobile.ts
+++ b/apps/v4/hooks/use-mobile.ts
@@ -1,17 +1,35 @@
-import * as React from "react"
+import { useSyncExternalStore } from "react";
 
-export function useIsMobile(mobileBreakpoint = 768) {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+const MOBILE_BREAKPOINT = 768;
 
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < mobileBreakpoint)
+let mqlCache: MediaQueryList | null = null;
+
+function getMql() {
+    if (typeof window === "undefined") return null;
+    if (!mqlCache) {
+        mqlCache = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
     }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < mobileBreakpoint)
-    return () => mql.removeEventListener("change", onChange)
-  }, [mobileBreakpoint])
+    return mqlCache;
+}
 
-  return !!isMobile
+function subscribe(callback: () => void) {
+    if (typeof window === "undefined") return () => {};
+    const mql = getMql();
+    if (!mql) return () => {};
+    mql.addEventListener("change", callback);
+    return () => mql.removeEventListener("change", callback);
+}
+
+function getSnapshot() {
+    if (typeof window === "undefined") return false;
+    const mql = getMql();
+    return mql ? mql.matches : false;
+}
+
+function getServerSnapshot() {
+    return false;
+}
+
+export function useIsMobile() {
+    return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/apps/v4/registry/bases/aria/hooks/use-mobile.ts
+++ b/apps/v4/registry/bases/aria/hooks/use-mobile.ts
@@ -1,19 +1,35 @@
-import * as React from "react"
+import { useSyncExternalStore } from "react";
 
-const MOBILE_BREAKPOINT = 768
+const MOBILE_BREAKPOINT = 768;
+
+let mqlCache: MediaQueryList | null = null;
+
+function getMql() {
+    if (typeof window === "undefined") return null;
+    if (!mqlCache) {
+        mqlCache = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    }
+    return mqlCache;
+}
+
+function subscribe(callback: () => void) {
+    if (typeof window === "undefined") return () => {};
+    const mql = getMql();
+    if (!mql) return () => {};
+    mql.addEventListener("change", callback);
+    return () => mql.removeEventListener("change", callback);
+}
+
+function getSnapshot() {
+    if (typeof window === "undefined") return false;
+    const mql = getMql();
+    return mql ? mql.matches : false;
+}
+
+function getServerSnapshot() {
+    return false;
+}
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+    return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/apps/v4/registry/bases/base/hooks/use-mobile.ts
+++ b/apps/v4/registry/bases/base/hooks/use-mobile.ts
@@ -1,19 +1,35 @@
-import * as React from "react"
+import { useSyncExternalStore } from "react";
 
-const MOBILE_BREAKPOINT = 768
+const MOBILE_BREAKPOINT = 768;
+
+let mqlCache: MediaQueryList | null = null;
+
+function getMql() {
+    if (typeof window === "undefined") return null;
+    if (!mqlCache) {
+        mqlCache = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    }
+    return mqlCache;
+}
+
+function subscribe(callback: () => void) {
+    if (typeof window === "undefined") return () => {};
+    const mql = getMql();
+    if (!mql) return () => {};
+    mql.addEventListener("change", callback);
+    return () => mql.removeEventListener("change", callback);
+}
+
+function getSnapshot() {
+    if (typeof window === "undefined") return false;
+    const mql = getMql();
+    return mql ? mql.matches : false;
+}
+
+function getServerSnapshot() {
+    return false;
+}
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+    return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/apps/v4/registry/bases/radix/hooks/use-mobile.ts
+++ b/apps/v4/registry/bases/radix/hooks/use-mobile.ts
@@ -1,19 +1,35 @@
-import * as React from "react"
+import { useSyncExternalStore } from "react";
 
-const MOBILE_BREAKPOINT = 768
+const MOBILE_BREAKPOINT = 768;
+
+let mqlCache: MediaQueryList | null = null;
+
+function getMql() {
+    if (typeof window === "undefined") return null;
+    if (!mqlCache) {
+        mqlCache = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    }
+    return mqlCache;
+}
+
+function subscribe(callback: () => void) {
+    if (typeof window === "undefined") return () => {};
+    const mql = getMql();
+    if (!mql) return () => {};
+    mql.addEventListener("change", callback);
+    return () => mql.removeEventListener("change", callback);
+}
+
+function getSnapshot() {
+    if (typeof window === "undefined") return false;
+    const mql = getMql();
+    return mql ? mql.matches : false;
+}
+
+function getServerSnapshot() {
+    return false;
+}
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+    return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/apps/v4/registry/new-york-v4/hooks/use-mobile.ts
+++ b/apps/v4/registry/new-york-v4/hooks/use-mobile.ts
@@ -1,19 +1,35 @@
-import * as React from "react"
+import { useSyncExternalStore } from "react";
 
-const MOBILE_BREAKPOINT = 768
+const MOBILE_BREAKPOINT = 768;
+
+let mqlCache: MediaQueryList | null = null;
+
+function getMql() {
+    if (typeof window === "undefined") return null;
+    if (!mqlCache) {
+        mqlCache = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    }
+    return mqlCache;
+}
+
+function subscribe(callback: () => void) {
+    if (typeof window === "undefined") return () => {};
+    const mql = getMql();
+    if (!mql) return () => {};
+    mql.addEventListener("change", callback);
+    return () => mql.removeEventListener("change", callback);
+}
+
+function getSnapshot() {
+    if (typeof window === "undefined") return false;
+    const mql = getMql();
+    return mql ? mql.matches : false;
+}
+
+function getServerSnapshot() {
+    return false;
+}
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+    return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
Closes #8739
Closes #11030

### Description
The current `use-mobile` hook calls a state setter inside a `useEffect`, which can cause React concurrent rendering tearing issues. 

This PR refactors the hook to use `useSyncExternalStore` while introducing an SSR-safe global singleton cache for the `MediaQueryList`.

### Implementation Details
* **Singleton Cache:** The `MediaQueryList` instance is cached so it is not recreated on every hook call. Even with multiple consumers across the application, only a single `window.matchMedia` instance is created in memory.
* **CSSOM Accuracy:** By strictly relying on `mql.matches` rather than manual window width calculations, the browser's CSS Object Model is queried directly. This guarantees the React state perfectly aligns with CSS/Tailwind media queries and prevents layout bugs caused by scrollbar width discrepancies.
* **SSR Safety:** Defensive checks (`typeof window === "undefined"`) are included across the helper functions. Additionally, the third parameter of `useSyncExternalStore` (`getServerSnapshot`) is explicitly provided to ensure safe, predictable default values are returned during server-side rendering.
* **Event Delegation:** The callback is attached directly to the `change` event of the `MediaQueryList`, aligning perfectly with the subscription model of `useSyncExternalStore`.

cc: @matteovava @myselfgautham @lightify97