### PR TITLE
fix(carousel): sync navigation state with useSyncExternalStore

### DIFF
--- a/apps/v4/registry/bases/aria/ui/carousel.tsx
+++ b/apps/v4/registry/bases/aria/ui/carousel.tsx
@@ -58,14 +58,34 @@ function Carousel({
     },
     plugins
   )
-  const [canScrollPrev, setCanScrollPrev] = React.useState(false)
-  const [canScrollNext, setCanScrollNext] = React.useState(false)
+  const subscribe = React.useCallback(
+    (onStoreChange: () => void) => {
+      if (!api) {
+        return () => {}
+      }
 
-  const onSelect = React.useCallback((api: CarouselApi) => {
-    if (!api) return
-    setCanScrollPrev(api.canScrollPrev())
-    setCanScrollNext(api.canScrollNext())
-  }, [])
+      api.on("reInit", onStoreChange)
+      api.on("select", onStoreChange)
+
+      return () => {
+        api.off("reInit", onStoreChange)
+        api.off("select", onStoreChange)
+      }
+    },
+    [api]
+  )
+
+  const canScrollPrev = React.useSyncExternalStore(
+    subscribe,
+    () => api?.canScrollPrev() ?? false,
+    () => false
+  )
+
+  const canScrollNext = React.useSyncExternalStore(
+    subscribe,
+    () => api?.canScrollNext() ?? false,
+    () => false
+  )
 
   const scrollPrev = React.useCallback(() => {
     api?.scrollPrev()
@@ -92,17 +112,6 @@ function Carousel({
     if (!api || !setApi) return
     setApi(api)
   }, [api, setApi])
-
-  React.useEffect(() => {
-    if (!api) return
-    onSelect(api)
-    api.on("reInit", onSelect)
-    api.on("select", onSelect)
-
-    return () => {
-      api?.off("select", onSelect)
-    }
-  }, [api, onSelect])
 
   return (
     <CarouselContext.Provider

--- a/apps/v4/registry/bases/base/ui/carousel.tsx
+++ b/apps/v4/registry/bases/base/ui/carousel.tsx
@@ -58,14 +58,34 @@ function Carousel({
     },
     plugins
   )
-  const [canScrollPrev, setCanScrollPrev] = React.useState(false)
-  const [canScrollNext, setCanScrollNext] = React.useState(false)
+  const subscribe = React.useCallback(
+    (onStoreChange: () => void) => {
+      if (!api) {
+        return () => {}
+      }
 
-  const onSelect = React.useCallback((api: CarouselApi) => {
-    if (!api) return
-    setCanScrollPrev(api.canScrollPrev())
-    setCanScrollNext(api.canScrollNext())
-  }, [])
+      api.on("reInit", onStoreChange)
+      api.on("select", onStoreChange)
+
+      return () => {
+        api.off("reInit", onStoreChange)
+        api.off("select", onStoreChange)
+      }
+    },
+    [api]
+  )
+
+  const canScrollPrev = React.useSyncExternalStore(
+    subscribe,
+    () => api?.canScrollPrev() ?? false,
+    () => false
+  )
+
+  const canScrollNext = React.useSyncExternalStore(
+    subscribe,
+    () => api?.canScrollNext() ?? false,
+    () => false
+  )
 
   const scrollPrev = React.useCallback(() => {
     api?.scrollPrev()
@@ -92,17 +112,6 @@ function Carousel({
     if (!api || !setApi) return
     setApi(api)
   }, [api, setApi])
-
-  React.useEffect(() => {
-    if (!api) return
-    onSelect(api)
-    api.on("reInit", onSelect)
-    api.on("select", onSelect)
-
-    return () => {
-      api?.off("select", onSelect)
-    }
-  }, [api, onSelect])
 
   return (
     <CarouselContext.Provider

--- a/apps/v4/registry/bases/radix/ui/carousel.tsx
+++ b/apps/v4/registry/bases/radix/ui/carousel.tsx
@@ -58,14 +58,34 @@ function Carousel({
     },
     plugins
   )
-  const [canScrollPrev, setCanScrollPrev] = React.useState(false)
-  const [canScrollNext, setCanScrollNext] = React.useState(false)
+  const subscribe = React.useCallback(
+    (onStoreChange: () => void) => {
+      if (!api) {
+        return () => {}
+      }
 
-  const onSelect = React.useCallback((api: CarouselApi) => {
-    if (!api) return
-    setCanScrollPrev(api.canScrollPrev())
-    setCanScrollNext(api.canScrollNext())
-  }, [])
+      api.on("reInit", onStoreChange)
+      api.on("select", onStoreChange)
+
+      return () => {
+        api.off("reInit", onStoreChange)
+        api.off("select", onStoreChange)
+      }
+    },
+    [api]
+  )
+
+  const canScrollPrev = React.useSyncExternalStore(
+    subscribe,
+    () => api?.canScrollPrev() ?? false,
+    () => false
+  )
+
+  const canScrollNext = React.useSyncExternalStore(
+    subscribe,
+    () => api?.canScrollNext() ?? false,
+    () => false
+  )
 
   const scrollPrev = React.useCallback(() => {
     api?.scrollPrev()
@@ -92,17 +112,6 @@ function Carousel({
     if (!api || !setApi) return
     setApi(api)
   }, [api, setApi])
-
-  React.useEffect(() => {
-    if (!api) return
-    onSelect(api)
-    api.on("reInit", onSelect)
-    api.on("select", onSelect)
-
-    return () => {
-      api?.off("select", onSelect)
-    }
-  }, [api, onSelect])
 
   return (
     <CarouselContext.Provider

--- a/apps/v4/registry/new-york-v4/ui/carousel.tsx
+++ b/apps/v4/registry/new-york-v4/ui/carousel.tsx
@@ -58,14 +58,34 @@ function Carousel({
     },
     plugins
   )
-  const [canScrollPrev, setCanScrollPrev] = React.useState(false)
-  const [canScrollNext, setCanScrollNext] = React.useState(false)
+  const subscribe = React.useCallback(
+    (onStoreChange: () => void) => {
+      if (!api) {
+        return () => {}
+      }
 
-  const onSelect = React.useCallback((api: CarouselApi) => {
-    if (!api) return
-    setCanScrollPrev(api.canScrollPrev())
-    setCanScrollNext(api.canScrollNext())
-  }, [])
+      api.on("reInit", onStoreChange)
+      api.on("select", onStoreChange)
+
+      return () => {
+        api.off("reInit", onStoreChange)
+        api.off("select", onStoreChange)
+      }
+    },
+    [api]
+  )
+
+  const canScrollPrev = React.useSyncExternalStore(
+    subscribe,
+    () => api?.canScrollPrev() ?? false,
+    () => false
+  )
+
+  const canScrollNext = React.useSyncExternalStore(
+    subscribe,
+    () => api?.canScrollNext() ?? false,
+    () => false
+  )
 
   const scrollPrev = React.useCallback(() => {
     api?.scrollPrev()
@@ -92,17 +112,6 @@ function Carousel({
     if (!api || !setApi) return
     setApi(api)
   }, [api, setApi])
-
-  React.useEffect(() => {
-    if (!api) return
-    onSelect(api)
-    api.on("reInit", onSelect)
-    api.on("select", onSelect)
-
-    return () => {
-      api?.off("select", onSelect)
-    }
-  }, [api, onSelect])
 
   return (
     <CarouselContext.Provider


### PR DESCRIPTION
Fixes #11811.

Related to #10564.

## Summary

The Carousel component synchronously called `onSelect(api)` inside an effect. 
Since `onSelect` immediately updated `canScrollPrev` and `canScrollNext`, 
this triggered the `react-hooks/set-state-in-effect` rule in current ESLint configurations.

This PR replaces the React state mirrored from Embla and the manual
effect synchronization with `useSyncExternalStore`, using the Embla API
as the external source of truth for the navigation state.

## Changes

- Subscribe to Embla's `select` and `reInit` events with `useSyncExternalStore`.
- Read `canScrollPrev` and `canScrollNext` directly from the Embla API.
- Remove the synchronous `onSelect(api)` call from the effect.
- Unsubscribe from both `select` and `reInit` events during cleanup.
- Apply the change to all four authored Carousel variants:
  - `aria`
  - `base`
  - `radix`
  - `new-york-v4`

## Lint Verification

### Before

Running ESLint against the generated Carousel reports `react-hooks/set-state-in-effect`.

<img width="727" height="173" alt="Carousel set-state-in-effect ESLint error" src="https://github.com/user-attachments/assets/53470452-959d-4bb8-9e7e-3c86afdf9c56" />

### After

Running ESLint against all four authored Carousel variants completes without errors.

<img width="727" height="169" alt="Carousel ESLint check passed" src="https://github.com/user-attachments/assets/badc3d94-0c9e-4f6f-84fd-6d04c5b84267" />

## Verification

### Manual testing
- Confirmed that the previous button is disabled on the first slide.
- Confirmed that both navigation buttons are enabled on intermediate slides.
- Confirmed that the next button is disabled on the last slide.
- Confirmed that navigation state updates after dragging between slides.
- Confirmed that both navigation buttons remain enabled when `loop` is enabled.

### Checks
- Passed `pnpm registry:build`.
- Passed `pnpm check`.
- Ran the tests package with:
  ```bash
  pnpm --filter=tests exec vitest run \
    --maxWorkers=1 \
    --no-file-parallelism \
    --silent=passed-only
  ```

### Result
<img width="882" height="88" alt="스크린샷 2026-09-07 오후 2 07 36" src="https://github.com/user-attachments/assets/703f5a3b-553f-4d4f-a379-13187398340e" />
