### PR TITLE
registry: add @knot-ui namespace

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -877,6 +877,13 @@
     "logo": "<svg width='40' height='40' viewBox='0 0 40 40' fill='none' xmlns='http://www.w3.org/2000/svg'><rect width='40' height='40' rx='10' fill='#eef1f4'/><g transform='translate(8 8)' stroke='#1e2a3a' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'><path d='M8 13v-8.5a1.5 1.5 0 0 1 3 0v7.5'/><path d='M11 11.5v-2a1.5 1.5 0 0 1 3 0v2.5'/><path d='M14 10.5a1.5 1.5 0 0 1 3 0v1.5'/><path d='M17 11.5a1.5 1.5 0 0 1 3 0v4.5a6 6 0 0 1 -6 6h-2h.208a6 6 0 0 1 -5.012 -2.7l-.196 -.3c-.312 -.479 -1.407 -2.388 -3.286 -5.728a1.5 1.5 0 0 1 .536 -2.022a1.867 1.867 0 0 1 2.28 .28l1.47 1.47'/><path d='M2.541 5.594a13.487 13.487 0 0 1 2.46 -1.427'/><path d='M14 3.458c1.32 .354 2.558 .902 3.685 1.612'/></g></svg>"
   },
   {
+    "name": "@knot-ui",
+    "homepage": "https://knot-ui.trupal.me",
+    "url": "https://knot-ui.trupal.me/r/{name}.json",
+    "description": "A registry of animated, cinematic React components and UI blocks for shadcn — buttons, cards, folders, navbars and more, built with Tailwind CSS v4 and Motion.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='8' fill='var(--foreground)'/><path d='M9 7v18h3.2v-6.6L18 25h3.8l-6.4-8.2L21.6 7H18l-4.8 6.4V7z' fill='var(--background)'/></svg>"
+  },
+  {
     "name": "@kokonutui",
     "homepage": "https://kokonutui.com",
     "url": "https://kokonutui.com/r/{name}.json",


### PR DESCRIPTION
## Summary
Adds the `@knot-ui` namespace to the registry directory.

- **name:** `@knot-ui`
- **homepage:** https://knot-ui.trupal.me
- **url:** https://knot-ui.trupal.me/r/{name}.json
- **description:** A registry of animated, cinematic React components and UI blocks for shadcn — buttons, cards, folders, navbars and more, built with Tailwind CSS v4 and Motion.

The registry is served as a flat registry at `/r/` (catalog at `/r/registry.json`, items at `/r/{name}.json`), and the catalog `files` array contains only `path`/`type` (no `content`).

### Verification
- `npx shadcn@latest registry add @knot-ui=https://knot-ui.trupal.me/r/{name}.json`
- `npx shadcn@latest list @knot-ui`
- `npx shadcn@latest add @knot-ui/button`

Once merged, `@knot-ui` will resolve automatically for `shadcn add` / `shadcn search`.

Generated from the upstream `apps/v4/registry/directory.json` (inserted in alphabetical order).