### PR TITLE
fix(table): remove hardcoded whitespace-nowrap from TableHead and TableCell

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/table.tsx
+++ b/apps/v4/registry/new-york-v4/ui/table.tsx
@@ -70,7 +70,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "h-10 px-2 text-left align-middle font-medium text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}
@@ -83,7 +83,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}


### PR DESCRIPTION
### What does this PR do?
Removes the hardcoded `whitespace-nowrap` utility class from `TableHead` and `TableCell` in the `new-york-v4` registry.

### Why is this change necessary?
Hardcoding `whitespace-nowrap` on every table header and table cell forces all text to render in a single line, causing horizontal overflow and clipping on mobile viewports or when rendering columns with long descriptions/text. Removing it allows table cells to wrap text naturally by default while still allowing developers to opt-in to `whitespace-nowrap` via `className` where specifically needed (e.g. badges, dates, actions).

### Testing Instructions
1. Run `pnpm registry:build` to verify registry compilation.
2. Run `pnpm dev` and view `/docs/components/table` and `/docs/components/data-table`.
3. Verify that cells containing multi-word descriptions wrap naturally and adjust fluidly to narrower viewports.

### Checklist
- [x] Code adheres to the project's style guide and component conventions.
- [x] Ran `pnpm registry:build` without errors.
- [x] Improves mobile responsive layout without breaking existing table structures.