### PR TITLE
Improve accessibility for Progress component

### DIFF
--- a/apps/v4/registry/bases/base/ui/progress.tsx
+++ b/apps/v4/registry/bases/base/ui/progress.tsx
@@ -45,6 +45,7 @@ function ProgressIndicator({
   return (
     <ProgressPrimitive.Indicator
       data-slot="progress-indicator"
+      role="progressbar"
       className={cn("cn-progress-indicator h-full transition-all", className)}
       {...props}
     />

--- a/apps/v4/registry/bases/radix/ui/progress.tsx
+++ b/apps/v4/registry/bases/radix/ui/progress.tsx
@@ -21,6 +21,7 @@ function Progress({
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
+        role="progressbar"
         className="cn-progress-indicator size-full flex-1 transition-all"
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />


### PR DESCRIPTION
This PR adds `role="progressbar"` to the base and radix Progress indicators.
This ensures assistive technologies correctly identify the element as a progress indicator, following WAI‑ARIA guidelines.
This change is non‑breaking and improves screen reader support.