### PR TITLE
fix(input-group): ignore clicks from portaled content

### DIFF
--- a/apps/v4/registry/bases/aria/ui/input-group.tsx
+++ b/apps/v4/registry/bases/aria/ui/input-group.tsx
@@ -53,6 +53,9 @@ function InputGroupAddon({
       data-align={align}
       className={cn(inputGroupAddonVariants({ align }), className)}
       onClick={(e) => {
+        if (!e.currentTarget.contains(e.target as Node)) {
+          return
+        }
         if ((e.target as HTMLElement).closest("button")) {
           return
         }

--- a/apps/v4/registry/bases/base/ui/input-group.tsx
+++ b/apps/v4/registry/bases/base/ui/input-group.tsx
@@ -53,6 +53,9 @@ function InputGroupAddon({
       data-align={align}
       className={cn(inputGroupAddonVariants({ align }), className)}
       onClick={(e) => {
+        if (!e.currentTarget.contains(e.target as Node)) {
+          return
+        }
         if ((e.target as HTMLElement).closest("button")) {
           return
         }

--- a/apps/v4/registry/bases/radix/ui/input-group.tsx
+++ b/apps/v4/registry/bases/radix/ui/input-group.tsx
@@ -53,6 +53,9 @@ function InputGroupAddon({
       data-align={align}
       className={cn(inputGroupAddonVariants({ align }), className)}
       onClick={(e) => {
+        if (!e.currentTarget.contains(e.target as Node)) {
+          return
+        }
         if ((e.target as HTMLElement).closest("button")) {
           return
         }

--- a/apps/v4/registry/new-york-v4/ui/input-group.tsx
+++ b/apps/v4/registry/new-york-v4/ui/input-group.tsx
@@ -69,6 +69,9 @@ function InputGroupAddon({
       data-align={align}
       className={cn(inputGroupAddonVariants({ align }), className)}
       onClick={(e) => {
+        if (!e.currentTarget.contains(e.target as Node)) {
+          return
+        }
         if ((e.target as HTMLElement).closest("button")) {
           return
         }


### PR DESCRIPTION
Closes #9723.

Supersedes and preserves the fix from #9760 by @yoonseooo71. The original PR could no longer be updated because its source fork and branch were deleted.

## Problem

React events from portaled content still bubble through the React component tree. `InputGroupAddon` therefore treats a click inside a portaled popover as an addon click, focuses the input, and can close the popover.

## Fix

Ignore click events whose target is not contained by the addon DOM node before applying the existing button guard and input-focus behavior.

## Coverage

The authored fix is applied to every current InputGroup source:

- React Aria
- Base UI
- Radix UI
- `new-york-v4`

A full registry build verified the generated result across all 25 current variants, including all eight React Aria styles and the generated RTL registries. Generated JSON files are intentionally not committed.

## Validation

- `pnpm registry:build`
- `pnpm typecheck`
- `pnpm validate:registries`