### PR TITLE
fix(types): correct KbdGroup props type to match rendered kbd element

### DIFF
--- a/apps/v4/registry/bases/aria/ui/kbd.tsx
+++ b/apps/v4/registry/bases/aria/ui/kbd.tsx
@@ -17,7 +17,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
   )
 }
 
-function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+function KbdGroup({ className, ...props }: React.ComponentProps<"kbd">) {
   return (
     <KbdPrimitive
       data-slot="kbd-group"

--- a/apps/v4/registry/bases/base/ui/kbd.tsx
+++ b/apps/v4/registry/bases/base/ui/kbd.tsx
@@ -13,7 +13,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
   )
 }
 
-function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+function KbdGroup({ className, ...props }: React.ComponentProps<"kbd">) {
   return (
     <kbd
       data-slot="kbd-group"

--- a/apps/v4/registry/bases/radix/ui/kbd.tsx
+++ b/apps/v4/registry/bases/radix/ui/kbd.tsx
@@ -13,7 +13,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
   )
 }
 
-function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+function KbdGroup({ className, ...props }: React.ComponentProps<"kbd">) {
   return (
     <kbd
       data-slot="kbd-group"

--- a/apps/v4/registry/new-york-v4/ui/kbd.tsx
+++ b/apps/v4/registry/new-york-v4/ui/kbd.tsx
@@ -15,7 +15,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
   )
 }
 
-function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+function KbdGroup({ className, ...props }: React.ComponentProps<"kbd">) {
   return (
     <kbd
       data-slot="kbd-group"


### PR DESCRIPTION
## Summary

- Correct the `KbdGroup` props type to match the rendered `kbd` element.
- Improve TypeScript type accuracy.
- Prevent incorrect or unsupported props from being accepted.

## Testing

- Verified the TypeScript types compile correctly.
- No unrelated changes were introduced.