### PR TITLE
fix(cli): allow template init in existing directory

### DIFF
--- a/packages/shadcn/src/templates/create-template.ts
+++ b/packages/shadcn/src/templates/create-template.ts
@@ -265,7 +265,7 @@ function defaultScaffold({
           "templates",
           templateDir
         )
-        await fs.move(extractedPath, projectPath)
+        await fs.copy(extractedPath, projectPath)
         await fs.remove(templatePath)
       }
 

--- a/packages/shadcn/src/utils/scaffold.test.ts
+++ b/packages/shadcn/src/utils/scaffold.test.ts
@@ -98,7 +98,7 @@ describe("defaultScaffold", () => {
     ])
   })
 
-  it("should move template directory to project path", async () => {
+  it("should copy template directory to project path", async () => {
     const template = createTestTemplate()
 
     await template.scaffold({
@@ -107,7 +107,7 @@ describe("defaultScaffold", () => {
       cwd: "/test",
     })
 
-    expect(vi.mocked(fs.move)).toHaveBeenCalledWith(
+    expect(vi.mocked(fs.copy)).toHaveBeenCalledWith(
       expect.stringContaining(path.join("templates", "next-app")),
       "/test/my-app"
     )


### PR DESCRIPTION
resoles this issue - #10885 

## Description
This PR fixes an issue where running `npx shadcn@latest init --monorepo` in the current directory (`.` or `./`) throws a `dest already exists` error, preventing the template from being initialized. 

**Root cause:** `fs.move` was being used to extract the downloaded template, which explicitly throws an error if the destination directory already exists. 
**Fix:** Changed the file moving strategy to use `fs.copy` and `fs.remove`. This allows the template files to cleanly merge into the existing directory without throwing.

## Changes
- Updated `create-template.ts` to use `fs.copy` instead of `fs.move`.
- Updated mock expectations in `scaffold.test.ts` to reflect the new behavior.

## How to test
1. Build the CLI package locally.
2. In a new or existing empty directory, run the local build: `node path/to/packages/shadcn/dist/index.js init --monorepo`
3. Enter `.` or `./` when prompted for the project directory.
4. Verify that the files merge successfully without the `dest already exists` error.

## Results
<img width="1107" height="677" alt="Screenshot 2026-09-03 112440" src="https://github.com/user-attachments/assets/4712ef4a-5152-4d8e-bc9d-efb24ecdb169" />