### PR TITLE
fix(styles): use border token for drawer borders

### DIFF
--- a/apps/v4/registry/styles/style-luma.css
+++ b/apps/v4/registry/styles/style-luma.css
@@ -750,7 +750,7 @@
   }
 
   .cn-drawer-popup {
-    @apply bg-popover text-popover-foreground border-popover dark:border-border rounded-4xl border text-sm shadow-xl [--drawer-bleed-background:transparent] [--drawer-inset:--spacing(2)] [--drawer-stacked-shadow:0_-20px_25px_-5px_rgb(0_0_0/0.1),0_-8px_10px_-6px_rgb(0_0_0/0.1)] data-[swipe-direction=down]:data-nested-drawer-open:shadow-(--drawer-stacked-shadow);
+    @apply bg-popover text-popover-foreground border-border rounded-4xl border text-sm shadow-xl [--drawer-bleed-background:transparent] [--drawer-inset:--spacing(2)] [--drawer-stacked-shadow:0_-20px_25px_-5px_rgb(0_0_0/0.1),0_-8px_10px_-6px_rgb(0_0_0/0.1)] data-[swipe-direction=down]:data-nested-drawer-open:shadow-(--drawer-stacked-shadow);
   }
 
   .cn-drawer-handle {

--- a/apps/v4/registry/styles/style-maia.css
+++ b/apps/v4/registry/styles/style-maia.css
@@ -499,7 +499,7 @@
   }
 
   .cn-drawer-popup {
-    @apply bg-popover text-popover-foreground border-popover dark:border-border rounded-4xl border text-sm [--drawer-bleed-background:transparent] [--drawer-inset:--spacing(2)];
+    @apply bg-popover text-popover-foreground border-border rounded-4xl border text-sm [--drawer-bleed-background:transparent] [--drawer-inset:--spacing(2)];
   }
 
   .cn-drawer-handle {

--- a/apps/v4/registry/styles/style-mira.css
+++ b/apps/v4/registry/styles/style-mira.css
@@ -498,7 +498,7 @@
   }
 
   .cn-drawer-popup {
-    @apply bg-popover text-popover-foreground border-popover dark:border-border rounded-xl border text-xs/relaxed [--drawer-bleed-background:transparent] [--drawer-inset:--spacing(2)];
+    @apply bg-popover text-popover-foreground border-border rounded-xl border text-xs/relaxed [--drawer-bleed-background:transparent] [--drawer-inset:--spacing(2)];
   }
 
   .cn-drawer-handle {

--- a/apps/v4/registry/styles/style-rhea.css
+++ b/apps/v4/registry/styles/style-rhea.css
@@ -750,7 +750,7 @@
   }
 
   .cn-drawer-popup {
-    @apply bg-popover text-popover-foreground rounded-[min(var(--radius-4xl),24px)] border border-popover dark:border-border text-sm shadow-xl [--drawer-bleed-background:transparent] [--drawer-inset:--spacing(2)] [--drawer-stacked-shadow:0_-20px_25px_-5px_rgb(0_0_0/0.1),0_-8px_10px_-6px_rgb(0_0_0/0.1)] data-[swipe-direction=down]:data-nested-drawer-open:shadow-(--drawer-stacked-shadow);
+    @apply bg-popover text-popover-foreground rounded-[min(var(--radius-4xl),24px)] border border-border text-sm shadow-xl [--drawer-bleed-background:transparent] [--drawer-inset:--spacing(2)] [--drawer-stacked-shadow:0_-20px_25px_-5px_rgb(0_0_0/0.1),0_-8px_10px_-6px_rgb(0_0_0/0.1)] data-[swipe-direction=down]:data-nested-drawer-open:shadow-(--drawer-stacked-shadow);
   }
 
   .cn-drawer-handle {


### PR DESCRIPTION
## Summary

This PR addresses the drawer border semantic-token inconsistency described in #11763.

The affected drawer styles were using two different semantic tokens for the same visual role depending on the color mode:

- Light mode: `border-popover`
- Dark mode: `border-border`

This means the semantic identity of the drawer border changes between light and dark mode, even though the element is still serving the same purpose: rendering the border of the drawer popup.

This becomes particularly noticeable when users customize the semantic color tokens independently. Since `--popover` and `--border` can represent different colors in a customized theme, the drawer border can unexpectedly change its semantic color when switching between light and dark mode.

## Changes

I changed the `.cn-drawer-popup` rule in the following four styles:

- `style-luma.css`
- `style-maia.css`
- `style-mira.css`
- `style-rhea.css`

The previous pattern was:

```css
border-popover dark:border-border

## Relation to #11763

This PR addresses the drawer-border portion of the semantic color inconsistencies discussed in #11763.

It is intentionally scoped to the drawer case rather than attempting to resolve every `--input` usage mentioned in the issue, since those usages involve different components and may have different semantic/visual requirements.

**Related to #11763.**