### PR TITLE
fix(base-ui): preserve functional Button className callbacks

### DIFF
--- a/apps/v4/registry/bases/base/ui/button.tsx
+++ b/apps/v4/registry/bases/base/ui/button.tsx
@@ -42,7 +42,11 @@ function Button({
   return (
     <ButtonPrimitive
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
+      className={
+        typeof className === "function"
+          ? (state) => cn(buttonVariants({ variant, size }), className(state))
+          : cn(buttonVariants({ variant, size, className }))
+      }
       {...props}
     />
   )


### PR DESCRIPTION
Preserves Base UI's functional `className` contract in the Base UI Button wrapper.

The wrapper currently passes `className` through CVA. CVA/clsx ignores function values, so TypeScript accepts state-based callbacks but the callback is never invoked at runtime. This change keeps the existing string path unchanged and only resolves callback values with the Button state before merging them with the variant classes.

Scope is intentionally limited to Button, the confirmed reproduction. The same pattern may affect other Base UI wrappers. I'd appreciate guidance on whether follow-up work should handle this locally per component or through a shared composition helper.

Verification:

- `pnpm registry:build`
- `pnpm --filter=v4 typecheck`
- SSR smoke check confirming both `cn-button` and the callback-returned `functional-disabled` class are rendered

Refs #11751
