### PR TITLE
fix(ci): skip registry health monitor on forks

### DIFF
--- a/.github/workflows/monitor-registries.yml
+++ b/.github/workflows/monitor-registries.yml
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   monitor:
     name: Monitor registry health
+    if: github.repository == 'shadcn-ui/ui'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:


### PR DESCRIPTION
Skip the registry health monitor job on forks by guarding it with a repository check.