### PR TITLE
fix(registry): register missing action/schema files for form-next examples

### DIFF
--- a/apps/v4/registry/__index__.tsx
+++ b/apps/v4/registry/__index__.tsx
@@ -4453,6 +4453,16 @@ export const Index: Record<string, Record<string, any>> = {
           type: "registry:example",
           target: "",
         },
+        {
+          path: "registry/new-york-v4/examples/form-next-demo-action.ts",
+          type: "registry:example",
+          target: "",
+        },
+        {
+          path: "registry/new-york-v4/examples/form-next-demo-schema.ts",
+          type: "registry:example",
+          target: "",
+        },
       ],
       categories: undefined,
       meta: undefined,
@@ -4478,6 +4488,16 @@ export const Index: Record<string, Record<string, any>> = {
       files: [
         {
           path: "registry/new-york-v4/examples/form-next-complex.tsx",
+          type: "registry:example",
+          target: "",
+        },
+        {
+          path: "registry/new-york-v4/examples/form-next-complex-action.ts",
+          type: "registry:example",
+          target: "",
+        },
+        {
+          path: "registry/new-york-v4/examples/form-next-complex-schema.ts",
           type: "registry:example",
           target: "",
         },

--- a/apps/v4/registry/new-york-v4/examples/_registry.ts
+++ b/apps/v4/registry/new-york-v4/examples/_registry.ts
@@ -966,7 +966,16 @@ export const examples: Registry["items"] = [
         path: "examples/form-next-demo.tsx",
         type: "registry:example",
       },
+      {
+        path: "examples/form-next-demo-action.ts",
+        type: "registry:example",
+      },
+      {
+        path: "examples/form-next-demo-schema.ts",
+        type: "registry:example",
+      },
     ],
+    dependencies: ["zod"],
   },
   {
     name: "form-next-complex",
@@ -989,7 +998,16 @@ export const examples: Registry["items"] = [
         path: "examples/form-next-complex.tsx",
         type: "registry:example",
       },
+      {
+        path: "examples/form-next-complex-action.ts",
+        type: "registry:example",
+      },
+      {
+        path: "examples/form-next-complex-schema.ts",
+        type: "registry:example",
+      },
     ],
+    dependencies: ["zod"],
   },
   {
     name: "form-rhf-demo",


### PR DESCRIPTION
## Summary
- `form-next-demo` and `form-next-complex` (`apps/v4/registry/new-york-v4/examples/_registry.ts`) render `.tsx` files that import from co-located `*-action.ts` (a Next.js Server Action, which must live in its own file) and `*-schema.ts` (zod schema) files.
- Neither sibling file was listed in the registry item's `files` array, `registryDependencies`, or `dependencies`, so `npx shadcn add form-next-demo` (or `form-next-complex`) only installs the single `.tsx` file — the resulting project has unresolved local imports and is missing the `zod` dependency the schema file needs.
- Added the missing `*-action.ts` / `*-schema.ts` file entries (typed `registry:example` so they land in the same directory as the main file and the relative imports keep resolving) and `dependencies: ["zod"]` to both registry items, following the same pattern already used by `form-rhf-demo`.

## Test plan
- [x] `pnpm registry:build` (full pipeline) regenerates `apps/v4/registry/__index__.tsx` and the installable JSON with no errors
- [x] Verified `apps/v4/public/r/styles/new-york-v4/form-next-demo.json` and `form-next-complex.json` now include the action/schema file contents and `"dependencies": ["zod"]`
- [x] `pnpm --filter=v4 validate:registries` passes
- [x] `pnpm --filter=v4 typecheck` passes