### PR TITLE
docs: document size prop and api reference for NativeSelect

### DIFF
--- a/apps/v4/content/docs/components/aria/native-select.mdx
+++ b/apps/v4/content/docs/components/aria/native-select.mdx
@@ -104,6 +104,17 @@ Use `NativeSelectOptGroup` to organize options into categories.
 
 <ComponentPreview styleName="aria-nova" name="native-select-groups" />
 
+## Size
+
+Use the `size` prop to change the size of the select.
+
+```tsx
+<NativeSelect size="sm">
+  <NativeSelectOption value="apple">Apple</NativeSelectOption>
+  <NativeSelectOption value="banana">Banana</NativeSelectOption>
+</NativeSelect>
+```
+
 ## Disabled
 
 Add the `disabled` prop to the `NativeSelect` component to disable the select.
@@ -136,6 +147,11 @@ To enable RTL support in shadcn/ui, see the [RTL configuration guide](/docs/rtl)
 ### NativeSelect
 
 The main select component that wraps the native HTML select element.
+
+| Prop        | Type                  | Default     |
+| ----------- | --------------------- | ----------- |
+| `size`      | `"sm" \| "default"`   | `"default"` |
+| `className` | `string`              |             |
 
 ```tsx
 <NativeSelect>

--- a/apps/v4/content/docs/components/base/native-select.mdx
+++ b/apps/v4/content/docs/components/base/native-select.mdx
@@ -104,6 +104,17 @@ Use `NativeSelectOptGroup` to organize options into categories.
 
 <ComponentPreview styleName="base-nova" name="native-select-groups" />
 
+## Size
+
+Use the `size` prop to change the size of the select.
+
+```tsx
+<NativeSelect size="sm">
+  <NativeSelectOption value="apple">Apple</NativeSelectOption>
+  <NativeSelectOption value="banana">Banana</NativeSelectOption>
+</NativeSelect>
+```
+
 ## Disabled
 
 Add the `disabled` prop to the `NativeSelect` component to disable the select.
@@ -136,6 +147,11 @@ To enable RTL support in shadcn/ui, see the [RTL configuration guide](/docs/rtl)
 ### NativeSelect
 
 The main select component that wraps the native HTML select element.
+
+| Prop        | Type                  | Default     |
+| ----------- | --------------------- | ----------- |
+| `size`      | `"sm" \| "default"`   | `"default"` |
+| `className` | `string`              |             |
 
 ```tsx
 <NativeSelect>

--- a/apps/v4/content/docs/components/radix/native-select.mdx
+++ b/apps/v4/content/docs/components/radix/native-select.mdx
@@ -104,6 +104,17 @@ Use `NativeSelectOptGroup` to organize options into categories.
 
 <ComponentPreview styleName="radix-nova" name="native-select-groups" />
 
+## Size
+
+Use the `size` prop to change the size of the select.
+
+```tsx
+<NativeSelect size="sm">
+  <NativeSelectOption value="apple">Apple</NativeSelectOption>
+  <NativeSelectOption value="banana">Banana</NativeSelectOption>
+</NativeSelect>
+```
+
 ## Disabled
 
 Add the `disabled` prop to the `NativeSelect` component to disable the select.
@@ -136,6 +147,11 @@ To enable RTL support in shadcn/ui, see the [RTL configuration guide](/docs/rtl)
 ### NativeSelect
 
 The main select component that wraps the native HTML select element.
+
+| Prop        | Type                  | Default     |
+| ----------- | --------------------- | ----------- |
+| `size`      | `"sm" \| "default"`   | `"default"` |
+| `className` | `string`              |             |
 
 ```tsx
 <NativeSelect>


### PR DESCRIPTION
## Summary

- Document the `size` prop for `NativeSelect`.
- Add the relevant API reference documentation.
- Improve the documentation for developers using the component.

## Testing

- Reviewed the updated documentation.
- No functional code changes were introduced.