### PR TITLE
fix(base-ui): preserve pagination link semantics

### DIFF
--- a/apps/v4/content/docs/components/base/pagination.mdx
+++ b/apps/v4/content/docs/components/base/pagination.mdx
@@ -109,7 +109,7 @@ A simple pagination with only page numbers.
 
 ## Icons Only
 
-Use just the previous and next buttons without page numbers. This is useful for data tables with a rows per page selector.
+Use just the previous and next links without page numbers. This is useful for data tables with a rows per page selector.
 
 <ComponentPreview styleName="base-nova" name="pagination-icons-only" />
 
@@ -117,31 +117,13 @@ Use just the previous and next buttons without page numbers. This is useful for 
 
 By default the `<PaginationLink />` component will render an `<a />` tag.
 
-To use the Next.js `<Link />` component, make the following updates to `pagination.tsx`.
+Use the `render` prop to compose it with the Next.js `<Link />` component.
 
-```diff showLineNumbers /typeof Link/ {1}
-+ import Link from "next/link"
+```tsx showLineNumbers
+import Link from "next/link"
 
-- type PaginationLinkProps = ... & React.ComponentProps<"a">
-+ type PaginationLinkProps = ... & React.ComponentProps<typeof Link>
-
-const PaginationLink = ({...props }: ) => (
-  <PaginationItem>
--   <a>
-+   <Link>
-      // ...
--   </a>
-+   </Link>
-  </PaginationItem>
-)
-
+;<PaginationLink render={<Link href="/page/2" />}>2</PaginationLink>
 ```
-
-<Callout className="mt-6">
-
-**Note:** We are making updates to the cli to automatically do this for you.
-
-</Callout>
 
 ## RTL
 

--- a/apps/v4/examples/base/pagination-demo.tsx
+++ b/apps/v4/examples/base/pagination-demo.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link"
+
 import {
   Pagination,
   PaginationContent,
@@ -16,7 +18,7 @@ export default function PaginationDemo() {
           <PaginationPrevious href="#" />
         </PaginationItem>
         <PaginationItem>
-          <PaginationLink href="#">1</PaginationLink>
+          <PaginationLink render={<Link href="?page=1" />}>1</PaginationLink>
         </PaginationItem>
         <PaginationItem>
           <PaginationLink href="#" isActive>

--- a/apps/v4/registry/bases/base/examples/pagination-example.tsx
+++ b/apps/v4/registry/bases/base/examples/pagination-example.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import Link from "next/link"
+
 import {
   Example,
   ExampleWrapper,
@@ -42,7 +44,7 @@ function PaginationBasic() {
             <PaginationPrevious href="#" />
           </PaginationItem>
           <PaginationItem>
-            <PaginationLink href="#">1</PaginationLink>
+            <PaginationLink render={<Link href="?page=1" />}>1</PaginationLink>
           </PaginationItem>
           <PaginationItem>
             <PaginationLink href="#" isActive>

--- a/apps/v4/registry/bases/base/ui/pagination.tsx
+++ b/apps/v4/registry/bases/base/ui/pagination.tsx
@@ -1,7 +1,9 @@
 import * as React from "react"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
 
 import { cn } from "@/registry/bases/base/lib/utils"
-import { Button } from "@/registry/bases/base/ui/button"
+import { buttonVariants, type Button } from "@/registry/bases/base/ui/button"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
 function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
@@ -39,30 +41,37 @@ function PaginationItem({ ...props }: React.ComponentProps<"li">) {
 type PaginationLinkProps = {
   isActive?: boolean
 } & Pick<React.ComponentProps<typeof Button>, "size"> &
-  React.ComponentProps<"a">
+  useRender.ComponentProps<"a">
 
 function PaginationLink({
   className,
   isActive,
   size = "icon",
+  render,
   ...props
 }: PaginationLinkProps) {
-  return (
-    <Button
-      variant={isActive ? "outline" : "ghost"}
-      size={size}
-      className={cn("cn-pagination-link", className)}
-      nativeButton={false}
-      render={
-        <a
-          aria-current={isActive ? "page" : undefined}
-          data-slot="pagination-link"
-          data-active={isActive}
-          {...props}
-        />
-      }
-    />
-  )
+  return useRender({
+    defaultTagName: "a",
+    render,
+    props: mergeProps<"a">(
+      {
+        "aria-current": isActive ? "page" : undefined,
+        "data-active": isActive,
+        className: cn(
+          "cn-pagination-link",
+          buttonVariants({
+            variant: isActive ? "outline" : "ghost",
+            size,
+          }),
+          className
+        ),
+      } as React.ComponentProps<"a">,
+      props
+    ),
+    state: {
+      slot: "pagination-link",
+    },
+  })
 }
 
 function PaginationPrevious({

--- a/packages/tests/src/tests/add.test.ts
+++ b/packages/tests/src/tests/add.test.ts
@@ -36,6 +36,41 @@ describe("shadcn add", () => {
     ).toBe(true)
   })
 
+  it("should preserve native link semantics in Base UI pagination", async () => {
+    const fixturePath = await createFixtureTestDirectory("next-app")
+    await npxShadcn(fixturePath, ["init", "--defaults"])
+
+    const result = await npxShadcn(fixturePath, ["add", "pagination", "--yes"])
+    expectCommandSuccess(result)
+
+    const paginationContent = await fs.readFile(
+      path.join(fixturePath, "components/ui/pagination.tsx"),
+      "utf-8"
+    )
+
+    expect(paginationContent).toContain('defaultTagName: "a"')
+    expect(paginationContent).toContain("buttonVariants({")
+    expect(paginationContent).not.toContain('role="button"')
+    expect(paginationContent).not.toContain("nativeButton={false}")
+    expect(paginationContent).not.toContain("<Button")
+
+    const appUrl = getRegistryUrl().replace(/\/r\/?$/, "")
+    const response = await fetch(`${appUrl}/examples/base/pagination-demo`)
+    expect(response.ok).toBe(true)
+
+    const html = await response.text()
+    const links =
+      html.match(/<a\b[^>]*data-slot="pagination-link"[^>]*>/g) ?? []
+
+    expect(links.length).toBeGreaterThan(0)
+    expect(links.some((link) => link.includes('href="?page=1"'))).toBe(true)
+    expect(links.some((link) => link.includes('aria-current="page"'))).toBe(
+      true
+    )
+    expect(links.some((link) => link.includes('data-active="true"'))).toBe(true)
+    expect(links.every((link) => !link.includes('role="button"'))).toBe(true)
+  })
+
   it("should add multiple items to project", async () => {
     const fixturePath = await createFixtureTestDirectory("next-app")
     await npxShadcn(fixturePath, ["init", "--defaults"])


### PR DESCRIPTION
## Summary

- make Base UI `PaginationLink` own a native anchor while retaining `buttonVariants` styling
- support custom router links through `useRender`
- preserve the existing `data-active="true"` DOM contract and cover installed output with a real Next.js `Link`

## Why

Base UI `Button` always owns button semantics. Rendering an anchor through it gives a pagination link button semantics instead of preserving its native link role.

`PaginationLink` should own the final anchor and use the Button only as a source of visual variants. This also lets consumers compose Next.js and other router links through the existing Base UI `render` contract without changing the component implementation.

Closes #11489
