### PR TITLE
Fix vertical Separator collapsing to 0px in flex containers without explicit height

### DIFF
--- a/apps/v4/registry/new-york-v4/ui/separator.tsx
+++ b/apps/v4/registry/new-york-v4/ui/separator.tsx
@@ -16,7 +16,7 @@ function Separator({
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch",
         className
       )}
       {...props}


### PR DESCRIPTION
data-[orientation=vertical]:h-full resolves height:100% against the flex row's own height, which is auto when nothing sets it, so the separator collapses to 0px. self-stretch sizes it to the flex line's cross size instead, independent of percentage resolution.

Fixes #4818. Note the min-h-full fix proposed there has the same bug, since percentage min-height also requires a definite containing block height.