### PR TITLE
fix(cli): preserve comments during cn migration

### DIFF
--- a/.changeset/preserve-migrate-cn-comments.md
+++ b/.changeset/preserve-migrate-cn-comments.md
@@ -1,0 +1,5 @@
+---
+"shadcn": patch
+---
+
+preserve leading comments when running `shadcn migrate cn`.

--- a/packages/shadcn/src/migrations/cn/transform.ts
+++ b/packages/shadcn/src/migrations/cn/transform.ts
@@ -75,6 +75,10 @@ function transformScriptSource(
       overwrite: true,
     }
   )
+  const leadingTrivia = content.slice(0, sourceFile.getStart())
+  if (leadingTrivia) {
+    sourceFile.replaceText([0, leadingTrivia.length], "")
+  }
   const pendingImports: PendingImport[] = []
   const unsupported: CnMigrationIssue[] = []
   const migratedPackages = new Set<OldPackage>()
@@ -116,11 +120,12 @@ function transformScriptSource(
     externalContent
   )
 
+  const transformed = `${leadingTrivia}${sourceFile.getFullText()}`
   const result = {
-    content: sourceFile.getText(),
+    content: transformed,
     changes,
     migratedPackages: Array.from(migratedPackages),
-    remainingPackages: getRemainingPackages(sourceFile.getText()),
+    remainingPackages: getRemainingPackages(transformed),
     unsupported: dedupeIssues(unsupported),
   }
   project.removeSourceFile(sourceFile)

--- a/packages/shadcn/src/migrations/migrate-cn.test.ts
+++ b/packages/shadcn/src/migrations/migrate-cn.test.ts
@@ -749,6 +749,40 @@ export const cn = (value) => twMerge(clsx(value))
 
     expect(transformCnSource(input).content).toBe(input)
   })
+
+  it("preserves leading comments in unchanged files", () => {
+    const input = `/**
+ * This component is adapted from an external example.
+ */
+"use client"
+
+export const classes = "flex"
+`
+    const result = transformCnSource(input)
+
+    expect(result.content).toBe(input)
+    expect(result.changes).toBe(0)
+  })
+
+  it("preserves leading comments in migrated files", () => {
+    const result =
+      transformCnSource(`// Copyright Example Authors. Licensed under MIT.
+// This file is generated.
+
+import { clsx } from "clsx"
+
+export const classes = clsx("flex")
+`)
+
+    expect(result.content)
+      .toBe(`// Copyright Example Authors. Licensed under MIT.
+// This file is generated.
+
+import { clsx } from "cn";
+
+export const classes = clsx("flex")
+`)
+  })
 })
 
 describe("migrateCn", () => {


### PR DESCRIPTION
Preserves leading comments and source trivia when running `shadcn migrate cn`, including files that do not otherwise require transformations. Adds regression coverage for migrated and unchanged files.