### PR TITLE
fix(base): preserve button className callbacks

### DIFF
--- a/apps/v4/registry/bases/base/ui/button.tsx
+++ b/apps/v4/registry/bases/base/ui/button.tsx
@@ -39,10 +39,16 @@ function Button({
   size = "default",
   ...props
 }: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  const buttonClassName = buttonVariants({ variant, size })
+
   return (
     <ButtonPrimitive
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
+      className={
+        typeof className === "function"
+          ? (state) => cn(buttonClassName, className(state))
+          : cn(buttonClassName, className)
+      }
       {...props}
     />
   )

--- a/packages/shadcn/src/styles/transform-style-map.test.ts
+++ b/packages/shadcn/src/styles/transform-style-map.test.ts
@@ -162,6 +162,98 @@ function Button({ className, ...props }: React.ComponentProps<"button">) {
     `)
   })
 
+  it("preserves functional className callbacks when applying button cva classes", async () => {
+    const source = `import { Button as ButtonPrimitive } from "@base-ui/react/button"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "cn-button inline-flex items-center",
+  {
+    variants: {
+      variant: {
+        default: "cn-button-variant-default",
+      },
+      size: {
+        default: "cn-button-size-default",
+      },
+    },
+  }
+)
+
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  const buttonClassName = buttonVariants({ variant, size })
+
+  return (
+    <ButtonPrimitive
+      className={
+        typeof className === "function"
+          ? (state) => cn(buttonClassName, className(state))
+          : cn(buttonClassName, className)
+      }
+      {...props}
+    />
+  )
+}
+`
+
+    const styleMap: StyleMap = {
+      "cn-button": "rounded-lg border text-sm",
+      "cn-button-variant-default": "bg-primary text-primary-foreground",
+      "cn-button-size-default": "h-9 px-4",
+    }
+
+    const result = await applyTransform(source, styleMap)
+
+    expect(result).toMatchInlineSnapshot(`
+      "import { Button as ButtonPrimitive } from "@base-ui/react/button"
+      import { cva, type VariantProps } from "class-variance-authority"
+
+      import { cn } from "@/lib/utils"
+
+      const buttonVariants = cva(
+        "rounded-lg border text-sm inline-flex items-center",
+        {
+          variants: {
+            variant: {
+              default: "bg-primary text-primary-foreground",
+            },
+            size: {
+              default: "h-9 px-4",
+            },
+          },
+        }
+      )
+
+      function Button({
+        className,
+        variant = "default",
+        size = "default",
+        ...props
+      }: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+        const buttonClassName = buttonVariants({ variant, size })
+
+        return (
+          <ButtonPrimitive
+            className={
+              typeof className === "function"
+                ? (state) => cn(buttonClassName, className(state))
+                : cn(buttonClassName, className)
+            }
+            {...props}
+          />
+        )
+      }
+      "
+    `)
+  })
+
   it("applies variant classes to cva variant entries", async () => {
     const source = `import * as React from "react"
 import { cva } from "class-variance-authority"


### PR DESCRIPTION
## Summary

Fixes the Base UI Button wrapper so it preserves functional `className` callbacks from `@base-ui/react/button`.

Base UI's Button API accepts `className` as either a string or a function of `Button.State`. The shadcn wrapper currently passes `className` directly into the `buttonVariants` CVA call:

```tsx
cn(buttonVariants({ variant, size, className }))
```

That works for static class names, but a functional `className` callback is treated as a CVA `class` value instead of being forwarded to Base UI. As a result, state-based callbacks like this are silently dropped:

```tsx
<Button className={(state) => (state.disabled ? opacity-40 : opacity-100)} />
```

This PR computes the shadcn variant classes independently, then preserves Base UI's callback contract by returning a composed callback when `className` is a function.

## Changes

- Compute `buttonClassName` from `variant` and `size` without passing through the consumer `className`.
- Preserve functional `className` callbacks by calling `className(state)` and merging the result with the wrapper classes.
- Keep existing static `className` behavior unchanged.
- Add a regression test for the style-map transformer so generated registry output keeps the callback-safe shape after `cn-*` style markers are inlined.

## Verification

- `pnpm --filter=shadcn exec vitest run src/styles/transform-style-map.test.ts`
- `pnpm --filter=v4 registry:build`
- `NODE_OPTIONS=--max-old-space-size=4096 tsc --noEmit` from `apps/v4`
- `pnpm exec prettier --check apps/v4/registry/bases/base/ui/button.tsx packages/shadcn/src/styles/transform-style-map.test.ts`

Closes #11751.
