### PR TITLE
fix(react): use native targeting for MessageScroller jumps

### DIFF
--- a/packages/react/src/message-scroller/geometry.ts
+++ b/packages/react/src/message-scroller/geometry.ts
@@ -217,16 +217,21 @@ function getElementScrollTop({
   const elementTop = getElementTop(element, viewport)
   const elementHeight = element.getBoundingClientRect().height
   const contentPadding = getContentBlockPadding(spacer)
+  const viewportScrollPadding = getBlockScrollPadding(viewport)
+  const padding = {
+    end: contentPadding.end + viewportScrollPadding.end,
+    start: contentPadding.start + viewportScrollPadding.start,
+  }
 
   if (align === "center") {
     const insetHeight = Math.max(
       0,
-      viewport.clientHeight - contentPadding.start - contentPadding.end
+      viewport.clientHeight - padding.start - padding.end
     )
 
     return (
       elementTop -
-      contentPadding.start -
+      padding.start -
       (insetHeight - elementHeight) / 2 -
       scrollMargin
     )
@@ -237,31 +242,31 @@ function getElementScrollTop({
       elementTop -
       viewport.clientHeight +
       elementHeight +
-      contentPadding.end +
+      padding.end +
       scrollMargin
     )
   }
 
   if (align === "nearest") {
     const elementBottom = elementTop + elementHeight
-    const viewportTop = viewport.scrollTop + contentPadding.start
+    const viewportTop = viewport.scrollTop + padding.start
     const viewportBottom =
-      viewport.scrollTop + viewport.clientHeight - contentPadding.end
+      viewport.scrollTop + viewport.clientHeight - padding.end
 
     if (elementTop >= viewportTop && elementBottom <= viewportBottom) {
       return viewport.scrollTop
     }
 
     if (elementTop < viewportTop) {
-      return elementTop - contentPadding.start - scrollMargin
+      return elementTop - padding.start - scrollMargin
     }
 
     return (
-      elementBottom - viewport.clientHeight + contentPadding.end + scrollMargin
+      elementBottom - viewport.clientHeight + padding.end + scrollMargin
     )
   }
 
-  return elementTop - contentPadding.start - scrollMargin
+  return elementTop - padding.start - scrollMargin
 }
 
 function getElementTop(element: HTMLElement, viewport: HTMLElement) {
@@ -344,6 +349,15 @@ function getContentBlockPadding(spacer: HTMLElement | null) {
   }
 
   return getBlockPadding(content)
+}
+
+function getBlockScrollPadding(element: HTMLElement) {
+  const style = window.getComputedStyle(element)
+
+  return {
+    end: readCssPixel(style.scrollPaddingBlockEnd),
+    start: readCssPixel(style.scrollPaddingBlockStart),
+  }
 }
 
 function getFlexGap(element: HTMLElement | null) {

--- a/packages/react/src/message-scroller/message-scroller.browser.test.tsx
+++ b/packages/react/src/message-scroller/message-scroller.browser.test.tsx
@@ -59,20 +59,24 @@ function Thread({
   autoScroll,
   defaultScrollPosition,
   items,
+  restoreMessageId,
   scrollPreviousItemPeek,
   showButton = false,
   showJumpButton = false,
   showVisibility = false,
+  virtualized = false,
 }: {
   autoScroll?: boolean
   defaultScrollPosition?: React.ComponentProps<
     typeof MessageScrollerProvider
   >["defaultScrollPosition"]
   items: TestItem[]
+  restoreMessageId?: string
   scrollPreviousItemPeek?: number
   showButton?: boolean
   showJumpButton?: boolean
   showVisibility?: boolean
+  virtualized?: boolean
 }) {
   return (
     <MessageScrollerProvider
@@ -94,11 +98,21 @@ function Thread({
                 messageId={item.id}
                 scrollAnchor={item.scrollAnchor}
                 style={{
-                  height: item.height ?? ITEM_HEIGHT,
+                  containIntrinsicSize: virtualized ? "auto 160px" : undefined,
+                  contentVisibility: virtualized ? "auto" : undefined,
                   flex: "none",
+                  height: virtualized
+                    ? undefined
+                    : (item.height ?? ITEM_HEIGHT),
                 }}
               >
-                {item.id}
+                {virtualized ? (
+                  <div style={{ height: item.height ?? ITEM_HEIGHT }}>
+                    {item.id}
+                  </div>
+                ) : (
+                  item.id
+                )}
               </MessageScrollerItem>
             ))}
           </MessageScrollerContent>
@@ -109,6 +123,9 @@ function Thread({
           </MessageScrollerButton>
         ) : null}
         {showJumpButton ? <JumpButton messageId="m5" /> : null}
+        {restoreMessageId ? (
+          <RestoreMessage messageId={restoreMessageId} />
+        ) : null}
         {showVisibility ? <VisibilityProbe /> : null}
       </MessageScroller>
     </MessageScrollerProvider>
@@ -158,6 +175,16 @@ function JumpButton({ messageId }: { messageId: string }) {
       Jump to message
     </button>
   )
+}
+
+function RestoreMessage({ messageId }: { messageId: string }) {
+  const { scrollToMessage } = useMessageScroller()
+
+  React.useLayoutEffect(() => {
+    scrollToMessage(messageId, { align: "start", behavior: "auto" })
+  }, [messageId, scrollToMessage])
+
+  return null
 }
 
 // Resolve after a few real animation frames so the component's rAF-scheduled
@@ -397,6 +424,40 @@ test("scrolls to a mounted message by id", async () => {
   await settle()
 
   expect(viewportOffsetOf("m5", viewport)).toBeLessThanOrEqual(1)
+})
+
+test("restores an estimated off-screen row using its real layout", async () => {
+  await renderThread({
+    defaultScrollPosition: "start",
+    items: [],
+    restoreMessageId: "m100",
+    virtualized: true,
+  })
+
+  const viewport = getViewport()
+  viewport.style.scrollPaddingBlockStart = "24px"
+  const items = Array.from({ length: 150 }, (_, index) => ({
+    height: index % 3 === 0 ? 320 : 32,
+    id: `m${index}`,
+  }))
+
+  flushSync(() => {
+    root!.render(
+      <Thread
+        defaultScrollPosition="start"
+        items={items}
+        restoreMessageId="m100"
+        virtualized
+      />
+    )
+  })
+
+  await settle(8)
+
+  // 24px authored scroll-padding + the provider's default 12px scrollMargin.
+  expect(Math.abs(viewportOffsetOf("m100", viewport) - 36)).toBeLessThanOrEqual(
+    2
+  )
 })
 
 test("preserves a scrolled-to turn across a prepend (command-path anchor)", async () => {

--- a/packages/react/src/message-scroller/use-message-scroller-commands.ts
+++ b/packages/react/src/message-scroller/use-message-scroller-commands.ts
@@ -1,6 +1,7 @@
 import * as React from "react"
 
 import {
+  getContentBlockPadding,
   getElementScrollTop,
   getElementViewportTop,
   getMaxScrollTop,
@@ -188,15 +189,18 @@ function useMessageScrollerCommands({
         return false
       }
 
-      const scrollTop = getElementScrollTop({
-        align,
-        element,
-        scrollMargin: keepPreviousPeek
-          ? scrollMargin + scrollPreviousItemPeekRef.current
-          : scrollMargin,
-        spacer: spacerRef.current,
-        viewport,
-      })
+      const effectiveScrollMargin = keepPreviousPeek
+        ? scrollMargin + scrollPreviousItemPeekRef.current
+        : scrollMargin
+      const getTargetScrollTop = () =>
+        getElementScrollTop({
+          align,
+          element,
+          scrollMargin: effectiveScrollMargin,
+          spacer: spacerRef.current,
+          viewport,
+        })
+      const scrollTop = getTargetScrollTop()
 
       const nextSpacerHeight = getTailSpacerHeight({
         content,
@@ -220,7 +224,59 @@ function useMessageScrollerCommands({
         : "settling-jump"
       streamingTurnRef.current = keepPreviousPeek ? element : null
 
-      scrollToPosition(scrollTop, { behavior })
+      if (typeof element.scrollIntoView !== "function") {
+        scrollToPosition(scrollTop, { behavior })
+        scheduleVisibilitySync()
+        return true
+      }
+
+      // Let the browser target the element directly. In particular, this makes
+      // content-visibility lay out the target before positioning it and honors
+      // viewport scroll-padding. Temporary logical scroll margins preserve the
+      // component's own content-padding and scrollMargin alignment contract.
+      const contentPadding = getContentBlockPadding(spacerRef.current)
+      const previousMarginStart = element.style.scrollMarginBlockStart
+      const previousMarginEnd = element.style.scrollMarginBlockEnd
+
+      if (align === "center") {
+        element.style.scrollMarginBlockStart = `${contentPadding.start + effectiveScrollMargin * 2}px`
+        element.style.scrollMarginBlockEnd = `${contentPadding.end}px`
+      } else if (align === "end") {
+        element.style.scrollMarginBlockEnd = `${contentPadding.end + effectiveScrollMargin}px`
+      } else if (align === "nearest") {
+        element.style.scrollMarginBlockStart = `${contentPadding.start + effectiveScrollMargin}px`
+        element.style.scrollMarginBlockEnd = `${contentPadding.end + effectiveScrollMargin}px`
+      } else {
+        element.style.scrollMarginBlockStart = `${contentPadding.start + effectiveScrollMargin}px`
+      }
+
+      const scrollIntoView = () =>
+        element.scrollIntoView({
+          behavior,
+          block: align,
+          inline: "nearest",
+        })
+
+      scrollIntoView()
+
+      // An automatic jump settles synchronously, so recompute the tail spacer
+      // once the browser has replaced any intrinsic-size estimate with the
+      // target's real layout. A smooth scroll must retain its native animation.
+      if (behavior !== "smooth") {
+        setTailSpacerHeight(
+          getTailSpacerHeight({
+            content,
+            scrollTop: getTargetScrollTop(),
+            spacer: spacerRef.current,
+            viewport,
+          })
+        )
+        scrollIntoView()
+      }
+
+      element.style.scrollMarginBlockStart = previousMarginStart
+      element.style.scrollMarginBlockEnd = previousMarginEnd
+      scheduleStateCommit()
       scheduleVisibilitySync()
 
       return true


### PR DESCRIPTION
## Summary

Fixes #11643.

`scrollToMessage()` computed a numeric `scrollTop` from row geometry. With the styled `MessageScrollerItem`, off-screen rows use `content-visibility: auto` and an intrinsic-size estimate, so a cold-load jump could accumulate placeholder-height error and miss its target. Numeric assignment also ignored authored viewport `scroll-padding`.

This keeps the existing alignment and tail-spacer policy, but lets the browser target the message element with `scrollIntoView()`. Temporary logical scroll margins preserve the component's content padding and `scrollMargin` API, while native targeting forces real target layout and honors viewport scroll padding. A numeric fallback remains for non-browser test environments.

The browser regression queues a target before 150 uneven virtualized rows mount and verifies the final offset includes both authored scroll padding and the provider margin.

## Testing

- Isolated TypeScript no-emit check for the changed production modules.
- `git diff --check`.
- Added a Chromium browser regression in `message-scroller.browser.test.tsx`.
- The full Vitest browser command was not available because the workspace install stopped on an uncached package while the configured registry was unreachable; CI still needs to execute the new browser case.
