### PR TITLE
fix(registry): link RTL setup docs that exist for every template

### DIFF
--- a/apps/v4/app/(app)/(create)/lib/build-instructions.ts
+++ b/apps/v4/app/(app)/(create)/lib/build-instructions.ts
@@ -6,6 +6,7 @@ import {
   getBodyFont,
   getHeadingFont,
   getInheritedHeadingFontValue,
+  rtlDocsUrl,
   type DesignSystemConfig,
 } from "@/registry/config"
 
@@ -271,9 +272,6 @@ function buildAvailableComponentsSection(config: DesignSystemConfig) {
 }
 
 function buildRtlSection(config: DesignSystemConfig) {
-  const template =
-    config.template === "next-monorepo" ? "next" : (config.template ?? "next")
-
   return dedent`
     ## RTL Support
 
@@ -283,6 +281,6 @@ function buildRtlSection(config: DesignSystemConfig) {
     <html dir="rtl">
     \`\`\`
 
-    For full RTL setup including the \`DirectionProvider\`, see the [RTL documentation](https://ui.shadcn.com/docs/rtl/${template}).
+    For full RTL setup including the \`DirectionProvider\`, see the [RTL documentation](${rtlDocsUrl(config.template)}).
   `
 }

--- a/apps/v4/registry/config.test.ts
+++ b/apps/v4/registry/config.test.ts
@@ -11,6 +11,7 @@ import {
   parseRegistryBaseParts,
   POINTER_CURSOR_SELECTOR,
   PRESETS,
+  rtlDocsUrl,
   STYLES,
 } from "./config"
 
@@ -162,6 +163,40 @@ describe("buildRegistryBase", () => {
     })
 
     expect(result.success).toBe(false)
+  })
+})
+
+describe("rtlDocsUrl", () => {
+  // Only these three frameworks have a /docs/rtl/<framework> page; the enum
+  // carries eight more templates that used to be pasted into the URL as-is.
+  it.each([
+    ["next", "https://ui.shadcn.com/docs/rtl/next"],
+    ["start", "https://ui.shadcn.com/docs/rtl/start"],
+    ["vite", "https://ui.shadcn.com/docs/rtl/vite"],
+  ] as const)("links %s at its own guide", (template, expected) => {
+    expect(rtlDocsUrl(template)).toBe(expected)
+  })
+
+  it.each([
+    ["next-monorepo", "https://ui.shadcn.com/docs/rtl/next"],
+    ["start-monorepo", "https://ui.shadcn.com/docs/rtl/start"],
+    ["vite-monorepo", "https://ui.shadcn.com/docs/rtl/vite"],
+  ] as const)("sends %s to its framework guide", (template, expected) => {
+    expect(rtlDocsUrl(template)).toBe(expected)
+  })
+
+  it.each([
+    "astro",
+    "astro-monorepo",
+    "laravel",
+    "react-router",
+    "react-router-monorepo",
+  ] as const)("sends %s to the RTL index rather than a missing page", (template) => {
+    expect(rtlDocsUrl(template)).toBe("https://ui.shadcn.com/docs/rtl")
+  })
+
+  it("falls back to the Next.js guide when no template is set", () => {
+    expect(rtlDocsUrl(undefined)).toBe("https://ui.shadcn.com/docs/rtl/next")
   })
 })
 

--- a/apps/v4/registry/config.ts
+++ b/apps/v4/registry/config.ts
@@ -856,9 +856,24 @@ export function buildRegistryBase(config: DesignSystemConfig) {
       },
     },
     ...(config.rtl && {
-      docs: `To learn how to set up the RTL provider and fonts for your app, see https://ui.shadcn.com/docs/rtl/${config.template === "next-monorepo" ? "next" : (config.template ?? "next")}`,
+      docs: `To learn how to set up the RTL provider and fonts for your app, see ${rtlDocsUrl(config.template)}`,
     }),
   }
+}
+
+// RTL setup guides are only written for these frameworks. Any other template —
+// and any framework added to the enum later — links to the RTL index instead of
+// a per-framework URL that does not exist.
+const RTL_DOCS_FRAMEWORKS = new Set(["next", "start", "vite"])
+
+export function rtlDocsUrl(template: DesignSystemConfig["template"]) {
+  // A monorepo template shares its framework's guide, so `vite-monorepo` and
+  // `vite` both point at /docs/rtl/vite.
+  const framework = (template ?? "next").replace(/-monorepo$/, "")
+
+  return RTL_DOCS_FRAMEWORKS.has(framework)
+    ? `https://ui.shadcn.com/docs/rtl/${framework}`
+    : "https://ui.shadcn.com/docs/rtl"
 }
 
 export function buildPartialRegistryBase(


### PR DESCRIPTION
Closes #11801.

### Problem

The RTL notice the CLI prints after `init --rtl` builds its link by pasting `config.template` straight into the URL:

```ts
`https://ui.shadcn.com/docs/rtl/${config.template === "next-monorepo" ? "next" : (config.template ?? "next")}`
```

RTL guides exist only for `next`, `start` and `vite`. `next-monorepo` is special-cased, but nothing else is, so seven of the eleven templates in the `template` enum print a URL that 404s:

| Template | URL printed | Status |
| --- | --- | --- |
| `next`, `start`, `vite` | `/docs/rtl/<framework>` | 200 |
| `next-monorepo` | `/docs/rtl/next` | 200 |
| `astro` | `/docs/rtl/astro` | **404** |
| `astro-monorepo` | `/docs/rtl/astro-monorepo` | **404** |
| `laravel` | `/docs/rtl/laravel` | **404** |
| `react-router` | `/docs/rtl/react-router` | **404** |
| `react-router-monorepo` | `/docs/rtl/react-router-monorepo` | **404** |
| `start-monorepo` | `/docs/rtl/start-monorepo` | **404** |
| `vite-monorepo` | `/docs/rtl/vite-monorepo` | **404** |

`apps/v4/content/docs/rtl/` holds `index.mdx`, `next.mdx`, `start.mdx` and `vite.mdx` only. The reporter hit this with the Astro template; the same line affects the other six.

`buildInstructions()` repeated the same mapping and had the same defect.

### Fix

`rtlDocsUrl()` strips a `-monorepo` suffix so a monorepo template reaches its framework's guide, and falls back to the `/docs/rtl` index — which does exist and links to all three guides — for any framework without a page of its own. A framework added to the enum later degrades to the index instead of a 404. `buildInstructions()` now shares the helper.

### Testing

`apps/v4/registry/config.test.ts` covers all eleven templates plus the `undefined` default.

```
pnpm exec vitest run apps/v4/registry/config.test.ts
 Test Files  1 passed (1)
      Tests  32 passed (32)

pnpm --filter=v4 typecheck
 (clean)
```

Link statuses in the table above were checked against the live site.