### PR TITLE
fix(popover): render semantic h2 element in PopoverTitle to match component types

### DIFF
--- a/apps/v4/registry/bases/radix/ui/popover.tsx
+++ b/apps/v4/registry/bases/radix/ui/popover.tsx
@@ -57,7 +57,7 @@ function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
 
 function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
   return (
-    <div
+    <h2
       data-slot="popover-title"
       className={cn("cn-popover-title", className)}
       {...props}

--- a/apps/v4/registry/new-york-v4/ui/popover.tsx
+++ b/apps/v4/registry/new-york-v4/ui/popover.tsx
@@ -57,7 +57,7 @@ function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
 
 function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
   return (
-    <div
+    <h2
       data-slot="popover-title"
       className={cn("font-medium", className)}
       {...props}


### PR DESCRIPTION
Fixes a type and element mismatch in the `PopoverTitle` component across the `new-york-v4` and `bases/radix` registries. The component previously had `React.ComponentProps<"h2">` as its type signature but rendered a generic `<div>` element. It now properly renders an `<h2>` element.

### Why is this change necessary
1. **Type Safety**: Consumers passing `HTMLHeadingElement` specific props or refs to `PopoverTitle` encountered TypeScript type inconsistencies with the underlying rendered `HTMLDivElement`.
2. **Accessibility (WCAG 2.1 AA Compliance)**: Assistive technologies (screen readers) rely on semantic heading tags (`<h2>`) to construct the accessibility tree and document outline inside popover modals.

### Testing Instructions
1. Run `pnpm dev` and navigate to `/docs/components/popover`.
2. Inspect the `PopoverTitle` element in the DOM to verify it renders as `<h2 data-slot="popover-title" class="font-medium ...">`.
3. Verify with TypeScript compiler (`pnpm typecheck`) that passing `HTMLHeadingElement` refs causes no type errors.

### Checklist
- [x] Code adheres to the project's style guide and component conventions (`data-slot`, `cn`).
- [x] Ran `pnpm registry:build` without errors.
- [x] No breaking visual changes (Tailwind CSS Preflight normalizes `h2` margins/sizes).
- [x] Verified in local development environment.