### PR TITLE
fix(ui): ensure pagination ellipsis screen-reader label is accessible

### DIFF
--- a/apps/v4/registry/bases/aria/ui/pagination.tsx
+++ b/apps/v4/registry/bases/aria/ui/pagination.tsx
@@ -119,7 +119,6 @@ function PaginationEllipsis({
 }: React.ComponentProps<"span">) {
   return (
     <span
-      aria-hidden
       data-slot="pagination-ellipsis"
       className={cn(
         "cn-pagination-ellipsis flex items-center justify-center",
@@ -128,6 +127,7 @@ function PaginationEllipsis({
       {...props}
     >
       <IconPlaceholder
+        aria-hidden="true"
         lucide="MoreHorizontalIcon"
         tabler="IconDots"
         hugeicons="MoreHorizontalCircle01Icon"

--- a/apps/v4/registry/bases/base/ui/pagination.tsx
+++ b/apps/v4/registry/bases/base/ui/pagination.tsx
@@ -125,7 +125,6 @@ function PaginationEllipsis({
 }: React.ComponentProps<"span">) {
   return (
     <span
-      aria-hidden
       data-slot="pagination-ellipsis"
       className={cn(
         "cn-pagination-ellipsis flex items-center justify-center",
@@ -134,6 +133,7 @@ function PaginationEllipsis({
       {...props}
     >
       <IconPlaceholder
+        aria-hidden="true"
         lucide="MoreHorizontalIcon"
         tabler="IconDots"
         hugeicons="MoreHorizontalCircle01Icon"

--- a/apps/v4/registry/bases/radix/ui/pagination.tsx
+++ b/apps/v4/registry/bases/radix/ui/pagination.tsx
@@ -124,7 +124,6 @@ function PaginationEllipsis({
 }: React.ComponentProps<"span">) {
   return (
     <span
-      aria-hidden
       data-slot="pagination-ellipsis"
       className={cn(
         "cn-pagination-ellipsis flex items-center justify-center",
@@ -133,6 +132,7 @@ function PaginationEllipsis({
       {...props}
     >
       <IconPlaceholder
+        aria-hidden="true"
         lucide="MoreHorizontalIcon"
         tabler="IconDots"
         hugeicons="MoreHorizontalCircle01Icon"

--- a/apps/v4/registry/new-york-v4/ui/pagination.tsx
+++ b/apps/v4/registry/new-york-v4/ui/pagination.tsx
@@ -105,12 +105,11 @@ function PaginationEllipsis({
 }: React.ComponentProps<"span">) {
   return (
     <span
-      aria-hidden
       data-slot="pagination-ellipsis"
       className={cn("flex size-9 items-center justify-center", className)}
       {...props}
     >
-      <MoreHorizontalIcon className="size-4" />
+      <MoreHorizontalIcon aria-hidden="true" className="size-4" />
       <span className="sr-only">More pages</span>
     </span>
   )


### PR DESCRIPTION
## Summary

- Improve accessibility for the pagination ellipsis.
- Ensure the ellipsis has a meaningful screen-reader label.
- Improve the experience for users relying on assistive technologies.

## Testing

- Verified the accessibility change locally.
- Confirmed there are no unrelated changes.