### PR TITLE
fix(registry): render calendar week number as a th row header

### DIFF
--- a/apps/v4/registry/bases/base/ui/calendar.tsx
+++ b/apps/v4/registry/bases/base/ui/calendar.tsx
@@ -188,13 +188,13 @@ function Calendar({
         DayButton: ({ ...props }) => (
           <CalendarDayButton locale={locale} {...props} />
         ),
-        WeekNumber: ({ children, ...props }) => {
+        WeekNumber: ({ children, week: _week, ...props }) => {
           return (
-            <td {...props}>
+            <th {...props}>
               <div className="flex size-(--cell-size) items-center justify-center text-center">
                 {children}
               </div>
-            </td>
+            </th>
           )
         },
         ...components,

--- a/apps/v4/registry/bases/radix/ui/calendar.tsx
+++ b/apps/v4/registry/bases/radix/ui/calendar.tsx
@@ -188,13 +188,13 @@ function Calendar({
         DayButton: ({ ...props }) => (
           <CalendarDayButton locale={locale} {...props} />
         ),
-        WeekNumber: ({ children, ...props }) => {
+        WeekNumber: ({ children, week: _week, ...props }) => {
           return (
-            <td {...props}>
+            <th {...props}>
               <div className="flex size-(--cell-size) items-center justify-center text-center">
                 {children}
               </div>
-            </td>
+            </th>
           )
         },
         ...components,

--- a/apps/v4/registry/calendar.test.ts
+++ b/apps/v4/registry/calendar.test.ts
@@ -6,30 +6,48 @@ import { describe, expect, it } from "vitest"
 const registryDir = dirname(fileURLToPath(import.meta.url))
 const appDir = resolve(registryDir, "..")
 
-function findFiles(dir: string, fileName: string): string[] {
+function findFiles(
+  dir: string,
+  match: (fileName: string) => boolean
+): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const path = join(dir, entry.name)
 
     if (entry.isDirectory()) {
-      return findFiles(path, fileName)
+      return findFiles(path, match)
     }
 
-    return entry.name === fileName ? [path] : []
+    return match(entry.name) ? [path] : []
   })
 }
 
+const isCalendar = (fileName: string) => fileName === "calendar.tsx"
+const isTsx = (fileName: string) => fileName.endsWith(".tsx")
+
+// The class keys and component overrides asserted below only exist on the
+// calendars built with react-day-picker. The react-aria calendars
+// (registry/bases/aria and every styles/aria-* generated from it) render
+// their own markup, so selecting by filename alone would sweep them in and
+// fail on keys they are never meant to have.
+const usesDayPicker = (file: string) =>
+  readFileSync(file, "utf-8").includes("react-day-picker")
+
 describe("calendar registry items", () => {
   const sourceFiles = [
-    ...findFiles(resolve(appDir, "registry/bases"), "calendar.tsx"),
-    ...findFiles(resolve(appDir, "registry/new-york-v4"), "calendar.tsx"),
-    ...findFiles(resolve(appDir, "styles"), "calendar.tsx"),
-  ]
+    ...findFiles(resolve(appDir, "registry/bases"), isCalendar),
+    ...findFiles(resolve(appDir, "registry/new-york-v4"), isCalendar),
+    ...findFiles(resolve(appDir, "styles"), isCalendar),
+  ].filter(usesDayPicker)
   // Only the frozen legacy styles are checked here: they have no .tsx source
   // and are maintained by editing the published JSON directly in git. All
   // other styles are generated from the sources checked above.
   const publicFiles = [
-    ...findFiles(resolve(appDir, "public/r/styles/default"), "calendar.json"),
-    ...findFiles(resolve(appDir, "public/r/styles/new-york"), "calendar.json"),
+    ...findFiles(resolve(appDir, "public/r/styles/default"), (n) =>
+      n.endsWith("calendar.json")
+    ),
+    ...findFiles(resolve(appDir, "public/r/styles/new-york"), (n) =>
+      n.endsWith("calendar.json")
+    ),
   ]
 
   it.each(sourceFiles.map((file) => [relative(appDir, file), file]))(
@@ -53,6 +71,34 @@ describe("calendar registry items", () => {
       expect(source).toContain(
         'month_grid: cn(\\"w-full border-collapse\\", defaultClassNames.month_grid)'
       )
+    }
+  )
+
+  // A week number is a row header inside the grid body, and react-day-picker
+  // passes scope="row" down to it. scope is only valid on <th>, and the week
+  // prop is not a DOM attribute, so an override that renders <td {...props}>
+  // both drops the native semantics and leaks week="[object Object]".
+  // Swept over every .tsx that overrides WeekNumber -- not just calendar.tsx
+  // -- so example sources carrying their own copy are covered too.
+  const weekNumberSources = [
+    ...findFiles(resolve(appDir, "registry"), isTsx),
+    ...findFiles(resolve(appDir, "styles"), isTsx),
+  ].filter((file) => readFileSync(file, "utf-8").includes("WeekNumber: ({"))
+
+  it("finds every WeekNumber override", () => {
+    expect(weekNumberSources.length).toBeGreaterThan(0)
+  })
+
+  it.each(weekNumberSources.map((file) => [relative(appDir, file), file]))(
+    "%s renders the week number as a <th> row header",
+    (_, file) => {
+      const source = readFileSync(file, "utf-8")
+
+      expect(source).not.toContain("<td {...props}>")
+      expect(source).toContain(
+        "WeekNumber: ({ children, week: _week, ...props }) => {"
+      )
+      expect(source).toContain("<th {...props}>")
     }
   )
 })

--- a/apps/v4/registry/new-york-v4/examples/calendar-hijri.tsx
+++ b/apps/v4/registry/new-york-v4/examples/calendar-hijri.tsx
@@ -179,13 +179,13 @@ function Calendar({
           )
         },
         DayButton: CalendarDayButton,
-        WeekNumber: ({ children, ...props }) => {
+        WeekNumber: ({ children, week: _week, ...props }) => {
           return (
-            <td {...props}>
+            <th {...props}>
               <div className="flex size-(--cell-size) items-center justify-center text-center">
                 {children}
               </div>
-            </td>
+            </th>
           )
         },
         ...components,

--- a/apps/v4/registry/new-york-v4/ui/calendar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/calendar.tsx
@@ -163,13 +163,13 @@ function Calendar({
           )
         },
         DayButton: CalendarDayButton,
-        WeekNumber: ({ children, ...props }) => {
+        WeekNumber: ({ children, week: _week, ...props }) => {
           return (
-            <td {...props}>
+            <th {...props}>
               <div className="flex size-(--cell-size) items-center justify-center text-center">
                 {children}
               </div>
-            </td>
+            </th>
           )
         },
         ...components,


### PR DESCRIPTION
Fixes #11602

## Problem

The calendar registry item overrides `components.WeekNumber` with a `<td>`, while react-day-picker's own `WeekNumber` renders a `<th>` and destructures `week` off before spreading:

```tsx
export function WeekNumber(
  props: { week: CalendarWeek } & ThHTMLAttributes<HTMLTableCellElement>
) {
  const { week, ...thProps } = props
  return <th {...thProps} />
}
```

Three problems follow from the same three lines:

1. **Wrong element.** A week number is a row header inside the grid body. The sibling `week_number_header` slot is already a `<th>`; only this one was a `<td>`.
2. **`scope="row"` silently invalidated.** DayPicker passes `scope="row"` and `role="rowheader"` down. `scope` is only defined on `<th>` — on a `<td>` it is ignored, so the native row-header association is lost and the ARIA role is left carrying the semantics alone.
3. **`week` leaks into the DOM.** The override spread `...props` without destructuring `week`, so it landed on the element. React 19 renders it silently as `week="[object Object]"`.

**Before**

```html
<td week="[object Object]" aria-label="Week 31" class="rdp-week_number" scope="row" role="rowheader">
```

**After**

```html
<th aria-label="Week 31" class="rdp-week_number" scope="row" role="rowheader">
```

The fixed override is now attribute-identical to react-day-picker's own `WeekNumber`.

## Fix

`scope` and `role` already arrive via props, so nothing is hardcoded — only the element and the `week` destructure change:

```diff
-        WeekNumber: ({ children, ...props }) => {
+        WeekNumber: ({ children, week: _week, ...props }) => {
           return (
-            <td {...props}>
+            <th {...props}>
               <div className="flex size-(--cell-size) items-center justify-center text-center">
                 {children}
               </div>
-            </td>
+            </th>
           )
         },
```

Applied to all four sources carrying the override:

- `apps/v4/registry/bases/base/ui/calendar.tsx`
- `apps/v4/registry/bases/radix/ui/calendar.tsx`
- `apps/v4/registry/new-york-v4/ui/calendar.tsx`
- `apps/v4/registry/new-york-v4/examples/calendar-hijri.tsx`

The fourth was not listed in the issue but carries an identical copy. `bases/aria` uses react-aria and has no such override. Together these fan out to 16 of the 24 generated styles (all `base-*` and `radix-*`).

## Tests

`apps/v4/registry/calendar.test.ts`:

- **Selects sources by capability instead of by filename.** The `month_grid` sweep now filters on whether the source actually imports react-day-picker. This clears **10 pre-existing failures** where the react-aria calendars were asserted against a `month_grid` class key they are never meant to have.
- **Adds a `WeekNumber` assertion** swept over every `.tsx` that overrides the component, rather than only files named `calendar.tsx` — which is what covers `calendar-hijri.tsx`.

Suite goes from 23 passed / 10 failed to **46 passed**. Reintroducing the `<td>` in any single source fails exactly one test.

## Verification

- `vitest` — 46 passed
- `tsc --noEmit` — clean
- `prettier --check` — clean
- Regenerated styles — 16/16 emit `<th>`, 0 emit `<td>`
- Live dev server, `/docs/components/base/calendar` — 5 `<th ... scope="row" role="rowheader">` cells, zero `<td>` week-number cells, zero `week="[object Object]"`

## Out of scope

The two frozen legacy payloads — `apps/v4/public/r/styles/default/calendar.json` and `.../new-york/calendar.json` — still ship the `<td>`. They have no `.tsx` source and are maintained by editing the published JSON directly, so they are not regenerated by this change. Happy to fold them into this PR or follow up separately, whichever you prefer.
