### PR TITLE
fix: fail the install spinner when a registry npm package is missing

### DIFF
--- a/packages/shadcn/src/utils/updaters/update-dependencies.test.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.test.ts
@@ -1,8 +1,7 @@
 import { getFixturesDir } from "@/src/test-helpers"
-import type { Config } from "@/src/utils/get-config"
 import { execa } from "execa"
 import prompts from "prompts"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   assertSafeDependencies,
@@ -11,10 +10,33 @@ import {
   updateDependencies,
 } from "./update-dependencies"
 
+const { spinnerInstance } = vi.hoisted(() => {
+  const spinner = {
+    start: vi.fn(),
+    succeed: vi.fn(),
+    fail: vi.fn(),
+    stop: vi.fn(),
+    stopAndPersist: vi.fn(),
+  }
+  spinner.start.mockReturnValue(spinner)
+  return { spinnerInstance: spinner }
+})
+
 vi.mock("execa")
 vi.mock("prompts")
+vi.mock("@/src/utils/spinner", () => ({
+  spinner: vi.fn(() => spinnerInstance),
+}))
+
+function packageManagerExecaOptions(cwd: string) {
+  return { cwd, stdin: "ignore" as const }
+}
 
 describe("updateDependencies", () => {
+  beforeEach(() => {
+    spinnerInstance.start.mockReturnValue(spinnerInstance)
+  })
+
   afterEach(() => {
     vi.restoreAllMocks()
   })
@@ -167,14 +189,16 @@ describe("updateDependencies", () => {
         expect(prompts).not.toHaveBeenCalled()
       }
 
-      expect(execa).toHaveBeenCalledWith(expectedPackageManager, expectedArgs, {
-        cwd: config?.resolvedPaths.cwd,
-      })
+      expect(execa).toHaveBeenCalledWith(
+        expectedPackageManager,
+        expectedArgs,
+        packageManagerExecaOptions(config?.resolvedPaths.cwd)
+      )
 
       expect(execa).toHaveBeenCalledWith(
         expectedPackageManager,
         expectedDevArgs,
-        { cwd: config?.resolvedPaths.cwd }
+        packageManagerExecaOptions(config?.resolvedPaths.cwd)
       )
     }
   )
@@ -201,14 +225,12 @@ describe("updateDependencies", () => {
     expect(execa).toHaveBeenCalledWith(
       "pnpm",
       ["add", "--", "react-is", "recharts@3.8.0"],
-      { cwd }
+      packageManagerExecaOptions(cwd)
     )
     expect(execa).toHaveBeenCalledWith(
       "pnpm",
       ["add", "-D", "--", "typescript"],
-      {
-        cwd,
-      }
+      packageManagerExecaOptions(cwd)
     )
   })
 
@@ -226,7 +248,7 @@ describe("updateDependencies", () => {
     expect(execa).toHaveBeenCalledWith(
       "pnpm",
       ["add", "--", "recharts@3.8.0", "@base-ui/react@1.4.1"],
-      { cwd }
+      packageManagerExecaOptions(cwd)
     )
   })
 
@@ -245,7 +267,7 @@ describe("updateDependencies", () => {
     expect(execa).toHaveBeenCalledWith(
       "npx",
       ["expo", "install", "--", "recharts", "react-is"],
-      { cwd }
+      packageManagerExecaOptions(cwd)
     )
   })
 
@@ -266,6 +288,27 @@ describe("updateDependencies", () => {
       expect.arrayContaining(["--registry=http://malicious"]),
       expect.anything()
     )
+  })
+
+  it("stops the spinner and rethrows when the package manager cannot install a dependency (#8851)", async () => {
+    const cwd = getFixturesDir("project-npm")
+    vi.mocked(execa).mockRejectedValueOnce(
+      Object.assign(new Error("404 Not Found"), { exitCode: 1 })
+    )
+
+    await expect(
+      updateDependencies(
+        ["this-package-definitely-does-not-exist-xyz-8851"],
+        [],
+        { resolvedPaths: { cwd } } as any,
+        { silent: true }
+      )
+    ).rejects.toThrow(/404 Not Found/)
+
+    expect(spinnerInstance.fail).toHaveBeenCalledWith(
+      "Failed to install dependencies."
+    )
+    expect(spinnerInstance.succeed).not.toHaveBeenCalled()
   })
 })
 
@@ -297,9 +340,11 @@ describe("dependency commands", () => {
 
     await installDependencies(cwd, ["cn"])
 
-    expect(execa).toHaveBeenCalledWith("pnpm", ["add", "--", "cn"], {
-      cwd,
-    })
+    expect(execa).toHaveBeenCalledWith(
+      "pnpm",
+      ["add", "--", "cn"],
+      packageManagerExecaOptions(cwd)
+    )
   })
 
   it("removes only dependencies declared by the project", async () => {
@@ -307,8 +352,10 @@ describe("dependency commands", () => {
 
     await removeDependencies(cwd, ["recharts", "not-installed"])
 
-    expect(execa).toHaveBeenCalledWith("pnpm", ["remove", "--", "recharts"], {
-      cwd,
-    })
+    expect(execa).toHaveBeenCalledWith(
+      "pnpm",
+      ["remove", "--", "recharts"],
+      packageManagerExecaOptions(cwd)
+    )
   })
 })

