### PR TITLE
fix(registry): render a single thumb when slider has no value

### DIFF
--- a/apps/v4/registry/bases/base/ui/slider.tsx
+++ b/apps/v4/registry/bases/base/ui/slider.tsx
@@ -13,7 +13,7 @@ function Slider({
     ? value
     : Array.isArray(defaultValue)
       ? defaultValue
-      : [min, max]
+      : [min]
 
   return (
     <SliderPrimitive.Root

--- a/apps/v4/registry/bases/radix/ui/slider.tsx
+++ b/apps/v4/registry/bases/radix/ui/slider.tsx
@@ -18,8 +18,8 @@ function Slider({
         ? value
         : Array.isArray(defaultValue)
           ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
+          : [min],
+    [value, defaultValue, min]
   )
 
   return (

--- a/apps/v4/registry/new-york-v4/ui/slider.tsx
+++ b/apps/v4/registry/new-york-v4/ui/slider.tsx
@@ -18,8 +18,8 @@ function Slider({
         ? value
         : Array.isArray(defaultValue)
           ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max]
+          : [min],
+    [value, defaultValue, min]
   )
 
   return (


### PR DESCRIPTION
When neither `value` nor `defaultValue` is provided, the slider wrappers compute a `[min, max]` fallback that is only used for the thumb count — the primitive never receives it. The result differs by primitive:

- **Base UI** (`bases/base`): Base UI defaults an uncontrolled slider to the scalar `min` and maps every thumb of a non-range slider to index 0 (`SliderThumb`: `const index = !range ? 0 : …`), so a bare `<Slider />` renders **two overlapping thumbs both stuck at min**, both announcing `aria-valuenow` = min.
- **Radix** (`bases/radix`, `new-york-v4`): Radix hides thumbs with no matching value (`style={{ display: 'none' }}`), so the second thumb is invisible dead DOM.

Changing the fallback to `[min]` renders one thumb in all trees — matching the primitives' actual uncontrolled default and the visual users already get on Radix — and removes the hidden extra thumb there. The `useMemo` dependency lists drop the now-unused `max`.

Found while building a Base UI-only registry on top of these sources; covered there by a regression test (`bare slider renders a single thumb at min`).