### PR TITLE
fix(registry): resolve {style} placeholder in health checks

### DIFF
--- a/apps/v4/lib/registry-health/dry-run.ts
+++ b/apps/v4/lib/registry-health/dry-run.ts
@@ -3,7 +3,7 @@ import { promises as fs } from "node:fs"
 import os from "node:os"
 import path from "node:path"
 
-import type { RegistryDryRunResult } from "./monitor"
+import { DEFAULT_STYLE, type RegistryDryRunResult } from "./monitor"
 
 async function runLocalCliDryRun({
   namespace,
@@ -33,7 +33,7 @@ async function runLocalCliDryRun({
         JSON.stringify(
           {
             $schema: "https://ui.shadcn.com/schema.json",
-            style: "new-york",
+            style: DEFAULT_STYLE,
             rsc: true,
             tsx: true,
             tailwind: {

--- a/apps/v4/lib/registry-health/monitor.test.ts
+++ b/apps/v4/lib/registry-health/monitor.test.ts
@@ -610,4 +610,25 @@ describe("runRegistryMonitor", () => {
     expect(result.run.totals.dryRuns).toBe(6)
     expect(maximumActive).toBe(4)
   })
+
+  it("resolves {style} urls with the default style", async () => {
+    const fetchJson = vi.fn(async () => createSuccessfulFetch())
+    await runRegistryMonitor({
+      directory: [
+        {
+          ...DIRECTORY[0],
+          url: "https://acme.example.com/r/{style}/{name}.json",
+        },
+      ],
+      mode: "daily",
+      now: NOW,
+      previousState: createState(createEntryState({ itemNames: ["button"] })),
+      fetchJson,
+      runDryRun: vi.fn(),
+    })
+
+    expect(fetchJson).toHaveBeenCalledWith(
+      "https://acme.example.com/r/radix-vega/button.json"
+    )
+  })
 })

--- a/apps/v4/lib/registry-health/monitor.ts
+++ b/apps/v4/lib/registry-health/monitor.ts
@@ -30,6 +30,10 @@ const DAILY_CHECK_INTERVAL_MS = 20 * 60 * 60 * 1000
 const WEEKLY_CHECK_INTERVAL_MS = 6 * DAY_MS
 const MAX_DRY_RUN_CONCURRENCY = 4
 
+// Registries cannot declare a default style yet, so resolve {style} urls
+// with the canonical first base and style combination.
+export const DEFAULT_STYLE = "radix-vega"
+
 export type RegistryMonitorMode = RegistryMonitorRun["mode"]
 
 export type RegistryDryRunResult = {
@@ -279,7 +283,7 @@ function recordDryRunObservation(
 }
 
 function replaceRegistryItem(url: string, item: string) {
-  return url.replace("{name}", item)
+  return url.replace("{name}", item).replace("{style}", DEFAULT_STYLE)
 }
 
 function hasIntervalElapsed(


### PR DESCRIPTION
Resolve {style} registry urls with a default style so health checks and dry runs stop reporting templated registries as unavailable.