### PR TITLE
fix(separator): drop data-vertical:self-stretch to fix vertical centering in flex containers

### DIFF
--- a/apps/v4/registry/bases/base/ui/separator.tsx
+++ b/apps/v4/registry/bases/base/ui/separator.tsx
@@ -14,7 +14,7 @@ function Separator({
       data-slot="separator"
       orientation={orientation}
       className={cn(
-        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px",
         className
       )}
       {...props}

--- a/apps/v4/registry/bases/radix/ui/separator.tsx
+++ b/apps/v4/registry/bases/radix/ui/separator.tsx
@@ -17,7 +17,7 @@ function Separator({
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
Fixes #11736 by removing `data-vertical:self-stretch` from the Separator base classes in both Radix and Base UI registries.

## Problem & Root Cause
When a flex item has both `align-self: stretch` and a definite cross-size (`data-vertical:w-px` alongside caller-provided `h-4`), CSS Flexbox resolves alignment to `flex-start`. Vertical separators inside containers with `items-center` were pinned to the top rather than vertically centered. Because the variant rule sits late in the stylesheet cascade, callers could not override it with utilities like `self-center`.

## Changes
- Dropped `data-vertical:self-stretch` from `apps/v4/registry/bases/base/ui/separator.tsx`
- Dropped `data-vertical:self-stretch` from `apps/v4/registry/bases/radix/ui/separator.tsx`
- Allows parent `items-center` and caller-provided classes to take effect without specificity conflicts. Callers who need full stretch can pass `self-stretch` directly.

## Verification
- Verified with `<div className="flex h-14 items-center"><Separator orientation="vertical" className="h-4" /></div>` to confirm 0px vertical offset.
- Ran `pnpm registry:build`.

Fixes #11736