### PR TITLE
fix(registry): make AlertDialogAction close the dialog in the base registry

### DIFF
--- a/apps/v4/registry/bases/base/ui/alert-dialog.tsx
+++ b/apps/v4/registry/bases/base/ui/alert-dialog.tsx
@@ -131,12 +131,16 @@ function AlertDialogDescription({
 
 function AlertDialogAction({
   className,
+  variant = "default",
+  size = "default",
   ...props
-}: React.ComponentProps<typeof Button>) {
+}: AlertDialogPrimitive.Close.Props &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
   return (
-    <Button
+    <AlertDialogPrimitive.Close
       data-slot="alert-dialog-action"
       className={cn("cn-alert-dialog-action", className)}
+      render={<Button variant={variant} size={size} />}
       {...props}
     />
   )


### PR DESCRIPTION
Fixes #9340

In the `bases/base` (Base UI) registry, `AlertDialogAction` is a plain `Button` with no connection to the dialog, so clicking the confirm button leaves the dialog open. The Radix tree doesn't have this problem because `RadixAlertDialog.Action` is itself a Close part.

This mirrors `AlertDialogCancel`'s existing implementation: render `AlertDialogPrimitive.Close` with `render={<Button variant={variant} size={size} />}`, defaulting `variant` to `"default"`. Base UI's own alert-dialog demos wire the confirm button as `<AlertDialog.Close>` too.

Async flows that need to keep the dialog open remain possible via the controlled `open` + `onOpenChange` `eventDetails.cancel()` pattern (or `preventBaseUIHandler()` in a user `onClick`).

Found while building a Base UI-only registry on top of these sources; covered there by a regression test asserting the dialog dismisses on Action click.