### PR TITLE
fix(registry): fallback to base rtl docs url for unsupported templates

### DIFF
--- a/apps/v4/registry/config.ts
+++ b/apps/v4/registry/config.ts
@@ -856,8 +856,13 @@ export function buildRegistryBase(config: DesignSystemConfig) {
       },
     },
     ...(config.rtl && {
-      docs: `To learn how to set up the RTL provider and fonts for your app, see https://ui.shadcn.com/docs/rtl/${config.template === "next-monorepo" ? "next" : (config.template ?? "next")}`,
-    }),
+        docs: (() => {
+          const supported = ["next", "vite", "start"]
+          const template = config.template === "next-monorepo" ? "next" : config.template
+          const path = template && supported.includes(template) ? `/${template}` : ""
+          return `To learn how to set up the RTL provider and fonts for your app, see https://ui.shadcn.com/docs/rtl${path}`
+        })(),
+      }),
   }
 }
 


### PR DESCRIPTION
### Description

Fixes #11801

When running `shadcn init` with `--rtl` on templates without dedicated RTL guides (such as `astro`), the CLI previously constructed a dead link (`https://ui.shadcn.com/docs/rtl/astro`) resulting in a 404.

This fix checks against the supported RTL pages defined in `apps/v4/content/docs/rtl/meta.json` (`next`, `vite`, `start`) and gracefully falls back to the base RTL documentation URL (`https://ui.shadcn.com/docs/rtl`) for all other templates.

### Testing

- Verified that `astro` and other unsupported templates now resolve to `https://ui.shadcn.com/docs/rtl`.
- Verified that `next`, `next-monorepo`, `vite`, and `start` continue to resolve to their respective `/docs/rtl/<template>` paths.