### PR TITLE
fix(sidebar): expose aria-expanded state on SidebarTrigger

### DIFF
--- a/apps/v4/registry/bases/aria/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/aria/ui/sidebar.tsx
@@ -260,7 +260,7 @@ function SidebarTrigger({
   onPress,
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { toggleSidebar } = useSidebar()
+  const { isMobile, open, openMobile, toggleSidebar } = useSidebar()
 
   return (
     <Button
@@ -268,6 +268,7 @@ function SidebarTrigger({
       data-slot="sidebar-trigger"
       variant="ghost"
       size="icon-sm"
+      aria-expanded={isMobile ? openMobile : open}
       className={cn("cn-sidebar-trigger", className)}
       onPress={(event) => {
         onPress?.(event)

--- a/apps/v4/registry/bases/base/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/base/ui/sidebar.tsx
@@ -256,7 +256,7 @@ function SidebarTrigger({
   onClick,
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { toggleSidebar } = useSidebar()
+  const { isMobile, open, openMobile, toggleSidebar } = useSidebar()
 
   return (
     <Button
@@ -264,6 +264,7 @@ function SidebarTrigger({
       data-slot="sidebar-trigger"
       variant="ghost"
       size="icon-sm"
+      aria-expanded={isMobile ? openMobile : open}
       className={cn("cn-sidebar-trigger", className)}
       onClick={(event) => {
         onClick?.(event)

--- a/apps/v4/registry/bases/radix/ui/sidebar.tsx
+++ b/apps/v4/registry/bases/radix/ui/sidebar.tsx
@@ -255,7 +255,7 @@ function SidebarTrigger({
   onClick,
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { toggleSidebar } = useSidebar()
+  const { isMobile, open, openMobile, toggleSidebar } = useSidebar()
 
   return (
     <Button
@@ -263,6 +263,7 @@ function SidebarTrigger({
       data-slot="sidebar-trigger"
       variant="ghost"
       size="icon-sm"
+      aria-expanded={isMobile ? openMobile : open}
       className={cn("cn-sidebar-trigger", className)}
       onClick={(event) => {
         onClick?.(event)

--- a/apps/v4/registry/new-york-v4/ui/sidebar.tsx
+++ b/apps/v4/registry/new-york-v4/ui/sidebar.tsx
@@ -258,7 +258,7 @@ function SidebarTrigger({
   onClick,
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { toggleSidebar } = useSidebar()
+  const { isMobile, open, openMobile, toggleSidebar } = useSidebar()
 
   return (
     <Button
@@ -266,6 +266,7 @@ function SidebarTrigger({
       data-slot="sidebar-trigger"
       variant="ghost"
       size="icon"
+      aria-expanded={isMobile ? openMobile : open}
       className={cn("size-7", className)}
       onClick={(event) => {
         onClick?.(event)


### PR DESCRIPTION
## Summary

Exposes the expanded/collapsed state on `SidebarTrigger` using `aria-expanded` in accordance with the [WAI-ARIA Disclosure pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/).

## Problem

`SidebarTrigger` toggles the sidebar but does not expose its state via `aria-expanded`. As a result, screen readers and assistive technology announce "Toggle Sidebar, button" without indicating whether the sidebar is currently open or collapsed.

Because the sidebar manages two distinct responsive states (desktop `open` vs mobile `openMobile` in a Sheet), reading only `open` would report an incorrect state on mobile devices.

## Solution

Derive `aria-expanded` from the active responsive branch using `isMobile ? openMobile : open`:

```tsx
const { isMobile, open, openMobile, toggleSidebar } = useSidebar()

<Button
  ...
  aria-expanded={isMobile ? openMobile : open}
  ...
/>
```

Applied consistently across all registry styles:
- `apps/v4/registry/new-york-v4/ui/sidebar.tsx`
- `apps/v4/registry/bases/base/ui/sidebar.tsx`
- `apps/v4/registry/bases/radix/ui/sidebar.tsx`
- `apps/v4/registry/bases/aria/ui/sidebar.tsx`

Closes #11591
