### PR TITLE
fix(separator): use data-[orientation=...] attribute selectors

### DIFF
--- a/apps/v4/registry/bases/base/ui/separator.tsx
+++ b/apps/v4/registry/bases/base/ui/separator.tsx
@@ -13,7 +13,7 @@ function Separator({
       data-slot="separator"
       orientation={orientation}
       className={cn(
-        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch",
         className
       )}
       {...props}

--- a/apps/v4/registry/bases/radix/ui/separator.tsx
+++ b/apps/v4/registry/bases/radix/ui/separator.tsx
@@ -16,7 +16,7 @@ function Separator({
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Fixes #11798.

Updates `Separator` in the Base UI and Radix base registries to use `data-[orientation=...]` selectors rather than `data-horizontal` / `data-vertical`.

## Problem

`Separator` in `apps/v4/registry/bases/base/ui/separator.tsx` and `apps/v4/registry/bases/radix/ui/separator.tsx` used orientation variant classes:

```
"data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch"
```

However, `@base-ui/react/separator` and `radix-ui` render orientation as:

```html
<div role="separator" data-orientation="horizontal"></div>
```

They do not render boolean `data-horizontal` or `data-vertical` attributes. As a result, the Tailwind CSS `data-horizontal:*` and `data-vertical:*` classes do not match the element, causing vertical and horizontal separators to fail to render with their intended dimensions.

Note that `apps/v4/registry/new-york-v4/ui/separator.tsx` already uses `data-[orientation=...]`:
```tsx
"shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px"
```

## Solution

Update the orientation variant classes in `apps/v4/registry/bases/base/ui/separator.tsx` and `apps/v4/registry/bases/radix/ui/separator.tsx` to match `data-orientation`:

```tsx
"shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch"
```

Closes #11798.
