### PR TITLE
chore(directory): update @soralabs URLs to ui.soralabs.studio

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1557,8 +1557,8 @@
   },
   {
     "name": "@soralabs",
-    "homepage": "https://ui.soralabs.io.vn",
-    "url": "https://ui.soralabs.io.vn/r/{name}.json",
+    "homepage": "https://ui.soralabs.studio",
+    "url": "https://ui.soralabs.studio/r/{name}.json",
     "description": "Motion-first React primitives and animated UI components for shadcn/ui. Copy, customize, and ship fluid interfaces.",
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' fill='currentColor'><g transform='translate(100 100) scale(0.8292) translate(-100 -100)'><path d='M 150.245 -0.676 L 150.658 49.581 L 49.237 49.477 L 49.714 -0.758 L 150.245 -0.676 Z M 49.342 150.419 L 49.237 49.477 L -1.04 49.794 L -1.304 150.337 L 49.342 150.419 Z M 150.763 150.523 L 150.658 49.581 L 201.304 49.663 L 201.04 150.206 L 150.763 150.523 Z M 150.763 150.523 L 49.342 150.419 L 49.755 200.676 L 150.286 200.758 L 150.763 150.523 Z'/></g></svg>"
   },


### PR DESCRIPTION
## Summary

Sora UI has moved from `ui.soralabs.io.vn` to `ui.soralabs.studio`. This updates the `@soralabs` entry in the community registry directory so homepage links and `npx shadcn add @soralabs/...` resolve to the new domain.

- Homepage: https://ui.soralabs.studio
- Registry URL: https://ui.soralabs.studio/r/{name}.json
- Follow-up to #10884

## Test plan

- [x] Confirmed no existing open issue/PR already covers this domain change
- [x] `directory.json` still matches the registry entry schema (`@` namespace, valid homepage URL, `{name}` placeholder)
- [x] Verified https://ui.soralabs.studio/r/registry.json is reachable and has no `content` in index file entries
- [x] Verified items resolve on the new domain (`accordion`, `custom-cursor`, `cursor-bubble`)
- [ ] `pnpm validate:registries` on CI