### PR TITLE
feat(registry): add @n3wth to the registry directory

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -2045,5 +2045,12 @@
     "url": "https://afterglow.thebuilder.dk/r/{name}.json",
     "description": "A complete terminal UI system for shadcn with Base UI components, terminal-specific building blocks, and eight phosphor color themes.",
     "logo": "<svg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg' fill='currentColor'><path d='M6.45 5.9L18.23 16L6.45 26.1L3 22.07L10.09 16L3 9.93Z'/><path d='M18.4 20.24H29V24.48H18.4Z'/></svg>"
+  },
+  {
+    "name": "@n3wth",
+    "homepage": "https://kit.n3wth.com",
+    "url": "https://kit.n3wth.com/r/{name}.json",
+    "description": "Flat, minimal, iOS-inspired design system. 49 components, hooks, and blocks installable with the shadcn CLI.",
+    "logo": "<svg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg' fill='currentColor'><path d='M8 6h4.4L20 18.4V6h4v20h-4.4L12 13.6V26H8z'/></svg>"
   }
 ]


### PR DESCRIPTION
Adds `@n3wth` to the community registry directory.

- **Namespace**: `@n3wth`
- **Homepage**: https://kit.n3wth.com
- **Registry URL**: `https://kit.n3wth.com/r/{name}.json`
- **Source**: https://github.com/n3wth/kit (public)
- **Index**: https://kit.n3wth.com/r/registry.json (49 items)

## Checklist

- [x] Open source and publicly accessible
- [x] Valid `registry.json` conforming to `https://ui.shadcn.com/schema/registry.json`
- [x] Flat registry under `/r/` (`/r/registry.json` + `/r/{name}.json`)
- [x] Catalog `files` entries do not include `content`
- [x] Live item URLs return valid `registry-item.json` with installable `files[].content`

Could not run `pnpm validate:registries` against the full monorepo. The new entry was checked against `registryDirectoryEntrySchema`: unique `@n3wth` namespace, `{name}` URL placeholder, and required fields only.