### PR TITLE
Hide decorative Skeleton component from screen readers

### DIFF
--- a/apps/v4/registry/bases/base/ui/skeleton.tsx
+++ b/apps/v4/registry/bases/base/ui/skeleton.tsx
@@ -4,6 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
+      aria-hidden={true}
       className={cn("cn-skeleton animate-pulse", className)}
       {...props}
     />

--- a/apps/v4/registry/bases/radix/ui/skeleton.tsx
+++ b/apps/v4/registry/bases/radix/ui/skeleton.tsx
@@ -4,6 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
+      aria-hidden={true}
       className={cn("cn-skeleton animate-pulse", className)}
       {...props}
     />


### PR DESCRIPTION
This PR adds `aria-hidden={true}` to the base as well as radix Skeleton component.
Skeletons are purely visual placeholders and should not be announced by screen readers.
This change improves accessibility without affecting layout or behavior.