### PR TITLE
fix(select): allow adaptive positioning on mobile touch devices (#11574)

### DIFF
--- a/apps/v4/registry/bases/base/ui/select.tsx
+++ b/apps/v4/registry/bases/base/ui/select.tsx
@@ -70,7 +70,7 @@ function SelectContent({
   sideOffset = 4,
   align = "center",
   alignOffset = 0,
-  alignItemWithTrigger = true,
+  alignItemWithTrigger,
   ...props
 }: SelectPrimitive.Popup.Props &
   Pick<
@@ -91,7 +91,7 @@ function SelectContent({
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
           className={cn(
-            "cn-select-content cn-select-content-logical cn-menu-target cn-menu-translucent relative isolate z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto data-[align-trigger=true]:animate-none",
+            "cn-select-content cn-select-content-logical cn-menu-target cn-menu-translucent relative isolate z-50 max-h-(--available-height) min-w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto data-[align-trigger=true]:animate-none",
             className
           )}
           {...props}


### PR DESCRIPTION
Fixes #11574

In Base UI (`@base-ui/react`), `alignItemWithTrigger` is automatically disabled on touch devices. Hardcoding `alignItemWithTrigger = true` in `SelectContent` broke this behavior and caused the popup positioning to fail on Android browsers.

This change removes the hardcoded default so Base UI can adaptively handle touch devices, and uses `min-w-(--anchor-width)` to avoid width collapse.
