### PR TITLE
registry: update @motion-menu directory entry to its own domain

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -990,9 +990,9 @@
   },
   {
     "name": "@motion-menu",
-    "homepage": "https://motion-menu-two.vercel.app",
-    "url": "https://motion-menu-two.vercel.app/r/{name}.json",
-    "description": "596 motion/3D UI patterns — scroll-driven WebGL, shader passes, spring choreography — as ready HTML/CSS/JS. 26 free, or $149 once for the rest.",
+    "homepage": "https://www.motionmenu.ca",
+    "url": "https://www.motionmenu.ca/r/{name}.json",
+    "description": "597 motion/3D UI patterns — scroll-driven WebGL, shader passes, spring choreography — as ready HTML/CSS/JS. 26 free, or $149 once for the rest.",
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' fill='none' stroke='var(--foreground)' stroke-width='2' stroke-linecap='round'><path d='M4 22c4-10 8 10 12 0s8-10 12 0'/></svg>"
   },
   {


### PR DESCRIPTION
Follow-up to #11456 (merged 2026-08-11). Motion Menu moved from its deployment URL to its own domain:

- `homepage`: https://motion-menu-two.vercel.app → https://www.motionmenu.ca
- `url`: https://www.motionmenu.ca/r/{name}.json (same registry, served from the domain — verified live, returns 200)
- description count refreshed to 597 (one pattern added since)

The old .vercel.app URLs continue to serve, so nothing breaks for anyone mid-transition — this just points the directory at the canonical domain.