### PR TITLE
Improve accessibility for Spinner component

### DIFF
--- a/apps/v4/registry/bases/base/ui/spinner.tsx
+++ b/apps/v4/registry/bases/base/ui/spinner.tsx
@@ -12,6 +12,7 @@ function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
       data-slot="spinner"
       role="status"
       aria-label="Loading"
+      aria-live="polite"
       className={cn("size-4 animate-spin", className)}
       {...props}
     />

--- a/apps/v4/registry/bases/radix/ui/spinner.tsx
+++ b/apps/v4/registry/bases/radix/ui/spinner.tsx
@@ -12,6 +12,7 @@ function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
       data-slot="spinner"
       role="status"
       aria-label="Loading"
+      aria-live="polite"
       className={cn("size-4 animate-spin", className)}
       {...props}
     />


### PR DESCRIPTION
This PR adds `aria-live="polite"` to both base and radix Spinner variants.
This ensures loading states are announced by screen readers without interrupting the user, following WAI‑ARIA best practices.
This change is non‑breaking and improves accessibility for assistive technology users.