### PR TITLE
feat(registry): add Watermelon UI

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1836,6 +1836,13 @@
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><defs><filter id='s' x='-50%' y='-50%' width='200%' height='200%'><feGaussianBlur stdDeviation='4.5'/></filter></defs><rect width='64' height='64' rx='16' fill='var(--background)'/><g filter='url(#s)'><circle cx='18' cy='16' r='13' fill='#2e63b8' fill-opacity='0.75'/><circle cx='50' cy='32' r='12' fill='#7b68c8' fill-opacity='0.7'/><circle cx='20' cy='50' r='13' fill='#d0722e' fill-opacity='0.7'/></g><rect x='10' y='10' width='44' height='44' rx='10' fill='var(--foreground)' fill-opacity='0.12'/><rect x='10' y='10' width='44' height='44' rx='10' fill='none' stroke='var(--foreground)' stroke-opacity='0.2'/></svg>"
   },
   {
+    "name": "@watermelon",
+    "homepage": "https://ui.watermelon.sh",
+    "url": "https://registry.watermelon.sh/r/{name}.json",
+    "description": "Free, open-source React components, animated interactions, blocks, dashboards, and templates for shadcn/ui projects. Install with the shadcn CLI and own the source.",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><rect width='24' height='24' rx='6' fill='#7ddc16'/><path d='M6 9.5c0-1.4 1.1-2.5 2.5-2.5S11 8.1 11 9.5 9.9 12 8.5 12 6 10.9 6 9.5Zm7 0C13 8.1 14.1 7 15.5 7S18 8.1 18 9.5 16.9 12 15.5 12 13 10.9 13 9.5ZM6 15.5c0-1.4 1.1-2.5 2.5-2.5s2.5 1.1 2.5 2.5S9.9 18 8.5 18 6 16.9 6 15.5Zm7 0c0-1.4 1.1-2.5 2.5-2.5s2.5 1.1 2.5 2.5-1.1 2.5-2.5 2.5-2.5-1.1-2.5-2.5Z' fill='#0a0a0a'/></svg>"
+  },
+  {
     "name": "@waves-cn",
     "homepage": "https://waves-cn.vercel.app",
     "url": "https://waves-cn.vercel.app/r/{name}.json",


### PR DESCRIPTION
## Summary

Adds `@watermelon` to the shadcn community registry directory.

- Registry URL: https://registry.watermelon.sh/r/{name}.json
- Registry index: https://registry.watermelon.sh/registry.json
- Homepage: https://ui.watermelon.sh
- Install example: `npx shadcn@latest add @watermelon/card-split-accordian`

## Verification

- The live component endpoint returns `application/json`.
- The payload is a valid `registry:component` entry with source files.
- The registry contains 262 generated component and base-variant entries.