### PR TITLE
fix: typo in september changelog

### DIFF
--- a/apps/v4/content/docs/changelog/2026-09-cn.mdx
+++ b/apps/v4/content/docs/changelog/2026-09-cn.mdx
@@ -16,9 +16,9 @@ drop-in replacement for `twMerge(clsx(...))`. It is smaller, faster and ships
 the same API, so nothing changes at the call site.
 
 ```tsx
-import { cn } from "cn"
+import { cn } from "cn";
 
-;<div className={cn("flex items-center", className)} />
+<div className={cn("flex items-center", className)} />;
 ```
 
 ## What changed
@@ -35,7 +35,7 @@ The `utils` registry item still exists. It now re-exports `cn` so your own code
 keeps working and you still have a single place for project helpers.
 
 ```ts title="lib/utils.ts"
-export { cn } from "cn"
+export { cn } from "cn";
 ```
 
 ## Existing projects


### PR DESCRIPTION
### Summary

- Added semicolons to the import and export statements in the `cn` usage examples in the documentation to align with standard TypeScript/JavaScript style.