### PR TITLE
docs(registry): update @wensity URL, homepage, and description

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1844,9 +1844,9 @@
   },
   {
     "name": "@wensity",
-    "homepage": "https://wensity.com",
-    "url": "https://raw.githubusercontent.com/ksparth12/wensity-shadcn-registry/main/{name}.json",
-    "description": "Motion-rich React components for AI interfaces, SaaS blocks, and cinematic interactions. Free Wensity components only.",
+    "homepage": "https://ui.wensity.com/components",
+    "url": "https://raw.githubusercontent.com/wensity/registry/main/{name}.json",
+    "description": "React and Next.js UI primitives, components, and motion, themeable end to end from one design token contract. Built on Base UI and Tailwind CSS v4. Free Wensity components.",
     "logo": "<svg width='512' height='512' viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'><rect width='512' height='512' fill='#ffffff'/><path d='M96 352L224 96H352L224 352H96Z' fill='#0a0a0a'/><path d='M160 416L288 160H416L288 416H160Z' fill='#cd1c18'/></svg>"
   },
   {


### PR DESCRIPTION
Updates the existing `@wensity` entry in `apps/v4/registry/directory.json`. Three fields on one object; no other entries are touched.

### What changed

| Field | Before | After |
| --- | --- | --- |
| `url` | `.../ksparth12/wensity-shadcn-registry/main/{name}.json` | `.../wensity/registry/main/{name}.json` |
| `homepage` | `https://wensity.com` | `https://ui.wensity.com/components` |
| `description` | Led on "AI interfaces" | Describes the catalog's actual breadth |

### Why

**URL.** The registry was first published from a personal account and has since moved to the Wensity organization at [wensity/registry](https://github.com/wensity/registry), which is now the canonical public host. The old repository remains published and unchanged, so anyone who hardcoded the previous raw URL in their own `components.json` keeps working.

The payloads at both locations are byte-identical (verified by SHA-256 on `registry.json` and item files), so resolution through the new URL returns exactly the same content. Verified with a clean project and no local `registries` config:

```
npx shadcn@latest add https://raw.githubusercontent.com/wensity/registry/main/button.json
✔ Created 3 files
```

**Homepage.** `wensity.com` is the studio site. `ui.wensity.com/components` is the component catalog, which is what someone clicking through from the directory is looking for.

**Description.** The previous wording led with "AI interfaces", which is 4 of 70 items. The replacement describes the registry as it actually is: UI primitives, components, and motion, on Base UI and Tailwind CSS v4.

### Notes

- The registry remains free-only and MIT; Pro components are not published to it.
- Flat registry, no nested items, no `content` property in the index `files` array.
- `registry.json` and all 70 item payloads resolve over HTTPS.