### PR TITLE
feat(cli): add cn migration command

### DIFF
--- a/.changeset/migrate-cn.md
+++ b/.changeset/migrate-cn.md
@@ -2,4 +2,4 @@
 "shadcn": minor
 ---
 
-add `npx shadcn migrate cn` to replace `clsx` and `tailwind-merge` in Tailwind CSS v4 projects.
+add `npx shadcn migrate cn` to replace `clsx`, `tailwind-merge` and `cnfast` in Tailwind CSS v4 projects.

--- a/.changeset/migrate-cn.md
+++ b/.changeset/migrate-cn.md
@@ -1,0 +1,5 @@
+---
+"shadcn": minor
+---
+
+add `npx shadcn migrate cn` to replace `clsx` and `tailwind-merge` in Tailwind CSS v4 projects.

--- a/apps/v4/content/docs/(root)/cli.mdx
+++ b/apps/v4/content/docs/(root)/cli.mdx
@@ -440,7 +440,7 @@ Options:
 
 ### migrate cn
 
-The `cn` migration replaces `clsx` and `tailwind-merge` with [`cn`](https://github.com/shadcn-ui/cn).
+The `cn` migration replaces `clsx`, `tailwind-merge` and `cnfast` with [`cn`](https://github.com/shadcn-ui/cn).
 
 ```bash
 npx shadcn@latest migrate cn
@@ -450,7 +450,7 @@ Unlike the other migrations, `migrate cn` does not require a `components.json` f
 
 This will:
 
-1. Rewrite imports from `clsx`, `clsx/lite` and `tailwind-merge`.
+1. Rewrite imports from `clsx`, `clsx/lite`, `tailwind-merge` and `cnfast`.
 2. Replace `twMerge(clsx(...))` compositions with direct `cn(...)` calls.
 3. Replace the standard shadcn utility with a direct re-export.
 4. Install `cn` and remove the old packages when no references remain.
@@ -478,6 +478,13 @@ The migration also preserves separate APIs when they are used independently:
 - import { clsx } from "clsx"
 - import { twMerge } from "tailwind-merge"
 + import { clsx, twMerge } from "cn"
+```
+
+Because `cnfast` has the same root API, its module specifiers are replaced directly:
+
+```diff
+- import { cn } from "cnfast"
++ import { cn } from "cn"
 ```
 
 Custom configuration APIs are moved to `cn/config`. Existing local names are preserved when an export was renamed:
@@ -508,7 +515,7 @@ npx shadcn@latest migrate cn src/lib/utils.ts
 npx shadcn@latest migrate cn "src/**/*.{ts,tsx}"
 ```
 
-Scoped migrations install `cn` but keep `clsx` and `tailwind-merge` in `package.json`, because files outside the selected path may still use them.
+Scoped migrations install `cn` but keep `clsx`, `tailwind-merge` and `cnfast` in `package.json`, because files outside the selected path may still use them.
 
 The command leaves unsupported imports unchanged and reports them for manual review. This includes `experimentalParseClassName`, namespace imports, dynamic import shapes, direct calls to `validators` and variadic `createTailwindMerge` calls that cannot be migrated safely. An old dependency is retained whenever one of its references remains.
 

--- a/apps/v4/content/docs/(root)/cli.mdx
+++ b/apps/v4/content/docs/(root)/cli.mdx
@@ -410,6 +410,7 @@ npx shadcn@latest migrate [migration]
 
 | Migration    | Description                                             |
 | ------------ | ------------------------------------------------------- |
+| `cn`         | Migrate `clsx` and `tailwind-merge` to `cn`.            |
 | `icons`      | Migrate your UI components to a different icon library. |
 | `base-color` | Migrate your theme to a different base color.           |
 | `radix`      | Migrate to radix-ui.                                    |
@@ -434,6 +435,82 @@ Options:
   -t, --to <name>    the base color or icon library to migrate to.
   -h, --help         display help for command
 ```
+
+---
+
+### migrate cn
+
+The `cn` migration replaces `clsx` and `tailwind-merge` with [`cn`](https://github.com/shadcn-ui/cn).
+
+```bash
+npx shadcn@latest migrate cn
+```
+
+Unlike the other migrations, `migrate cn` does not require a `components.json` file. You can run it in any JavaScript or TypeScript package project using Tailwind CSS v4.
+
+This will:
+
+1. Rewrite imports from `clsx`, `clsx/lite` and `tailwind-merge`.
+2. Replace `twMerge(clsx(...))` compositions with direct `cn(...)` calls.
+3. Replace the standard shadcn utility with a direct re-export.
+4. Install `cn` and remove the old packages when no references remain.
+
+**Before**
+
+```tsx
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+```
+
+**After**
+
+```tsx
+export { cn } from "cn"
+```
+
+The migration also preserves separate APIs when they are used independently:
+
+```diff
+- import { clsx } from "clsx"
+- import { twMerge } from "tailwind-merge"
++ import { clsx, twMerge } from "cn"
+```
+
+Custom configuration APIs are moved to `cn/config`. Existing local names are preserved when an export was renamed:
+
+```diff
+- import { createTailwindMerge, getDefaultConfig } from "tailwind-merge"
++ import {
++   createTwMerge as createTailwindMerge,
++   defaultConfig as getDefaultConfig,
++ } from "cn/config"
+```
+
+<Callout icon={<TriangleAlertIcon />}>
+  The `cn` merge engine supports Tailwind CSS v4, like `tailwind-merge` v3.
+  Projects using Tailwind CSS v3 should continue using `tailwind-merge` v2. A
+  `clsx`-only migration is safe in a Tailwind CSS v3 project.
+</Callout>
+
+**Migrate specific files**
+
+You can migrate a file, directory or glob pattern:
+
+```bash
+# Migrate a specific file.
+npx shadcn@latest migrate cn src/lib/utils.ts
+
+# Migrate files matching a glob pattern.
+npx shadcn@latest migrate cn "src/**/*.{ts,tsx}"
+```
+
+Scoped migrations install `cn` but keep `clsx` and `tailwind-merge` in `package.json`, because files outside the selected path may still use them.
+
+The command leaves unsupported imports unchanged and reports them for manual review. This includes `experimentalParseClassName`, namespace imports, dynamic import shapes, direct calls to `validators` and variadic `createTailwindMerge` calls that cannot be migrated safely. An old dependency is retained whenever one of its references remains.
 
 ---
 

--- a/packages/shadcn/src/commands/migrate.ts
+++ b/packages/shadcn/src/commands/migrate.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import { migrateBaseColor } from "@/src/migrations/migrate-base-color"
+import { migrateCn } from "@/src/migrations/migrate-cn"
 import { migrateIcons } from "@/src/migrations/migrate-icons"
 import { migrateRadix } from "@/src/migrations/migrate-radix"
 import { migrateRtl } from "@/src/migrations/migrate-rtl"
@@ -11,6 +12,10 @@ import { Command } from "commander"
 import { z } from "zod"
 
 export const migrations = [
+  {
+    name: "cn",
+    description: "migrate clsx and tailwind-merge to cn.",
+  },
   {
     name: "icons",
     description: "migrate your ui components to a different icon library.",
@@ -86,18 +91,24 @@ export const migrate = new Command()
         return
       }
 
-      if (!options.migration) {
+      if (options.migration === "cn") {
+        await migrateCn({
+          cwd: options.cwd,
+          path: options.path,
+          yes: options.yes,
+        })
+        return
+      }
+
+      const { errors, config } = await preFlightMigrate(options)
+
+      if (errors[ERRORS.MISSING_DIR_OR_EMPTY_PROJECT]) {
         throw new Error(
-          "You must specify a migration. Run `shadcn migrate --list` to see available migrations."
+          "No `components.json` file found. Ensure you are at the root of your project."
         )
       }
 
-      let { errors, config } = await preFlightMigrate(options)
-
-      if (
-        errors[ERRORS.MISSING_DIR_OR_EMPTY_PROJECT] ||
-        errors[ERRORS.MISSING_CONFIG]
-      ) {
+      if (errors[ERRORS.MISSING_CONFIG]) {
         throw new Error(
           "No `components.json` file found. Ensure you are at the root of your project."
         )

--- a/packages/shadcn/src/migrations/cn/bindings.ts
+++ b/packages/shadcn/src/migrations/cn/bindings.ts
@@ -1,0 +1,321 @@
+import {
+  Node,
+  SyntaxKind,
+  type ArrowFunction,
+  type CallExpression,
+  type FunctionDeclaration,
+  type FunctionExpression,
+  type Identifier,
+  type SourceFile,
+  type VariableStatement,
+} from "ts-morph"
+
+import type { Binding, OldPackage } from "./types"
+
+export function collapseCanonicalWrappers(
+  sourceFile: SourceFile,
+  bindings: Binding[],
+  migratedPackages: Set<OldPackage>
+) {
+  const clsxBindings = getClsxBindings(bindings).filter(
+    (binding) => binding.kind === "esm"
+  )
+  const twMergeBindings = getTwMergeBindings(bindings).filter(
+    (binding) => binding.kind === "esm"
+  )
+  let changes = 0
+  const candidates: Array<{
+    statement: FunctionDeclaration | VariableStatement
+    name: Identifier
+    expression: Node
+    restName: string
+    isInlineExport: boolean
+    isDefaultExport: boolean
+  }> = []
+
+  for (const declaration of sourceFile.getFunctions()) {
+    const name = declaration.getNameNode()
+    if (!name) {
+      continue
+    }
+
+    const data = getFunctionWrapperData(declaration)
+    if (data) {
+      candidates.push({
+        statement: declaration,
+        name,
+        ...data,
+        isInlineExport:
+          declaration.isExported() && !declaration.isDefaultExport(),
+        isDefaultExport: declaration.isDefaultExport(),
+      })
+    }
+  }
+
+  for (const statement of sourceFile.getVariableStatements()) {
+    if (statement.getDeclarations().length !== 1) {
+      continue
+    }
+
+    const declaration = statement.getDeclarations()[0]
+    const name = declaration.getNameNode()
+    const initializer = declaration.getInitializer()
+    if (
+      !Node.isIdentifier(name) ||
+      (!Node.isArrowFunction(initializer) &&
+        !Node.isFunctionExpression(initializer))
+    ) {
+      continue
+    }
+
+    const data = getFunctionWrapperData(initializer)
+    if (data) {
+      candidates.push({
+        statement,
+        name,
+        ...data,
+        isInlineExport: statement.isExported(),
+        isDefaultExport: false,
+      })
+    }
+  }
+
+  for (const candidate of candidates) {
+    if (
+      !isCanonicalComposition(
+        candidate.expression,
+        candidate.restName,
+        clsxBindings,
+        twMergeBindings
+      )
+    ) {
+      continue
+    }
+
+    const references = candidate.name.findReferencesAsNodes()
+    const exportSpecifiers = references
+      .map((reference) => reference.getParentIfKind(SyntaxKind.ExportSpecifier))
+      .filter((specifier) => specifier !== undefined)
+
+    if (references.length !== exportSpecifiers.length) {
+      continue
+    }
+
+    if (
+      !candidate.isInlineExport &&
+      !candidate.isDefaultExport &&
+      !exportSpecifiers.length
+    ) {
+      continue
+    }
+
+    const exportedNames = new Set<string>()
+    if (candidate.isInlineExport) {
+      exportedNames.add(candidate.name.getText())
+    }
+    if (candidate.isDefaultExport) {
+      exportedNames.add("default")
+    }
+
+    for (const specifier of exportSpecifiers) {
+      exportedNames.add(
+        specifier.getAliasNode()?.getText() ?? specifier.getNameNode().getText()
+      )
+      const exportDeclaration = specifier.getExportDeclaration()
+      if (exportDeclaration.getNamedExports().length === 1) {
+        exportDeclaration.remove()
+      } else {
+        specifier.remove()
+      }
+    }
+
+    const statementIndex = sourceFile
+      .getStatements()
+      .findIndex((statement) => statement === candidate.statement)
+    candidate.statement.remove()
+    sourceFile.insertExportDeclaration(Math.max(statementIndex, 0), {
+      moduleSpecifier: "cn",
+      namedExports: Array.from(exportedNames).map((exportedName) => ({
+        name: "cn",
+        alias: exportedName === "cn" ? undefined : exportedName,
+      })),
+    })
+    migratedPackages.add("clsx")
+    migratedPackages.add("tailwind-merge")
+    changes++
+  }
+
+  return changes
+}
+
+function getFunctionWrapperData(
+  declaration: FunctionDeclaration | ArrowFunction | FunctionExpression
+) {
+  const parameters = declaration.getParameters()
+  if (parameters.length !== 1 || !parameters[0].isRestParameter()) {
+    return null
+  }
+
+  const parameterName = parameters[0].getNameNode()
+  const body = declaration.getBody()
+  if (!Node.isIdentifier(parameterName) || !body) {
+    return null
+  }
+
+  if (!Node.isBlock(body)) {
+    return { expression: body, restName: parameterName.getText() }
+  }
+
+  const statements = body.getStatements()
+  if (statements.length !== 1 || !Node.isReturnStatement(statements[0])) {
+    return null
+  }
+
+  const expression = statements[0].getExpression()
+  return expression ? { expression, restName: parameterName.getText() } : null
+}
+
+function isCanonicalComposition(
+  node: Node,
+  restName: string,
+  clsxBindings: Binding[],
+  twMergeBindings: Binding[]
+) {
+  if (!Node.isCallExpression(node) || !isBoundCall(node, twMergeBindings)) {
+    return false
+  }
+
+  const args = node.getArguments()
+  if (
+    args.length !== 1 ||
+    !Node.isCallExpression(args[0]) ||
+    !isBoundCall(args[0], clsxBindings)
+  ) {
+    return false
+  }
+
+  const clsxArgs = args[0].getArguments()
+  if (clsxArgs.length !== 1) {
+    return false
+  }
+
+  const argument = clsxArgs[0]
+  if (Node.isIdentifier(argument)) {
+    return argument.getText() === restName
+  }
+
+  return (
+    Node.isSpreadElement(argument) &&
+    Node.isIdentifier(argument.getExpression()) &&
+    argument.getExpression().getText() === restName
+  )
+}
+
+export function findCompositions(sourceFile: SourceFile, bindings: Binding[]) {
+  const clsxBindings = getClsxBindings(bindings)
+  const twMergeBindings = getTwMergeBindings(bindings)
+  const compositions: Array<{
+    outerCall: CallExpression
+    argumentsText: string
+    kind: Binding["kind"]
+  }> = []
+
+  for (const call of sourceFile.getDescendantsOfKind(
+    SyntaxKind.CallExpression
+  )) {
+    const twMergeBinding = findBindingForCall(call, twMergeBindings)
+    if (!twMergeBinding) {
+      continue
+    }
+
+    let hasClsxCall = false
+    const args = call.getArguments().flatMap((argument) => {
+      const clsxBinding = findBindingForCall(argument, clsxBindings)
+      if (!clsxBinding || clsxBinding.kind !== twMergeBinding.kind) {
+        return [argument.getText()]
+      }
+
+      hasClsxCall = true
+      const innerArguments = formatCnArguments(argument)
+      return innerArguments ? [innerArguments] : []
+    })
+
+    if (hasClsxCall) {
+      compositions.push({
+        outerCall: call,
+        argumentsText: args.join(", "),
+        kind: twMergeBinding.kind,
+      })
+    }
+  }
+
+  return compositions
+}
+
+function getClsxBindings(bindings: Binding[]) {
+  return bindings.filter(
+    (binding) =>
+      binding.module.startsWith("clsx") &&
+      (binding.importedName === "default" || binding.importedName === "clsx")
+  )
+}
+
+function getTwMergeBindings(bindings: Binding[]) {
+  return bindings.filter(
+    (binding) =>
+      binding.module === "tailwind-merge" && binding.importedName === "twMerge"
+  )
+}
+
+function isBoundCall(call: Node, bindings: Binding[]) {
+  return findBindingForCall(call, bindings) !== null
+}
+
+function findBindingForCall(call: Node, bindings: Binding[]) {
+  if (!Node.isCallExpression(call)) {
+    return null
+  }
+
+  const expression = call.getExpression()
+  if (!Node.isIdentifier(expression)) {
+    return null
+  }
+
+  return (
+    bindings.find(
+      (binding) =>
+        binding.localName === expression.getText() &&
+        binding.identifier
+          .findReferencesAsNodes()
+          .some((reference) => reference.getStart() === expression.getStart())
+    ) ?? null
+  )
+}
+
+function formatCnArguments(call: Node) {
+  if (!Node.isCallExpression(call)) {
+    return ""
+  }
+
+  return call
+    .getArguments()
+    .map((argument) => {
+      if (!Node.isIdentifier(argument)) {
+        return argument.getText()
+      }
+
+      const functionLike = argument.getFirstAncestor((ancestor) =>
+        Node.isFunctionLikeDeclaration(ancestor)
+      )
+      const restParameter = functionLike
+        ?.getParameters()
+        .find(
+          (parameter) =>
+            parameter.isRestParameter() &&
+            parameter.getNameNode().getText() === argument.getText()
+        )
+
+      return restParameter ? `...${argument.getText()}` : argument.getText()
+    })
+    .join(", ")
+}

--- a/packages/shadcn/src/migrations/cn/cnfast.ts
+++ b/packages/shadcn/src/migrations/cn/cnfast.ts
@@ -1,0 +1,51 @@
+import { Node, SyntaxKind, type SourceFile } from "ts-morph"
+
+import type { OldPackage } from "./types"
+
+export function migrateCnfastSpecifiers(
+  sourceFile: SourceFile,
+  migratedPackages: Set<OldPackage>
+) {
+  let changes = 0
+
+  for (const declaration of sourceFile.getImportDeclarations()) {
+    if (declaration.getModuleSpecifierValue() === "cnfast") {
+      declaration.setModuleSpecifier("cn")
+      changes++
+    }
+  }
+
+  for (const declaration of sourceFile.getExportDeclarations()) {
+    if (declaration.getModuleSpecifierValue() === "cnfast") {
+      declaration.setModuleSpecifier("cn")
+      changes++
+    }
+  }
+
+  for (const call of sourceFile.getDescendantsOfKind(
+    SyntaxKind.CallExpression
+  )) {
+    const expression = call.getExpression()
+    if (
+      expression.getKind() !== SyntaxKind.ImportKeyword &&
+      (!Node.isIdentifier(expression) || expression.getText() !== "require")
+    ) {
+      continue
+    }
+
+    const argument = call.getArguments()[0]
+    if (
+      Node.isStringLiteral(argument) &&
+      argument.getLiteralValue() === "cnfast"
+    ) {
+      argument.replaceWithText('"cn"')
+      changes++
+    }
+  }
+
+  if (changes) {
+    migratedPackages.add("cnfast")
+  }
+
+  return changes
+}

--- a/packages/shadcn/src/migrations/cn/collect-bindings.ts
+++ b/packages/shadcn/src/migrations/cn/collect-bindings.ts
@@ -1,0 +1,108 @@
+import { Node, type SourceFile } from "ts-morph"
+
+import { getRequiredPackage } from "./references"
+import type { Binding, OldModule } from "./types"
+
+export function collectBindings(sourceFile: SourceFile) {
+  return [
+    ...collectEsmBindings(sourceFile),
+    ...collectCommonJsBindings(sourceFile),
+  ]
+}
+
+function collectEsmBindings(sourceFile: SourceFile) {
+  const bindings: Binding[] = []
+
+  for (const declaration of sourceFile.getImportDeclarations()) {
+    const module = declaration.getModuleSpecifierValue()
+    if (!isOldModule(module)) {
+      continue
+    }
+
+    const defaultImport = declaration.getDefaultImport()
+    if (defaultImport && module.startsWith("clsx")) {
+      bindings.push({
+        identifier: defaultImport,
+        localName: defaultImport.getText(),
+        importedName: "default",
+        module,
+        kind: "esm",
+      })
+    }
+
+    for (const specifier of declaration.getNamedImports()) {
+      if (declaration.isTypeOnly() || specifier.isTypeOnly()) {
+        continue
+      }
+
+      const identifier = specifier.getAliasNode() ?? specifier.getNameNode()
+      if (!Node.isIdentifier(identifier)) {
+        continue
+      }
+
+      bindings.push({
+        identifier,
+        localName: identifier.getText(),
+        importedName: specifier.getName(),
+        module,
+        kind: "esm",
+      })
+    }
+  }
+
+  return bindings
+}
+
+function collectCommonJsBindings(sourceFile: SourceFile) {
+  const bindings: Binding[] = []
+
+  for (const declaration of sourceFile.getVariableDeclarations()) {
+    const initializer = declaration.getInitializer()
+    if (!initializer || !Node.isCallExpression(initializer)) {
+      continue
+    }
+
+    const module = getRequiredPackage(initializer)
+    if (!module) {
+      continue
+    }
+
+    const nameNode = declaration.getNameNode()
+    if (Node.isIdentifier(nameNode) && module.startsWith("clsx")) {
+      bindings.push({
+        identifier: nameNode,
+        localName: nameNode.getText(),
+        importedName: "default",
+        module,
+        kind: "cjs",
+      })
+      continue
+    }
+
+    if (!Node.isObjectBindingPattern(nameNode)) {
+      continue
+    }
+
+    for (const element of nameNode.getElements()) {
+      const identifier = element.getNameNode()
+      if (!Node.isIdentifier(identifier)) {
+        continue
+      }
+
+      bindings.push({
+        identifier,
+        localName: identifier.getText(),
+        importedName:
+          element.getPropertyNameNode()?.getText() ?? identifier.getText(),
+        module,
+        kind: "cjs",
+      })
+    }
+  }
+
+  return bindings
+}
+
+function isOldModule(value: string): value is OldModule {
+  return value === "clsx" || value === "clsx/lite" || value === "tailwind-merge"
+}

--- a/packages/shadcn/src/migrations/cn/emit.ts
+++ b/packages/shadcn/src/migrations/cn/emit.ts
@@ -1,0 +1,80 @@
+import { Node, type SourceFile } from "ts-morph"
+
+import type { PendingImport } from "./types"
+
+export function addCommonJsCnRequire(
+  sourceFile: SourceFile,
+  localName: string
+) {
+  const binding = localName === "cn" ? "cn" : `cn: ${localName}`
+  const statements = sourceFile.getStatements()
+  let index = 0
+
+  while (index < statements.length) {
+    const statement = statements[index]
+    if (
+      Node.isExpressionStatement(statement) &&
+      Node.isStringLiteral(statement.getExpression())
+    ) {
+      index++
+      continue
+    }
+    break
+  }
+
+  sourceFile.insertStatements(index, `const { ${binding} } = require("cn")`)
+}
+
+export function addPendingImports(
+  sourceFile: SourceFile,
+  pendingImports: PendingImport[]
+) {
+  for (const pendingImport of dedupePendingImports(pendingImports)) {
+    let declaration = sourceFile
+      .getImportDeclarations()
+      .find(
+        (candidate) =>
+          candidate.getModuleSpecifierValue() ===
+            pendingImport.moduleSpecifier &&
+          !candidate.getNamespaceImport() &&
+          !candidate.isTypeOnly()
+      )
+
+    declaration ??= sourceFile.addImportDeclaration({
+      moduleSpecifier: pendingImport.moduleSpecifier,
+    })
+
+    const exists = declaration.getNamedImports().some((specifier) => {
+      const localName =
+        specifier.getAliasNode()?.getText() ?? specifier.getNameNode().getText()
+      return (
+        specifier.getName() === pendingImport.importedName &&
+        localName === pendingImport.localName
+      )
+    })
+
+    if (!exists) {
+      declaration.addNamedImport({
+        name: pendingImport.importedName,
+        alias:
+          pendingImport.importedName === pendingImport.localName
+            ? undefined
+            : pendingImport.localName,
+        isTypeOnly: pendingImport.isTypeOnly,
+      })
+    }
+  }
+}
+
+function dedupePendingImports(imports: PendingImport[]) {
+  return imports.filter(
+    (item, index) =>
+      imports.findIndex(
+        (candidate) =>
+          candidate.moduleSpecifier === item.moduleSpecifier &&
+          candidate.importedName === item.importedName &&
+          candidate.localName === item.localName &&
+          candidate.isTypeOnly === item.isTypeOnly
+      ) === index
+  )
+}

--- a/packages/shadcn/src/migrations/cn/files.ts
+++ b/packages/shadcn/src/migrations/cn/files.ts
@@ -68,7 +68,7 @@ function findSourceFiles(cwd: string, pattern = SOURCE_PATTERN) {
 
 export function getScriptRegions(content: string, filename: string) {
   const regions: SourceRegion[] = []
-  const pattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi
+  const pattern = /<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi
   let match: RegExpExecArray | null
 
   while ((match = pattern.exec(content)) !== null) {

--- a/packages/shadcn/src/migrations/cn/files.ts
+++ b/packages/shadcn/src/migrations/cn/files.ts
@@ -1,0 +1,126 @@
+import { promises as fs } from "fs"
+import path from "path"
+import fg from "fast-glob"
+import { ScriptKind } from "ts-morph"
+
+import type { SourceRegion } from "./types"
+
+const SOURCE_PATTERN = "**/*.{js,jsx,ts,tsx,mjs,mts,cjs,cts,vue,svelte,astro}"
+const SOURCE_IGNORE = [
+  "**/node_modules/**",
+  "**/.git/**",
+  "**/.next/**",
+  "**/.nuxt/**",
+  "**/.svelte-kit/**",
+  "**/.astro/**",
+  "**/.output/**",
+  "**/.vercel/**",
+  "**/dist/**",
+  "**/build/**",
+  "**/out/**",
+  "**/coverage/**",
+]
+
+export async function resolveMigrationFiles(cwd: string, migratePath?: string) {
+  if (!migratePath) {
+    return findSourceFiles(cwd)
+  }
+
+  if (migratePath.includes("*")) {
+    const files = await findSourceFiles(cwd, migratePath)
+    if (!files.length) {
+      throw new Error(`No files found matching: ${migratePath}`)
+    }
+    return files
+  }
+
+  const resolvedPath = path.resolve(cwd, migratePath)
+  const stat = await fs.stat(resolvedPath).catch(() => null)
+  if (!stat) {
+    throw new Error(`File not found: ${migratePath}`)
+  }
+
+  if (stat.isFile()) {
+    return [resolvedPath]
+  }
+
+  if (stat.isDirectory()) {
+    const files = await findSourceFiles(resolvedPath)
+    if (!files.length) {
+      throw new Error(`No files found matching: ${migratePath}`)
+    }
+    return files
+  }
+
+  throw new Error(`Unsupported path type: ${migratePath}`)
+}
+
+function findSourceFiles(cwd: string, pattern = SOURCE_PATTERN) {
+  return fg(pattern, {
+    cwd,
+    absolute: true,
+    onlyFiles: true,
+    ignore: SOURCE_IGNORE,
+    suppressErrors: true,
+    dot: true,
+  })
+}
+
+export function getScriptRegions(content: string, filename: string) {
+  const regions: SourceRegion[] = []
+  const pattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi
+  let match: RegExpExecArray | null
+
+  while ((match = pattern.exec(content)) !== null) {
+    const attributes = match[1]
+    const source = match[2]
+    const offset = match[0].indexOf(source)
+    const language = attributes.match(/\blang=["'](js|jsx|ts|tsx)["']/i)?.[1]
+    regions.push({
+      start: match.index + offset,
+      end: match.index + offset + source.length,
+      filename: `${filename}.${regions.length}.${language?.toLowerCase() ?? "js"}`,
+    })
+  }
+
+  return regions
+}
+
+export function getAstroFrontmatterRegions(content: string, filename: string) {
+  const match = content.match(/^(?:\uFEFF)?---[\t ]*\r?\n([\s\S]*?)\r?\n---/)
+  if (!match || match.index === undefined) {
+    return []
+  }
+
+  const source = match[1]
+  const offset = match[0].indexOf(source)
+  return [
+    {
+      start: match.index + offset,
+      end: match.index + offset + source.length,
+      filename: `${filename}.frontmatter.ts`,
+    },
+  ]
+}
+
+export function normalizeVirtualFilename(filename: string) {
+  const basename = path.basename(filename).replace(/[^a-zA-Z0-9_.-]/g, "-")
+  return basename.match(/\.(?:js|jsx|ts|tsx|mjs|mts|cjs|cts)$/)
+    ? `/${basename}`
+    : `/${basename}.tsx`
+}
+
+export function getScriptKind(filename: string) {
+  switch (path.extname(filename).toLowerCase()) {
+    case ".ts":
+    case ".mts":
+    case ".cts":
+      return ScriptKind.TS
+    case ".tsx":
+      return ScriptKind.TSX
+    case ".jsx":
+      return ScriptKind.JSX
+    default:
+      return ScriptKind.JS
+  }
+}

--- a/packages/shadcn/src/migrations/cn/files.ts
+++ b/packages/shadcn/src/migrations/cn/files.ts
@@ -68,7 +68,7 @@ function findSourceFiles(cwd: string, pattern = SOURCE_PATTERN) {
 
 export function getScriptRegions(content: string, filename: string) {
   const regions: SourceRegion[] = []
-  const pattern = /<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi
+  const pattern = /<script\b([^>]*)>([\s\S]*?)<\/script(?:\s[^>]*)?>/gi
   let match: RegExpExecArray | null
 
   while ((match = pattern.exec(content)) !== null) {

--- a/packages/shadcn/src/migrations/cn/index.ts
+++ b/packages/shadcn/src/migrations/cn/index.ts
@@ -1,0 +1,187 @@
+import { promises as fs } from "fs"
+import path from "path"
+import { getPackageInfo } from "@/src/utils/get-package-info"
+import { highlighter } from "@/src/utils/highlighter"
+import { logger } from "@/src/utils/logger"
+import { spinner } from "@/src/utils/spinner"
+import {
+  installDependencies,
+  removeDependencies,
+} from "@/src/utils/updaters/update-dependencies"
+import fsExtra from "fs-extra"
+import prompts from "prompts"
+
+import { resolveMigrationFiles } from "./files"
+import { createCnTransformer } from "./transform"
+import { OLD_PACKAGES, type CnMigrationIssue, type OldPackage } from "./types"
+
+export { transformCnSource } from "./transform"
+export type { CnMigrationIssue, CnSourceTransformResult } from "./types"
+
+export async function migrateCn(options: {
+  cwd: string
+  path?: string
+  yes?: boolean
+}) {
+  if (!fsExtra.existsSync(path.resolve(options.cwd, "package.json"))) {
+    throw new Error(
+      "No `package.json` file found. Ensure you are at the root of your project."
+    )
+  }
+
+  const files = await resolveMigrationFiles(options.cwd, options.path)
+  const contents = await Promise.all(
+    files.map((file) => fs.readFile(file, "utf-8"))
+  )
+  const transform = createCnTransformer()
+  const results = files.map((file, index) => {
+    const content = contents[index]
+    return { file, content, result: transform(content, file) }
+  })
+
+  const changedFiles = results.filter(
+    ({ content, result }) => content !== result.content
+  )
+  const unsupported = results.flatMap(({ file, result }) =>
+    result.unsupported.map((issue) => ({ ...issue, file }))
+  )
+  const migratedPackages = new Set(
+    results.flatMap(({ result }) => result.migratedPackages)
+  )
+
+  if (!changedFiles.length) {
+    logger.info("No supported clsx or tailwind-merge usage found.")
+    printUnsupportedIssues(unsupported, options.cwd)
+    return
+  }
+
+  assertTailwindCompatibility(options.cwd, migratedPackages)
+
+  if (!options.yes) {
+    const { confirm } = await prompts({
+      type: "confirm",
+      name: "confirm",
+      initial: true,
+      message: `We will migrate ${highlighter.info(
+        changedFiles.length
+      )} file(s) to ${highlighter.info("cn")}${
+        unsupported.length
+          ? ` and leave ${highlighter.warn(
+              unsupported.length
+            )} item(s) for manual review`
+          : ""
+      }. Continue?`,
+    })
+
+    if (!confirm) {
+      logger.info("Migration cancelled.")
+      return
+    }
+  }
+
+  const migrationSpinner = spinner("Migrating to cn...")?.start()
+  await installDependencies(options.cwd, ["cn"])
+
+  for (const { file, result } of changedFiles) {
+    await fs.writeFile(file, result.content)
+  }
+
+  migrationSpinner?.succeed(
+    `Migrated ${changedFiles.length} file${changedFiles.length === 1 ? "" : "s"}.`
+  )
+
+  const retainedPackages = new Set(
+    results.flatMap(({ result }) => result.remainingPackages)
+  )
+  const removablePackages = options.path
+    ? []
+    : OLD_PACKAGES.filter(
+        (packageName) =>
+          migratedPackages.has(packageName) &&
+          !retainedPackages.has(packageName)
+      )
+
+  if (removablePackages.length) {
+    try {
+      await removeDependencies(options.cwd, removablePackages)
+    } catch {
+      logger.warn(
+        `Could not remove ${removablePackages.join(
+          ", "
+        )}. Remove them manually after reviewing the migration.`
+      )
+    }
+  }
+
+  if (options.path) {
+    logger.info(
+      "Kept clsx and tailwind-merge dependencies because this was a scoped migration."
+    )
+  }
+
+  printUnsupportedIssues(unsupported, options.cwd)
+}
+
+function assertTailwindCompatibility(
+  cwd: string,
+  migratedPackages: Set<OldPackage>
+) {
+  if (!migratedPackages.has("tailwind-merge")) {
+    return
+  }
+
+  const packageInfo = getPackageInfo(cwd, false)
+  const tailwindVersion = findDependencyVersion(packageInfo, "tailwindcss")
+  const tailwindMergeVersion = findDependencyVersion(
+    packageInfo,
+    "tailwind-merge"
+  )
+
+  if (
+    (getDeclaredMajor(tailwindVersion) ?? 4) < 4 ||
+    (getDeclaredMajor(tailwindMergeVersion) ?? 3) < 3
+  ) {
+    throw new Error(
+      "The cn migration requires Tailwind CSS v4 and tailwind-merge v3. Tailwind CSS v3 projects should continue using tailwind-merge v2."
+    )
+  }
+}
+
+function findDependencyVersion(
+  packageInfo: ReturnType<typeof getPackageInfo>,
+  packageName: string
+) {
+  return (
+    packageInfo?.dependencies?.[packageName] ??
+    packageInfo?.devDependencies?.[packageName] ??
+    packageInfo?.optionalDependencies?.[packageName] ??
+    packageInfo?.peerDependencies?.[packageName]
+  )
+}
+
+function getDeclaredMajor(version?: string) {
+  if (!version || /^(?:workspace|file|link|git|https?):/i.test(version)) {
+    return null
+  }
+
+  const match = version.match(/(?:^|[^0-9])(\d+)(?:\.|$)/)
+  return match ? Number(match[1]) : null
+}
+
+function printUnsupportedIssues(issues: CnMigrationIssue[], cwd: string) {
+  if (!issues.length) {
+    return
+  }
+
+  logger.break()
+  logger.warn(
+    `Manual review required for ${issues.length} item${
+      issues.length === 1 ? "" : "s"
+    }:`
+  )
+  for (const issue of issues) {
+    const file = issue.file ? path.relative(cwd, issue.file) : "unknown file"
+    const symbol = issue.symbol ? ` (${issue.symbol})` : ""
+    logger.warn(`  - ${file}${symbol}: ${issue.reason}`)
+  }
+}

--- a/packages/shadcn/src/migrations/cn/index.ts
+++ b/packages/shadcn/src/migrations/cn/index.ts
@@ -50,7 +50,7 @@ export async function migrateCn(options: {
   )
 
   if (!changedFiles.length) {
-    logger.info("No supported clsx or tailwind-merge usage found.")
+    logger.info("No supported clsx, tailwind-merge or cnfast usage found.")
     printUnsupportedIssues(unsupported, options.cwd)
     return
   }
@@ -115,7 +115,7 @@ export async function migrateCn(options: {
 
   if (options.path) {
     logger.info(
-      "Kept clsx and tailwind-merge dependencies because this was a scoped migration."
+      "Kept clsx, tailwind-merge and cnfast dependencies because this was a scoped migration."
     )
   }
 

--- a/packages/shadcn/src/migrations/cn/issues.ts
+++ b/packages/shadcn/src/migrations/cn/issues.ts
@@ -1,0 +1,101 @@
+import { Node, SyntaxKind, type SourceFile } from "ts-morph"
+
+import {
+  OLD_PACKAGES,
+  type CnMigrationIssue,
+  type OldModule,
+  type OldPackage,
+} from "./types"
+
+export function reportUnsupportedReferences(
+  sourceFile: SourceFile,
+  unsupported: CnMigrationIssue[]
+) {
+  reportDynamicImports(sourceFile, unsupported)
+  reportExportDeclarations(sourceFile, unsupported)
+}
+
+function reportDynamicImports(
+  sourceFile: SourceFile,
+  unsupported: CnMigrationIssue[]
+) {
+  for (const call of sourceFile.getDescendantsOfKind(
+    SyntaxKind.CallExpression
+  )) {
+    if (call.getExpression().getKind() !== SyntaxKind.ImportKeyword) {
+      continue
+    }
+
+    const argument = call.getArguments()[0]
+    if (!argument || !Node.isStringLiteral(argument)) {
+      continue
+    }
+
+    const moduleSpecifier = argument.getLiteralValue()
+    if (isOldModule(moduleSpecifier)) {
+      unsupported.push({
+        packageName: getOldPackage(moduleSpecifier),
+        reason: "dynamic imports require manual migration",
+      })
+    }
+  }
+}
+
+function reportExportDeclarations(
+  sourceFile: SourceFile,
+  unsupported: CnMigrationIssue[]
+) {
+  for (const declaration of sourceFile.getExportDeclarations()) {
+    const moduleSpecifier = declaration.getModuleSpecifierValue()
+    if (!moduleSpecifier || !isOldModule(moduleSpecifier)) {
+      continue
+    }
+
+    const packageName = getOldPackage(moduleSpecifier)
+    const namedExports = declaration.getNamedExports()
+    if (!namedExports.length) {
+      unsupported.push({
+        packageName,
+        reason: "export-from declarations require manual migration",
+      })
+      continue
+    }
+
+    for (const specifier of namedExports) {
+      unsupported.push({
+        packageName,
+        symbol: specifier.getName(),
+        reason: "export-from declarations require manual migration",
+      })
+    }
+  }
+}
+
+export function getRemainingPackages(content: string) {
+  return OLD_PACKAGES.filter((packageName) => {
+    const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    return new RegExp(
+      `(?:from\\s*|import\\s*\\(|require\\s*\\()\\s*["']${escaped}(?:/lite)?["']`
+    ).test(content)
+  })
+}
+
+export function dedupeIssues(issues: CnMigrationIssue[]) {
+  return issues.filter(
+    (issue, index) =>
+      issues.findIndex(
+        (candidate) =>
+          candidate.packageName === issue.packageName &&
+          candidate.symbol === issue.symbol &&
+          candidate.reason === issue.reason
+      ) === index
+  )
+}
+
+function getOldPackage(module: OldModule): OldPackage {
+  return module.startsWith("clsx") ? "clsx" : "tailwind-merge"
+}
+
+function isOldModule(value: string): value is OldModule {
+  return value === "clsx" || value === "clsx/lite" || value === "tailwind-merge"
+}

--- a/packages/shadcn/src/migrations/cn/references.ts
+++ b/packages/shadcn/src/migrations/cn/references.ts
@@ -1,0 +1,127 @@
+import { Node, SyntaxKind, type Identifier, type SourceFile } from "ts-morph"
+
+import type { OldModule } from "./types"
+
+export function getLiveReferences(identifier: Identifier) {
+  const symbol = identifier.getSymbol()?.compilerSymbol
+  const candidates = identifier
+    .getSourceFile()
+    .getDescendantsOfKind(SyntaxKind.Identifier)
+    .filter((candidate) => candidate !== identifier)
+  const references = candidates.filter(
+    (candidate) => symbol && candidate.getSymbol()?.compilerSymbol === symbol
+  )
+
+  for (const reference of identifier.findReferencesAsNodes()) {
+    const candidate = candidates.find(
+      (current) =>
+        current.getStart() === reference.getStart() &&
+        current.getText() === reference.getText()
+    )
+    if (candidate && !references.includes(candidate)) {
+      references.push(candidate)
+    }
+  }
+
+  return references
+}
+
+export function getUnsupportedBindingReason(
+  identifier: Identifier,
+  importedName: string
+) {
+  const references = getLiveReferences(identifier)
+
+  if (importedName === "validators") {
+    const hasUnsupportedUsage = references.some((reference) => {
+      const access = reference.getParentIfKind(
+        SyntaxKind.PropertyAccessExpression
+      )
+      if (access) {
+        const call = access.getParentIfKind(SyntaxKind.CallExpression)
+        if (
+          call !== undefined &&
+          call.getExpression().getStart() === access.getStart()
+        ) {
+          return true
+        }
+      }
+
+      const declaration = reference.getParentIfKind(
+        SyntaxKind.VariableDeclaration
+      )
+      return (
+        declaration !== undefined &&
+        Node.isObjectBindingPattern(declaration.getNameNode()) &&
+        declaration.getInitializer()?.getStart() === reference.getStart()
+      )
+    })
+
+    if (hasUnsupportedUsage) {
+      return "callable validators are not supported by cn"
+    }
+  }
+
+  if (importedName === "createTailwindMerge") {
+    const hasVariadicCall = references.some((reference) => {
+      const call = reference.getParentIfKind(SyntaxKind.CallExpression)
+      return (
+        call !== undefined &&
+        call.getExpression().getStart() === reference.getStart() &&
+        call.getArguments().length > 1
+      )
+    })
+
+    if (hasVariadicCall) {
+      return "variadic createTailwindMerge calls are not supported by cn"
+    }
+  }
+
+  return null
+}
+
+export function getAvailableLocalName(
+  sourceFile: SourceFile,
+  preferred: string,
+  fallback: string
+) {
+  const names = new Set(
+    sourceFile
+      .getDescendantsOfKind(SyntaxKind.Identifier)
+      .map((identifier) => identifier.getText())
+  )
+
+  if (!names.has(preferred)) {
+    return preferred
+  }
+  if (!names.has(fallback)) {
+    return fallback
+  }
+
+  let index = 2
+  while (names.has(`${fallback}${index}`)) {
+    index++
+  }
+  return `${fallback}${index}`
+}
+
+export function getRequiredPackage(call: Node) {
+  if (
+    !Node.isCallExpression(call) ||
+    call.getExpression().getText() !== "require"
+  ) {
+    return null
+  }
+
+  const args = call.getArguments()
+  if (args.length !== 1 || !Node.isStringLiteral(args[0])) {
+    return null
+  }
+
+  const value = args[0].getLiteralValue()
+  return isOldModule(value) ? value : null
+}
+
+function isOldModule(value: string): value is OldModule {
+  return value === "clsx" || value === "clsx/lite" || value === "tailwind-merge"
+}

--- a/packages/shadcn/src/migrations/cn/specifiers.ts
+++ b/packages/shadcn/src/migrations/cn/specifiers.ts
@@ -1,0 +1,358 @@
+import {
+  Node,
+  type Identifier,
+  type SourceFile,
+  type VariableDeclaration,
+} from "ts-morph"
+
+import { addPendingImports } from "./emit"
+import { reportUnsupportedReferences } from "./issues"
+import {
+  getLiveReferences,
+  getRequiredPackage,
+  getUnsupportedBindingReason,
+} from "./references"
+import {
+  TAILWIND_CONFIG_EXPORTS,
+  TAILWIND_ROOT_EXPORTS,
+  type CnMigrationIssue,
+  type OldModule,
+  type OldPackage,
+  type PendingImport,
+} from "./types"
+
+export function migrateSpecifiers(
+  sourceFile: SourceFile,
+  pendingImports: PendingImport[],
+  unsupported: CnMigrationIssue[],
+  migratedPackages: Set<OldPackage>,
+  externalContent: string
+) {
+  const changes =
+    migrateEsmImports(
+      sourceFile,
+      pendingImports,
+      unsupported,
+      migratedPackages,
+      externalContent
+    ) + migrateCommonJsRequires(sourceFile, unsupported, migratedPackages)
+
+  reportUnsupportedReferences(sourceFile, unsupported)
+  addPendingImports(sourceFile, pendingImports)
+  return changes
+}
+
+function migrateEsmImports(
+  sourceFile: SourceFile,
+  pendingImports: PendingImport[],
+  unsupported: CnMigrationIssue[],
+  migratedPackages: Set<OldPackage>,
+  externalContent: string
+) {
+  let changes = 0
+
+  for (const declaration of [...sourceFile.getImportDeclarations()]) {
+    const moduleSpecifier = declaration.getModuleSpecifierValue()
+    if (!isOldModule(moduleSpecifier)) {
+      continue
+    }
+
+    const packageName = getOldPackage(moduleSpecifier)
+    const hadImportClause = Boolean(declaration.getImportClause())
+    const namespaceImport = declaration.getNamespaceImport()
+    if (namespaceImport) {
+      unsupported.push({
+        packageName,
+        symbol: namespaceImport.getText(),
+        reason: "namespace imports cannot be migrated safely",
+      })
+    }
+
+    const defaultImport = declaration.getDefaultImport()
+    if (defaultImport) {
+      if (packageName === "clsx") {
+        if (hasReferences(defaultImport, externalContent)) {
+          pendingImports.push({
+            moduleSpecifier: moduleSpecifier === "clsx/lite" ? "cn/lite" : "cn",
+            importedName: "clsx",
+            localName: defaultImport.getText(),
+            isTypeOnly: false,
+          })
+        }
+        declaration.removeDefaultImport()
+        migratedPackages.add("clsx")
+        changes++
+      } else {
+        unsupported.push({
+          packageName,
+          symbol: defaultImport.getText(),
+          reason: "tailwind-merge has no compatible default import mapping",
+        })
+      }
+    }
+
+    for (const specifier of [...declaration.getNamedImports()]) {
+      const importedName = specifier.getName()
+      const localName =
+        specifier.getAliasNode()?.getText() ?? specifier.getNameNode().getText()
+      const isTypeOnly = declaration.isTypeOnly() || specifier.isTypeOnly()
+      const target = getImportTarget(moduleSpecifier, importedName, isTypeOnly)
+
+      if (!target) {
+        unsupported.push({
+          packageName,
+          symbol: importedName,
+          reason:
+            importedName.startsWith("Experimental") ||
+            importedName === "experimentalParseClassName"
+              ? "experimentalParseClassName is not supported by cn"
+              : "no compatible cn export is available",
+        })
+        continue
+      }
+
+      const identifier = specifier.getAliasNode() ?? specifier.getNameNode()
+      if (!Node.isIdentifier(identifier)) {
+        unsupported.push({
+          packageName,
+          symbol: importedName,
+          reason: "string-named imports cannot be migrated safely",
+        })
+        continue
+      }
+
+      const unsupportedReason = getUnsupportedBindingReason(
+        identifier,
+        importedName
+      )
+      if (unsupportedReason) {
+        unsupported.push({
+          packageName,
+          symbol: importedName,
+          reason: unsupportedReason,
+        })
+        continue
+      }
+
+      if (hasReferences(identifier, externalContent)) {
+        pendingImports.push({ ...target, localName, isTypeOnly })
+      }
+      specifier.remove()
+      migratedPackages.add(packageName)
+      changes++
+    }
+
+    if (
+      hadImportClause &&
+      !declaration.getDefaultImport() &&
+      !declaration.getNamespaceImport() &&
+      declaration.getNamedImports().length === 0
+    ) {
+      declaration.remove()
+    } else if (!hadImportClause) {
+      unsupported.push({
+        packageName,
+        reason: "side-effect imports are left unchanged",
+      })
+    }
+  }
+
+  return changes
+}
+
+function getImportTarget(
+  moduleSpecifier: OldModule,
+  importedName: string,
+  isTypeOnly: boolean
+): Omit<PendingImport, "localName" | "isTypeOnly"> | null {
+  if (moduleSpecifier === "clsx") {
+    return {
+      moduleSpecifier: "cn",
+      importedName: importedName === "default" ? "clsx" : importedName,
+    }
+  }
+
+  if (moduleSpecifier === "clsx/lite") {
+    if (
+      (importedName === "clsx" || importedName === "default") &&
+      !isTypeOnly
+    ) {
+      return { moduleSpecifier: "cn/lite", importedName: "clsx" }
+    }
+
+    if (
+      ["ClassValue", "ClassArray", "ClassDictionary"].includes(importedName)
+    ) {
+      return { moduleSpecifier: "cn", importedName }
+    }
+    return null
+  }
+
+  if (TAILWIND_ROOT_EXPORTS.has(importedName)) {
+    return { moduleSpecifier: "cn", importedName }
+  }
+
+  const configExport = TAILWIND_CONFIG_EXPORTS.get(importedName)
+  return configExport
+    ? { moduleSpecifier: "cn/config", importedName: configExport }
+    : null
+}
+
+function migrateCommonJsRequires(
+  sourceFile: SourceFile,
+  unsupported: CnMigrationIssue[],
+  migratedPackages: Set<OldPackage>
+) {
+  let changes = 0
+
+  for (const declaration of sourceFile.getVariableDeclarations()) {
+    const initializer = declaration.getInitializer()
+    if (!initializer || !Node.isCallExpression(initializer)) {
+      continue
+    }
+
+    const requiredPackage = getRequiredPackage(initializer)
+    if (!requiredPackage) {
+      continue
+    }
+
+    const packageName = getOldPackage(requiredPackage)
+    const nameNode = declaration.getNameNode()
+    if (Node.isIdentifier(nameNode) && requiredPackage.startsWith("clsx")) {
+      if (!getLiveReferences(nameNode).length) {
+        removeVariableDeclaration(declaration)
+      } else {
+        initializer.replaceWithText(
+          `require(${JSON.stringify(
+            requiredPackage === "clsx/lite" ? "cn/lite" : "cn"
+          )}).clsx`
+        )
+      }
+      migratedPackages.add("clsx")
+      changes++
+      continue
+    }
+
+    if (!Node.isObjectBindingPattern(nameNode)) {
+      unsupported.push({
+        packageName,
+        reason: "this CommonJS require shape cannot be migrated safely",
+      })
+      continue
+    }
+
+    const elements = nameNode.getElements()
+    const unsafeElement = elements.find((element) => {
+      const identifier = element.getNameNode()
+      const importedName =
+        element.getPropertyNameNode()?.getText() ?? identifier.getText()
+      return (
+        Node.isIdentifier(identifier) &&
+        getUnsupportedBindingReason(identifier, importedName)
+      )
+    })
+    if (unsafeElement) {
+      const identifier = unsafeElement.getNameNode() as Identifier
+      const importedName =
+        unsafeElement.getPropertyNameNode()?.getText() ?? identifier.getText()
+      unsupported.push({
+        packageName,
+        symbol: importedName,
+        reason: getUnsupportedBindingReason(identifier, importedName)!,
+      })
+      continue
+    }
+
+    if (
+      elements.every((element) => {
+        const identifier = element.getNameNode()
+        return (
+          Node.isIdentifier(identifier) && !getLiveReferences(identifier).length
+        )
+      })
+    ) {
+      removeVariableDeclaration(declaration)
+      migratedPackages.add(packageName)
+      changes++
+      continue
+    }
+
+    const importedNames = elements.map(
+      (element) =>
+        element.getPropertyNameNode()?.getText() ??
+        element.getNameNode().getText()
+    )
+    const targetModules = new Set(
+      importedNames.map(
+        (importedName) =>
+          getImportTarget(requiredPackage, importedName, false)
+            ?.moduleSpecifier ?? null
+      )
+    )
+
+    if (targetModules.size !== 1 || targetModules.has(null)) {
+      unsupported.push({
+        packageName,
+        reason:
+          "mixed or unsupported CommonJS exports require manual migration",
+      })
+      continue
+    }
+
+    initializer
+      .getArguments()[0]
+      .replaceWithText(JSON.stringify(Array.from(targetModules)[0]))
+
+    for (const element of elements) {
+      const importedName =
+        element.getPropertyNameNode()?.getText() ??
+        element.getNameNode().getText()
+      const target = getImportTarget(requiredPackage, importedName, false)!
+      if (target.importedName !== importedName) {
+        element.replaceWithText(
+          `${target.importedName}: ${element.getNameNode().getText()}`
+        )
+      }
+    }
+
+    migratedPackages.add(packageName)
+    changes++
+  }
+
+  return changes
+}
+
+function removeVariableDeclaration(declaration: VariableDeclaration) {
+  const statement = declaration.getVariableStatement()
+  if (statement?.getDeclarations().length === 1) {
+    statement.remove()
+  } else {
+    declaration.remove()
+  }
+}
+
+function hasReferences(identifier: Identifier, externalContent: string) {
+  return (
+    getLiveReferences(identifier).length > 0 ||
+    containsIdentifier(externalContent, identifier.getText())
+  )
+}
+
+function containsIdentifier(content: string, identifier: string) {
+  if (!content) {
+    return false
+  }
+
+  const escaped = identifier.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  return new RegExp(`(^|[^a-zA-Z0-9_$])${escaped}(?=$|[^a-zA-Z0-9_$])`).test(
+    content
+  )
+}
+
+function getOldPackage(module: OldModule): OldPackage {
+  return module.startsWith("clsx") ? "clsx" : "tailwind-merge"
+}
+
+function isOldModule(value: string): value is OldModule {
+  return value === "clsx" || value === "clsx/lite" || value === "tailwind-merge"
+}

--- a/packages/shadcn/src/migrations/cn/transform.ts
+++ b/packages/shadcn/src/migrations/cn/transform.ts
@@ -1,0 +1,167 @@
+import path from "path"
+import { Project } from "ts-morph"
+
+import { collapseCanonicalWrappers, findCompositions } from "./bindings"
+import { collectBindings } from "./collect-bindings"
+import { addCommonJsCnRequire } from "./emit"
+import {
+  getAstroFrontmatterRegions,
+  getScriptKind,
+  getScriptRegions,
+  normalizeVirtualFilename,
+} from "./files"
+import { dedupeIssues, getRemainingPackages } from "./issues"
+import { getAvailableLocalName } from "./references"
+import { migrateSpecifiers } from "./specifiers"
+import type {
+  CnMigrationIssue,
+  CnSourceTransformResult,
+  OldPackage,
+  PendingImport,
+  SourceRegion,
+} from "./types"
+
+export function transformCnSource(
+  content: string,
+  filename: string = "source.tsx"
+): CnSourceTransformResult {
+  return createCnTransformer()(content, filename)
+}
+
+export function createCnTransformer() {
+  const project = new Project({
+    useInMemoryFileSystem: true,
+    compilerOptions: { allowJs: true },
+  })
+
+  return (content: string, filename: string = "source.tsx") => {
+    const extension = path.extname(filename).toLowerCase()
+
+    if (extension === ".vue" || extension === ".svelte") {
+      return transformSourceRegions(
+        content,
+        getScriptRegions(content, filename),
+        project
+      )
+    }
+
+    if (extension === ".astro") {
+      return transformSourceRegions(
+        content,
+        [
+          ...getAstroFrontmatterRegions(content, filename),
+          ...getScriptRegions(content, filename),
+        ],
+        project
+      )
+    }
+
+    return transformScriptSource(content, filename, project)
+  }
+}
+
+function transformScriptSource(
+  content: string,
+  filename: string,
+  project: Project,
+  externalContent = ""
+): CnSourceTransformResult {
+  const sourceFile = project.createSourceFile(
+    normalizeVirtualFilename(filename),
+    content,
+    {
+      scriptKind: getScriptKind(filename),
+      overwrite: true,
+    }
+  )
+  const pendingImports: PendingImport[] = []
+  const unsupported: CnMigrationIssue[] = []
+  const migratedPackages = new Set<OldPackage>()
+  const bindings = collectBindings(sourceFile)
+  let changes = collapseCanonicalWrappers(
+    sourceFile,
+    bindings,
+    migratedPackages
+  )
+
+  const compositions = findCompositions(sourceFile, bindings)
+  if (compositions.length) {
+    const cnLocalName = getAvailableLocalName(sourceFile, "cn", "cnMerge")
+    const hasEsmComposition = compositions.some(
+      (composition) => composition.kind === "esm"
+    )
+
+    if (hasEsmComposition) {
+      pendingImports.push({
+        moduleSpecifier: "cn",
+        importedName: "cn",
+        localName: cnLocalName,
+        isTypeOnly: false,
+      })
+    } else {
+      addCommonJsCnRequire(sourceFile, cnLocalName)
+    }
+
+    for (const { outerCall, argumentsText } of compositions.reverse()) {
+      outerCall.replaceWithText(`${cnLocalName}(${argumentsText})`)
+      changes++
+    }
+    migratedPackages.add("clsx")
+    migratedPackages.add("tailwind-merge")
+  }
+
+  changes += migrateSpecifiers(
+    sourceFile,
+    pendingImports,
+    unsupported,
+    migratedPackages,
+    externalContent
+  )
+
+  const result = {
+    content: sourceFile.getText(),
+    changes,
+    migratedPackages: Array.from(migratedPackages),
+    remainingPackages: getRemainingPackages(sourceFile.getText()),
+    unsupported: dedupeIssues(unsupported),
+  }
+  project.removeSourceFile(sourceFile)
+
+  return result
+}
+
+function transformSourceRegions(
+  content: string,
+  regions: SourceRegion[],
+  project: Project
+) {
+  let transformed = content
+  let changes = 0
+  const migratedPackages = new Set<OldPackage>()
+  const unsupported: CnMigrationIssue[] = []
+
+  for (const region of regions.sort((a, b) => b.start - a.start)) {
+    const source = transformed.slice(region.start, region.end)
+    const externalContent = `${transformed.slice(0, region.start)}${transformed.slice(region.end)}`
+    const result = transformScriptSource(
+      source,
+      region.filename,
+      project,
+      externalContent
+    )
+    transformed = `${transformed.slice(0, region.start)}${result.content}${transformed.slice(region.end)}`
+    changes += result.changes
+    result.migratedPackages.forEach((packageName) =>
+      migratedPackages.add(packageName)
+    )
+    unsupported.push(...result.unsupported)
+  }
+
+  return {
+    content: transformed,
+    changes,
+    migratedPackages: Array.from(migratedPackages),
+    remainingPackages: getRemainingPackages(transformed),
+    unsupported: dedupeIssues(unsupported),
+  } satisfies CnSourceTransformResult
+}

--- a/packages/shadcn/src/migrations/cn/transform.ts
+++ b/packages/shadcn/src/migrations/cn/transform.ts
@@ -2,6 +2,7 @@ import path from "path"
 import { Project } from "ts-morph"
 
 import { collapseCanonicalWrappers, findCompositions } from "./bindings"
+import { migrateCnfastSpecifiers } from "./cnfast"
 import { collectBindings } from "./collect-bindings"
 import { addCommonJsCnRequire } from "./emit"
 import {
@@ -77,12 +78,9 @@ function transformScriptSource(
   const pendingImports: PendingImport[] = []
   const unsupported: CnMigrationIssue[] = []
   const migratedPackages = new Set<OldPackage>()
+  let changes = migrateCnfastSpecifiers(sourceFile, migratedPackages)
   const bindings = collectBindings(sourceFile)
-  let changes = collapseCanonicalWrappers(
-    sourceFile,
-    bindings,
-    migratedPackages
-  )
+  changes += collapseCanonicalWrappers(sourceFile, bindings, migratedPackages)
 
   const compositions = findCompositions(sourceFile, bindings)
   if (compositions.length) {

--- a/packages/shadcn/src/migrations/cn/types.ts
+++ b/packages/shadcn/src/migrations/cn/types.ts
@@ -1,0 +1,61 @@
+import type { Identifier } from "ts-morph"
+
+export const OLD_PACKAGES = ["clsx", "tailwind-merge"] as const
+
+export const TAILWIND_ROOT_EXPORTS = new Set([
+  "twMerge",
+  "twJoin",
+  "ClassNameValue",
+])
+
+export const TAILWIND_CONFIG_EXPORTS = new Map([
+  ["extendTailwindMerge", "extendTailwindMerge"],
+  ["createTailwindMerge", "createTwMerge"],
+  ["getDefaultConfig", "defaultConfig"],
+  ["fromTheme", "fromTheme"],
+  ["validators", "validators"],
+  ["mergeConfigs", "mergeConfigs"],
+  ["ConfigExtension", "ConfigExtension"],
+  ["DefaultClassGroupIds", "DefaultClassGroupIds"],
+  ["DefaultThemeGroupIds", "DefaultThemeGroupIds"],
+])
+
+export type OldPackage = (typeof OLD_PACKAGES)[number]
+export type OldModule = OldPackage | "clsx/lite"
+export type CnModule = "cn" | "cn/config" | "cn/lite"
+
+export type CnMigrationIssue = {
+  file?: string
+  packageName: OldPackage
+  symbol?: string
+  reason: string
+}
+
+export type CnSourceTransformResult = {
+  content: string
+  changes: number
+  migratedPackages: OldPackage[]
+  remainingPackages: OldPackage[]
+  unsupported: CnMigrationIssue[]
+}
+
+export type Binding = {
+  identifier: Identifier
+  localName: string
+  importedName: string
+  module: OldModule
+  kind: "esm" | "cjs"
+}
+
+export type PendingImport = {
+  moduleSpecifier: CnModule
+  importedName: string
+  localName: string
+  isTypeOnly: boolean
+}
+
+export type SourceRegion = {
+  start: number
+  end: number
+  filename: string
+}

--- a/packages/shadcn/src/migrations/cn/types.ts
+++ b/packages/shadcn/src/migrations/cn/types.ts
@@ -1,6 +1,6 @@
 import type { Identifier } from "ts-morph"
 
-export const OLD_PACKAGES = ["clsx", "tailwind-merge"] as const
+export const OLD_PACKAGES = ["clsx", "tailwind-merge", "cnfast"] as const
 
 export const TAILWIND_ROOT_EXPORTS = new Set([
   "twMerge",
@@ -21,7 +21,7 @@ export const TAILWIND_CONFIG_EXPORTS = new Map([
 ])
 
 export type OldPackage = (typeof OLD_PACKAGES)[number]
-export type OldModule = OldPackage | "clsx/lite"
+export type OldModule = Exclude<OldPackage, "cnfast"> | "clsx/lite"
 export type CnModule = "cn" | "cn/config" | "cn/lite"
 
 export type CnMigrationIssue = {

--- a/packages/shadcn/src/migrations/migrate-cn.test.ts
+++ b/packages/shadcn/src/migrations/migrate-cn.test.ts
@@ -220,6 +220,30 @@ const merged = twMerge("px-2 px-4")
     expect(result.content).toContain('const merged = twMerge("px-2 px-4")')
   })
 
+  it("swaps cnfast module specifiers without changing its API", () => {
+    const result =
+      transformCnSource(`import { cn, clsx, twMerge, twJoin } from "cnfast"
+
+export { cn as merge } from "cnfast"
+export * from "cnfast"
+export const loadCn = () => import("cnfast")
+export const runtime = require("cnfast")
+export const classes = cn(clsx("px-2"), twMerge("px-4"), twJoin("flex"))
+`)
+
+    expect(result.content).not.toContain('"cnfast"')
+    expect(result.content).toContain(
+      'import { cn, clsx, twMerge, twJoin } from "cn"'
+    )
+    expect(result.content).toContain('export { cn as merge } from "cn"')
+    expect(result.content).toContain('export * from "cn"')
+    expect(result.content).toContain('import("cn")')
+    expect(result.content).toContain('require("cn")')
+    expect(result.migratedPackages).toEqual(["cnfast"])
+    expect(result.remainingPackages).toEqual([])
+    expect(result.unsupported).toEqual([])
+  })
+
   it("splits root and custom-config imports", () => {
     const result = transformCnSource(`import {
   twMerge,
@@ -879,6 +903,21 @@ export const classes = clsx("flex")
 
     expect(installDependencies).toHaveBeenCalledWith(cwd, ["cn"])
     expect(removeDependencies).toHaveBeenCalledWith(cwd, ["clsx"])
+  })
+
+  it("migrates cnfast and removes its dependency", async () => {
+    await setupProject({
+      source: `export { cn } from "cnfast"
+`,
+      dependencies: { cnfast: "^0.1.0" },
+    })
+    await migrateCn({ cwd, yes: true })
+
+    expect(
+      (await fs.readFile(path.join(cwd, "src/classes.ts"), "utf-8")).trim()
+    ).toBe('export { cn } from "cn"')
+    expect(installDependencies).toHaveBeenCalledWith(cwd, ["cn"])
+    expect(removeDependencies).toHaveBeenCalledWith(cwd, ["cnfast"])
   })
 
   it("scans dot directories before removing old dependencies", async () => {

--- a/packages/shadcn/src/migrations/migrate-cn.test.ts
+++ b/packages/shadcn/src/migrations/migrate-cn.test.ts
@@ -529,13 +529,13 @@ import { clsx } from "clsx"
     )
   })
 
-  it("transforms script blocks with whitespace in the closing tag", () => {
+  it("transforms browser-tolerated script closing tags", () => {
     const result = transformCnSource(
       `<script setup lang="ts">
 import { clsx } from "clsx"
 
 const classes = clsx("flex")
-</script >
+</script\t\n bar>
 
 <template><div :class="classes" /></template>
 `,
@@ -544,7 +544,7 @@ const classes = clsx("flex")
 
     expect(result.content).toContain('import { clsx } from "cn"')
     expect(result.content).toContain('const classes = clsx("flex")')
-    expect(result.content).toContain("</script >")
+    expect(result.content).toContain("</script\t\n bar>")
   })
 
   it("preserves Svelte imports referenced only by the markup", () => {

--- a/packages/shadcn/src/migrations/migrate-cn.test.ts
+++ b/packages/shadcn/src/migrations/migrate-cn.test.ts
@@ -1,0 +1,895 @@
+import { promises as fs } from "fs"
+import { tmpdir } from "os"
+import path from "path"
+import {
+  installDependencies,
+  removeDependencies,
+} from "@/src/utils/updaters/update-dependencies"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createCnTransformer } from "./cn/transform"
+import { migrateCn, transformCnSource } from "./migrate-cn"
+
+vi.mock("@/src/utils/spinner", () => ({
+  spinner: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn(),
+    fail: vi.fn(),
+    text: "",
+  })),
+}))
+
+vi.mock("@/src/utils/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    break: vi.fn(),
+  },
+}))
+
+vi.mock("@/src/utils/updaters/update-dependencies", () => ({
+  installDependencies: vi.fn(),
+  removeDependencies: vi.fn(),
+}))
+
+describe("transformCnSource", () => {
+  it("replaces an exported shadcn helper with a direct re-export", () => {
+    const result =
+      transformCnSource(`import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+`)
+
+    expect(result.content.trim()).toBe('export { cn } from "cn";')
+    expect(result.migratedPackages).toEqual(["clsx", "tailwind-merge"])
+    expect(result.remainingPackages).toEqual([])
+  })
+
+  it("replaces a separately exported function declaration", () => {
+    const result = transformCnSource(`import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+function cn(...inputs) {
+  return twMerge(clsx(inputs))
+}
+
+export { cn }
+`)
+
+    expect(result.content.trim()).toBe('export { cn } from "cn";')
+  })
+
+  it("replaces a separately exported const declaration", () => {
+    const result = transformCnSource(`import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+const cn = (...inputs) => twMerge(clsx(inputs))
+
+export { cn }
+`)
+
+    expect(result.content.trim()).toBe('export { cn } from "cn";')
+  })
+
+  it("preserves an aliased public export", () => {
+    const result = transformCnSource(`import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+const cx = (...inputs) => twMerge(clsx(inputs))
+
+export { cx }
+`)
+
+    expect(result.content.trim()).toBe('export { cn as cx } from "cn";')
+  })
+
+  it("keeps a locally used helper and aliases the package import", () => {
+    const result =
+      transformCnSource(`import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+
+const buttonClassName = cn("px-2", "px-4")
+
+export { buttonClassName, cn }
+`)
+
+    expect(result.content).toContain(
+      'import { cn as cnMerge, type ClassValue } from "cn"'
+    )
+    expect(result.content).toContain("return cnMerge(...inputs)")
+    expect(result.content).toContain("export { buttonClassName, cn }")
+    expect(result.content).not.toContain('from "clsx"')
+    expect(result.content).not.toContain('from "tailwind-merge"')
+  })
+
+  it("preserves a default-exported helper", () => {
+    const result = transformCnSource(`import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+const cn = (...inputs) => twMerge(clsx(inputs))
+
+export default cn
+`)
+
+    expect(result.content).toContain('import { cn as cnMerge } from "cn"')
+    expect(result.content).toContain(
+      "const cn = (...inputs) => cnMerge(...inputs)"
+    )
+    expect(result.content).toContain("export default cn")
+  })
+
+  it("preserves an inline default export when collapsing a helper", () => {
+    const result = transformCnSource(`import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export default function cn(...inputs) {
+  return twMerge(clsx(inputs))
+}
+`)
+
+    expect(result.content.trim()).toBe('export { cn as default } from "cn";')
+  })
+
+  it("preserves named and default exports for the same helper", () => {
+    const result = transformCnSource(`import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export default function cn(...inputs) {
+  return twMerge(clsx(inputs))
+}
+
+export { cn }
+`)
+
+    expect(result.content).toContain("cn as default")
+    expect(result.content).toMatch(/export \{[^}]*\bcn\b[^}]*\} from "cn"/)
+  })
+
+  it("does not crash on an anonymous default-exported helper", () => {
+    const result = transformCnSource(`import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export default function (...inputs) {
+  return twMerge(clsx(inputs))
+}
+`)
+
+    expect(result.content).toContain('import { cn } from "cn"')
+    expect(result.content).toContain("export default function (...inputs)")
+    expect(result.content).toContain("return cn(...inputs)")
+  })
+
+  it("collapses helpers that spread their rest parameter into clsx", () => {
+    const result = transformCnSource(`import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs) {
+  return twMerge(clsx(...inputs))
+}
+`)
+
+    expect(result.content.trim()).toBe('export { cn } from "cn";')
+  })
+
+  it("rewrites a composed default clsx import", () => {
+    const result = transformCnSource(`import cx from "clsx"
+import { twMerge as merge } from "tailwind-merge"
+
+const className = merge(cx("px-2", active && "px-4"))
+`)
+
+    expect(result.content).toContain('import { cn } from "cn"')
+    expect(result.content).toContain(
+      'const className = cn("px-2", active && "px-4")'
+    )
+    expect(result.content).not.toContain("clsx")
+    expect(result.content).not.toContain("tailwind-merge")
+  })
+
+  it("flattens clsx calls mixed with other twMerge arguments", () => {
+    const result = transformCnSource(`import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+const className = twMerge("px-1", clsx(active && "px-2"), "px-4")
+`)
+
+    expect(result.content).toContain(
+      'const className = cn("px-1", active && "px-2", "px-4")'
+    )
+  })
+
+  it("keeps separate clsx and twMerge calls as separate APIs", () => {
+    const result = transformCnSource(`import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+const conditional = clsx("flex", enabled && "block")
+const merged = twMerge("px-2 px-4")
+`)
+
+    expect(result.content).toContain('import { clsx, twMerge } from "cn"')
+    expect(result.content).toContain(
+      'const conditional = clsx("flex", enabled && "block")'
+    )
+    expect(result.content).toContain('const merged = twMerge("px-2 px-4")')
+  })
+
+  it("splits root and custom-config imports", () => {
+    const result = transformCnSource(`import {
+  twMerge,
+  extendTailwindMerge,
+  createTailwindMerge,
+  getDefaultConfig,
+  type ConfigExtension,
+} from "tailwind-merge"
+
+export { twMerge, extendTailwindMerge, createTailwindMerge, getDefaultConfig }
+export type { ConfigExtension }
+`)
+
+    expect(result.content).toContain('import { twMerge } from "cn"')
+    expect(result.content).toContain(
+      'import { extendTailwindMerge, createTwMerge as createTailwindMerge, defaultConfig as getDefaultConfig, type ConfigExtension } from "cn/config"'
+    )
+    expect(result.remainingPackages).toEqual([])
+  })
+
+  it("moves clsx/lite runtime imports and root types separately", () => {
+    const result =
+      transformCnSource(`import clsx, { type ClassValue } from "clsx/lite"
+
+export const classes = (...inputs: ClassValue[]) => clsx(inputs)
+`)
+
+    expect(result.content).toContain('import { clsx } from "cn/lite"')
+    expect(result.content).toContain('import { type ClassValue } from "cn"')
+  })
+
+  it("maps a named default clsx import to the named cn export", () => {
+    const result = transformCnSource(`import { default as cx } from "clsx/lite"
+
+export const classes = cx("flex", active && "block")
+`)
+
+    expect(result.content).toContain('import { clsx as cx } from "cn/lite"')
+    expect(result.content).not.toContain('from "clsx/lite"')
+  })
+
+  it("migrates clsx imports in JavaScript files", () => {
+    const result = transformCnSource(
+      `import { clsx } from "clsx"
+
+export const classes = clsx("flex")
+`,
+      "classes.js"
+    )
+
+    expect(result.content).toContain('import { clsx } from "cn"')
+    expect(result.content).toContain('export const classes = clsx("flex")')
+  })
+
+  it("migrates CommonJS requires in cjs files", () => {
+    const result = transformCnSource(
+      `const cx = require("clsx")
+
+module.exports = cx("flex")
+`,
+      "classes.cjs"
+    )
+
+    expect(result.content).toContain('const cx = require("cn").clsx')
+    expect(result.content).toContain('module.exports = cx("flex")')
+  })
+
+  it("migrates compositions in JSX files", () => {
+    const result = transformCnSource(
+      `import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export const element = <div className={twMerge(clsx("px-2"))} />
+`,
+      "component.jsx"
+    )
+
+    expect(result.content).toContain('import { cn } from "cn"')
+    expect(result.content).toContain('<div className={cn("px-2")} />')
+  })
+
+  it("leaves direct validator calls for manual review", () => {
+    const result =
+      transformCnSource(`import { validators } from "tailwind-merge"
+
+export const valid = validators.isNumber("2")
+`)
+
+    expect(result.content).toContain('from "tailwind-merge"')
+    expect(result.remainingPackages).toEqual(["tailwind-merge"])
+    expect(result.unsupported).toContainEqual({
+      packageName: "tailwind-merge",
+      symbol: "validators",
+      reason: "callable validators are not supported by cn",
+    })
+  })
+
+  it("leaves destructured validators for manual review", () => {
+    const result =
+      transformCnSource(`import { validators } from "tailwind-merge"
+
+const { isNumber } = validators
+export const valid = isNumber("2")
+`)
+
+    expect(result.content).toContain('from "tailwind-merge"')
+    expect(result.unsupported).toContainEqual({
+      packageName: "tailwind-merge",
+      symbol: "validators",
+      reason: "callable validators are not supported by cn",
+    })
+  })
+
+  it("migrates validators used as configuration markers", () => {
+    const result = transformCnSource(`import {
+  extendTailwindMerge,
+  validators,
+} from "tailwind-merge"
+
+export const merge = extendTailwindMerge({
+  extend: { classGroups: { tab: [validators.isNumber] } },
+})
+`)
+
+    expect(result.content).toContain(
+      'import { extendTailwindMerge, validators } from "cn/config"'
+    )
+    expect(result.remainingPackages).toEqual([])
+  })
+
+  it("leaves variadic createTailwindMerge calls for manual review", () => {
+    const result =
+      transformCnSource(`import { createTailwindMerge } from "tailwind-merge"
+
+export const merge = createTailwindMerge(() => config, () => extension)
+`)
+
+    expect(result.content).toContain('from "tailwind-merge"')
+    expect(result.unsupported).toContainEqual({
+      packageName: "tailwind-merge",
+      symbol: "createTailwindMerge",
+      reason: "variadic createTailwindMerge calls are not supported by cn",
+    })
+  })
+
+  it("leaves unsupported experimental imports for manual review", () => {
+    const result = transformCnSource(`import {
+  twMerge,
+  type ExperimentalParseClassNameParam,
+} from "tailwind-merge"
+
+export { twMerge }
+export type { ExperimentalParseClassNameParam }
+`)
+
+    expect(result.content).toContain('import { twMerge } from "cn"')
+    expect(result.content).toContain("type ExperimentalParseClassNameParam")
+    expect(result.content).toContain('from "tailwind-merge"')
+    expect(result.remainingPackages).toEqual(["tailwind-merge"])
+    expect(result.unsupported).toEqual([
+      {
+        packageName: "tailwind-merge",
+        symbol: "ExperimentalParseClassNameParam",
+        reason: "experimentalParseClassName is not supported by cn",
+      },
+    ])
+  })
+
+  it("reports dynamic imports without changing them", () => {
+    const input = `export const loadMerge = () => import("tailwind-merge")
+`
+    const result = transformCnSource(input)
+
+    expect(result.content).toBe(input)
+    expect(result.remainingPackages).toEqual(["tailwind-merge"])
+    expect(result.unsupported).toEqual([
+      {
+        packageName: "tailwind-merge",
+        reason: "dynamic imports require manual migration",
+      },
+    ])
+  })
+
+  it("reports export-from declarations without changing them", () => {
+    const input = `export { twMerge } from "tailwind-merge"
+export * from "clsx"
+`
+    const result = transformCnSource(input)
+
+    expect(result.content).toBe(input)
+    expect(result.remainingPackages).toEqual(["clsx", "tailwind-merge"])
+    expect(result.unsupported).toEqual([
+      {
+        packageName: "tailwind-merge",
+        symbol: "twMerge",
+        reason: "export-from declarations require manual migration",
+      },
+      {
+        packageName: "clsx",
+        reason: "export-from declarations require manual migration",
+      },
+    ])
+  })
+
+  it("migrates supported CommonJS requires", () => {
+    const result = transformCnSource(`const cx = require("clsx")
+const { twMerge } = require("tailwind-merge")
+
+module.exports = (...inputs) => twMerge(cx(inputs))
+`)
+
+    expect(result.content).toContain('const { cn } = require("cn")')
+    expect(result.content).toContain(
+      "module.exports = (...inputs) => cn(...inputs)"
+    )
+    expect(result.content).not.toContain("const cx")
+    expect(result.content).not.toContain("twMerge")
+    expect(result.remainingPackages).toEqual([])
+  })
+
+  it("keeps referenced CommonJS clsx bindings on cn", () => {
+    const result = transformCnSource(`const cx = require("clsx")
+const { twMerge } = require("tailwind-merge")
+
+const merged = twMerge(cx("px-2", "px-4"))
+const joined = cx("flex", active && "block")
+
+module.exports = { merged, joined }
+`)
+
+    expect(result.content).toContain('const cx = require("cn").clsx')
+    expect(result.content).toContain('const { cn } = require("cn")')
+    expect(result.content).toContain('const merged = cn("px-2", "px-4")')
+    expect(result.content).toContain(
+      'const joined = cx("flex", active && "block")'
+    )
+  })
+
+  it("leaves unsafe CommonJS config calls for manual review", () => {
+    const result =
+      transformCnSource(`const { validators } = require("tailwind-merge")
+
+module.exports = validators.isNumber("2")
+`)
+
+    expect(result.content).toContain('require("tailwind-merge")')
+    expect(result.unsupported).toContainEqual({
+      packageName: "tailwind-merge",
+      symbol: "validators",
+      reason: "callable validators are not supported by cn",
+    })
+  })
+
+  it("reports CommonJS requires that span multiple cn entrypoints", () => {
+    const result = transformCnSource(`const {
+  twMerge,
+  extendTailwindMerge,
+} = require("tailwind-merge")
+
+module.exports = { twMerge, extendTailwindMerge }
+`)
+
+    expect(result.content).toContain('require("tailwind-merge")')
+    expect(result.unsupported).toContainEqual({
+      packageName: "tailwind-merge",
+      reason: "mixed or unsupported CommonJS exports require manual migration",
+    })
+  })
+
+  it("transforms Vue script blocks without changing the template", () => {
+    const result = transformCnSource(
+      `<script setup lang="ts">
+import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+const classes = twMerge(clsx("px-2", active && "px-4"))
+</script>
+
+<template><div :class="classes" /></template>
+`,
+      "component.vue"
+    )
+
+    expect(result.content).toContain('import { cn } from "cn"')
+    expect(result.content).toContain(
+      'const classes = cn("px-2", active && "px-4")'
+    )
+    expect(result.content).toContain(
+      '<template><div :class="classes" /></template>'
+    )
+  })
+
+  it("preserves Vue imports referenced only by the template", () => {
+    const result = transformCnSource(
+      `<script setup lang="ts">
+import { clsx } from "clsx"
+</script>
+
+<template><div :class="clsx('flex', active && 'block')" /></template>
+`,
+      "component.vue"
+    )
+
+    expect(result.content).toContain('import { clsx } from "cn"')
+    expect(result.content).toContain(
+      `<template><div :class="clsx('flex', active && 'block')" /></template>`
+    )
+  })
+
+  it("preserves Svelte imports referenced only by the markup", () => {
+    const result = transformCnSource(
+      `<script lang="ts">
+import { clsx } from "clsx"
+</script>
+
+<div class={clsx("flex", active && "block")} />
+`,
+      "component.svelte"
+    )
+
+    expect(result.content).toContain('import { clsx } from "cn"')
+    expect(result.content).toContain(
+      '<div class={clsx("flex", active && "block")} />'
+    )
+  })
+
+  it("transforms plain JavaScript Svelte script blocks", () => {
+    const result = transformCnSource(
+      `<script>
+import { clsx } from "clsx"
+
+const classes = clsx("flex", active && "block")
+</script>
+
+<div class={classes} />
+`,
+      "component.svelte"
+    )
+
+    expect(result.content).toContain('import { clsx } from "cn"')
+    expect(result.content).toContain(
+      'const classes = clsx("flex", active && "block")'
+    )
+  })
+
+  it("transforms Astro frontmatter", () => {
+    const result = transformCnSource(
+      `---
+import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+const classes = twMerge(clsx("px-2", Astro.props.className))
+---
+
+<div class={classes}><slot /></div>
+`,
+      "component.astro"
+    )
+
+    expect(result.content).toContain('import { cn } from "cn"')
+    expect(result.content).toContain(
+      'const classes = cn("px-2", Astro.props.className)'
+    )
+  })
+
+  it("preserves Astro imports referenced only by the template", () => {
+    const result = transformCnSource(
+      `---
+import { clsx } from "clsx"
+---
+
+<div class={clsx("flex", Astro.props.active && "block")} />
+`,
+      "component.astro"
+    )
+
+    expect(result.content).toContain('import { clsx } from "cn"')
+    expect(result.content).toContain(
+      '<div class={clsx("flex", Astro.props.active && "block")} />'
+    )
+  })
+
+  it("parses legacy TypeScript assertions without treating them as JSX", () => {
+    const result = transformCnSource(
+      `import { clsx } from "clsx"
+
+const element = <HTMLInputElement>document.getElementById("field")
+export const classes = clsx("flex", element.disabled && "opacity-50")
+`,
+      "classes.ts"
+    )
+
+    expect(result.content).toContain('import { clsx } from "cn"')
+    expect(result.content).toContain(
+      'const element = <HTMLInputElement>document.getElementById("field")'
+    )
+    expect(result.content).toContain(
+      'export const classes = clsx("flex", element.disabled && "opacity-50")'
+    )
+  })
+
+  it("uses the script language when parsing embedded TypeScript", () => {
+    const result = transformCnSource(
+      `<script setup lang="ts">
+import { clsx } from "clsx"
+
+const element = <HTMLInputElement>document.getElementById("field")
+const classes = clsx("flex", element.disabled && "opacity-50")
+</script>
+
+<template><div :class="classes" /></template>
+`,
+      "component.vue"
+    )
+
+    expect(result.content).toContain('import { clsx } from "cn"')
+    expect(result.content).toContain(
+      'const element = <HTMLInputElement>document.getElementById("field")'
+    )
+  })
+
+  it("does not retain imports for shadowed ESM bindings", () => {
+    const result = transformCnSource(`import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+const merged = twMerge(clsx("px-2", "px-4"))
+
+export function join(clsx) {
+  return clsx("flex")
+}
+`)
+
+    expect(result.content).toContain('import { cn } from "cn"')
+    expect(result.content).not.toMatch(/import \{[^}]*clsx[^}]*\} from "cn"/)
+    expect(result.content).toContain('return clsx("flex")')
+  })
+
+  it("does not retain references from earlier transformed files", () => {
+    const transform = createCnTransformer()
+    transform(
+      `import { cn } from "./utils"
+
+export const classes = cn("px-2")
+`,
+      "/repo/src/lib/button.tsx"
+    )
+    const utils = transform(
+      `import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs) {
+  return twMerge(clsx(inputs))
+}
+`,
+      "/repo/src/lib/utils.ts"
+    )
+
+    expect(utils.content.trim()).toBe('export { cn } from "cn";')
+  })
+
+  it("is idempotent", () => {
+    const input = `import { clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export const classes = twMerge(clsx("px-2", active && "px-4"))
+`
+    const first = transformCnSource(input)
+    const second = transformCnSource(first.content)
+
+    expect(second.content).toBe(first.content)
+    expect(second.changes).toBe(0)
+  })
+
+  it("does not replace unrelated functions with the same names", () => {
+    const input = `function clsx(value) {
+  return value
+}
+
+function twMerge(value) {
+  return value
+}
+
+export const cn = (value) => twMerge(clsx(value))
+`
+
+    expect(transformCnSource(input).content).toBe(input)
+  })
+})
+
+describe("migrateCn", () => {
+  let cwd: string
+
+  beforeEach(async () => {
+    cwd = await fs.mkdtemp(path.join(tmpdir(), "shadcn-cn-migrate-"))
+    await fs.mkdir(path.join(cwd, "src"), { recursive: true })
+    vi.mocked(installDependencies).mockReset().mockResolvedValue(undefined)
+    vi.mocked(removeDependencies).mockReset().mockResolvedValue(undefined)
+  })
+
+  afterEach(async () => {
+    await fs.rm(cwd, { recursive: true, force: true })
+  })
+
+  async function setupProject({
+    source,
+    dependencies,
+  }: {
+    source: string
+    dependencies: Record<string, string>
+  }) {
+    await fs.writeFile(
+      path.join(cwd, "package.json"),
+      JSON.stringify({ name: "fixture", dependencies }, null, 2)
+    )
+    await fs.writeFile(path.join(cwd, "src/classes.ts"), source)
+  }
+
+  it("requires package.json without requiring components.json", async () => {
+    await expect(migrateCn({ cwd, yes: true })).rejects.toThrow(
+      "No `package.json` file found"
+    )
+    expect(installDependencies).not.toHaveBeenCalled()
+  })
+
+  it("migrates a package project without components.json", async () => {
+    await setupProject({
+      source: `import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+`,
+      dependencies: {
+        clsx: "^2.1.1",
+        "tailwind-merge": "^3.3.1",
+        tailwindcss: "^4.1.0",
+      },
+    })
+    await migrateCn({ cwd, yes: true })
+
+    expect(
+      (await fs.readFile(path.join(cwd, "src/classes.ts"), "utf-8")).trim()
+    ).toBe('export { cn } from "cn";')
+    expect(installDependencies).toHaveBeenCalledWith(cwd, ["cn"])
+    expect(removeDependencies).toHaveBeenCalledWith(cwd, [
+      "clsx",
+      "tailwind-merge",
+    ])
+  })
+
+  it("retains old dependencies for a scoped migration", async () => {
+    await setupProject({
+      source: `import { clsx } from "clsx"
+
+export const classes = clsx("flex")
+`,
+      dependencies: { clsx: "^2.1.1" },
+    })
+    await migrateCn({ cwd, path: "src/classes.ts", yes: true })
+
+    expect(installDependencies).toHaveBeenCalledWith(cwd, ["cn"])
+    expect(removeDependencies).not.toHaveBeenCalled()
+  })
+
+  it("does not write source files when installing cn fails", async () => {
+    const source = `import { clsx } from "clsx"
+
+export const classes = clsx("flex")
+`
+    await setupProject({
+      source,
+      dependencies: { clsx: "^2.1.1" },
+    })
+
+    vi.mocked(installDependencies).mockRejectedValue(
+      new Error("install failed")
+    )
+
+    await expect(migrateCn({ cwd, yes: true })).rejects.toThrow(
+      "install failed"
+    )
+    expect(await fs.readFile(path.join(cwd, "src/classes.ts"), "utf-8")).toBe(
+      source
+    )
+  })
+
+  it("refuses to migrate tailwind-merge v2 projects", async () => {
+    const source = `import { twMerge } from "tailwind-merge"
+
+export const classes = twMerge("px-2 px-4")
+`
+    await setupProject({
+      source,
+      dependencies: {
+        "tailwind-merge": "^2.6.0",
+        tailwindcss: "^3.4.0",
+      },
+    })
+    await expect(migrateCn({ cwd, yes: true })).rejects.toThrow(
+      "requires Tailwind CSS v4"
+    )
+    expect(installDependencies).not.toHaveBeenCalled()
+    expect(await fs.readFile(path.join(cwd, "src/classes.ts"), "utf-8")).toBe(
+      source
+    )
+  })
+
+  it("refuses versions older than the supported Tailwind pair", async () => {
+    const source = `import { twMerge } from "tailwind-merge"
+
+export const classes = twMerge("px-2 px-4")
+`
+    await setupProject({
+      source,
+      dependencies: {
+        "tailwind-merge": "^1.14.0",
+        tailwindcss: "^2.2.19",
+      },
+    })
+    await expect(migrateCn({ cwd, yes: true })).rejects.toThrow(
+      "requires Tailwind CSS v4"
+    )
+    expect(installDependencies).not.toHaveBeenCalled()
+  })
+
+  it("allows a clsx-only migration in a Tailwind CSS v3 project", async () => {
+    await setupProject({
+      source: `import clsx from "clsx"
+
+export const classes = clsx("flex")
+`,
+      dependencies: {
+        clsx: "^2.1.1",
+        tailwindcss: "^3.4.0",
+      },
+    })
+    await migrateCn({ cwd, yes: true })
+
+    expect(installDependencies).toHaveBeenCalledWith(cwd, ["cn"])
+    expect(removeDependencies).toHaveBeenCalledWith(cwd, ["clsx"])
+  })
+
+  it("scans dot directories before removing old dependencies", async () => {
+    await setupProject({
+      source: `import { clsx } from "clsx"
+
+export const classes = clsx("flex")
+`,
+      dependencies: { clsx: "^2.1.1" },
+    })
+    await fs.mkdir(path.join(cwd, ".storybook"), { recursive: true })
+    await fs.writeFile(
+      path.join(cwd, ".storybook/preview.ts"),
+      'export * from "clsx"\n'
+    )
+    await migrateCn({ cwd, yes: true })
+
+    expect(removeDependencies).not.toHaveBeenCalled()
+  })
+
+  it("throws when an explicit glob matches no files", async () => {
+    await setupProject({
+      source: `export const classes = "flex"
+`,
+      dependencies: {},
+    })
+
+    await expect(
+      migrateCn({ cwd, path: "missing/**/*.ts", yes: true })
+    ).rejects.toThrow("No files found matching")
+  })
+})

--- a/packages/shadcn/src/migrations/migrate-cn.test.ts
+++ b/packages/shadcn/src/migrations/migrate-cn.test.ts
@@ -529,6 +529,24 @@ import { clsx } from "clsx"
     )
   })
 
+  it("transforms script blocks with whitespace in the closing tag", () => {
+    const result = transformCnSource(
+      `<script setup lang="ts">
+import { clsx } from "clsx"
+
+const classes = clsx("flex")
+</script >
+
+<template><div :class="classes" /></template>
+`,
+      "component.vue"
+    )
+
+    expect(result.content).toContain('import { clsx } from "cn"')
+    expect(result.content).toContain('const classes = clsx("flex")')
+    expect(result.content).toContain("</script >")
+  })
+
   it("preserves Svelte imports referenced only by the markup", () => {
     const result = transformCnSource(
       `<script lang="ts">

--- a/packages/shadcn/src/migrations/migrate-cn.ts
+++ b/packages/shadcn/src/migrations/migrate-cn.ts
@@ -1,0 +1,2 @@
+export { migrateCn, transformCnSource } from "./cn"
+export type { CnMigrationIssue, CnSourceTransformResult } from "./cn"

--- a/packages/shadcn/src/preflights/preflight-migrate.test.ts
+++ b/packages/shadcn/src/preflights/preflight-migrate.test.ts
@@ -1,0 +1,48 @@
+import { promises as fs } from "fs"
+import { tmpdir } from "os"
+import path from "path"
+import * as ERRORS from "@/src/utils/errors"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { preFlightMigrate } from "./preflight-migrate"
+
+describe("preFlightMigrate", () => {
+  let cwd: string
+
+  beforeEach(async () => {
+    cwd = await fs.mkdtemp(path.join(tmpdir(), "shadcn-preflight-migrate-"))
+    await fs.writeFile(
+      path.join(cwd, "package.json"),
+      JSON.stringify({ name: "fixture" })
+    )
+  })
+
+  afterEach(async () => {
+    await fs.rm(cwd, { recursive: true, force: true })
+  })
+
+  const getOptions = (cwd: string) => ({
+    cwd,
+    list: false,
+    yes: true,
+    migration: "rtl",
+  })
+
+  it("requires components.json for config migrations", async () => {
+    const result = await preFlightMigrate(getOptions(cwd))
+
+    expect(result.errors).toEqual({ [ERRORS.MISSING_CONFIG]: true })
+    expect(result.config).toBeNull()
+  })
+
+  it("requires package.json", async () => {
+    await fs.rm(path.join(cwd, "package.json"))
+
+    const result = await preFlightMigrate(getOptions(cwd))
+
+    expect(result.errors).toEqual({
+      [ERRORS.MISSING_DIR_OR_EMPTY_PROJECT]: true,
+    })
+    expect(result.config).toBeNull()
+  })
+})

--- a/packages/shadcn/src/utils/updaters/update-dependencies.test.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.test.ts
@@ -6,6 +6,8 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
   assertSafeDependencies,
+  installDependencies,
+  removeDependencies,
   updateDependencies,
 } from "./update-dependencies"
 
@@ -282,5 +284,31 @@ describe("assertSafeDependencies", () => {
 
   it("throws when a dash follows leading whitespace", () => {
     expect(() => assertSafeDependencies(["  -D"])).toThrow(/cannot start with/)
+  })
+})
+
+describe("dependency commands", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("installs dependencies from a cwd without a shadcn config", async () => {
+    const cwd = getFixturesDir("project-pnpm")
+
+    await installDependencies(cwd, ["cn"])
+
+    expect(execa).toHaveBeenCalledWith("pnpm", ["add", "--", "cn"], {
+      cwd,
+    })
+  })
+
+  it("removes only dependencies declared by the project", async () => {
+    const cwd = getFixturesDir("project-pnpm-existing-deps")
+
+    await removeDependencies(cwd, ["recharts", "not-installed"])
+
+    expect(execa).toHaveBeenCalledWith("pnpm", ["remove", "--", "recharts"], {
+      cwd,
+    })
   })
 })

--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -1,3 +1,4 @@
+import path from "path"
 import { SHADCN_URL } from "@/src/registry/constants"
 import { RegistryItem } from "@/src/schema"
 import { Config } from "@/src/utils/get-config"
@@ -6,6 +7,7 @@ import { getPackageManager } from "@/src/utils/get-package-manager"
 import { logger } from "@/src/utils/logger"
 import { spinner } from "@/src/utils/spinner"
 import { execa } from "execa"
+import fsExtra from "fs-extra"
 import prompts from "prompts"
 
 export async function updateDependencies(
@@ -84,6 +86,64 @@ export async function updateDependencies(
   )
 
   dependenciesSpinner?.succeed()
+}
+
+export async function installDependencies(
+  cwd: string,
+  dependencies: string[],
+  devDependencies: string[] = []
+) {
+  const packageInfo = getPackageInfo(cwd, false)
+  dependencies = normalizeDependencyRequests(dependencies, packageInfo)
+  devDependencies = normalizeDependencyRequests(devDependencies, packageInfo)
+
+  if (!dependencies.length && !devDependencies.length) {
+    return
+  }
+
+  await installWithPackageManager(
+    await getPackageManager(cwd),
+    dependencies,
+    devDependencies,
+    cwd
+  )
+}
+
+export async function removeDependencies(cwd: string, dependencies: string[]) {
+  assertSafeDependencies(dependencies)
+  const packageInfo = getPackageInfo(cwd, false)
+  dependencies = dependencies.filter((dependency) =>
+    hasDeclaredDependency(packageInfo, dependency)
+  )
+
+  if (!dependencies.length) {
+    return
+  }
+
+  const packageManager = await getPackageManager(cwd)
+  if (packageManager === "npm") {
+    await execa("npm", ["uninstall", "--", ...dependencies], { cwd })
+    return
+  }
+
+  if (packageManager === "deno") {
+    const packageJsonPath = path.resolve(cwd, "package.json")
+    const packageJson = await fsExtra.readJson(packageJsonPath)
+    for (const field of [
+      "dependencies",
+      "devDependencies",
+      "optionalDependencies",
+      "peerDependencies",
+    ]) {
+      for (const dependency of dependencies) {
+        delete packageJson[field]?.[dependency]
+      }
+    }
+    await fsExtra.writeJson(packageJsonPath, packageJson, { spaces: 2 })
+    return
+  }
+
+  await execa(packageManager, ["remove", "--", ...dependencies], { cwd })
 }
 
 /**
@@ -166,6 +226,18 @@ function parsePackageRequest(dependency: string) {
     name: match[1],
     hasSpecifier: Boolean(match[2]),
   }
+}
+
+function hasDeclaredDependency(
+  packageInfo: ReturnType<typeof getPackageInfo>,
+  dependency: string
+) {
+  return Boolean(
+    packageInfo?.dependencies?.[dependency] ??
+      packageInfo?.devDependencies?.[dependency] ??
+      packageInfo?.optionalDependencies?.[dependency] ??
+      packageInfo?.peerDependencies?.[dependency]
+  )
 }
 
 function shouldPromptForNpmFlag(config: Config) {


### PR DESCRIPTION
Adds `shadcn migrate cn` for migrating JavaScript and TypeScript projects from `clsx`, `tailwind-merge`, and `cnfast` to `cn`. Includes framework-file support, safe dependency cleanup, unsupported-usage reporting, documentation, and regression coverage.