### PR TITLE
feat(registry): update @payload-components directory logo

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1118,7 +1118,7 @@
     "homepage": "https://www.payload-components.xyz",
     "url": "https://www.payload-components.xyz/r/{name}.json",
     "description": "MIT registry of typed Payload CMS blocks for Payload v3 + Next.js. Each block installs as reviewable source; the companion CLI also wires collection config, RenderBlocks, types, and the admin import map.",
-    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><rect x='2' y='2' width='20' height='20' rx='5' fill='var(--foreground)'/><path d='M7 7h5.4c2.45 0 4.1 1.53 4.1 3.85s-1.65 3.85-4.1 3.85H9.7V17H7V7Zm2.7 2.25v3.2h2.4c1.02 0 1.65-.62 1.65-1.6s-.63-1.6-1.65-1.6H9.7Zm8.2-.25h1.9v8h-1.9V9Zm-2.15 3.05h6.2v1.9h-6.2v-1.9Z' fill='var(--background)'/></svg>"
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><rect width='24' height='24' rx='6' fill='#059669'/><rect x='4.8' y='4.8' width='8.4' height='8.4' rx='1.9' fill='#fff'/><rect x='10.8' y='10.8' width='8.4' height='8.4' rx='1.9' fill='#fff'/></svg>"
   },
   {
     "name": "@pastecn",


### PR DESCRIPTION
## Summary

Updates the `@payload-components` directory logo to the registry's current two-block mark. The directory entry still carries the retired `P` mark, while the canonical favicon and site branding changed on 2026-07-31.

The change is limited to the inline SVG in `apps/v4/registry/directory.json`.

## Validation

- directory JSON parses successfully
- SVG geometry matches the canonical `public/favicon.svg` mark
- `https://www.payload-components.xyz/r/registry.json` returns 200
- `https://www.payload-components.xyz/r/hero-basic.json` returns 200