### PR TITLE
style(www): use radix-luma buttons in page headers

### DIFF
--- a/apps/v4/app/(app)/blocks/layout.tsx
+++ b/apps/v4/app/(app)/blocks/layout.tsx
@@ -10,7 +10,7 @@ import {
   PageHeaderHeading,
 } from "@/components/page-header"
 import { PageNav } from "@/components/page-nav"
-import { Button } from "@/registry/new-york-v4/ui/button"
+import { Button } from "@/styles/radix-luma/ui/button"
 
 const title = "Building Blocks for the Web"
 const description =
@@ -52,10 +52,10 @@ export default function BlocksLayout({
         <PageHeaderHeading>{title}</PageHeaderHeading>
         <PageHeaderDescription>{description}</PageHeaderDescription>
         <PageActions>
-          <Button asChild size="sm">
+          <Button asChild className="h-[35px]">
             <a href="#blocks">Browse Blocks</a>
           </Button>
-          <Button asChild variant="ghost" size="sm">
+          <Button asChild variant="secondary">
             <Link href="/docs/components">View Components</Link>
           </Button>
         </PageActions>

--- a/apps/v4/app/(app)/charts/layout.tsx
+++ b/apps/v4/app/(app)/charts/layout.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/page-header"
 import { PageNav } from "@/components/page-nav"
 import { ThemeSelector } from "@/components/theme-selector"
-import { Button } from "@/registry/new-york-v4/ui/button"
+import { Button } from "@/styles/radix-luma/ui/button"
 
 const title = "Beautiful Charts & Graphs"
 const description =
@@ -53,10 +53,10 @@ export default function ChartsLayout({
         <PageHeaderHeading>{title}</PageHeaderHeading>
         <PageHeaderDescription>{description}</PageHeaderDescription>
         <PageActions>
-          <Button asChild size="sm">
+          <Button asChild className="h-[35px]">
             <a href="#charts">Browse Charts</a>
           </Button>
-          <Button asChild variant="ghost" size="sm">
+          <Button asChild variant="secondary">
             <Link href="/docs/components/chart">Documentation</Link>
           </Button>
         </PageActions>

--- a/apps/v4/app/(app)/colors/layout.tsx
+++ b/apps/v4/app/(app)/colors/layout.tsx
@@ -9,7 +9,7 @@ import {
   PageHeaderDescription,
   PageHeaderHeading,
 } from "@/components/page-header"
-import { Button } from "@/registry/new-york-v4/ui/button"
+import { Button } from "@/styles/radix-luma/ui/button"
 
 const title = "Tailwind Colors in Every Format"
 const description =
@@ -51,10 +51,10 @@ export default function ColorsLayout({
         <PageHeaderHeading>{title}</PageHeaderHeading>
         <PageHeaderDescription>{description}</PageHeaderDescription>
         <PageActions>
-          <Button asChild size="sm">
+          <Button asChild className="h-[35px]">
             <a href="#colors">Browse Colors</a>
           </Button>
-          <Button asChild variant="ghost" size="sm">
+          <Button asChild variant="secondary">
             <Link href="/docs/theming">Documentation</Link>
           </Button>
         </PageActions>

--- a/apps/v4/app/(app)/examples/layout.tsx
+++ b/apps/v4/app/(app)/examples/layout.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/page-header"
 import { PageNav } from "@/components/page-nav"
 import { ThemeSelector } from "@/components/theme-selector"
-import { Button } from "@/registry/new-york-v4/ui/button"
+import { Button } from "@/styles/radix-luma/ui/button"
 
 export const dynamic = "force-static"
 export const revalidate = false
@@ -56,10 +56,10 @@ export default function ExamplesLayout({
         <PageHeaderHeading className="max-w-4xl">{title}</PageHeaderHeading>
         <PageHeaderDescription>{description}</PageHeaderDescription>
         <PageActions>
-          <Button asChild size="sm">
+          <Button asChild className="h-[35px]">
             <Link href="/docs/installation">Get Started</Link>
           </Button>
-          <Button asChild size="sm" variant="ghost">
+          <Button asChild variant="secondary">
             <Link href="/docs/components">View Components</Link>
           </Button>
         </PageActions>


### PR DESCRIPTION
Use radix-luma buttons in the Blocks, Charts, Colors, and Examples page headers so they match the homepage.