### PR TITLE
fix(combobox): keep Combobox.Input as the real input so Enter selects

### DIFF
--- a/apps/v4/registry/bases/base/ui/combobox.tsx
+++ b/apps/v4/registry/bases/base/ui/combobox.tsx
@@ -9,7 +9,6 @@ import {
   InputGroup,
   InputGroupAddon,
   InputGroupButton,
-  InputGroupInput,
 } from "@/registry/bases/base/ui/input-group"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
@@ -77,7 +76,9 @@ function ComboboxInput({
   return (
     <InputGroup className={cn("cn-combobox-input w-auto", className)}>
       <ComboboxPrimitive.Input
-        render={<InputGroupInput disabled={disabled} />}
+        disabled={disabled}
+        data-slot="input-group-control"
+        className="cn-input cn-input-group-input w-full min-w-0 flex-1 outline-none placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
         {...props}
       />
       <InputGroupAddon align="inline-end">

--- a/apps/v4/registry/bases/radix/ui/combobox.tsx
+++ b/apps/v4/registry/bases/radix/ui/combobox.tsx
@@ -9,7 +9,6 @@ import {
   InputGroup,
   InputGroupAddon,
   InputGroupButton,
-  InputGroupInput,
 } from "@/registry/bases/radix/ui/input-group"
 import { IconPlaceholder } from "@/app/(create)/components/icon-placeholder"
 
@@ -77,7 +76,9 @@ function ComboboxInput({
   return (
     <InputGroup className={cn("cn-combobox-input w-auto", className)}>
       <ComboboxPrimitive.Input
-        render={<InputGroupInput disabled={disabled} />}
+        disabled={disabled}
+        data-slot="input-group-control"
+        className="cn-input cn-input-group-input w-full min-w-0 flex-1 outline-none placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
         {...props}
       />
       <InputGroupAddon align="inline-end">

--- a/apps/v4/registry/new-york-v4/ui/combobox.tsx
+++ b/apps/v4/registry/new-york-v4/ui/combobox.tsx
@@ -10,7 +10,6 @@ import {
   InputGroup,
   InputGroupAddon,
   InputGroupButton,
-  InputGroupInput,
 } from "@/registry/new-york-v4/ui/input-group"
 
 const Combobox = ComboboxPrimitive.Root
@@ -66,7 +65,9 @@ function ComboboxInput({
   return (
     <InputGroup className={cn("w-auto", className)}>
       <ComboboxPrimitive.Input
-        render={<InputGroupInput disabled={disabled} />}
+        disabled={disabled}
+        data-slot="input-group-control"
+        className="h-9 w-full min-w-0 flex-1 rounded-none border-0 bg-transparent px-3 py-1 text-base shadow-none outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground transition-[color,box-shadow] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-transparent"
         {...props}
       />
       <InputGroupAddon align="inline-end">


### PR DESCRIPTION
Closes #11554

Keyboard users can open the combobox, move through the options, and still never choose one. Enter closes the list and leaves the input empty. While the popup is open, focus also leaves the field and sits on the listbox, so you cannot type to filter while you browse. Those two reports in the issue are the same bug wearing two hats.

This is easy to miss if you only try it on the docs site. The registry here runs on React 19, where `ref` is a normal prop, so the current wrap already works. The issue was filed against React 18.3.1, which is still what a lot of apps get from `npx shadcn add combobox`. On 18, the same code quietly drops the ref and the keyboard path falls apart.

## Why

`ComboboxInput` was handing Base UI a stand-in host:

```tsx
<ComboboxPrimitive.Input render={<InputGroupInput disabled={disabled} />} />
```

`InputGroupInput` is a plain function component. It does not forward a ref. On React 18 that ref never reaches the real `<input>`, so Base UI never registers the field. Arrow keys then move real DOM focus into the list, and Enter closes the popup without writing a value, because as far as the primitive can tell there is no input at all.

I went looking at Base UI first. The primitive is doing its job. The wrap is the problem.

## What changed

`Combobox.Input` is the real `<input>` again. `InputGroup` stays around it for the chevron and the clear button, and the input-group classes move onto `Combobox.Input` so the chrome looks the same.

Same change in all three copies of this composition:

- `registry/bases/base/ui/combobox.tsx`
- `registry/bases/radix/ui/combobox.tsx`
- `registry/new-york-v4/ui/combobox.tsx`

The React Aria combobox is a different primitive, so I left it alone.

## Testing

I reproduced this on a small React 18 page that matches the issue. Before the change, focus landed on the listbox after ArrowDown, and Enter left the value as `""`. After, focus stayed on the input and Enter wrote `"Banana"`. React 19 already passed, and this does not take that path backwards. It just stops us from needing React 19 for a ref to land.

- [ ] On React 18, tab to the input, press Down to an option, press Enter. The input should show that option.
- [ ] While the list is open, focus should stay on the input, not the listbox.
- [ ] Typing to filter with the list open should still work.
- [ ] Clicking an option with the mouse should still work.
- [ ] The chevron and clear button should look and behave the same.
- [ ] Repeat the same checks on React 19.
