### PR TITLE
fix(registry): keep link semantics on pagination links in the base registry

### DIFF
--- a/apps/v4/registry/bases/base/ui/pagination.tsx
+++ b/apps/v4/registry/bases/base/ui/pagination.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { cn } from "cn"
 
-import { Button } from "@/registry/bases/base/ui/button"
+import { Button, buttonVariants } from "@/registry/bases/base/ui/button"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
 function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
@@ -48,19 +48,16 @@ function PaginationLink({
   ...props
 }: PaginationLinkProps) {
   return (
-    <Button
-      variant={isActive ? "outline" : "ghost"}
-      size={size}
-      className={cn("cn-pagination-link", className)}
-      nativeButton={false}
-      render={
-        <a
-          aria-current={isActive ? "page" : undefined}
-          data-slot="pagination-link"
-          data-active={isActive}
-          {...props}
-        />
-      }
+    <a
+      aria-current={isActive ? "page" : undefined}
+      data-slot="pagination-link"
+      data-active={isActive || undefined}
+      className={cn(
+        buttonVariants({ variant: isActive ? "outline" : "ghost", size }),
+        "cn-pagination-link",
+        className
+      )}
+      {...props}
     />
   )
 }


### PR DESCRIPTION
In the `bases/base` (Base UI) registry, `PaginationLink` renders through `Button` with `nativeButton={false}` + `render={<a/>}`. Base UI's `useButton` unconditionally merges `role="button"` onto non-native buttons, so every pagination link is announced as a **button**: links disappear from screen-reader link lists, `aria-current="page"` sits on a "button", and Space-key activation is grafted onto anchors. Base UI's Button docs are explicit that it "should not be used for links", and there is no supported way to suppress the role.

This switches `PaginationLink` to a plain `<a>` styled with `buttonVariants` — the same approach `new-york-v4` uses — preserving the exact visual output while restoring real link semantics.

It also changes `data-active={isActive}` to `data-active={isActive || undefined}`: an explicit `isActive={false}` currently serializes as `data-active="false"`, which still matches `[data-active]` / Tailwind `data-active:` selectors. (That second footgun exists in the other trees too; kept this PR scoped to the base registry.)

Found while building a Base UI-only registry on top of these sources; covered there by regression tests (`getByRole("link")`, absent `data-active` on inactive links).