### PR TITLE
fix(registry): repair health dry runs

### DIFF
--- a/apps/v4/lib/registry-health/dry-run.test.ts
+++ b/apps/v4/lib/registry-health/dry-run.test.ts
@@ -4,6 +4,7 @@ import path from "node:path"
 import { describe, expect, it } from "vitest"
 
 import { getDryRunEnvironment, runLocalCliDryRun } from "./dry-run"
+import { REGISTRY_DRY_RUN_FAILURE_MESSAGE_MAX_LENGTH } from "./schema"
 
 describe("getDryRunEnvironment", () => {
   it("allowlists process variables and excludes credentials", () => {
@@ -22,6 +23,69 @@ describe("getDryRunEnvironment", () => {
 })
 
 describe("runLocalCliDryRun", () => {
+  it("creates a TypeScript project the CLI can load", async () => {
+    const directory = await fs.mkdtemp(
+      path.join(os.tmpdir(), "registry-health-cli-test-")
+    )
+    const cliPath = path.join(directory, "cli.mjs")
+    await fs.writeFile(
+      cliPath,
+      `
+        import { readFileSync } from "node:fs"
+
+        const tsconfig = JSON.parse(readFileSync("tsconfig.json", "utf8"))
+        if (tsconfig.compilerOptions.paths["@/*"][0] !== "./*") {
+          process.exit(1)
+        }
+      `
+    )
+
+    try {
+      await expect(
+        runLocalCliDryRun({
+          namespace: "@acme",
+          item: "button",
+          registryUrl: "https://acme.example.com/r/{name}.json",
+          cliPath,
+        })
+      ).resolves.toMatchObject({ success: true })
+    } finally {
+      await fs.rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it("captures bounded sanitized CLI errors", async () => {
+    const directory = await fs.mkdtemp(
+      path.join(os.tmpdir(), "registry-health-cli-test-")
+    )
+    const cliPath = path.join(directory, "cli.mjs")
+    await fs.writeFile(
+      cliPath,
+      'process.stderr.write("\\u001b[31m" + "x".repeat(1500) + " useful failure\\u001b[0m"); process.exit(1)'
+    )
+
+    try {
+      const result = await runLocalCliDryRun({
+        namespace: "@acme",
+        item: "button",
+        registryUrl: "https://acme.example.com/r/{name}.json",
+        cliPath,
+      })
+
+      expect(result).toMatchObject({
+        success: false,
+        failureCode: "exit_1",
+      })
+      expect(result.failureMessage).toContain("useful failure")
+      expect(result.failureMessage).not.toContain("\u001b")
+      expect(result.failureMessage?.length).toBeLessThanOrEqual(
+        REGISTRY_DRY_RUN_FAILURE_MESSAGE_MAX_LENGTH
+      )
+    } finally {
+      await fs.rm(directory, { recursive: true, force: true })
+    }
+  })
+
   it("force kills a CLI process that ignores SIGTERM", async () => {
     const directory = await fs.mkdtemp(
       path.join(os.tmpdir(), "registry-health-cli-test-")

--- a/apps/v4/lib/registry-health/dry-run.ts
+++ b/apps/v4/lib/registry-health/dry-run.ts
@@ -2,8 +2,19 @@ import { spawn, type ChildProcess } from "node:child_process"
 import { promises as fs } from "node:fs"
 import os from "node:os"
 import path from "node:path"
+import { stripVTControlCharacters } from "node:util"
 
 import { DEFAULT_STYLE, type RegistryDryRunResult } from "./monitor"
+import { REGISTRY_DRY_RUN_FAILURE_MESSAGE_MAX_LENGTH } from "./schema"
+
+const MAX_CAPTURED_OUTPUT_LENGTH = 4000
+
+function getFailureMessage(output: string) {
+  const message = stripVTControlCharacters(output).replace(/\s+/g, " ").trim()
+  return message
+    ? message.slice(-REGISTRY_DRY_RUN_FAILURE_MESSAGE_MAX_LENGTH)
+    : undefined
+}
 
 async function runLocalCliDryRun({
   namespace,
@@ -64,6 +75,22 @@ async function runLocalCliDryRun({
         path.join(temporaryDirectory, "package.json"),
         JSON.stringify({ private: true })
       ),
+      fs.writeFile(
+        path.join(temporaryDirectory, "tsconfig.json"),
+        JSON.stringify(
+          {
+            compilerOptions: {
+              baseUrl: ".",
+              paths: {
+                "@/*": ["./*"],
+              },
+              jsx: "preserve",
+            },
+          },
+          null,
+          2
+        )
+      ),
     ])
 
     return await new Promise<RegistryDryRunResult>((resolve) => {
@@ -81,12 +108,17 @@ async function runLocalCliDryRun({
         {
           cwd: temporaryDirectory,
           env: getDryRunEnvironment(temporaryDirectory),
-          stdio: "ignore",
+          stdio: ["ignore", "pipe", "pipe"],
         }
       )
       let completed = false
       let timedOut = false
+      let output = ""
       let forceKillTimeout: NodeJS.Timeout | undefined
+      const captureOutput = (chunk: Buffer | string) => {
+        const value = typeof chunk === "string" ? chunk : chunk.toString("utf8")
+        output = `${output}${value}`.slice(-MAX_CAPTURED_OUTPUT_LENGTH)
+      }
       const finish = (result: RegistryDryRunResult) => {
         if (completed) return
         completed = true
@@ -102,14 +134,19 @@ async function runLocalCliDryRun({
         }, killGraceMs)
       }, timeoutMs)
 
-      child.on("error", () =>
+      child.stdout?.on("data", captureOutput)
+      child.stderr?.on("data", captureOutput)
+      child.on("error", (error) => {
+        captureOutput(error.message)
+        const failureMessage = getFailureMessage(output)
         finish({
           success: false,
           failureCode: timedOut ? "timeout" : "spawn_error",
+          ...(failureMessage ? { failureMessage } : {}),
           durationMs: Date.now() - startedAt,
         })
-      )
-      child.on("exit", (code, signal) => {
+      })
+      child.on("close", (code, signal) => {
         const failureCode = timedOut
           ? "timeout"
           : code === 0
@@ -117,10 +154,13 @@ async function runLocalCliDryRun({
             : signal
               ? "terminated"
               : `exit_${code}`
+        const failureMessage =
+          code === 0 ? undefined : getFailureMessage(output)
 
         finish({
           success: !timedOut && code === 0,
           failureCode,
+          ...(failureMessage ? { failureMessage } : {}),
           durationMs: Date.now() - startedAt,
         })
       })

--- a/apps/v4/lib/registry-health/monitor.test.ts
+++ b/apps/v4/lib/registry-health/monitor.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi } from "vitest"
 
 import type { RegistryDirectoryEntry } from "../registry-directory"
 import { runRegistryMonitor } from "./monitor"
-import type { RegistryMonitorEntryState, RegistryMonitorState } from "./schema"
+import {
+  REGISTRY_DRY_RUN_VERSION,
+  type RegistryMonitorEntryState,
+  type RegistryMonitorState,
+} from "./schema"
 
 const NOW = new Date("2026-08-24T12:00:00.000Z")
 const DIRECTORY: RegistryDirectoryEntry[] = [
@@ -40,6 +44,7 @@ function createState(entry = createEntryState()) {
   return {
     schemaVersion: 1,
     scoreVersion: 1,
+    dryRunVersion: REGISTRY_DRY_RUN_VERSION,
     updatedAt: "2026-08-24T10:00:00.000Z",
     registries: { "@acme": entry },
   } satisfies RegistryMonitorState
@@ -420,6 +425,113 @@ describe("runRegistryMonitor", () => {
     expect(result.run.totals.dryRuns).toBe(1)
     expect(result.state.registries["@acme"].recentDryRuns).toHaveLength(1)
     expect(result.state.lastWeeklyRunAt).toBe(NOW.toISOString())
+  })
+
+  it("discards invalid pre-tsconfig dry runs and reruns the weekly check", async () => {
+    const now = new Date("2026-09-02T12:00:00.000Z")
+    const recentIndex = Array.from({ length: 24 }, (_, index) => ({
+      checkedAt: new Date(
+        now.getTime() - (24 - index) * 60 * 60 * 1000
+      ).toISOString(),
+      outcome: "reachable" as const,
+      status: 200,
+      durationMs: 100,
+      redirectCount: 0,
+      schemaValid: true,
+    }))
+    const previousState = {
+      ...createState(
+        createEntryState({
+          itemNames: ["button"],
+          recentIndex,
+          recentDryRuns: [
+            {
+              checkedAt: "2026-08-25T12:04:27.443Z",
+              item: "button",
+              success: false,
+              failureCode: "exit_1",
+              durationMs: 1500,
+            },
+            {
+              checkedAt: "2026-08-31T12:38:36.084Z",
+              item: "dialog",
+              success: false,
+              failureCode: "exit_1",
+              durationMs: 1700,
+            },
+          ],
+          daily: [
+            {
+              date: "2026-08-25",
+              availabilitySuccesses: 0,
+              availabilityObservations: 0,
+              challengeObservations: 0,
+              schemaSuccesses: 0,
+              schemaObservations: 0,
+              itemSuccesses: 0,
+              itemObservations: 0,
+              dryRunSuccesses: 0,
+              dryRunObservations: 1,
+            },
+            {
+              date: "2026-08-31",
+              availabilitySuccesses: 0,
+              availabilityObservations: 0,
+              challengeObservations: 0,
+              schemaSuccesses: 0,
+              schemaObservations: 0,
+              itemSuccesses: 0,
+              itemObservations: 0,
+              dryRunSuccesses: 0,
+              dryRunObservations: 1,
+            },
+          ],
+          latestHygiene: {
+            contentTypeJson: true,
+            noDuplicateNames: true,
+            nameMatches: true,
+          },
+        })
+      ),
+      dryRunVersion: 0,
+      lastDailyRunAt: "2026-09-02T11:00:00.000Z",
+      lastWeeklyRunAt: "2026-08-31T12:38:36.084Z",
+    }
+    const runDryRun = vi.fn(async () => ({
+      success: true,
+      durationMs: 250,
+    }))
+
+    const result = await runRegistryMonitor({
+      directory: DIRECTORY,
+      previousState,
+      mode: "auto",
+      now,
+      fetchJson: vi.fn(async () => createSuccessfulFetch()),
+      runDryRun,
+    })
+
+    expect(runDryRun).toHaveBeenCalledOnce()
+    expect(result.state.registries["@acme"].recentDryRuns).toEqual([
+      {
+        checkedAt: now.toISOString(),
+        item: "item-0",
+        success: true,
+        durationMs: 250,
+      },
+    ])
+    expect(result.state.registries["@acme"].daily.slice(0, 2)).toMatchObject([
+      { date: "2026-08-25", dryRunSuccesses: 0, dryRunObservations: 0 },
+      { date: "2026-08-31", dryRunSuccesses: 0, dryRunObservations: 0 },
+    ])
+    expect(result.state.lastWeeklyRunAt).toBe(now.toISOString())
+    expect(result.run.diagnostics).toEqual([
+      "Discarded 2 invalid CLI dry-run observations from the pre-tsconfig scaffold.",
+    ])
+    expect(result.snapshot.registries["@acme"]).toMatchObject({
+      status: "healthy",
+      breakdown: { installability: 18.5 },
+    })
   })
 
   it("continues weekly rotation after dry-run history is trimmed", async () => {

--- a/apps/v4/lib/registry-health/monitor.ts
+++ b/apps/v4/lib/registry-health/monitor.ts
@@ -6,6 +6,7 @@ import {
 } from "../registry-directory"
 import { fetchRegistryJson, type RegistryJsonResult } from "./network"
 import {
+  REGISTRY_DRY_RUN_VERSION,
   REGISTRY_HEALTH_SCHEMA_VERSION,
   REGISTRY_HEALTH_SCORE_VERSION,
   registryHealthSnapshotSchema,
@@ -39,6 +40,7 @@ export type RegistryMonitorMode = RegistryMonitorRun["mode"]
 export type RegistryDryRunResult = {
   success: boolean
   failureCode?: string
+  failureMessage?: string
   durationMs: number
 }
 
@@ -55,6 +57,42 @@ function createDailyBucket(date: string) {
     dryRunSuccesses: 0,
     dryRunObservations: 0,
   } satisfies RegistryHealthDailyBucket
+}
+
+function discardInvalidDryRunHistory(
+  previousState: RegistryMonitorState | null | undefined
+) {
+  if (!previousState) {
+    return { state: previousState, discardedDryRuns: 0 }
+  }
+
+  const state = structuredClone(previousState)
+  if (state.dryRunVersion === REGISTRY_DRY_RUN_VERSION) {
+    return { state, discardedDryRuns: 0 }
+  }
+
+  let discardedRecentDryRuns = 0
+  let discardedDailyDryRuns = 0
+
+  for (const entry of Object.values(state.registries)) {
+    discardedRecentDryRuns += entry.recentDryRuns.length
+    entry.recentDryRuns = []
+
+    for (const bucket of entry.daily) {
+      discardedDailyDryRuns += bucket.dryRunObservations
+      bucket.dryRunSuccesses = 0
+      bucket.dryRunObservations = 0
+    }
+  }
+
+  const discardedDryRuns = Math.max(
+    discardedRecentDryRuns,
+    discardedDailyDryRuns
+  )
+  state.dryRunVersion = REGISTRY_DRY_RUN_VERSION
+  delete state.lastWeeklyRunAt
+
+  return { state, discardedDryRuns }
 }
 
 function getDailyBucket(state: RegistryMonitorEntryState, now: Date) {
@@ -409,16 +447,19 @@ export async function runRegistryMonitor({
   concurrency?: number
 }): Promise<RegistryMonitorOutput> {
   const startedAt = now.toISOString()
-  const checks = getChecks(mode, now, previousState)
+  const { state: repairedPreviousState, discardedDryRuns } =
+    discardInvalidDryRunHistory(previousState)
+  const checks = getChecks(mode, now, repairedPreviousState)
   const state: RegistryMonitorState = {
     schemaVersion: REGISTRY_HEALTH_SCHEMA_VERSION,
     scoreVersion: REGISTRY_HEALTH_SCORE_VERSION,
+    dryRunVersion: REGISTRY_DRY_RUN_VERSION,
     updatedAt: now.toISOString(),
-    ...(previousState?.lastDailyRunAt
-      ? { lastDailyRunAt: previousState.lastDailyRunAt }
+    ...(repairedPreviousState?.lastDailyRunAt
+      ? { lastDailyRunAt: repairedPreviousState.lastDailyRunAt }
       : {}),
-    ...(previousState?.lastWeeklyRunAt
-      ? { lastWeeklyRunAt: previousState.lastWeeklyRunAt }
+    ...(repairedPreviousState?.lastWeeklyRunAt
+      ? { lastWeeklyRunAt: repairedPreviousState.lastWeeklyRunAt }
       : {}),
     registries: {},
   }
@@ -434,10 +475,9 @@ export async function runRegistryMonitor({
   }
 
   for (const entry of directory) {
-    state.registries[entry.name] = structuredClone(
-      previousState?.registries[entry.name] ??
-        createRegistryMonitorEntryState(now)
-    )
+    state.registries[entry.name] =
+      repairedPreviousState?.registries[entry.name] ??
+      createRegistryMonitorEntryState(now)
     runResults[entry.name] = { items: [] }
   }
 
@@ -559,7 +599,12 @@ export async function runRegistryMonitor({
     mode,
     totals,
     results: runResults,
-    diagnostics: [],
+    diagnostics:
+      discardedDryRuns > 0
+        ? [
+            `Discarded ${discardedDryRuns} invalid CLI dry-run observations from the pre-tsconfig scaffold.`,
+          ]
+        : [],
   }
 
   return {

--- a/apps/v4/lib/registry-health/schema.ts
+++ b/apps/v4/lib/registry-health/schema.ts
@@ -4,6 +4,8 @@ import { registryNamespaceSchema } from "../registry-directory"
 
 export const REGISTRY_HEALTH_SCHEMA_VERSION = 1 as const
 export const REGISTRY_HEALTH_SCORE_VERSION = 1 as const
+export const REGISTRY_DRY_RUN_VERSION = 1 as const
+export const REGISTRY_DRY_RUN_FAILURE_MESSAGE_MAX_LENGTH = 1000
 
 export const registryHealthStatusSchema = z.enum([
   "healthy",
@@ -109,6 +111,10 @@ export const registryDryRunObservationSchema = z
     item: z.string(),
     success: z.boolean(),
     failureCode: z.string().optional(),
+    failureMessage: z
+      .string()
+      .max(REGISTRY_DRY_RUN_FAILURE_MESSAGE_MAX_LENGTH)
+      .optional(),
     durationMs: z.number().int().nonnegative(),
   })
   .strict()
@@ -227,6 +233,7 @@ export const registryMonitorStateSchema = z
   .object({
     schemaVersion: z.literal(REGISTRY_HEALTH_SCHEMA_VERSION),
     scoreVersion: z.literal(REGISTRY_HEALTH_SCORE_VERSION),
+    dryRunVersion: z.number().int().nonnegative().optional(),
     updatedAt: z.string().datetime(),
     lastDailyRunAt: z.string().datetime().optional(),
     lastWeeklyRunAt: z.string().datetime().optional(),


### PR DESCRIPTION
Add the missing TypeScript config to registry-health dry-run projects so the shadcn CLI can load them. Reset the invalid pre-fix dry-run history once, immediately collect a fresh round, and retain bounded sanitized failure output in private monitor state for future diagnosis.