### PR TITLE
fix(toast): render Base UI toasts above overlays

### DIFF
--- a/apps/v4/registry/bases/base/ui/toast.tsx
+++ b/apps/v4/registry/bases/base/ui/toast.tsx
@@ -22,7 +22,7 @@ function ToastViewport({ className, ...props }: ToastPrimitive.Viewport.Props) {
     <ToastPrimitive.Viewport
       data-slot="toast-viewport"
       className={cn(
-        "pointer-events-none fixed inset-x-4 bottom-4 z-50 mx-auto w-auto max-w-sm outline-none sm:right-4 sm:left-auto sm:mx-0 sm:w-full",
+        "pointer-events-none fixed inset-x-4 bottom-4 z-100 mx-auto w-auto max-w-sm outline-none sm:right-4 sm:left-auto sm:mx-0 sm:w-full",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

- raise the Base UI toast viewport from z-50 to z-100
- keep toasts visible and interactive above dialog, sheet, alert-dialog, and drawer overlays
- restore the toast stacking tier used by the legacy implementation

## Testing

- pnpm --filter=v4 exec eslint registry/bases/base/ui/toast.tsx --no-cache
- git diff --check
- verified Tailwind CSS 4.3 compiles z-100 to z-index: 100

Fixes #11741