### PR TITLE
fix(registry): correct logo quoting in directory JSON

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -109,7 +109,7 @@
     "homepage": "https://designali.com",
     "url": "https://designali.com/r/{name}.json",
     "description": "Where thoughtful design meets production-ready code. I design and build digital experiences that look great, feel intuitive, and work beautifully.",
-    "logo": "<svg width='658' height='376' viewBox="0 0 658 376" xmlns='http://www.w3.org/2000/svg'><path d='M326.063 0L376.777 137.054L513.831 187.768L376.777 238.482L326.063 375.536L275.349 238.482L138.295 187.768L275.349 137.054L326.063 0Z' fill='#00A8FF'/> <path d='M420.049 321.622V277.733L627.998 184.731V189.956L420.049 96.9536V53.0649L657.257 159.652V215.035L420.049 321.622Z' fill='#00A8FF'/> <path d='M237.208 321.622L0 215.035V159.652L237.208 53.0649V96.9536L29.2591 189.956V184.731L237.208 277.733V321.622Z' fill='#00A8FF'/></svg>"
+    "logo": "<svg width='658' height='376' viewBox='0 0 658 376' xmlns='http://www.w3.org/2000/svg'><path d='M326.063 0L376.777 137.054L513.831 187.768L376.777 238.482L326.063 375.536L275.349 238.482L138.295 187.768L275.349 137.054L326.063 0Z' fill='#00A8FF'/> <path d='M420.049 321.622V277.733L627.998 184.731V189.956L420.049 96.9536V53.0649L657.257 159.652V215.035L420.049 321.622Z' fill='#00A8FF'/> <path d='M237.208 321.622L0 215.035V159.652L237.208 53.0649V96.9536L29.2591 189.956V184.731L237.208 277.733V321.622Z' fill='#00A8FF'/></svg>"
   },
   {
     "name": "@amicro",

--- a/packages/shadcn/src/utils/updaters/update-css.ts
+++ b/packages/shadcn/src/utils/updaters/update-css.ts
@@ -10,12 +10,12 @@ import { TailwindVersion } from "@/src/utils/get-project-info"
 import { highlighter } from "@/src/utils/highlighter"
 import { spinner } from "@/src/utils/spinner"
 import { transformCssVars } from "@/src/utils/updaters/update-css-vars"
+import { twMerge } from "cn"
 import postcss from "postcss"
 import AtRule from "postcss/lib/at-rule"
 import Declaration from "postcss/lib/declaration"
 import Root from "postcss/lib/root"
 import Rule from "postcss/lib/rule"
-import { twMerge } from "cn"
 import { z } from "zod"
 
 export async function updateCss(


### PR DESCRIPTION
Fix the SVG viewBox quotes in the registry directory so the reserved namespace check and registry validation can parse the JSON.
