### PR TITLE
fix(registry): add missing spacing to ChartTooltipContent

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/chart.tsx
+++ b/apps/v4/registry/new-york-v4/ui/chart.tsx
@@ -242,7 +242,7 @@ function ChartTooltipContent({
                     )}
                     <div
                       className={cn(
-                        "flex flex-1 justify-between leading-none",
+                        "flex flex-1 justify-between leading-none gap-2",
                         nestLabel ? "items-end" : "items-center"
                       )}
                     >


### PR DESCRIPTION
## Summary

Simple fix that adds a missing gap between the label and the value in the **ChartTooltipContent** component.

**Without the fix**:
<img width="273" height="257" alt="image" src="https://github.com/user-attachments/assets/a47d6a23-4f42-4826-9bad-472a255d975a" />

**With the fix**:
<img width="269" height="263" alt="image" src="https://github.com/user-attachments/assets/58783eb2-47d6-4659-bfde-23680a480e25" />
