### PR TITLE
fix(registry): pass blob store id for oidc

### DIFF
--- a/apps/v4/app/r/registries.json/route.test.ts
+++ b/apps/v4/app/r/registries.json/route.test.ts
@@ -65,6 +65,7 @@ describe("GET /r/registries.json", () => {
     vi.setSystemTime(new Date("2026-08-24T13:00:00.000Z"))
     vi.stubEnv("REGISTRY_HEALTH_ENABLED", "1")
     vi.stubEnv("BLOB_READ_WRITE_TOKEN", "test-token")
+    vi.stubEnv("REGISTRY_HEALTH_BLOB_STORE_ID", "test-store-id")
     loadSnapshot.mockReset()
     vi.spyOn(console, "warn").mockImplementation(() => {})
   })
@@ -105,6 +106,21 @@ describe("GET /r/registries.json", () => {
     })
     expect(loadSnapshot).toHaveBeenCalledWith({
       token: "test-token",
+      storeId: "test-store-id",
+      abortSignal: expect.any(AbortSignal),
+    })
+  })
+
+  it("falls back to the default Blob store ID", async () => {
+    vi.stubEnv("REGISTRY_HEALTH_BLOB_STORE_ID", "")
+    vi.stubEnv("BLOB_STORE_ID", "default-store-id")
+    loadSnapshot.mockResolvedValue(createSnapshot({}))
+
+    await GET()
+
+    expect(loadSnapshot).toHaveBeenCalledWith({
+      token: "test-token",
+      storeId: "default-store-id",
       abortSignal: expect.any(AbortSignal),
     })
   })

--- a/apps/v4/app/r/registries.json/route.ts
+++ b/apps/v4/app/r/registries.json/route.ts
@@ -23,6 +23,8 @@ async function getHealthSnapshot() {
   try {
     const snapshot = await loadRegistryHealthSnapshot({
       token: process.env.BLOB_READ_WRITE_TOKEN,
+      storeId:
+        process.env.REGISTRY_HEALTH_BLOB_STORE_ID || process.env.BLOB_STORE_ID,
       abortSignal: controller.signal,
     })
     if (!snapshot) throw new Error("missing_snapshot")

--- a/apps/v4/lib/registry-health/blob.test.ts
+++ b/apps/v4/lib/registry-health/blob.test.ts
@@ -112,6 +112,7 @@ describe("loadRegistryHealthSnapshot", () => {
     await expect(
       loadRegistryHealthSnapshot({
         token: "test-token",
+        storeId: "test-store-id",
         abortSignal: abortController.signal,
         operations,
       })
@@ -121,6 +122,7 @@ describe("loadRegistryHealthSnapshot", () => {
       {
         access: "private",
         token: "test-token",
+        storeId: "test-store-id",
         useCache: false,
         abortSignal: abortController.signal,
       }

--- a/apps/v4/lib/registry-health/blob.ts
+++ b/apps/v4/lib/registry-health/blob.ts
@@ -28,6 +28,7 @@ type BlobOperations = {
     options: {
       access: "private"
       token?: string
+      storeId?: string
       useCache: false
       abortSignal?: AbortSignal
     }
@@ -106,16 +107,19 @@ export async function loadRegistryMonitorState({
 
 export async function loadRegistryHealthSnapshot({
   token,
+  storeId,
   abortSignal,
   operations = defaultOperations,
 }: {
   token?: string
+  storeId?: string
   abortSignal?: AbortSignal
   operations?: BlobOperations
 }) {
   const result = await operations.get(LATEST_PATH, {
     access: "private",
     token,
+    storeId,
     useCache: false,
     abortSignal,
   })

--- a/apps/v4/registry/README.md
+++ b/apps/v4/registry/README.md
@@ -131,10 +131,12 @@ ranking.
 
 ### Authentication and configuration
 
-New Blob connections use Vercel OIDC inside the linked Vercel project. A
-server-only `BLOB_READ_WRITE_TOKEN` is also supported when OIDC is unavailable.
-The website must receive one of these credentials to read `latest.json`; client
-code never receives them.
+New Blob connections use Vercel OIDC inside the linked Vercel project. The
+connected registry health store exposes `REGISTRY_HEALTH_BLOB_STORE_ID`, which
+the website passes explicitly when reading `latest.json`. The standard
+`BLOB_STORE_ID` name remains supported as a fallback. A server-only
+`BLOB_READ_WRITE_TOKEN` is also supported when OIDC is unavailable. Client code
+never receives these credentials.
 
 The monitor runs in GitHub Actions, outside Vercel's OIDC runtime. Configure a
 separate repository Actions secret named `BLOB_READ_WRITE_TOKEN` for that
@@ -145,6 +147,9 @@ expose the token through a `NEXT_PUBLIC_` variable, logs, or step summaries.
 
 Configure this Vercel server environment variable:
 
+- `REGISTRY_HEALTH_BLOB_STORE_ID`: the ID of the connected private registry
+  health Blob store. Vercel provides this value when the store is connected to
+  the project.
 - `REGISTRY_HEALTH_ENABLED`: set to `1` to merge the additive health object into
   `/r/registries.json`; set to `0` to return the original four-field payload.
   The Registry Directory does not consume the health object during the initial


### PR DESCRIPTION
Pass the connected registry health Blob store ID explicitly when reading the private health snapshot with Vercel OIDC. This keeps the existing token fallback, generic store-ID fallback, fail-open behavior, and five-minute ISR caching unchanged.