--- a/packages/shadcn/src/utils/updaters/update-dependencies.ts
+++ b/packages/shadcn/src/utils/updaters/update-dependencies.ts
@@ -77,15 +77,19 @@ export async function updateDependencies(
 
   dependenciesSpinner?.start()
 
-  await installWithPackageManager(
-    packageManager,
-    dependencies,
-    devDependencies,
-    config.resolvedPaths.cwd,
-    flag
-  )
-
-  dependenciesSpinner?.succeed()
+  try {
+    await installWithPackageManager(
+      packageManager,
+      dependencies,
+      devDependencies,
+      config.resolvedPaths.cwd,
+      flag
+    )
+    dependenciesSpinner?.succeed()
+  } catch (error) {
+    dependenciesSpinner?.fail("Failed to install dependencies.")
+    throw error
+  }
 }
 
 export async function installDependencies(
@@ -122,7 +126,7 @@ export async function removeDependencies(cwd: string, dependencies: string[]) {
 
   const packageManager = await getPackageManager(cwd)
   if (packageManager === "npm") {
-    await execa("npm", ["uninstall", "--", ...dependencies], { cwd })
+    await execa("npm", ["uninstall", "--", ...dependencies], execaOptions(cwd))
     return
   }
 
@@ -143,7 +147,11 @@ export async function removeDependencies(cwd: string, dependencies: string[]) {
     return
   }
 
-  await execa(packageManager, ["remove", "--", ...dependencies], { cwd })
+  await execa(
+    packageManager,
+    ["remove", "--", ...dependencies],
+    execaOptions(cwd)
+  )
 }
 
 /**
@@ -312,15 +320,19 @@ async function installWithPackageManager(
   assertSafeDependencies(devDependencies)
 
   if (dependencies?.length) {
-    await execa(packageManager, ["add", "--", ...dependencies], {
-      cwd,
-    })
+    await execa(
+      packageManager,
+      ["add", "--", ...dependencies],
+      execaOptions(cwd)
+    )
   }
 
   if (devDependencies?.length) {
-    await execa(packageManager, ["add", "-D", "--", ...devDependencies], {
-      cwd,
-    })
+    await execa(
+      packageManager,
+      ["add", "-D", "--", ...devDependencies],
+      execaOptions(cwd)
+    )
   }
 }
 
@@ -337,7 +349,7 @@ async function installWithNpm(
     await execa(
       "npm",
       ["install", ...(flag ? [`--${flag}`] : []), "--", ...dependencies],
-      { cwd }
+      execaOptions(cwd)
     )
   }
 
@@ -351,7 +363,7 @@ async function installWithNpm(
         "--",
         ...devDependencies,
       ],
-      { cwd }
+      execaOptions(cwd)
     )
   }
 }
@@ -362,16 +374,18 @@ async function installWithDeno(
   cwd: string
 ) {
   if (dependencies?.length) {
-    await execa("deno", ["add", ...dependencies.map((dep) => `npm:${dep}`)], {
-      cwd,
-    })
+    await execa(
+      "deno",
+      ["add", ...dependencies.map((dep) => `npm:${dep}`)],
+      execaOptions(cwd)
+    )
   }
 
   if (devDependencies?.length) {
     await execa(
       "deno",
       ["add", "-D", ...devDependencies.map((dep) => `npm:${dep}`)],
-      { cwd }
+      execaOptions(cwd)
     )
   }
 }
@@ -385,12 +399,23 @@ async function installWithExpo(
   assertSafeDependencies(devDependencies)
 
   if (dependencies.length) {
-    await execa("npx", ["expo", "install", "--", ...dependencies], { cwd })
+    await execa(
+      "npx",
+      ["expo", "install", "--", ...dependencies],
+      execaOptions(cwd)
+    )
   }
 
   if (devDependencies.length) {
-    await execa("npx", ["expo", "install", "-- -D", "--", ...devDependencies], {
-      cwd,
-    })
+    await execa(
+      "npx",
+      ["expo", "install", "-- -D", "--", ...devDependencies],
+      execaOptions(cwd)
+    )
   }
+}
+
+function execaOptions(cwd: string) {
+  // Ignore stdin so a 404 or auth prompt cannot block the spinner forever.
+  return { cwd, stdin: "ignore" as const }
 }


### PR DESCRIPTION
Closes #8851

When a registry item lists an npm package that does not exist, `shadcn add` sits on **Installing dependencies.** and looks frozen. The package manager is not stuck. `npm install` returns E404 in under a second. The CLI never stopped the spinner, and it ran the install with stdin piped, so a 404 or a login prompt could leave you staring at a spinner with no error.

This matches how we already handle font updates: wrap the work, `succeed` on the way out, `fail` and rethrow on the way down. Install and remove calls now pass `stdin: "ignore"` so the child process cannot wait on input that nobody will ever type.

## Testing

I added a registry item whose only dependency was a fake package and ran the built CLI. It exits in a few seconds with **Failed to install dependencies.** plus the npm 404.

- [x] `updateDependencies` fails the spinner and rethrows when `execa` rejects
- [ ] `shadcn add` a local registry item whose `dependencies` include a package that is not on npm. Confirm the spinner fails and the process exits.
- [ ] Same path with a real package still installs as before.