### PR TITLE
fix(select): use Tailwind v4 CSS variable syntax in SelectViewport

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/select.tsx
+++ b/apps/v4/registry/new-york-v4/ui/select.tsx
@@ -76,7 +76,7 @@ function SelectContent({
           className={cn(
             "p-1",
             position === "popper" &&
-              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+              "h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width) scroll-my-1"
           )}
         >
           {children}


### PR DESCRIPTION
### What does this PR do?
Normalizes the arbitrary CSS variable syntax in the `SelectViewport` component (`new-york-v4` registry) to use Tailwind CSS v4's standard parentheses syntax: `h-(--radix-select-trigger-height)` and `min-w-(--radix-select-trigger-width)`.

### Why is this change necessary?
In `new-york-v4/ui/select.tsx`, `SelectContent` already uses the modern Tailwind v4 syntax `max-h-(--radix-select-content-available-height)` on line 65, but `SelectViewport` was still using the legacy v3 syntax `h-[var(--radix-select-trigger-height)]` on line 79. This aligns the styling syntax across the v4 registry.

### Testing Instructions
1. Run `pnpm registry:build` to verify registry compilation.
2. Run `pnpm dev` and check the Select component documentation/examples at `/docs/components/select`.
3. Verify that Popper positioning maintains the proper trigger width and height constraints.

### Checklist
- [x] Code adheres to the project's style guide and component conventions.
- [x] Ran `pnpm registry:build` without errors.
- [x] Zero visual regressions.