### PR TITLE
perf(v4): use cn for class merging

### DIFF
--- a/apps/v4/lib/utils.ts
+++ b/apps/v4/lib/utils.ts
@@ -1,9 +1,4 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}
+export { cn } from "cn"
 
 export function absoluteUrl(path: string) {
   return `${process.env.NEXT_PUBLIC_APP_URL}${path}`

--- a/apps/v4/package.json
+++ b/apps/v4/package.json
@@ -61,6 +61,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "cn": "^0.2.2",
     "date-fns": "^4.1.0",
     "dedent": "^1.6.0",
     "embla-carousel-autoplay": "8.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      cn:
+        specifier: ^0.2.2
+        version: 0.2.2
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -5144,6 +5147,11 @@ packages:
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
+
+  cn@0.2.2:
+    resolution: {integrity: sha512-1TjHp2yGdFzu5Td2bc2bnceh/WKPEvLYVtcg6czWSifHBy5oN/bK5/I0eFNIr839Hlh5cxrV93Yh2ByrpO5Stw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
@@ -14248,6 +14256,8 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  cn@0.2.2: {}
 
   code-block-writer@13.0.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,12 @@ packages:
   - "!packages/tests/temp/**"
 
 minimumReleaseAge: 2880
+# TODO: remove once cn@0.2.2 (published 2026-09-01) is older than the 48h
+# minimumReleaseAge window.
 # TODO: remove once @tanstack/react-table@9.0.0 (published 2026-08-04) is older
 # than the 48h minimumReleaseAge window.
 minimumReleaseAgeExclude:
+  - "cn"
   - "@tanstack/react-table"
   - "@tanstack/table-core"
   - "@tanstack/react-store"


### PR DESCRIPTION
Use the new cn package behind apps/v4/lib/utils.ts so we can test it on the site.

This intentionally leaves registry utilities, examples, styles, docs, and generated project output unchanged. cn@0.2.2 is temporarily allowlisted because it is newer than the workspace 48-hour minimum release age.