### PR TITLE
fix(base-ui): preserve native link semantics

### DIFF
--- a/.changeset/clean-buttons-link.md
+++ b/.changeset/clean-buttons-link.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+Preserve native link semantics when transforming button-styled links for Base UI.

--- a/apps/v4/app/(app)/(create)/components/v0-button.tsx
+++ b/apps/v4/app/(app)/(create)/components/v0-button.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useMounted } from "@/hooks/use-mounted"
 import { Icons } from "@/components/icons"
-import { Button } from "@/styles/base-nova/ui/button"
+import { buttonVariants } from "@/styles/base-nova/ui/button"
 import { Skeleton } from "@/styles/base-nova/ui/skeleton"
 import { useDesignSystemSearchParams } from "@/app/(app)/(create)/lib/search-params"
 
@@ -38,20 +38,17 @@ export function V0Button({ className }: { className?: string }) {
   }
 
   return (
-    <Button
-      nativeButton={false}
-      role="link"
-      variant={isMobile ? "default" : "outline"}
-      className={cn("h-[31px] gap-1 rounded-lg", className)}
-      render={
-        <a
-          href={`${process.env.NEXT_PUBLIC_V0_URL}/chat/api/open?url=${url}&title=${title}`}
-          target="_blank"
-        />
-      }
+    <a
+      href={`${process.env.NEXT_PUBLIC_V0_URL}/chat/api/open?url=${url}&title=${title}`}
+      target="_blank"
+      className={cn(
+        buttonVariants({ variant: isMobile ? "default" : "outline" }),
+        "h-[31px] gap-1 rounded-lg",
+        className
+      )}
     >
       <span>Open in</span>
       <Icons.v0 className="size-5" data-icon="inline-end" />
-    </Button>
+    </a>
   )
 }

--- a/apps/v4/app/(app)/(typeset)/components/docs-panel.tsx
+++ b/apps/v4/app/(app)/(typeset)/components/docs-panel.tsx
@@ -7,7 +7,7 @@ import { CheckIcon, CopyIcon } from "lucide-react"
 import { trackEvent } from "@/lib/events"
 import { absoluteUrl, cn } from "@/lib/utils"
 import { useConfig } from "@/hooks/use-config"
-import { Button } from "@/styles/base-nova/ui/button"
+import { Button, buttonVariants } from "@/styles/base-nova/ui/button"
 import {
   Select,
   SelectContent,
@@ -38,15 +38,16 @@ export function TypesetDocsPanel() {
       <div className="isolate flex max-h-[calc(100vh-16rem)] w-full flex-col overflow-hidden rounded-2xl bg-background ring-1 ring-foreground/10">
         <TypesetDocsContent />
       </div>
-      <Button
-        variant="link"
-        size="sm"
-        className="text-muted-foreground"
-        render={<Link href="/docs/typeset" />}
-        nativeButton={false}
+      <Link
+        href="/docs/typeset"
+        className={buttonVariants({
+          variant: "link",
+          size: "sm",
+          className: "text-muted-foreground",
+        })}
       >
         Read the docs
-      </Button>
+      </Link>
     </div>
   )
 }

--- a/apps/v4/examples/base/empty-card.tsx
+++ b/apps/v4/examples/base/empty-card.tsx
@@ -1,6 +1,6 @@
 import { ArrowUpRightIcon, FolderIcon } from "lucide-react"
 
