### PR TITLE
fix(registry): align EmptyDescription and KbdGroup prop types with their rendered elements

### DIFF
--- a/apps/v4/registry/bases/base/ui/empty.tsx
+++ b/apps/v4/registry/bases/base/ui/empty.tsx
@@ -67,7 +67,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/registry/bases/base/ui/kbd.tsx
+++ b/apps/v4/registry/bases/base/ui/kbd.tsx
@@ -13,7 +13,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
   )
 }
 
-function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+function KbdGroup({ className, ...props }: React.ComponentProps<"kbd">) {
   return (
     <kbd
       data-slot="kbd-group"

--- a/apps/v4/registry/bases/radix/ui/empty.tsx
+++ b/apps/v4/registry/bases/radix/ui/empty.tsx
@@ -67,7 +67,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/registry/bases/radix/ui/kbd.tsx
+++ b/apps/v4/registry/bases/radix/ui/kbd.tsx
@@ -13,7 +13,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
   )
 }
 
-function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+function KbdGroup({ className, ...props }: React.ComponentProps<"kbd">) {
   return (
     <kbd
       data-slot="kbd-group"

--- a/apps/v4/registry/new-york-v4/ui/empty.tsx
+++ b/apps/v4/registry/new-york-v4/ui/empty.tsx
@@ -67,7 +67,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+function EmptyDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="empty-description"

--- a/apps/v4/registry/new-york-v4/ui/kbd.tsx
+++ b/apps/v4/registry/new-york-v4/ui/kbd.tsx
@@ -15,7 +15,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
   )
 }
 
-function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+function KbdGroup({ className, ...props }: React.ComponentProps<"kbd">) {
   return (
     <kbd
       data-slot="kbd-group"


### PR DESCRIPTION
Two components are typed for a different element than the one they render, in all three trees (`bases/base`, `bases/radix`, `new-york-v4`):

- `EmptyDescription` is typed `React.ComponentProps<"p">` but renders a `<div>`.
- `KbdGroup` is typed `React.ComponentProps<"div">` but renders a `<kbd>`.

This keeps the rendered DOM as-is and fixes only the TypeScript types (`"div"` / `"kbd"`). The rendered elements are the sensible ones: a `<div>` keeps the description permissive (a `<p>` cannot contain flow content), and `<kbd>` wrapping `<kbd>` elements is the spec-blessed markup for key combinations.