### PR TITLE
feat(registry): add @plotcn to registry directory

### DIFF
--- a/apps/v4/registry/directory.json
+++ b/apps/v4/registry/directory.json
@@ -1248,6 +1248,13 @@
     "logo": "<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='lucide lucide-minus-icon lucide-minus'><path d='M5 12h14'/></svg>"
   },
   {
+    "name": "@plotcn",
+    "homepage": "https://plotcn.vercel.app",
+    "description": "Source-first React visualization components for Recharts, D3.js, and Google Charts",
+    "url": "https://plotcn.vercel.app/r/{name}.json",
+    "logo": "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='24' height='24' fill='none'><path fill='currentColor' d='M3 19V10C3 6.13 6.13 3 10 3H19C24.52 3 29 7.48 29 13C29 18.32 24.85 22.67 19.6 22.98V17.5C22.71 17.81 25 15.73 25 12.8C25 9.93 23.05 8 20.5 8C19.26 8 18.25 8.44 17.1 9.2L6.2 16.4C4.75 17.36 3.65 18.09 3 19Z'/><path fill='currentColor' d='M3 24.2C3 21.98 4.14 20.06 6 18.85L7.5 17.88C8.58 17.18 9.5 17.8 9.5 19V29H6.5C4.57 29 3 27.43 3 25.5V24.2ZM11.5 17.13C11.5 16.43 11.78 16.02 12.37 15.63L14.9 13.98C16.12 13.18 17.5 13.88 17.5 15.3V28C17.5 28.55 17.05 29 16.5 29H12.5C11.95 29 11.5 28.55 11.5 28V17.13Z'/><path fill='currentColor' d='M23 12.8A2 2 0 1 1 19 12.8A2 2 0 1 1 23 12.8Z'/></svg>"
+  },
+  {
     "name": "@preskok",
     "homepage": "https://ui-three-mu.vercel.app",
     "url": "https://ui-three-mu.vercel.app/r/{name}.json",


### PR DESCRIPTION
### Summary
Adds `@plotcn` to the official shadcn Registry Directory (`apps/v4/registry/directory.json`).

Plotcn is an open-source, source-first visualization registry for React providing theme-aware, accessible chart components and dashboard blocks built on Recharts, modular D3.js, and Google Charts.

### Registry Details
- **Namespace**: `@plotcn`
- **Homepage**: https://plotcn.vercel.app
- **URL Template**: `https://plotcn.vercel.app/r/{name}.json`
- **Catalog Endpoint**: `https://plotcn.vercel.app/r/registry.json`
- **Source Repository**: https://github.com/CodeWithEswar/plotcn
- **License**: MIT

### Verification & Compatibility Audit
The registry has undergone a complete pre-submission audit against the official shadcn CLI:
- [x] Conforms to the flat registry schema (`/registry.json` and `/{name}.json`).
- [x] Passed `pnpm validate:registries` locally.
- [x] `public/r/*.json` endpoints verified via HTTP requests.
- [x] Tested in clean external consumer projects with:
  ```bash
  npx shadcn@latest list @plotcn
  npx shadcn@latest search @plotcn --query line
  npx shadcn@latest view @plotcn/line-basic
  npx shadcn@latest add @plotcn/line-basic
