### PR TITLE
feat(utils): form submission first invalid field auto-focus helper

### DIFF
--- a/packages/shadcn/src/utils/formErrorFocus.ts
+++ b/packages/shadcn/src/utils/formErrorFocus.ts
@@ -1,0 +1,1 @@
+export function focusFirstError(form: HTMLFormElement): boolean { const err = form.querySelector('[aria-invalid="true"]') as HTMLElement; if (err) { err.focus(); return true; } return false; }


### PR DESCRIPTION
## Summary

feat(utils): form submission first invalid field auto-focus helper.

Lightweight zero-dependency utility with strict TypeScript definitions.