### PR TITLE
feat(charts): add Scatter chart type

### DIFF
--- a/apps/v4/app/(app)/charts/[type]/page.tsx
+++ b/apps/v4/app/(app)/charts/[type]/page.tsx
@@ -28,6 +28,7 @@ const chartTypes = [
   "pie",
   "radar",
   "radial",
+  "scatter",
   "tooltip",
 ] as const
 type ChartType = (typeof chartTypes)[number]

--- a/apps/v4/app/(app)/charts/charts.tsx
+++ b/apps/v4/app/(app)/charts/charts.tsx
@@ -61,6 +61,7 @@ import { ChartRadialShape } from "@/registry/new-york-v4/charts/chart-radial-sha
 import { ChartRadialSimple } from "@/registry/new-york-v4/charts/chart-radial-simple"
 import { ChartRadialStacked } from "@/registry/new-york-v4/charts/chart-radial-stacked"
 import { ChartRadialText } from "@/registry/new-york-v4/charts/chart-radial-text"
+import { ChartScatterDefault } from "@/registry/new-york-v4/charts/chart-scatter-default"
 import { ChartTooltipAdvanced } from "@/registry/new-york-v4/charts/chart-tooltip-advanced"
 import { ChartTooltipDefault } from "@/registry/new-york-v4/charts/chart-tooltip-default"
 import { ChartTooltipFormatter } from "@/registry/new-york-v4/charts/chart-tooltip-formatter"
@@ -86,6 +87,7 @@ interface ChartGroups {
   pie: ChartItem[]
   radar: ChartItem[]
   radial: ChartItem[]
+  scatter: ChartItem[]
   tooltip: ChartItem[]
 }
 
@@ -178,6 +180,9 @@ export const charts: ChartGroups = {
     { id: "chart-radial-shape", component: ChartRadialShape },
     { id: "chart-radial-stacked", component: ChartRadialStacked },
   ],
+  scatter: [
+    { id: "chart-scatter-default", component: ChartScatterDefault },
+  ],
   tooltip: [
     { id: "chart-tooltip-default", component: ChartTooltipDefault },
     {
@@ -263,6 +268,7 @@ export {
   ChartRadialText,
   ChartRadialShape,
   ChartRadialStacked,
+  ChartScatterDefault,
   ChartTooltipDefault,
   ChartTooltipIndicatorLine,
   ChartTooltipIndicatorNone,

--- a/apps/v4/registry.json
+++ b/apps/v4/registry.json
@@ -2206,6 +2206,18 @@
       "categories": ["charts", "charts-radial"]
     },
     {
+      "name": "chart-scatter-default",
+      "type": "registry:block",
+      "registryDependencies": ["card", "chart"],
+      "files": [
+        {
+          "path": "registry/new-york-v4/charts/chart-scatter-default.tsx",
+          "type": "registry:block"
+        }
+      ],
+      "categories": ["charts", "charts-scatter"]
+    },
+    {
       "name": "chart-tooltip-default",
       "type": "registry:block",
       "registryDependencies": ["card", "chart"],

--- a/apps/v4/registry/new-york-v4/charts/chart-scatter-default.tsx
+++ b/apps/v4/registry/new-york-v4/charts/chart-scatter-default.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { CartesianGrid, Scatter, ScatterChart, XAxis, YAxis } from "recharts"
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/registry/new-york-v4/ui/card"
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/registry/new-york-v4/ui/chart"
+
+export const description = "A scatter chart"
+
+const chartData = [
+  { hours: 1, score: 40 },
+  { hours: 2, score: 48 },
+  { hours: 3, score: 55 },
+  { hours: 4, score: 61 },
+  { hours: 5, score: 67 },
+  { hours: 6, score: 74 },
+  { hours: 7, score: 79 },
+  { hours: 8, score: 85 },
+]
+
+const chartConfig = {
+  score: {
+    label: "Score",
+    color: "var(--chart-1)",
+  },
+} satisfies ChartConfig
+
+export function ChartScatterDefault() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Scatter Chart</CardTitle>
+        <CardDescription>Study hours vs. test score</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className="min-h-[250px] w-full">
+          <ScatterChart>
+            <CartesianGrid />
+            <XAxis
+              type="number"
+              dataKey="hours"
+              name="Hours"
+              tickLine={false}
+              axisLine={false}
+            />
+            <YAxis
+              type="number"
+              dataKey="score"
+              name="Score"
+              tickLine={false}
+              axisLine={false}
+            />
+            <ChartTooltip
+              cursor={{ strokeDasharray: "3 3" }}
+              content={<ChartTooltipContent />}
+            />
+            <Scatter
+              name="Score"
+              data={chartData}
+              fill="var(--color-score)"
+            />
+          </ScatterChart>
+        </ChartContainer>
+      </CardContent>
+      <CardFooter className="flex-col items-start gap-2 text-sm">
+        <div className="text-muted-foreground leading-none">
+          Each point represents one student's study hours and test score.
+        </div>
+      </CardFooter>
+    </Card>
+  )
+}


### PR DESCRIPTION
## What
Adds Scatter as a new chart type to the `/charts` gallery, following
the exact pattern already used by Area, Bar, Line, Pie, Radar, and
Radial.

## Context
Relates to #11621, which asked for dedicated examples per chart type.
Most of that request already exists -- shadcn has a comprehensive
`/charts/[type]` gallery covering Area, Bar, Line, Pie (including
Donut), Radar, and Radial (which covers the "Gauge" use case), each
with 6-14 worked examples wired through the registry.

The one type genuinely missing end-to-end was **Scatter** -- not in
the gallery, not in the registry, no component existed at all. This
PR adds it as a scoped first step, starting with one default variant
(matching how other types started small before growing more variants
over time).

## Changes
- New component: `registry/new-york-v4/charts/chart-scatter-default.tsx`
- New registry entry in `registry.json`
- Wired into the `/charts/[type]` gallery (`charts.tsx`, `chartTypes`
  in `[type]/page.tsx`)
- Regenerated registry JSON via `pnpm registry:build`

## Testing
- `pnpm registry:build`: succeeds
- `npx tsc --noEmit -p apps/v4`: clean, no type errors
- Wasn't able to fully load `/charts/scatter` in the local dev server
  due to memory usage on this machine -- confirmed this is
  **pre-existing and unrelated to this change**: an existing,
  unmodified route (`/charts/bar`) shows identical heavy memory usage
  locally. Happy to have the Vercel preview deploy or a maintainer
  confirm the render.