-import { Button } from "@/styles/base-nova/ui/button"
+import { Button, buttonVariants } from "@/styles/base-nova/ui/button"
 import {
   Empty,
   EmptyContent,
@@ -25,19 +25,20 @@ export function EmptyInCard() {
       </EmptyHeader>
       <EmptyContent>
         <div className="flex gap-2">
-          <Button render={<a href="#" />} nativeButton={false}>
+          <a href="#" className={buttonVariants()}>
             Create project
-          </Button>
+          </a>
           <Button variant="outline">Import project</Button>
         </div>
-        <Button
-          variant="link"
-          render={<a href="#" />}
-          className="text-muted-foreground"
-          nativeButton={false}
+        <a
+          href="#"
+          className={buttonVariants({
+            variant: "link",
+            className: "text-muted-foreground",
+          })}
         >
           Learn more <ArrowUpRightIcon />
-        </Button>
+        </a>
       </EmptyContent>
     </Empty>
   )

--- a/apps/v4/examples/base/empty-demo.tsx
+++ b/apps/v4/examples/base/empty-demo.tsx
@@ -1,7 +1,7 @@
 import { IconFolderCode } from "@tabler/icons-react"
 import { ArrowUpRightIcon } from "lucide-react"
 
-import { Button } from "@/styles/base-nova/ui/button"
+import { Button, buttonVariants } from "@/styles/base-nova/ui/button"
 import {
   Empty,
   EmptyContent,
@@ -28,15 +28,16 @@ export default function EmptyDemo() {
         <Button>Create Project</Button>
         <Button variant="outline">Import Project</Button>
       </EmptyContent>
-      <Button
-        variant="link"
-        render={<a href="#" />}
-        className="text-muted-foreground"
-        size="sm"
-        nativeButton={false}
+      <a
+        href="#"
+        className={buttonVariants({
+          variant: "link",
+          size: "sm",
+          className: "text-muted-foreground",
+        })}
       >
         Learn More <ArrowUpRightIcon />
-      </Button>
+      </a>
     </Empty>
   )
 }

--- a/apps/v4/examples/base/empty-rtl.tsx
+++ b/apps/v4/examples/base/empty-rtl.tsx
@@ -8,7 +8,7 @@ import {
   useTranslation,
   type Translations,
 } from "@/components/language-selector"
-import { Button } from "@/styles/base-nova/ui-rtl/button"
+import { Button, buttonVariants } from "@/styles/base-nova/ui-rtl/button"
 import {
   Empty,
   EmptyContent,
@@ -69,16 +69,17 @@ export function EmptyRtl() {
         <Button>{t.createProject}</Button>
         <Button variant="outline">{t.importProject}</Button>
       </EmptyContent>
-      <Button
-        variant="link"
-        render={<a href="#" />}
-        className="text-muted-foreground"
-        size="sm"
-        nativeButton={false}
+      <a
+        href="#"
+        className={buttonVariants({
+          variant: "link",
+          size: "sm",
+          className: "text-muted-foreground",
+        })}
       >
         {t.learnMore}{" "}
         <ArrowUpRightIcon className="rtl:rotate-270" data-icon="inline-end" />
-      </Button>
+      </a>
     </Empty>
   )
 }

--- a/apps/v4/registry/bases/base/examples/empty-example.tsx
+++ b/apps/v4/registry/bases/base/examples/empty-example.tsx
@@ -2,7 +2,7 @@ import {
   Example,
   ExampleWrapper,
 } from "@/registry/bases/base/components/example"
-import { Button } from "@/registry/bases/base/ui/button"
+import { Button, buttonVariants } from "@/registry/bases/base/ui/button"
 import {
   Empty,
   EmptyContent,
@@ -45,16 +45,17 @@ function EmptyBasic() {
         </EmptyHeader>
         <EmptyContent>
           <div className="flex gap-2">
-            <Button render={<a href="#" />} nativeButton={false}>
+            <a href="#" className={buttonVariants()}>
               Create project
-            </Button>
+            </a>
             <Button variant="outline">Import project</Button>
           </div>
-          <Button
-            variant="link"
-            render={<a href="#" />}
-            className="text-muted-foreground"
-            nativeButton={false}
+          <a
+            href="#"
+            className={buttonVariants({
+              variant: "link",
+              className: "text-muted-foreground",
+            })}
           >
             Learn more{" "}
             <IconPlaceholder
@@ -64,7 +65,7 @@ function EmptyBasic() {
               phosphor="ArrowUpRightIcon"
               remixicon="RiArrowRightUpLine"
             />
-          </Button>
+          </a>
         </EmptyContent>
       </Empty>
     </Example>
@@ -83,11 +84,12 @@ function EmptyWithMutedBackground() {
         </EmptyHeader>
         <EmptyContent>
           <Button>Try again</Button>
-          <Button
-            variant="link"
-            render={<a href="#" />}
-            className="text-muted-foreground"
-            nativeButton={false}
+          <a
+            href="#"
+            className={buttonVariants({
+              variant: "link",
+              className: "text-muted-foreground",
+            })}
           >
             Learn more{" "}
             <IconPlaceholder
@@ -97,7 +99,7 @@ function EmptyWithMutedBackground() {
               phosphor="ArrowUpRightIcon"
               remixicon="RiArrowRightUpLine"
             />
-          </Button>
+          </a>
         </EmptyContent>
       </Empty>
     </Example>
@@ -236,16 +238,17 @@ function EmptyInCard() {
         </EmptyHeader>
         <EmptyContent>
           <div className="flex gap-2">
-            <Button render={<a href="#" />} nativeButton={false}>
+            <a href="#" className={buttonVariants()}>
               Create project
-            </Button>
+            </a>
             <Button variant="outline">Import project</Button>
           </div>
-          <Button
-            variant="link"
-            render={<a href="#" />}
-            className="text-muted-foreground"
-            nativeButton={false}
+          <a
+            href="#"
+            className={buttonVariants({
+              variant: "link",
+              className: "text-muted-foreground",
+            })}
           >
             Learn more{" "}
             <IconPlaceholder
@@ -255,7 +258,7 @@ function EmptyInCard() {
               phosphor="ArrowUpRightIcon"
               remixicon="RiArrowRightUpLine"
             />
-          </Button>
+          </a>
         </EmptyContent>
       </Empty>
     </Example>

--- a/apps/v4/registry/bases/base/examples/spinner-example.tsx
+++ b/apps/v4/registry/bases/base/examples/spinner-example.tsx
@@ -3,7 +3,7 @@ import {
   ExampleWrapper,
 } from "@/registry/bases/base/components/example"
 import { Badge } from "@/registry/bases/base/ui/badge"
-import { Button } from "@/registry/bases/base/ui/button"
+import { Button, buttonVariants } from "@/registry/bases/base/ui/button"
 import {
   Empty,
   EmptyContent,
@@ -123,16 +123,17 @@ function SpinnerInEmpty() {
         </EmptyHeader>
         <EmptyContent>
           <div className="flex gap-2">
-            <Button render={<a href="#" />} nativeButton={false}>
+            <a href="#" className={buttonVariants()}>
               Create project
-            </Button>
+            </a>
             <Button variant="outline">Import project</Button>
           </div>
-          <Button
-            variant="link"
-            render={<a href="#" />}
-            nativeButton={false}
-            className="text-muted-foreground"
+          <a
+            href="#"
+            className={buttonVariants({
+              variant: "link",
+              className: "text-muted-foreground",
+            })}
           >
             Learn more{" "}
             <IconPlaceholder
@@ -142,7 +143,7 @@ function SpinnerInEmpty() {
               phosphor="ArrowRightIcon"
               remixicon="RiArrowRightLine"
             />
-          </Button>
+          </a>
         </EmptyContent>
       </Empty>
     </Example>

--- a/packages/shadcn/src/utils/transformers/transform-aschild.test.ts
+++ b/packages/shadcn/src/utils/transformers/transform-aschild.test.ts
@@ -1,5 +1,7 @@
+import path from "path"
 import { type Config } from "@/src/utils/get-config"
 import { transformAsChild } from "@/src/utils/transformers/transform-aschild"
+import { Project, ts } from "ts-morph"
 import { describe, expect, test } from "vitest"
 
 import { transform } from "."
@@ -30,6 +32,51 @@ const testConfig: Config = {
   },
 }
 
+function getGeneratedTypeScriptDiagnostics(source: string) {
+  const appRoot = path.resolve(process.cwd(), "../../apps/v4")
+  const generatedFile = path.join(
+    appRoot,
+    "registry/bases/base/ui/__generated-component.tsx"
+  )
+  const buttonFile = path.join(
+    appRoot,
+    "registry/bases/base/ui/__generated-button.ts"
+  )
+  const compilerOptions: ts.CompilerOptions = {
+    allowSyntheticDefaultImports: true,
+    baseUrl: appRoot,
+    jsx: ts.JsxEmit.ReactJSX,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    paths: {
+      "@/components/ui/button": ["registry/bases/base/ui/__generated-button"],
+    },
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2022,
+  }
+  const project = new Project({
+    compilerOptions,
+    skipAddingFilesFromTsConfig: true,
+  })
+  project.createSourceFile(
+    buttonFile,
+    `export function buttonVariants(props?: {
+  variant?: "default" | "outline"
+  size?: "default" | "sm"
+  className?: string
+}) {
+  return ""
+}`
+  )
+
+  return project
+    .createSourceFile(generatedFile, source)
+    .getPreEmitDiagnostics()
+    .map((diagnostic) => diagnostic.getMessageText())
+}
+
 describe("transformAsChild", () => {
   describe("DialogTrigger with Button child", () => {
     test("transforms asChild to render prop without nativeButton", async () => {
@@ -38,6 +85,7 @@ describe("transformAsChild", () => {
           {
             filename: "test.tsx",
             raw: `import * as React from "react"
+import { Button } from "@/components/ui/button"
 
 export function Component() {
   return (
@@ -52,6 +100,7 @@ export function Component() {
         )
       ).toMatchInlineSnapshot(`
         "import * as React from "react"
+        import { Button } from "@/components/ui/button"
 
         export function Component() {
           return (
@@ -94,12 +143,13 @@ export function Component() {
   })
 
   describe("Button with anchor child", () => {
-    test("transforms asChild to render prop with nativeButton={false}", async () => {
+    test("styles the anchor directly with buttonVariants", async () => {
       expect(
         await transform(
           {
             filename: "test.tsx",
             raw: `import * as React from "react"
+import { Button } from "@/components/ui/button"
 
 export function Component() {
   return (
@@ -114,10 +164,11 @@ export function Component() {
         )
       ).toMatchInlineSnapshot(`
         "import * as React from "react"
+        import { buttonVariants } from "@/components/ui/button"
 
         export function Component() {
           return (
-            <Button render={<a href="#" />} nativeButton={false}>Create project</Button>
+            <a data-slot="button" href="#" className={buttonVariants()}>Create project</a>
           )
         }"
       `)
@@ -131,6 +182,7 @@ export function Component() {
           {
             filename: "test.tsx",
             raw: `import * as React from "react"
+import { Button } from "@/components/ui/button"
 
 export function Component() {
   return (
@@ -145,6 +197,7 @@ export function Component() {
         )
       ).toMatchInlineSnapshot(`
         "import * as React from "react"
+        import { Button } from "@/components/ui/button"
 
         export function Component() {
           return (
@@ -187,12 +240,14 @@ export function Component() {
   })
 
   describe("Button with Link child", () => {
-    test("transforms asChild to render prop with nativeButton={false}", async () => {
+    test("styles the Link directly with buttonVariants", async () => {
       expect(
         await transform(
           {
             filename: "test.tsx",
             raw: `import * as React from "react"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
 
 export function Component() {
   return (
@@ -207,10 +262,12 @@ export function Component() {
         )
       ).toMatchInlineSnapshot(`
         "import * as React from "react"
+        import Link from "next/link"
+        import { buttonVariants } from "@/components/ui/button"
 
         export function Component() {
           return (
-            <Button render={<Link href="/" />} nativeButton={false}>Home</Button>
+            <Link data-slot="button" href="/" className={buttonVariants()}>Home</Link>
           )
         }"
       `)
@@ -224,6 +281,7 @@ export function Component() {
           {
             filename: "test.tsx",
             raw: `import * as React from "react"
+import { Button } from "@/components/ui/button"
 
 export function Component() {
   return (
@@ -240,11 +298,12 @@ export function Component() {
         )
       ).toMatchInlineSnapshot(`
         "import * as React from "react"
+        import { buttonVariants } from "@/components/ui/button"
 
         export function Component() {
           return (
-            <Button variant="link" className="text-muted-foreground" render={<a href="#" className="font-bold" data-test="link" />} nativeButton={false}>Learn more
-                    </Button>
+            <a data-slot="button" href="#" data-test="link" className={buttonVariants({ variant: "link", className: ["text-muted-foreground", "font-bold"] })}>Learn more
+                    </a>
           )
         }"
       `)
@@ -258,6 +317,7 @@ export function Component() {
           {
             filename: "test.tsx",
             raw: `import * as React from "react"
+import { Button } from "@/components/ui/button"
 
 export function Component() {
   return (
@@ -274,13 +334,705 @@ export function Component() {
         )
       ).toMatchInlineSnapshot(`
         "import * as React from "react"
+        import { buttonVariants } from "@/components/ui/button"
 
         export function Component() {
           return (
-            <Button render={<a href="#" />} nativeButton={false}>Learn more <Icon /></Button>
+            <a data-slot="button" href="#" className={buttonVariants()}>Learn more <Icon /></a>
           )
         }"
       `)
+    })
+  })
+
+  describe("link attributes and imports", () => {
+    test("preserves static props and consumes Button style props", async () => {
+      expect(
+        await transform(
+          {
+            filename: "test.tsx",
+            raw: `import { Button } from "@/components/ui/button"
+
+export function Component({ variant, outerClass, linkClass, handleClick, linkRef }) {
+  return (
+    <Button
+      variant={variant}
+      size="sm"
+      id="cta"
+      aria-label="Open dashboard"
+      onClick={handleClick}
+      ref={linkRef}
+      className={outerClass}
+      asChild
+    >
+      <a
+        href="/dashboard"
+        target="_blank"
+        rel="noreferrer"
+        data-track="dashboard"
+        className={linkClass}
+      >
+        Dashboard
+      </a>
+    </Button>
+  )
+}`,
+            config: testConfig,
+          },
+          [transformAsChild]
+        )
+      ).toMatchInlineSnapshot(`
+        "import { buttonVariants } from "@/components/ui/button"
+
+        export function Component({ variant, outerClass, linkClass, handleClick, linkRef }) {
+          return (
+            <a data-slot="button" id="cta" aria-label="Open dashboard" onClick={handleClick} ref={linkRef} href="/dashboard" target="_blank" rel="noreferrer" data-track="dashboard" className={buttonVariants({ variant: variant, size: "sm", className: [outerClass, linkClass] })}>Dashboard
+                    </a>
+          )
+        }"
+      `)
+    })
+
+    test("keeps Button imported when the file still uses it", async () => {
+      expect(
+        await transform(
+          {
+            filename: "test.tsx",
+            raw: `import { Button } from "@/components/ui/button"
+
+export function Component() {
+  return (
+    <>
+      <Button>Save</Button>
+      <Button asChild><a href="/docs">Docs</a></Button>
+    </>
+  )
+}`,
+            config: testConfig,
+          },
+          [transformAsChild]
+        )
+      ).toMatchInlineSnapshot(`
+        "import { Button, buttonVariants } from "@/components/ui/button"
+
+        export function Component() {
+          return (
+            <>
+              <Button>Save</Button>
+              <a data-slot="button" href="/docs" className={buttonVariants()}>Docs</a>
+            </>
+          )
+        }"
+      `)
+    })
+
+    test("reuses aliased imports and resolves an aliased Link", async () => {
+      expect(
+        await transform(
+          {
+            filename: "test.tsx",
+            raw: `import NextLink from "next/link"
+import { Button as UiButton, buttonVariants as styles } from "@/components/ui/button"
+
+export function Component() {
+  return <UiButton asChild><NextLink href="/">Home</NextLink></UiButton>
+}`,
+            config: testConfig,
+          },
+          [transformAsChild]
+        )
+      ).toMatchInlineSnapshot(`
+        "import NextLink from "next/link"
+        import { buttonVariants as styles } from "@/components/ui/button"
+
+        export function Component() {
+          return <NextLink data-slot="button" href="/" className={styles()}>Home</NextLink>
+        }"
+      `)
+    })
+
+    test("recognizes Remix Link and NavLink exports", async () => {
+      expect(
+        await transform(
+          {
+            filename: "test.tsx",
+            raw: `import { Link, NavLink as RemixNavLink } from "@remix-run/react"
+import { Button } from "@/components/ui/button"
+
+export function Component() {
+  return (
+    <>
+      <Button asChild><Link to="/docs">Docs</Link></Button>
+      <Button variant="outline" asChild><RemixNavLink to="/account">Account</RemixNavLink></Button>
+    </>
+  )
+}`,
+            config: testConfig,
+          },
+          [transformAsChild]
+        )
+      ).toMatchInlineSnapshot(`
+        "import { Link, NavLink as RemixNavLink } from "@remix-run/react"
+        import { buttonVariants } from "@/components/ui/button"
+
+        export function Component() {
+          return (
+            <>
+              <Link data-slot="button" to="/docs" className={buttonVariants()}>Docs</Link>
+              <RemixNavLink data-slot="button" to="/account" className={buttonVariants({ variant: "outline" })}>Account</RemixNavLink>
+            </>
+          )
+        }"
+      `)
+    })
+
+    test("aliases buttonVariants when the local name is already used", async () => {
+      expect(
+        await transform(
+          {
+            filename: "test.tsx",
+            raw: `import { Button } from "@/components/ui/button"
+
+const buttonVariants = "custom"
+
+export function Component() {
+  return <Button asChild><a href="/">Home</a></Button>
+}`,
+            config: testConfig,
+          },
+          [transformAsChild]
+        )
+      ).toMatchInlineSnapshot(`
+        "import { buttonVariants as shadcnButtonVariants } from "@/components/ui/button"
+
+        const buttonVariants = "custom"
+
+        export function Component() {
+          return <a data-slot="button" href="/" className={shadcnButtonVariants()}>Home</a>
+        }"
+      `)
+    })
+
+    test("keeps the link as owner with unknown parent spread props", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import { Button } from "@/components/ui/button"
+
+export function Component({ buttonProps, linkProps }) {
+  return (
+    <Button {...buttonProps} asChild>
+      <a href="/docs" {...linkProps}>Docs</a>
+    </Button>
+  )
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain("function ButtonLink(")
+      expect(output).toContain(
+        '<ButtonLink {...buttonProps} render={<a href="/docs" {...linkProps} />}>Docs</ButtonLink>'
+      )
+      expect(output).not.toContain("<Button ")
+    })
+
+    test("uses a semantic helper for child spread props", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import { Button } from "@/components/ui/button"
+
+export function Component({ linkProps }) {
+  return (
+    <Button variant="outline" className="wide" asChild>
+      <a href="/docs" {...linkProps}>Docs</a>
+    </Button>
+  )
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain("function ButtonLink(")
+      expect(output).toContain(
+        '<ButtonLink variant="outline" className="wide" render={<a href="/docs" {...linkProps} />}>Docs</ButtonLink>'
+      )
+      expect(output).toContain('state: { slot: "button" }')
+    })
+
+    test("preserves the Button slot used by ButtonGroup", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import { Button } from "@/components/ui/button"
+import { ButtonGroup } from "@/components/ui/button-group"
+
+export function Component({ linkProps }) {
+  return (
+    <ButtonGroup>
+      <Button asChild><a href="/docs">Docs</a></Button>
+      <Button asChild><a href="/about" {...linkProps}>About</a></Button>
+    </ButtonGroup>
+  )
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain('<a data-slot="button" href="/docs"')
+      expect(output).toContain('state: { slot: "button" }')
+    })
+
+    test("preserves composed handlers, styles, and refs", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import { Button } from "@/components/ui/button"
+
+export function Component({ parentClick, childClick, parentRef, childRef }) {
+  return (
+    <Button
+      onClick={parentClick}
+      style={{ color: "red" }}
+      ref={parentRef}
+      asChild
+    >
+      <a
+        href="/docs"
+        onClick={childClick}
+        style={{ background: "blue" }}
+        ref={childRef}
+      >
+        Docs
+      </a>
+    </Button>
+  )
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain("function ButtonLink(")
+      expect(output).toContain(
+        'onClick={parentClick} style={{ color: "red" }} ref={parentRef}'
+      )
+      expect(output).toContain(
+        'onClick={childClick} style={{ background: "blue" }} ref={childRef}'
+      )
+      expect(output).toContain("props: {")
+      expect(output).toContain("render,")
+      expect(output).toContain('state: { slot: "button" }')
+    })
+
+    test("emits a type-safe router-link helper", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import * as React from "react"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+
+interface ComponentProps {
+  buttonProps: React.ComponentProps<"button">
+  linkProps: React.ComponentProps<typeof Link>
+  parentClick: React.MouseEventHandler<HTMLButtonElement>
+  childClick: React.MouseEventHandler<HTMLAnchorElement>
+  parentRef: React.Ref<HTMLButtonElement>
+  childRef: React.Ref<HTMLAnchorElement>
+}
+
+export function Component({ buttonProps, linkProps, parentClick, childClick, parentRef, childRef }: ComponentProps) {
+  return (
+    <Button {...buttonProps} onClick={parentClick} ref={parentRef} asChild>
+      <Link {...linkProps} href="/docs" onClick={childClick} ref={childRef}>Docs</Link>
+    </Button>
+  )
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(getGeneratedTypeScriptDiagnostics(output)).toEqual([])
+    })
+
+    test("preserves spread order and evaluates each expression once", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import { Button } from "@/components/ui/button"
+
+export function Component() {
+  return (
+    <Button variant="outline" {...getButtonProps()} size="sm" asChild>
+      <a className="fixed" {...getLinkProps()} href="/docs">Docs</a>
+    </Button>
+  )
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain(
+        '<ButtonLink variant="outline" {...getButtonProps()} size="sm" render={<a className="fixed" {...getLinkProps()} href="/docs" />}>Docs</ButtonLink>'
+      )
+      expect(output.match(/getButtonProps\(\)/g)).toHaveLength(1)
+      expect(output.match(/getLinkProps\(\)/g)).toHaveLength(1)
+    })
+  })
+
+  describe("link detection boundaries", () => {
+    test("does not rewrite a local component named Link", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import { Button } from "@/components/ui/button"
+
+function Link({ children }) {
+  return <span>{children}</span>
+}
+
+export function Component() {
+  return <Button asChild><Link href="/docs">Docs</Link></Button>
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain(
+        '<Button render={<Link href="/docs" />} nativeButton={false}>Docs</Button>'
+      )
+      expect(output).not.toContain("buttonVariants")
+    })
+
+    test("keeps Button behavior for an anchor without a link target", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import { Button } from "@/components/ui/button"
+
+export function Component() {
+  return <Button asChild><a>Action</a></Button>
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain(
+        "<Button render={<a />} nativeButton={false}>Action</Button>"
+      )
+      expect(output).not.toContain("buttonVariants")
+    })
+
+    test("keeps a spread-only anchor as the final element", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import { Button } from "@/components/ui/button"
+
+export function Component({ anchorProps }) {
+  return <Button asChild><a {...anchorProps}>Action</a></Button>
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain("function ButtonLink(")
+      expect(output).toContain(
+        "<ButtonLink render={<a {...anchorProps} />}>Action</ButtonLink>"
+      )
+      expect(output).not.toContain("<Button ")
+    })
+
+    test("keeps a spread-only router link as the final element", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import Link from "next/link"
+import { Button } from "@/components/ui/button"
+
+export function Component({ linkProps }) {
+  return <Button asChild><Link {...linkProps}>Docs</Link></Button>
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain("function ButtonLink(")
+      expect(output).toContain(
+        "<ButtonLink render={<Link {...linkProps} />}>Docs</ButtonLink>"
+      )
+      expect(output).not.toContain("<Button ")
+    })
+
+    test("recognizes router links imported through a namespace", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import * as Router from "react-router-dom"
+import { Button } from "@/components/ui/button"
+
+export function Component() {
+  return <Button asChild><Router.Link to="/docs">Docs</Router.Link></Button>
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain(
+        '<Router.Link data-slot="button" to="/docs" className={buttonVariants()}>Docs</Router.Link>'
+      )
+      expect(output).not.toContain("<Button ")
+    })
+
+    test("does not rewrite shadowed Button or Link bindings", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import Link from "next/link"
+import { Button } from "@/components/ui/button"
+
+export function ShadowedButton(Button) {
+  return <Button asChild><a href="/docs">Docs</a></Button>
+}
+
+export function ShadowedLink(Link) {
+  return <Button asChild><Link href="/docs">Docs</Link></Button>
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain(
+        '<Button render={<a href="/docs" />}>Docs</Button>'
+      )
+      expect(output).toContain(
+        '<Button render={<Link href="/docs" />} nativeButton={false}>Docs</Button>'
+      )
+      expect(output).not.toContain("buttonVariants")
+    })
+
+    test("keeps generated helper component names capitalized", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import { Button } from "@/components/ui/button"
+
+const ButtonLink = "existing"
+
+export function Component({ linkProps }) {
+  return <Button asChild><a href="/docs" {...linkProps}>Docs</a></Button>
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain("function ButtonLink2(")
+      expect(output).toContain(
+        '<ButtonLink2 render={<a href="/docs" {...linkProps} />}>Docs</ButtonLink2>'
+      )
+      expect(output).not.toContain("<shadcnButtonLink")
+    })
+
+    test("removes Button-only props from a semantic link", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import { Button } from "@/components/ui/button"
+
+export function Component() {
+  return <Button disabled asChild><a href="/docs">Docs</a></Button>
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain("function ButtonLink(")
+      expect(output).toContain(
+        '<ButtonLink disabled render={<a href="/docs" />}>Docs</ButtonLink>'
+      )
+      expect(output).not.toContain("<a disabled")
+      expect(output).toContain("Reflect.deleteProperty(linkProps, prop)")
+      expect(output).not.toContain("<Button ")
+    })
+
+    test("recognizes an aliased UI Button for nativeButton", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import { Button as UiButton } from "@/components/ui/button"
+
+export function Component() {
+  return <UiButton asChild><span>Action</span></UiButton>
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain(
+        "<UiButton render={<span />} nativeButton={false}>Action</UiButton>"
+      )
+    })
+
+    test("does not inject buttonVariants into a third-party Button", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import { Button } from "@acme/button"
+
+export function Component() {
+  return <Button asChild><a href="/docs">Docs</a></Button>
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain('import { Button } from "@acme/button"')
+      expect(output).not.toContain("buttonVariants")
+    })
+
+    test("uses the configured UI alias for Button detection", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import { Button } from "@/ui/button"
+
+export function Component() {
+  return <Button asChild><a href="/docs">Docs</a></Button>
+}`,
+          config: {
+            ...testConfig,
+            aliases: {
+              ...testConfig.aliases,
+              ui: "@/ui",
+            },
+          },
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain('import { buttonVariants } from "@/ui/button"')
+      expect(output).toContain(
+        '<a data-slot="button" href="/docs" className={buttonVariants()}>Docs</a>'
+      )
+    })
+  })
+
+  describe("buttonVariants import handling", () => {
+    test("converts an existing type-only import to a value import", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import { Button, type buttonVariants } from "@/components/ui/button"
+
+export function Component() {
+  return <Button asChild><a href="/docs">Docs</a></Button>
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain(
+        'import { buttonVariants } from "@/components/ui/button"'
+      )
+      expect(output).not.toContain("type buttonVariants")
+    })
+
+    test("cleans up a split Button import declaration", async () => {
+      const output = await transform(
+        {
+          filename: "test.tsx",
+          raw: `import { buttonVariants } from "@/components/ui/button"
+import { Button } from "@/components/ui/button"
+
+export function Component() {
+  return <Button asChild><a href="/docs">Docs</a></Button>
+}`,
+          config: testConfig,
+        },
+        [transformAsChild]
+      )
+
+      expect(output.match(/from "@\/components\/ui\/button"/g)).toHaveLength(1)
+      expect(output).not.toContain("{ Button }")
+    })
+
+    test("strips generated helper types for JSX projects", async () => {
+      const output = await transform(
+        {
+          filename: "test.jsx",
+          raw: `import { Link } from "react-router-dom"
+import { Button } from "@/components/ui/button"
+
+export function Component({ parentClick, childClick, parentRef, childRef }) {
+  return (
+    <Button {...getButtonProps()} onClick={parentClick} ref={parentRef} asChild>
+      <Link {...getLinkProps()} to="/docs" onClick={childClick} ref={childRef}>Docs</Link>
+    </Button>
+  )
+}`,
+          config: {
+            ...testConfig,
+            tsx: false,
+          },
+          transformJsx: true,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain("function ButtonLink(")
+      expect(output).toContain("onClick={parentClick}")
+      expect(output).toContain("onClick={childClick}")
+      expect(output).toContain("ref={parentRef}")
+      expect(output).toContain("ref={childRef}")
+      expect(output.match(/getButtonProps\(\)/g)).toHaveLength(1)
+      expect(output.match(/getLinkProps\(\)/g)).toHaveLength(1)
+      expect(output).not.toContain("type ButtonLinkProps")
+      expect(output).not.toContain(": ButtonLinkProps")
+      expect(output).not.toContain('mergeProps<"a">')
+    })
+
+    test("does not rewrite shadowed bindings in JSX projects", async () => {
+      const output = await transform(
+        {
+          filename: "test.jsx",
+          raw: `import Link from "next/link"
+import { Button } from "@/components/ui/button"
+
+export function Component({ Button, Link }) {
+  return <Button asChild><Link href="/docs">Docs</Link></Button>
+}`,
+          config: {
+            ...testConfig,
+            tsx: false,
+          },
+          transformJsx: true,
+        },
+        [transformAsChild]
+      )
+
+      expect(output).toContain(
+        '<Button render={<Link href="/docs" />}>Docs</Button>'
+      )
+      expect(output).not.toContain("buttonVariants")
+      expect(output).not.toContain("ButtonLink")
     })
   })
 
@@ -417,37 +1169,6 @@ export function Component() {
         export function Component() {
           return (
             <Collapsible render={<SidebarMenuButton render={<a href="#" />} />}>Home</Collapsible>
-          )
-        }"
-      `)
-    })
-
-    test("adds nativeButton={false} only on nested Button", async () => {
-      expect(
-        await transform(
-          {
-            filename: "test.tsx",
-            raw: `import * as React from "react"
-
-export function Component() {
-  return (
-    <DialogTrigger asChild>
-      <Button asChild>
-        <a href="#">Open</a>
-      </Button>
-    </DialogTrigger>
-  )
-}`,
-            config: testConfig,
-          },
-          [transformAsChild]
-        )
-      ).toMatchInlineSnapshot(`
-        "import * as React from "react"
-
-        export function Component() {
-          return (
-            <DialogTrigger render={<Button render={<a href="#" />} nativeButton={false} />}>Open</DialogTrigger>
           )
         }"
       `)

--- a/packages/shadcn/src/utils/transformers/transform-aschild.ts
+++ b/packages/shadcn/src/utils/transformers/transform-aschild.ts
@@ -1,8 +1,15 @@
 import { Transformer } from "@/src/utils/transformers"
-import { JsxElement, SyntaxKind } from "ts-morph"
+import {
+  ImportDeclaration,
+  JsxAttribute,
+  JsxElement,
+  Node,
+  SourceFile,
+  SyntaxKind,
+  type Identifier,
+  type JsxAttributeLike,
+} from "ts-morph"
 
-// Elements that require nativeButton={false} when used as render prop.
-// These are non-button elements that don't have native button semantics.
 const ELEMENTS_REQUIRING_NATIVE_BUTTON_FALSE = [
   "a",
   "span",
@@ -12,6 +19,26 @@ const ELEMENTS_REQUIRING_NATIVE_BUTTON_FALSE = [
   "Label",
 ]
 
+const BUTTON_BEHAVIOR_PROPS: readonly string[] = [
+  "disabled",
+  "focusableWhenDisabled",
+  "form",
+  "formAction",
+  "formEncType",
+  "formMethod",
+  "formNoValidate",
+  "formTarget",
+  "name",
+  "type",
+  "value",
+]
+
+const BUTTON_ONLY_PROPS = [
+  "asChild",
+  ...BUTTON_BEHAVIOR_PROPS,
+  "nativeButton",
+] as const
+
 interface TransformInfo {
   parentElement: JsxElement
   parentTagName: string
@@ -19,22 +46,49 @@ interface TransformInfo {
   childProps: string
   childChildren: string
   needsNativeButton: boolean
+  link?: {
+    attributes?: string
+    buttonLocalName: string
+    helperName?: string
+  }
 }
 
+interface ButtonLinkHelper {
+  buttonVariants: string
+  helperName: string
+  propsName: string
+}
+
+const ROUTER_LINK_MODULES = new Set([
+  "@remix-run/react",
+  "@tanstack/react-router",
+  "expo-router",
+  "gatsby",
+  "next-view-transitions",
+  "next/link",
+  "react-router",
+  "react-router-dom",
+])
+
+const ROUTER_LINK_EXPORTS = new Set(["Link", "NavLink"])
+
 export const transformAsChild: Transformer = async ({ sourceFile, config }) => {
-  // Only run for base- styles.
   if (!config.style?.startsWith("base-")) {
     return sourceFile
   }
 
-  // Process asChild elements iteratively, starting from leaf-level elements.
-  // Each iteration transforms only elements with no asChild descendants,
-  // ensuring inner transforms complete before outer ones read the tree.
+  if (!config.tsx) {
+    sourceFile.getProject().compilerOptions.set({ allowJs: true })
+  }
+
+  const convertedButtons = new Set<string>()
+  let buttonLinkHelper: ButtonLinkHelper | undefined
+  const uiButtonImport = `${
+    config.aliases.ui ?? `${config.aliases.components}/ui`
+  }/button`.replace(/\/{2,}/g, "/")
   const MAX_ITERATIONS = 10
   for (let i = 0; i < MAX_ITERATIONS; i++) {
     const jsxElements = sourceFile.getDescendantsOfKind(SyntaxKind.JsxElement)
-
-    // Find all JSX elements with asChild attribute.
     const asChildElements = jsxElements.filter((el) =>
       el.getOpeningElement().getAttribute("asChild")
     )
@@ -43,7 +97,6 @@ export const transformAsChild: Transformer = async ({ sourceFile, config }) => {
       break
     }
 
-    // Filter to leaf-only: elements with no asChild descendants.
     const leafElements = asChildElements.filter((el) => {
       const descendants = el.getDescendantsOfKind(SyntaxKind.JsxElement)
       return !descendants.some((d) =>
@@ -51,8 +104,6 @@ export const transformAsChild: Transformer = async ({ sourceFile, config }) => {
       )
     })
 
-    // Collect all transformations first, then apply them in reverse order.
-    // This prevents issues with invalidated nodes when modifying the tree.
     const transformations: TransformInfo[] = []
 
     for (const jsxElement of leafElements) {
@@ -63,10 +114,9 @@ export const transformAsChild: Transformer = async ({ sourceFile, config }) => {
         continue
       }
 
-      const parentTagName = openingElement.getTagNameNode().getText()
+      const parentTagNode = openingElement.getTagNameNode()
+      const parentTagName = parentTagNode.getText()
       const children = jsxElement.getJsxChildren()
-
-      // Find the first JSX element child (skip whitespace/text).
       const childElement = children.find(
         (child) =>
           child.getKind() === SyntaxKind.JsxElement ||
@@ -74,46 +124,104 @@ export const transformAsChild: Transformer = async ({ sourceFile, config }) => {
       )
 
       if (!childElement) {
-        // No child element found, just remove asChild.
         asChildAttr.remove()
         continue
       }
 
-      // Get child element info.
       let childTagName: string
+      let childTagNode: Node
       let childProps: string
       let childChildren: string
+      let childAttributes: JsxAttributeLike[]
 
       if (childElement.getKind() === SyntaxKind.JsxSelfClosingElement) {
         const selfClosing = childElement.asKindOrThrow(
           SyntaxKind.JsxSelfClosingElement
         )
-        childTagName = selfClosing.getTagNameNode().getText()
-        childProps = selfClosing
-          .getAttributes()
-          .map((attr) => attr.getText())
-          .join(" ")
+        childTagNode = selfClosing.getTagNameNode()
+        childTagName = childTagNode.getText()
+        childAttributes = selfClosing.getAttributes()
+        childProps = childAttributes.map((attr) => attr.getText()).join(" ")
         childChildren = ""
       } else {
         const jsxChild = childElement.asKindOrThrow(SyntaxKind.JsxElement)
         const openingEl = jsxChild.getOpeningElement()
-        childTagName = openingEl.getTagNameNode().getText()
-        childProps = openingEl
-          .getAttributes()
-          .map((attr) => attr.getText())
-          .join(" ")
-        // Get the children's text content.
+        childTagNode = openingEl.getTagNameNode()
+        childTagName = childTagNode.getText()
+        childAttributes = openingEl.getAttributes()
+        childProps = childAttributes.map((attr) => attr.getText()).join(" ")
         childChildren = jsxChild
           .getJsxChildren()
           .map((c) => c.getText())
           .join("")
       }
 
-      // Determine if we need nativeButton={false}.
-      // Only add it on Button when the child is a non-button element.
+      const buttonImport = findButtonImport(parentTagNode, uiButtonImport)
+      const isLink = isLinkElement(childTagNode, childAttributes)
+
+      // Base UI Button always applies button semantics, so links must own the
+      // final element and receive only the Button's visual variants.
+      if (buttonImport && isLink) {
+        const moduleSpecifier = buttonImport.getModuleSpecifierValue()
+        const buttonVariants = ensureValueImport(
+          sourceFile,
+          moduleSpecifier,
+          "buttonVariants",
+          buttonImport
+        )
+        let helper: ButtonLinkHelper | undefined
+
+        if (
+          requiresButtonLinkHelper(
+            openingElement.getAttributes(),
+            childAttributes
+          )
+        ) {
+          helper = buttonLinkHelper
+
+          if (!helper) {
+            const helperName = getAvailableComponentIdentifier(
+              sourceFile,
+              "ButtonLink"
+            )
+            helper = {
+              buttonVariants,
+              helperName,
+              propsName: getAvailableIdentifier(
+                sourceFile,
+                `${helperName}Props`
+              ),
+            }
+            buttonLinkHelper = helper
+          }
+        }
+
+        transformations.push({
+          parentElement: jsxElement,
+          parentTagName,
+          childTagName,
+          childProps,
+          childChildren,
+          needsNativeButton: false,
+          link: {
+            attributes: helper
+              ? undefined
+              : buildLinkAttributes(
+                  openingElement.getAttributes(),
+                  childAttributes,
+                  buttonVariants
+                ),
+            buttonLocalName: parentTagName,
+            helperName: helper?.helperName,
+          },
+        })
+        continue
+      }
+
       const needsNativeButton =
-        parentTagName === "Button" &&
-        ELEMENTS_REQUIRING_NATIVE_BUTTON_FALSE.includes(childTagName)
+        Boolean(buttonImport) &&
+        ELEMENTS_REQUIRING_NATIVE_BUTTON_FALSE.includes(childTagName) &&
+        !openingElement.getAttribute("nativeButton")
 
       transformations.push({
         parentElement: jsxElement,
@@ -125,11 +233,48 @@ export const transformAsChild: Transformer = async ({ sourceFile, config }) => {
       })
     }
 
-    // Apply transformations in reverse order to preserve node validity.
-    for (const info of transformations.reverse()) {
-      const openingElement = info.parentElement.getOpeningElement()
+    if (transformations.length === 0) {
+      break
+    }
 
-      // Get existing attributes (excluding asChild).
+    for (const info of transformations.reverse()) {
+      if (info.link) {
+        let newElementText: string
+        if (info.link.helperName) {
+          const openingElement = info.parentElement.getOpeningElement()
+          const existingAttrs = openingElement
+            .getAttributes()
+            .filter((attribute) => {
+              if (attribute.getKind() !== SyntaxKind.JsxAttribute) {
+                return true
+              }
+
+              const name = attribute
+                .asKindOrThrow(SyntaxKind.JsxAttribute)
+                .getNameNode()
+                .getText()
+              return name !== "asChild" && name !== "nativeButton"
+            })
+            .map((attribute) => attribute.getText())
+            .join(" ")
+          const renderValue = info.childProps
+            ? `{<${info.childTagName} ${info.childProps} />}`
+            : `{<${info.childTagName} />}`
+          const attributes = existingAttrs ? `${existingAttrs} ` : ""
+          newElementText = `<${info.link.helperName} ${attributes}render=${renderValue}>${info.childChildren}</${info.link.helperName}>`
+        } else {
+          const attributes = info.link.attributes
+            ? ` ${info.link.attributes}`
+            : ""
+          newElementText = `<${info.childTagName}${attributes}>${info.childChildren}</${info.childTagName}>`
+        }
+
+        info.parentElement.replaceWithText(newElementText)
+        convertedButtons.add(info.link.buttonLocalName)
+        continue
+      }
+
+      const openingElement = info.parentElement.getOpeningElement()
       const existingAttrs = openingElement
         .getAttributes()
         .filter((attr) => {
@@ -142,28 +287,429 @@ export const transformAsChild: Transformer = async ({ sourceFile, config }) => {
         .map((attr) => attr.getText())
         .join(" ")
 
-      // Build the render prop value.
       const renderValue = info.childProps
         ? `{<${info.childTagName} ${info.childProps} />}`
         : `{<${info.childTagName} />}`
 
-      // Build new attributes.
       let newAttrs = existingAttrs ? `${existingAttrs} ` : ""
       newAttrs += `render=${renderValue}`
       if (info.needsNativeButton) {
         newAttrs += ` nativeButton={false}`
       }
 
-      // Build the new element text.
-      const newChildren = info.childChildren.trim()
-        ? `${info.childChildren}`
-        : ""
-
-      const newElementText = `<${info.parentTagName} ${newAttrs}>${newChildren}</${info.parentTagName}>`
-
+      const newElementText = `<${info.parentTagName} ${newAttrs}>${info.childChildren}</${info.parentTagName}>`
       info.parentElement.replaceWithText(newElementText)
     }
   }
 
+  if (buttonLinkHelper) {
+    insertButtonLinkHelper(sourceFile, buttonLinkHelper)
+  }
+
+  convertedButtons.forEach((localName) => {
+    removeUnusedButtonImport(sourceFile, uiButtonImport, localName)
+  })
+
   return sourceFile
+}
+
+function findButtonImport(tagNameNode: Node, moduleSpecifier: string) {
+  if (!Node.isIdentifier(tagNameNode)) {
+    return undefined
+  }
+
+  const specifier = getImportBinding(tagNameNode)
+  if (!Node.isImportSpecifier(specifier)) {
+    return undefined
+  }
+
+  const declaration = specifier?.getImportDeclaration()
+
+  return specifier.getName() === "Button" &&
+    declaration?.getModuleSpecifierValue() === moduleSpecifier
+    ? declaration
+    : undefined
+}
+
+function isLinkElement(tagNameNode: Node, attributes: JsxAttributeLike[]) {
+  const hasSpread = attributes.some(Node.isJsxSpreadAttribute)
+  const attributeNames = new Set(
+    attributes
+      .filter(Node.isJsxAttribute)
+      .map((attribute) => attribute.getNameNode().getText())
+  )
+
+  if (tagNameNode.getText() === "a") {
+    return attributeNames.has("href") || hasSpread
+  }
+
+  if (!attributeNames.has("href") && !attributeNames.has("to") && !hasSpread) {
+    return false
+  }
+
+  if (Node.isIdentifier(tagNameNode)) {
+    const binding = getImportBinding(tagNameNode)
+    const declaration = binding?.getFirstAncestorByKind(
+      SyntaxKind.ImportDeclaration
+    )
+
+    if (
+      !declaration ||
+      !ROUTER_LINK_MODULES.has(declaration.getModuleSpecifierValue())
+    ) {
+      return false
+    }
+
+    return (
+      (Node.isImportClause(binding) &&
+        declaration.getDefaultImport()?.getText() === tagNameNode.getText()) ||
+      (Node.isImportSpecifier(binding) &&
+        ROUTER_LINK_EXPORTS.has(binding.getName()))
+    )
+  }
+
+  if (Node.isPropertyAccessExpression(tagNameNode)) {
+    const namespace = tagNameNode.getExpression()
+    const binding = Node.isIdentifier(namespace)
+      ? getImportBinding(namespace)
+      : undefined
+    const declaration = binding?.getFirstAncestorByKind(
+      SyntaxKind.ImportDeclaration
+    )
+
+    if (!Node.isNamespaceImport(binding) || !declaration) {
+      return false
+    }
+
+    return (
+      ROUTER_LINK_MODULES.has(declaration.getModuleSpecifierValue()) &&
+      ROUTER_LINK_EXPORTS.has(tagNameNode.getName())
+    )
+  }
+
+  return false
+}
+
+function getImportBinding(identifier: Identifier) {
+  return identifier.getSymbol()?.getDeclarations()[0]
+}
+
+function ensureValueImport(
+  sourceFile: SourceFile,
+  moduleSpecifier: string,
+  importName: string,
+  preferredDeclaration?: ImportDeclaration
+) {
+  const existingDeclaration = sourceFile
+    .getImportDeclarations()
+    .find(
+      (declaration) =>
+        declaration.getModuleSpecifierValue() === moduleSpecifier &&
+        declaration
+          .getNamedImports()
+          .some((specifier) => specifier.getName() === importName)
+    )
+  const existing = existingDeclaration
+    ?.getNamedImports()
+    .find((specifier) => specifier.getName() === importName)
+
+  if (existing && existingDeclaration) {
+    if (existingDeclaration.isTypeOnly()) {
+      existingDeclaration.setIsTypeOnly(false)
+      existingDeclaration
+        .getNamedImports()
+        .filter((specifier) => specifier !== existing)
+        .forEach((specifier) => specifier.setIsTypeOnly(true))
+    }
+    existing.setIsTypeOnly(false)
+    return existing.getAliasNode()?.getText() ?? existing.getName()
+  }
+
+  const localName = getAvailableIdentifier(sourceFile, importName)
+  const declaration =
+    preferredDeclaration ??
+    sourceFile
+      .getImportDeclarations()
+      .find(
+        (item) =>
+          item.getModuleSpecifierValue() === moduleSpecifier &&
+          !item.isTypeOnly()
+      )
+
+  if (declaration) {
+    declaration.addNamedImport(
+      localName === importName
+        ? importName
+        : { name: importName, alias: localName }
+    )
+  } else {
+    const importSpecifier =
+      localName === importName ? importName : `${importName} as ${localName}`
+    const statements = sourceFile.getStatements()
+    const insertIndex = statements.reduce(
+      (index, statement, statementIndex) =>
+        statement.getKind() === SyntaxKind.ImportDeclaration
+          ? statementIndex + 1
+          : index,
+      0
+    )
+    sourceFile.insertStatements(
+      insertIndex,
+      `import { ${importSpecifier} } from "${moduleSpecifier}"`
+    )
+  }
+
+  return localName
+}
+
+function getAvailableIdentifier(sourceFile: SourceFile, preferred: string) {
+  const identifiers = new Set(
+    sourceFile
+      .getDescendantsOfKind(SyntaxKind.Identifier)
+      .map((identifier) => identifier.getText())
+  )
+
+  if (!identifiers.has(preferred)) {
+    return preferred
+  }
+
+  const fallback = `shadcn${preferred[0].toUpperCase()}${preferred.slice(1)}`
+  if (!identifiers.has(fallback)) {
+    return fallback
+  }
+
+  let index = 2
+  while (identifiers.has(`${fallback}${index}`)) {
+    index++
+  }
+  return `${fallback}${index}`
+}
+
+function getAvailableComponentIdentifier(
+  sourceFile: SourceFile,
+  preferred: string
+) {
+  const identifiers = new Set(
+    sourceFile
+      .getDescendantsOfKind(SyntaxKind.Identifier)
+      .map((identifier) => identifier.getText())
+  )
+
+  if (!identifiers.has(preferred)) {
+    return preferred
+  }
+
+  let index = 2
+  while (identifiers.has(`${preferred}${index}`)) {
+    index++
+  }
+  return `${preferred}${index}`
+}
+
+function requiresButtonLinkHelper(
+  parentAttributes: JsxAttributeLike[],
+  childAttributes: JsxAttributeLike[]
+) {
+  if (
+    [...parentAttributes, ...childAttributes].some(Node.isJsxSpreadAttribute)
+  ) {
+    return true
+  }
+
+  const childAttributeNames = new Set(
+    childAttributes
+      .filter(Node.isJsxAttribute)
+      .map((attribute) => attribute.getNameNode().getText())
+  )
+
+  return parentAttributes.filter(Node.isJsxAttribute).some((attribute) => {
+    const name = attribute.getNameNode().getText()
+    return (
+      BUTTON_BEHAVIOR_PROPS.includes(name) ||
+      (childAttributeNames.has(name) &&
+        (name === "ref" || name === "style" || /^on[A-Z]/.test(name)))
+    )
+  })
+}
+
+function buildLinkAttributes(
+  parentAttributes: JsxAttributeLike[],
+  childAttributes: JsxAttributeLike[],
+  buttonVariants: string
+) {
+  const parentClassName = getAttributeValue(parentAttributes, "className")
+  const childClassName = getAttributeValue(childAttributes, "className")
+  const variant = getAttributeValue(parentAttributes, "variant")
+  const size = getAttributeValue(parentAttributes, "size")
+  const childAttributeNames = new Set(
+    childAttributes
+      .filter(Node.isJsxAttribute)
+      .map((attribute) => attribute.getNameNode().getText())
+  )
+  const attributes = parentAttributes
+    .filter((attribute) => {
+      if (!Node.isJsxAttribute(attribute)) {
+        return true
+      }
+
+      const name = attribute.getNameNode().getText()
+      return (
+        !["asChild", "className", "nativeButton", "size", "variant"].includes(
+          name
+        ) && !childAttributeNames.has(name)
+      )
+    })
+    .map((attribute) => attribute.getText())
+
+  if (!childAttributeNames.has("data-slot")) {
+    const hasParentSlot = parentAttributes.some(
+      (attribute) =>
+        Node.isJsxAttribute(attribute) &&
+        attribute.getNameNode().getText() === "data-slot"
+    )
+    if (!hasParentSlot) {
+      attributes.unshift('data-slot="button"')
+    }
+  }
+
+  attributes.push(
+    ...childAttributes
+      .filter(
+        (attribute) =>
+          !Node.isJsxAttribute(attribute) ||
+          attribute.getNameNode().getText() !== "className"
+      )
+      .map((attribute) => attribute.getText())
+  )
+
+  const options = [
+    variant && `variant: ${variant}`,
+    size && `size: ${size}`,
+    (parentClassName || childClassName) &&
+      `className: [${[parentClassName, childClassName]
+        .filter(Boolean)
+        .join(", ")}]`,
+  ].filter(Boolean)
+  const call = options.length
+    ? `${buttonVariants}({ ${options.join(", ")} })`
+    : `${buttonVariants}()`
+  attributes.push(`className={${call}}`)
+
+  return attributes.join(" ")
+}
+
+function getAttributeValue(attributes: JsxAttributeLike[], name: string) {
+  const attribute = attributes.find(
+    (candidate): candidate is JsxAttribute =>
+      Node.isJsxAttribute(candidate) &&
+      candidate.getNameNode().getText() === name
+  )
+  const initializer = attribute?.getInitializer()
+
+  if (!initializer) {
+    return undefined
+  }
+
+  if (Node.isStringLiteral(initializer)) {
+    return initializer.getText()
+  }
+
+  if (Node.isJsxExpression(initializer)) {
+    return initializer.getExpression()?.getText()
+  }
+
+  return initializer.getText()
+}
+
+function insertButtonLinkHelper(
+  sourceFile: SourceFile,
+  helper: ButtonLinkHelper
+) {
+  const useRender = ensureValueImport(
+    sourceFile,
+    "@base-ui/react/use-render",
+    "useRender"
+  )
+  const statements = sourceFile.getStatements()
+  const insertIndex = statements.reduce(
+    (index, statement, statementIndex) =>
+      statement.getKind() === SyntaxKind.ImportDeclaration
+        ? statementIndex + 1
+        : index,
+    0
+  )
+
+  sourceFile.insertStatements(
+    insertIndex,
+    `type ${helper.propsName} = Omit<${useRender}.ComponentProps<"button">, "size"> &
+  NonNullable<Parameters<typeof ${helper.buttonVariants}>[0]> &
+  Partial<Record<${BUTTON_ONLY_PROPS.map((prop) => `"${prop}"`).join(" | ")}, unknown>>
+
+function ${helper.helperName}({
+  className,
+  variant,
+  size,
+  render,
+  ...props
+}: ${helper.propsName}) {
+  const linkProps = { ...props }
+  for (const prop of ${JSON.stringify(BUTTON_ONLY_PROPS)}) {
+    Reflect.deleteProperty(linkProps, prop)
+  }
+
+  return ${useRender}({
+    defaultTagName: "a",
+    render,
+    props: {
+      ...linkProps,
+      className: ${helper.buttonVariants}({ variant, size, className }),
+    },
+    state: { slot: "button" },
+  })
+}`
+  )
+}
+
+function removeUnusedButtonImport(
+  sourceFile: SourceFile,
+  moduleSpecifier: string,
+  localName: string
+) {
+  const declaration = sourceFile.getImportDeclarations().find(
+    (item) =>
+      item.getModuleSpecifierValue() === moduleSpecifier &&
+      item.getNamedImports().some((specifier) => {
+        const name = specifier.getAliasNode()?.getText() ?? specifier.getName()
+        return specifier.getName() === "Button" && name === localName
+      })
+  )
+  const buttonImport = declaration?.getNamedImports().find((specifier) => {
+    const name = specifier.getAliasNode()?.getText() ?? specifier.getName()
+    return specifier.getName() === "Button" && name === localName
+  })
+
+  if (!declaration || !buttonImport) {
+    return
+  }
+
+  const isUsed = sourceFile
+    .getDescendantsOfKind(SyntaxKind.Identifier)
+    .some(
+      (identifier) =>
+        identifier.getText() === localName &&
+        !identifier.getFirstAncestorByKind(SyntaxKind.ImportSpecifier)
+    )
+
+  if (isUsed) {
+    return
+  }
+
+  buttonImport.remove()
+  if (
+    declaration.getNamedImports().length === 0 &&
+    !declaration.getDefaultImport() &&
+    !declaration.getNamespaceImport()
+  ) {
+    declaration.remove()
+  }
 }

--- a/packages/shadcn/src/utils/transformers/transform-render.test.ts
+++ b/packages/shadcn/src/utils/transformers/transform-render.test.ts
@@ -374,7 +374,7 @@ export function Component() {
 
 export function Component() {
   return (
-    <Button render={<a href="/home" />}>Go Home</Button>
+    <NavigationMenuLink render={<a href="/home" />}>Go Home</NavigationMenuLink>
   )
 }`,
             config: testConfig,
@@ -386,7 +386,7 @@ export function Component() {
 
         export function Component() {
           return (
-            <Button render={<a href="/home">Go Home</a>} />
+            <NavigationMenuLink render={<a href="/home">Go Home</a>} />
           )
         }"
       `)

--- a/skills/migrate-radix-to-base/SKILL.md
+++ b/skills/migrate-radix-to-base/SKILL.md
@@ -113,6 +113,11 @@ full build.
   Indicator have no equivalent: inert passthrough + flag.
 - `button.tsx` migrates to the REAL `@base-ui/react/button` primitive, never
   a hand-rolled useRender wrapper.
+- `nativeButton={false}` is only for a component that still owns button
+  behavior while rendering a non-`<button>` element. Never render a navigation
+  link through `Button` or add button semantics to it; apply `buttonVariants`
+  to the `<a>` or router link instead. Flag links that also act as triggers or
+  close controls for manual separation.
 - Behavior deltas are FLAGGED, never silently patched (tabs manual
   activation, menu items not closing on click, nav-menu 50ms delay). The
   target is idiomatic Base UI matching the shadcn base registry.

--- a/skills/migrate-radix-to-base/disclosure.md
+++ b/skills/migrate-radix-to-base/disclosure.md
@@ -5,7 +5,7 @@ Sources: radix-ui.com primitives docs + base-ui.com `.md` docs, cross-checked ag
 
 Conventions that apply to every component below:
 
-- `asChild` (boolean, default `false`) → `render` (`ReactElement | (props: HTMLProps, state) => ReactElement`). Signature changed: instead of a lone child element, pass the element to `render`; Base UI merges props onto it. Button-rendering parts additionally accept `nativeButton` (default `true`), set it to `false` when `render` produces a non-`<button>` element.
+- `asChild` (boolean, default `false`) → `render` (`ReactElement | (props: HTMLProps, state) => ReactElement`). Signature changed: instead of a lone child element, pass the element to `render`; Base UI merges props onto it. Button-rendering parts additionally accept `nativeButton` (default `true`); set it to `false` only when the rendered element still owns button behavior. Navigation links keep link semantics and receive styles directly.
 - Base UI `className` and `style` also accept a `(state) => value` function form.
 - Radix `data-[state=...]` value attributes become Base UI presence attributes (`data-open`, `data-closed`, `data-pressed`, `data-active`).
 - Base UI change callbacks all gained a second `eventDetails` argument (`{ reason, event, cancel(), ... }`).

--- a/skills/migrate-radix-to-base/display-misc.md
+++ b/skills/migrate-radix-to-base/display-misc.md
@@ -253,7 +253,7 @@ Base UI only on Root: `toast` (required `Toast.Root.ToastObject`: `id`, `title`,
 | `asChild` | `boolean` / `false` | `render` | Signature changed. |
 | `altText` (required) | `string` / - | Dropped | No equivalent prop. When creating toasts via the manager, pass the button's props (including handlers and aria attributes) through `add({ actionProps })`. |
 
-Base UI only: `nativeButton` (`boolean`, default `true`, set `false` when `render` is not a button).
+Base UI only: `nativeButton` (`boolean`, default `true`; set `false` only when the rendered element still owns the toast action's button behavior, never for navigation links).
 
 ## Toast.Close → Toast.Close
 

--- a/skills/migrate-radix-to-base/form-controls.md
+++ b/skills/migrate-radix-to-base/form-controls.md
@@ -38,7 +38,7 @@ Base UI `Select.Root` renders no HTML element (Radix Root doesn't either).
 
 | Radix prop | Type / default | Base UI equivalent | Migration note |
 | --- | --- | --- | --- |
-| `asChild` | `boolean`, `false` | `render` | See global conventions. Base UI Trigger renders `<button>` by default; `nativeButton` defaults to `true` here, set it to `false` when rendering a non-button via `render`. |
+| `asChild` | `boolean`, `false` | `render` | See global conventions. Base UI Trigger renders `<button>` by default; set `nativeButton={false}` only when a non-button target still owns trigger behavior, never for navigation links. |
 | (none) | - | `disabled: boolean` | Base UI allows disabling just the trigger. |
 
 ## Select.Value → Select.Value

--- a/skills/migrate-radix-to-base/menus.md
+++ b/skills/migrate-radix-to-base/menus.md
@@ -34,7 +34,7 @@ Cross-cutting rules (apply to every part below):
 
 | Radix prop | Type / default | Base UI equivalent | Migration note |
 | --- | --- | --- | --- |
-| `asChild` | `boolean` / `false` | `render` | See cross-cutting rules. When rendering a non-button, also set `nativeButton={false}`. |
+| `asChild` | `boolean` / `false` | `render` | See cross-cutting rules. Set `nativeButton={false}` only when a non-button target still owns trigger behavior, never for navigation links. |
 
 ## Portal → Menu.Portal
 
@@ -274,7 +274,7 @@ Note: `Menu.Root` inside a Menubar accepts all Menu.Root props (`open`, `default
 
 | Radix prop | Type / default | Base UI equivalent | Migration note |
 | --- | --- | --- | --- |
-| `asChild` | `boolean` / `false` | `render` (+ `nativeButton={false}` for non-buttons) | Radix Menubar.Trigger data attrs `[data-state]`/`[data-highlighted]`/`[data-disabled]` → `data-popup-open`/`data-pressed` (no highlighted state on Base trigger). |
+| `asChild` | `boolean` / `false` | `render` | Set `nativeButton={false}` only when a non-button target still owns trigger behavior, never for navigation links. Radix Menubar.Trigger data attrs `[data-state]`/`[data-highlighted]`/`[data-disabled]` → `data-popup-open`/`data-pressed` (no highlighted state on Base trigger). |
 
 ## Portal / Content / Arrow / Item / Group / Label / CheckboxItem / RadioGroup / RadioItem / ItemIndicator / Separator / Sub / SubTrigger / SubContent
 

--- a/skills/migrate-radix-to-base/overlays.md
+++ b/skills/migrate-radix-to-base/overlays.md
@@ -6,7 +6,7 @@ Sources: radix-ui.com primitives docs (fetched 2026-07-02) and base-ui.com `/rea
 
 Global conventions that apply to every component below:
 
-- `asChild` (Radix, every part) → `render` (Base UI, every part). Radix: `asChild?: boolean` merges props onto the single child. Base UI: `render?: ReactElement | ((props: HTMLProps, state: Part.State) => ReactElement)`. For buttons replaced with non-button elements, also set `nativeButton={false}`.
+- `asChild` (Radix, every part) → `render` (Base UI, every part). Radix: `asChild?: boolean` merges props onto the single child. Base UI: `render?: ReactElement | ((props: HTMLProps, state: Part.State) => ReactElement)`. Set `nativeButton={false}` only when a non-button target still owns button behavior. Navigation links keep link semantics; links that also act as triggers or close controls require manual separation.
 - `onOpenChange` signature changed everywhere. Radix: `(open: boolean) => void`. Base UI: `(open: boolean, eventDetails: X.Root.ChangeEventDetails) => void` where `eventDetails` is `{ reason, event, trigger, cancel(), allowPropagation(), isCanceled, isPropagationAllowed, preventUnmountOnClose() }`.
 - Radix per-interaction dismiss callbacks (`onEscapeKeyDown`, `onPointerDownOutside`, `onFocusOutside`, `onInteractOutside`) have NO 1:1 Base UI props. They are replaced by `onOpenChange`'s `eventDetails.reason` (`'escape-key'`, `'outside-press'`, `'focus-out'`) + `eventDetails.cancel()` to prevent the close (the equivalent of Radix `event.preventDefault()`).
 - `forceMount` (Radix, Portal/Overlay/Content) → `keepMounted` on Base UI `Portal` only (`boolean`, default `false`). For exit animations Base UI does not need it: it holds the popup mounted itself and exposes `data-starting-style` / `data-ending-style`, `onOpenChangeComplete`, and `actionsRef.current.unmount()` for externally-controlled animations.
@@ -32,7 +32,7 @@ Part mapping: Root→Root, Trigger→Trigger, Portal→Portal, Overlay→Backdro
 
 | Radix prop | Type / default | Base UI equivalent | Migration note |
 | --- | --- | --- | --- |
-| `asChild` | `boolean` / `false` | `render` | `render={<MyButton />}`; add `nativeButton={false}` if the rendered element is not a `<button>`. |
+| `asChild` | `boolean` / `false` | `render` | `render={<MyButton />}`; set `nativeButton={false}` only when the target still owns trigger behavior. Do not use a navigation link as the trigger. |
 
 ## Portal → Portal
 

--- a/skills/migrate-radix-to-base/universal-patterns.md
+++ b/skills/migrate-radix-to-base/universal-patterns.md
@@ -274,6 +274,12 @@ Two rules:
 2. Always cast object literals containing `data-*` keys passed to
    `mergeProps` (`as React.ComponentProps<"tag">`), or tsc fails on every one.
 
+Links styled as buttons are the exception to the Button `render` pattern.
+Keep the `<a>` or router link as the final element and apply `buttonVariants`
+directly. Do not use `nativeButton={false}` for navigation; it intentionally
+adds button semantics. If a navigation link is also a trigger or close
+control, flag it for manual separation instead of choosing either behavior.
+
 ## Positioner props: Pick means FORWARD
 
 When a wrapper exposes positioning props via

--- a/skills/shadcn/rules/base-vs-radix.md
+++ b/skills/shadcn/rules/base-vs-radix.md
@@ -5,7 +5,7 @@ API differences between `base` and `radix`. Check the `base` field from `npx sha
 ## Contents
 
 - Composition: asChild vs render
-- Button / trigger as non-button element
+- Links styled as buttons and non-native buttons
 - Select (items prop, placeholder, positioning, multiple, object values)
 - ToggleGroup (type vs multiple)
 - Slider (scalar vs array)
@@ -45,23 +45,31 @@ This applies to all trigger and close components: `DialogTrigger`, `SheetTrigger
 
 ---
 
-## Button / trigger as non-button element (base only)
+## Links styled as buttons and non-native buttons
 
-When `render` changes an element to a non-button (`<a>`, `<span>`), add `nativeButton={false}`.
+Base UI `Button` always owns button semantics. Do not render links through it.
+Apply `buttonVariants` directly to the link so the `<a>` or router link keeps
+its native semantics.
 
-**Incorrect (base):** missing `nativeButton={false}`.
-
-```tsx
-<Button render={<a href="/docs" />}>Read the docs</Button>
-```
-
-**Correct (base):**
+**Incorrect (base):**
 
 ```tsx
 <Button render={<a href="/docs" />} nativeButton={false}>
   Read the docs
 </Button>
 ```
+
+**Correct (base):**
+
+```tsx
+<a href="/docs" className={buttonVariants()}>
+  Read the docs
+</a>
+```
+
+When spreads or composed props require runtime merging, use a local
+`useRender` helper and remove Button-only props instead of forwarding them to
+the link.
 
 **Correct (radix):**
 
@@ -71,14 +79,17 @@ When `render` changes an element to a non-button (`<a>`, `<span>`), add `nativeB
 </Button>
 ```
 
-Same for triggers whose `render` is not a `Button`:
+Use `nativeButton={false}` only when a Base UI button or trigger still owns
+button behavior but renders a non-button element such as a `<span>`:
 
 ```tsx
-// base.
 <PopoverTrigger render={<InputGroupAddon />} nativeButton={false}>
   Pick date
 </PopoverTrigger>
 ```
+
+Do not combine a navigation link with another button action, such as a
+`DialogTrigger`. Keep the dialog action and navigation as separate elements.
 
 ---
 


### PR DESCRIPTION
## Summary

- remove the remaining authored Base UI links rendered through `Button`
- harden the Radix `asChild` transformer so supported native and router links retain element ownership, Slot-style prop composition, and single spread evaluation
- align migration guidance and internal rules with the native link contract

## Why

#11625 fixes the concrete `PaginationLink` implementation. This follow-up applies the same ownership rule to authored examples and CLI-generated Radix migrations while remaining independently reviewable.

The transformer emits a direct styled link when static props are safe to move. When spreads or overlapping handlers, styles, or refs require runtime composition, it generates a local `useRender` helper and removes Button-only props. Navigation links that also act as triggers or close controls remain documented as manual migrations instead of being presented as safe automatic rewrites.

Closes #11624
