### PR TITLE
docs(figma): add shadcncraft Free Starter Kit to free section

### DIFF
--- a/apps/v4/content/docs/(root)/figma.mdx
+++ b/apps/v4/content/docs/(root)/figma.mdx
@@ -13,6 +13,7 @@ description: Every component recreated in Figma. With customizable props, typogr
 - [shadcn/ui components](https://www.figma.com/community/file/1342715840824755935) by [Sitsiilia Bergmann](https://x.com/sitsiilia) - A well-structured component library aligned with the shadcn component system, regularly maintained.
 - [shadcn/ui design system](https://www.figma.com/community/file/1203061493325953101) by [Pietro Schirano](https://twitter.com/skirano) - A design companion for shadcn/ui. Each component was painstakingly crafted to perfectly match the code implementation.
 - [Obra shadcn/ui Community Edition](https://www.figma.com/community/file/1514746685758799870/) by [Obra Studio](https://obra.studio/) - The most complete free shadcn/ui kit for Figma, with all components and an easy theming system. Maintained by a team of designers.
+- [shadcncraft Free Starter Kit](https://www.figma.com/community/file/1534076420225325960) by [shadcncraft](https://shadcncraft.com) - Native Figma variables for all eight shadcn/ui styles, import themes from tweakcn and shadcn/ui Create, icon switching, and matching React components. Actively maintained.
 
 ## Paid
 


### PR DESCRIPTION
Adds the shadcncraft Free Starter Kit to the Free section, following the existing entry format (Figma Community link, author link, one-line description).

The [Figma Community file](https://www.figma.com/community/file/1534076420225325960) has 12,800+ users and is actively maintained (last updated August 2026).

The existing shadcncraft entry in the Paid section is unchanged.