### PR TITLE
fix(react): correct MessageScroller resize before paint

### DIFF
--- a/.changeset/fix-message-scroller-resize-paint.md
+++ b/.changeset/fix-message-scroller-resize-paint.md
@@ -1,0 +1,5 @@
+---
+"@shadcn/react": patch
+---
+
+Fix MessageScroller resize corrections painting one frame late during streamed content growth.

--- a/packages/react/src/message-scroller/components.tsx
+++ b/packages/react/src/message-scroller/components.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 
 import { composeRefs, mergeProps, useRender } from "../use-render"
-import { USER_SCROLL_KEYS } from "./types"
+import { SCROLL_POSITION_EPSILON, USER_SCROLL_KEYS } from "./types"
 import type {
   MessageScrollerButtonProps,
   MessageScrollerContentProps,
@@ -199,9 +199,9 @@ function MessageScrollerViewport({
       return
     }
 
-    // Coalesce into rAF: handleResize mutates the spacer inside the observed
-    // content, and resizing an observed element during delivery fires
-    // "ResizeObserver loop completed with undelivered notifications".
+    // Viewport resizes can re-anchor a turn by mutating the separately observed
+    // content spacer. Keep this path outside ResizeObserver delivery; streamed
+    // content growth is handled synchronously by the content observer below.
     let frame = 0
 
     const observer = new ResizeObserver(() => {
@@ -248,6 +248,7 @@ function MessageScrollerContent({
     handleResize,
     setContentElement,
     setSpacerElement,
+    shouldSuspendContentResizeObserver,
   } = useMessageScrollerContext()
   const contentRef = React.useRef<HTMLDivElement | null>(null)
 
@@ -289,23 +290,55 @@ function MessageScrollerContent({
       return
     }
 
-    // Coalesce into rAF: handleResize mutates the spacer inside this observed
-    // element, and resizing an observed element during delivery fires
-    // "ResizeObserver loop completed with undelivered notifications".
     let frame = 0
+    let disposed = false
+    let observedHeight = content.getBoundingClientRect().height
 
     const observer = new ResizeObserver(() => {
-      window.cancelAnimationFrame(frame)
-      frame = window.requestAnimationFrame(handleResize)
+      const nextHeight = content.getBoundingClientRect().height
+
+      // observe() queues an initial delivery. Ignore it when re-observing the
+      // same size so spacer corrections cannot bounce between deliveries.
+      if (Math.abs(nextHeight - observedHeight) <= SCROLL_POSITION_EPSILON) {
+        return
+      }
+
+      const shouldSuspend = shouldSuspendContentResizeObserver()
+
+      if (shouldSuspend) {
+        observer.unobserve(content)
+      }
+
+      handleResize()
+      observedHeight = content.getBoundingClientRect().height
+
+      if (shouldSuspend) {
+        // Re-anchoring changes the tail spacer and therefore the observed
+        // content box. Resume outside this delivery cycle to avoid the browser's
+        // "ResizeObserver loop completed with undelivered notifications" error.
+        // The next initial delivery also catches growth that happened while the
+        // observer was suspended.
+        window.cancelAnimationFrame(frame)
+        frame = window.requestAnimationFrame(() => {
+          if (
+            !disposed &&
+            contentRef.current === content &&
+            content.isConnected
+          ) {
+            observer.observe(content)
+          }
+        })
+      }
     })
 
     observer.observe(content)
 
     return () => {
+      disposed = true
       window.cancelAnimationFrame(frame)
       observer.disconnect()
     }
-  }, [handleResize])
+  }, [handleResize, shouldSuspendContentResizeObserver])
 
   return (
     <div

--- a/packages/react/src/message-scroller/message-scroller.browser.test.tsx
+++ b/packages/react/src/message-scroller/message-scroller.browser.test.tsx
@@ -190,6 +190,35 @@ function getDistanceToBottom(viewport: HTMLElement) {
   )
 }
 
+async function measureNextResizeDelivery<T>(
+  element: Element,
+  mutate: () => void,
+  read: () => T
+) {
+  let armed = false
+  const measured = new Promise<T>((resolve) => {
+    const observer = new ResizeObserver(() => {
+      if (!armed) {
+        return
+      }
+
+      observer.disconnect()
+      resolve(read())
+    })
+
+    observer.observe(element)
+  })
+
+  // Discard the probe's initial delivery. Since this observer was registered
+  // after MessageScroller's observers, its next callback runs later in the
+  // same delivery batch and sees the geometry that would be painted.
+  await settle(1)
+  armed = true
+  mutate()
+
+  return measured
+}
+
 function getScrollTop(viewport: HTMLElement) {
   return Math.round(viewport.scrollTop)
 }
@@ -259,28 +288,99 @@ test("opens at the bottom by default", async () => {
   expect(getDistanceToBottom(getViewport())).toBeLessThanOrEqual(1)
 })
 
-test("keeps auto-scroll pinned when the final message grows", async () => {
+test("corrects follow growth during ResizeObserver delivery", async () => {
   const initial = createItems(6)
 
   await renderThread({ autoScroll: true, items: initial })
 
   const viewport = getViewport()
+  const content = document.querySelector('[role="log"]') as HTMLElement
+  const lastMessage = document.querySelector(
+    `[data-message-id="m${initial.length - 1}"]`
+  ) as HTMLElement
 
   expect(getDistanceToBottom(viewport)).toBeLessThanOrEqual(1)
+
+  const distanceDuringDelivery = await measureNextResizeDelivery(
+    content,
+    () => {
+      lastMessage.style.height = "240px"
+    },
+    () => getDistanceToBottom(viewport)
+  )
+
+  // A later observer in the same pre-paint batch must see the corrected live
+  // edge. Waiting for the next animation frame produces a visible thumb bounce.
+  expect(distanceDuringDelivery).toBeLessThanOrEqual(1)
+})
+
+test("corrects anchored growth during ResizeObserver delivery without a loop", async () => {
+  const initial = createItems(6)
+
+  await renderThread({ autoScroll: true, items: initial })
 
   flushSync(() => {
     root!.render(
       <Thread
         autoScroll
-        items={initial.map((item, index) =>
-          index === initial.length - 1 ? { ...item, height: 240 } : item
-        )}
+        items={[
+          ...initial,
+          { id: "turn", height: 20, scrollAnchor: true },
+          { id: "reply", height: 20 },
+        ]}
       />
     )
   })
   await settle()
 
-  expect(getDistanceToBottom(viewport)).toBeLessThanOrEqual(1)
+  const viewport = getViewport()
+  const content = document.querySelector('[role="log"]') as HTMLElement
+  const reply = document.querySelector(
+    '[data-message-id="reply"]'
+  ) as HTMLElement
+  const spacer = document.querySelector(
+    "[data-message-scroller-spacer]"
+  ) as HTMLElement
+  const baselineScrollHeight = viewport.scrollHeight
+  const baselineAnchorOffset = viewportOffsetOf("turn", viewport)
+  const loopErrors: string[] = []
+  const onError = (event: ErrorEvent) => {
+    if (event.message.includes("ResizeObserver loop")) {
+      loopErrors.push(event.message)
+      event.preventDefault()
+    }
+  }
+
+  expect(spacer.hidden).toBe(false)
+  expect(Number.parseFloat(spacer.style.height)).toBeGreaterThan(20)
+  window.addEventListener("error", onError)
+
+  try {
+    const geometryDuringDelivery = await measureNextResizeDelivery(
+      content,
+      () => {
+        reply.style.height = "40px"
+      },
+      () => ({
+        anchorOffset: viewportOffsetOf("turn", viewport),
+        scrollHeight: viewport.scrollHeight,
+      })
+    )
+
+    // The growing reply consumes the reserved spacer in the same pre-paint
+    // delivery, so neither the scrollbar nor the anchored turn wobbles.
+    expect(
+      Math.abs(geometryDuringDelivery.scrollHeight - baselineScrollHeight)
+    ).toBeLessThanOrEqual(1)
+    expect(
+      Math.abs(geometryDuringDelivery.anchorOffset - baselineAnchorOffset)
+    ).toBeLessThanOrEqual(1)
+
+    await settle()
+    expect(loopErrors).toEqual([])
+  } finally {
+    window.removeEventListener("error", onError)
+  }
 })
 
 test("keeps the end pinned when bulk appending anchored turns with autoScroll", async () => {

--- a/packages/react/src/message-scroller/message-scroller.test.tsx
+++ b/packages/react/src/message-scroller/message-scroller.test.tsx
@@ -112,11 +112,25 @@ class TestResizeObserver {
 
   observe(element: Element) {
     this.elements.add(element)
-    window.requestAnimationFrame(() => this.trigger())
+    window.requestAnimationFrame(() => {
+      if (this.elements.has(element)) {
+        this.trigger()
+      }
+    })
   }
 
   trigger() {
-    this.callback([], this as unknown as ResizeObserver)
+    const entries = Array.from(this.elements).map(
+      (element) =>
+        ({
+          target: element,
+          contentRect: element.getBoundingClientRect(),
+        }) as ResizeObserverEntry
+    )
+
+    if (entries.length > 0) {
+      this.callback(entries, this as unknown as ResizeObserver)
+    }
   }
 
   unobserve(element: Element) {
@@ -675,7 +689,7 @@ describe("MessageScroller", () => {
     expect(rendered.scroller().hasAttribute("data-autoscrolling")).toBe(true)
   })
 
-  it("follows late content resize while autoScroll remains engaged", async () => {
+  it("follows late content resize before the next animation frame", async () => {
     const rendered = await renderTestScroller({
       autoScroll: true,
       defaultScrollPosition: "end",
@@ -689,9 +703,15 @@ describe("MessageScroller", () => {
     expect(rendered.viewport().scrollTop).toBe(140)
 
     rendered.message("message-3").dataset.testHeight = "140"
-    await triggerResize(rendered.content())
+    triggerResizeSync(rendered.content())
 
+    // ResizeObserver delivery runs before paint. The live edge must already be
+    // corrected here, without waiting for a requestAnimationFrame callback.
     expect(rendered.viewport().scrollTop).toBe(200)
+
+    await act(async () => {
+      await flushAnimationFrames()
+    })
     expect(rendered.state()).toMatchObject({
       start: true,
       end: false,
@@ -1498,7 +1518,9 @@ function renderPendingScrollToContainer(tree: React.ReactElement) {
     scroller: container.querySelector("[data-testid=scroller]"),
     viewport: container.querySelector("[data-testid=viewport]"),
     async hydrate() {
-      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {})
 
       await act(async () => {
         hydrateRoot(container, tree)
@@ -1711,13 +1733,17 @@ function installIntersectionObserver() {
   ).IntersectionObserver = TestIntersectionObserver
 }
 
+function triggerResizeSync(element: Element) {
+  resizeObservers.forEach((observer) => {
+    if (observer.has(element)) {
+      observer.trigger()
+    }
+  })
+}
+
 async function triggerResize(element: Element) {
   await act(async () => {
-    resizeObservers.forEach((observer) => {
-      if (observer.has(element)) {
-        observer.trigger()
-      }
-    })
+    triggerResizeSync(element)
     await flushAnimationFrames()
   })
 }

--- a/packages/react/src/message-scroller/types.ts
+++ b/packages/react/src/message-scroller/types.ts
@@ -182,6 +182,7 @@ type MessageScrollerContextValue = {
   setViewportElement: (element: HTMLDivElement | null) => void
   pendingDefaultScrollStore: MessageScrollerStore<boolean>
   stateStore: MessageScrollerStore<MessageScrollerScrollable>
+  shouldSuspendContentResizeObserver: () => boolean
   syncAfterScroll: () => void
   unobserveVisibility: () => void
   userScrollIntent: () => void

--- a/packages/react/src/message-scroller/use-message-scroller-controller.ts
+++ b/packages/react/src/message-scroller/use-message-scroller-controller.ts
@@ -665,6 +665,14 @@ function useMessageScrollerController({
     []
   )
 
+  const shouldSuspendContentResizeObserver = React.useCallback(
+    () =>
+      modeRef.current === "anchored-to-message" &&
+      streamingTurnRef.current !== null &&
+      streamingTurnRef.current.isConnected,
+    []
+  )
+
   const syncAfterScroll = React.useCallback(() => {
     commitScrollState()
     scheduleVisibilitySync()
@@ -685,6 +693,7 @@ function useMessageScrollerController({
       setRootElement,
       setSpacerElement,
       setViewportElement,
+      shouldSuspendContentResizeObserver,
       stateStore,
       syncAfterScroll,
       unobserveVisibility,
@@ -704,6 +713,7 @@ function useMessageScrollerController({
       setRootElement,
       setSpacerElement,
       setViewportElement,
+      shouldSuspendContentResizeObserver,
       stateStore,
       syncAfterScroll,
       unobserveVisibility,


### PR DESCRIPTION
Fixes #11577.

## Problem

`MessageScrollerViewport` and `MessageScrollerContent` deferred every `ResizeObserver` delivery through `requestAnimationFrame`. During streaming, the browser therefore painted one frame with stale scroll geometry before follow-bottom or anchored spacer correction ran. On classic scrollbars this made the thumb bounce for every chunk; anchored turns also exposed a one-frame `scrollHeight` wobble.

## Fix

- Handle content growth synchronously during ResizeObserver delivery so follow and anchor corrections settle before paint.
- Suspend the content observer only while anchored correction can mutate the tail spacer, then re-observe on the next frame.
- Memoize the post-correction content height so re-observation's initial delivery settles instead of creating an observe/mutate loop.
- Keep viewport resize correction deferred because that path can mutate the separately observed content spacer.
- Guard deferred re-observation against cleanup and content replacement.

## Tests

- Add a unit regression asserting follow-bottom is corrected before the next animation frame.
- Add real Chromium regressions where a later ResizeObserver reads geometry from the same delivery batch:
  - follow growth is already pinned to the live edge;
  - anchored growth has already consumed the spacer without changing scroll height or anchor offset;
  - no `ResizeObserver loop` error is emitted.
- Confirmed both browser regressions fail against the original implementation (160px follow gap and 20px anchored scroll-height change) and pass with this patch.

Validation:

- `pnpm --filter @shadcn/react typecheck`
- `pnpm --filter @shadcn/react test` (138 tests)
- `pnpm --filter @shadcn/react exec vitest run -c vitest.browser.config.ts src/message-scroller/message-scroller.browser.test.tsx` (18 tests)
