### PR TITLE
fix(registry): unsubscribe reInit listener in carousel cleanup

### DIFF
--- a/apps/v4/registry/bases/base/ui/carousel.tsx
+++ b/apps/v4/registry/bases/base/ui/carousel.tsx
@@ -100,6 +100,7 @@ function Carousel({
     api.on("select", onSelect)
 
     return () => {
+      api?.off("reInit", onSelect)
       api?.off("select", onSelect)
     }
   }, [api, onSelect])

--- a/apps/v4/registry/bases/radix/ui/carousel.tsx
+++ b/apps/v4/registry/bases/radix/ui/carousel.tsx
@@ -100,6 +100,7 @@ function Carousel({
     api.on("select", onSelect)
 
     return () => {
+      api?.off("reInit", onSelect)
       api?.off("select", onSelect)
     }
   }, [api, onSelect])

--- a/apps/v4/registry/new-york-v4/ui/carousel.tsx
+++ b/apps/v4/registry/new-york-v4/ui/carousel.tsx
@@ -100,6 +100,7 @@ function Carousel({
     api.on("select", onSelect)
 
     return () => {
+      api?.off("reInit", onSelect)
       api?.off("select", onSelect)
     }
   }, [api, onSelect])


### PR DESCRIPTION
The carousel effect subscribes `api.on("reInit", onSelect)` and `api.on("select", onSelect)`, but the cleanup only calls `api?.off("select", onSelect)` — in all three trees (`bases/base`, `bases/radix`, `new-york-v4`).

Today the leak is practically unreachable (`onSelect` is a stable `useCallback` and Embla's `destroy()` clears all listeners on unmount), but the asymmetry becomes a real duplicate-listener leak the moment `onSelect` gains a dependency. One line makes the effect self-consistent:

```ts
return () => {
  api?.off("reInit", onSelect)
  api?.off("select", onSelect)
}
```