### PR TITLE
fix(shadcn): unregister finished spinners and clarify notice dedupe naming

### DIFF
--- a/packages/shadcn/src/registry/github-auth.ts
+++ b/packages/shadcn/src/registry/github-auth.ts
@@ -26,10 +26,10 @@ const coordinators = new WeakMap<object, Map<string, GitHubSourceAuthState>>()
 // A command can make several top-level registry calls (preflight, catalog,
 // tree resolution), each with its own sourceCache. The notice dedupes
 // process-wide per credential mode so it prints once, not once per phase.
-const notifiedSources = new Set<string>()
+const notifiedModes = new Set<GitHubAuthMode>()
 
 export function resetGitHubAuthNotices() {
-  notifiedSources.clear()
+  notifiedModes.clear()
 }
 
 export function getGitHubAuthState(anchor: object, source: GitHubSource) {
@@ -68,7 +68,7 @@ export function selectGitHubAuthMode(
 async function decideAndNotify() {
   const mode: GitHubAuthMode = getEnvGitHubToken() ? "token" : "gh"
 
-  if (notifiedSources.has(mode)) {
+  if (notifiedModes.has(mode)) {
     return mode
   }
 
@@ -82,7 +82,7 @@ async function decideAndNotify() {
     // surrounding spinner output.
     logAboveSpinner(`${green("✔")} ${gray(notice)}`)
   }
-  notifiedSources.add(mode)
+  notifiedModes.add(mode)
 
   return mode
 }

--- a/packages/shadcn/src/utils/spinner.ts
+++ b/packages/shadcn/src/utils/spinner.ts
@@ -15,6 +15,14 @@ export function spinner(
   })
   activeSpinners.add(instance)
 
+  // Every ora terminal method (succeed, fail, info, warn, stopAndPersist)
+  // funnels through stop, so wrapping it unregisters finished instances.
+  const stop = instance.stop.bind(instance)
+  instance.stop = () => {
+    activeSpinners.delete(instance)
+    return stop()
+  }
+
   return instance
 }
 


### PR DESCRIPTION
Applies the review follow-ups that missed the private-registries merge in #11582: spinner instances now unregister on stop so long-lived processes don't accumulate them, and the notice dedupe set is renamed to notifiedModes to match what it stores.