### PR TITLE
fix: add global hotkey listener for nested Command dialogs

### DIFF
--- a/src/solution_patch.ts
+++ b/src/solution_patch.ts
@@ -1,0 +1,1 @@
+useEffect(() => { const down = (e: KeyboardEvent) => { if (e.key === 'k' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); setOpen((open) => !open); } }; document.addEventListener('keydown', down); return () => document.removeEventListener('keydown', down); }, []);


### PR DESCRIPTION
Closing this PR — found an issue with the implementation and will resubmit a corrected version if still relevant.